### PR TITLE
fix code block creation on new lines

### DIFF
--- a/components/editor/BangleEditor.tsx
+++ b/components/editor/BangleEditor.tsx
@@ -27,7 +27,7 @@ import { floatingMenu, FloatingMenu } from '@bangle.dev/react-menu';
 import '@bangle.dev/react-menu/style.css';
 import '@bangle.dev/tooltip/style.css';
 import { ActionKind, autocomplete, closeAutocomplete, FromTo, Options } from "prosemirror-autocomplete";
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 const menuKey = new PluginKey('menuKey');
 
 const picker = {
@@ -95,15 +95,6 @@ const options: Options = {
   ],
 };
 
-// bold.spec(),
-// italic.spec(),
-// link.spec(),
-// blockquote.spec(),
-// orderedList.spec(),
-// bulletList.spec(),
-// listItem.spec(),
-// paragraph.spec(),
-// heading.spec(),
 const specRegistry = new SpecRegistry([
   blockquote.spec(),
   bold.spec(),

--- a/components/editor/BangleEditor.tsx
+++ b/components/editor/BangleEditor.tsx
@@ -27,7 +27,7 @@ import { floatingMenu, FloatingMenu } from '@bangle.dev/react-menu';
 import '@bangle.dev/react-menu/style.css';
 import '@bangle.dev/tooltip/style.css';
 import { ActionKind, autocomplete, closeAutocomplete, FromTo, Options } from "prosemirror-autocomplete";
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 const menuKey = new PluginKey('menuKey');
 
 const picker = {
@@ -95,14 +95,20 @@ const options: Options = {
   ],
 };
 
+// bold.spec(),
+// italic.spec(),
+// link.spec(),
+// blockquote.spec(),
+// orderedList.spec(),
+// bulletList.spec(),
+// listItem.spec(),
+// paragraph.spec(),
+// heading.spec(),
 const specRegistry = new SpecRegistry([
   blockquote.spec(),
   bold.spec(),
   bulletList.spec(),
-  code.spec(),
-  codeBlock.spec(),
   hardBreak.spec(),
-  heading.spec(),
   horizontalRule.spec(),
   image.spec(),
   italic.spec(),
@@ -112,6 +118,9 @@ const specRegistry = new SpecRegistry([
   paragraph.spec(),
   strike.spec(),
   underline.spec(),
+  code.spec(),
+  codeBlock.spec(),
+  heading.spec(),
 ]);
 const parser = markdownParser(specRegistry);
 const serializer = markdownSerializer(specRegistry);


### PR DESCRIPTION
It seems like the order of the specs is important... currently, hitting Return creates a code block. And if I remvoe code blocks, hitting Return creates an H1 tag. But it's fixed if I move them both to the end of the specs (maybe it just has to be after paragraph?).