### PR TITLE
add emoji next to page title

### DIFF
--- a/components/common/Emoji.tsx
+++ b/components/common/Emoji.tsx
@@ -1,0 +1,15 @@
+import Box from '@mui/material/Box';
+import styled from '@emotion/styled';
+
+const Emoji = styled(Box)`
+  /* font family taken from Notion */
+  font-family: "Apple Color Emoji", "Segoe UI Emoji", NotoColorEmoji, "Noto Color Emoji", "Segoe UI Symbol", "Android Emoji", EmojiSymbols;
+  line-height: 1em;
+  white-space: nowrap;
+`;
+
+export default function EmojiCon ({ children, ...props }: React.ComponentProps<typeof Emoji>) {
+  return (
+    <Emoji role='image' {...props}>{children}</Emoji>
+  )
+}

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -1,6 +1,7 @@
 import Typography from '@mui/material/Typography';
 import styled from '@emotion/styled';
 import BangleEditor from './BangleEditor';
+import Emoji from 'components/common/Emoji';
 
 const Container = styled.div`
   width: 900px;
@@ -24,6 +25,7 @@ export function Editor () {
       <Controls>
 
       </Controls>
+      <Emoji sx={{ fontSize: 78 }}>📌</Emoji>
       <Typography variant='h1'>{page.title}</Typography>
     </Container>
     <Container>

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -1,3 +1,5 @@
+
+import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import styled from '@emotion/styled';
 import BangleEditor from './BangleEditor';
@@ -25,7 +27,9 @@ export function Editor () {
       <Controls>
 
       </Controls>
-      <Emoji sx={{ fontSize: 78 }}>📌</Emoji>
+      <Box py={3}>
+        <Emoji sx={{ fontSize: 78 }}>📌</Emoji>
+      </Box>
       <Typography variant='h1'>{page.title}</Typography>
     </Container>
     <Container>

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -6,7 +6,7 @@ import BangleEditor from './BangleEditor';
 import Emoji from 'components/common/Emoji';
 
 const Container = styled.div`
-  width: 900px;
+  width: 800px;
   max-width: 100%;
   margin: 0 auto 5px;
 `;
@@ -14,6 +14,12 @@ const Container = styled.div`
 const Controls = styled.div`
   margin-top: 80px;
   margin-bottom: 4px;
+`;
+
+const PageTitle = styled(Typography)`
+  cursor: text;
+  font-size: 40px;
+  font-weight: 700;
 `;
 
 export function Editor () {
@@ -30,7 +36,7 @@ export function Editor () {
       <Box py={3}>
         <Emoji sx={{ fontSize: 78 }}>📌</Emoji>
       </Box>
-      <Typography variant='h1'>{page.title}</Typography>
+      <PageTitle>{page.title}</PageTitle>
     </Container>
     <Container>
       <BangleEditor />

--- a/styles/index.css
+++ b/styles/index.css
@@ -5,6 +5,7 @@ body > div:first-child,
 div#__next,
 div#__next > div {
   height: 100%;
+  font-size: 14px;
 }
 
 /* The default ID for the decoration, can override with decorationAttrs = { id: 'something' }  */

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -54,6 +54,7 @@ const theme = createTheme({
   },
   typography: {
     fontFamily: 'ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol"',
+    htmlFontSize: 14,
     h1: {
       fontSize: '2rem',
       fontWeight: 500


### PR DESCRIPTION
We want to support emojis for pages like Notion does, this adds a component we can use that will apply the emoji font.

I also adjusted the font sizes for page title and Bangle editor to match Notion