### PR TITLE
Add Next.js cache to CI builds

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,18 +19,20 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-      - name: Cache npm dependencies # copied from https://github.com/vercel/next.js/blob/canary/errors/no-cache.md
+      - name: Cache Next.js build # copied from https://github.com/vercel/next.js/blob/canary/errors/no-cache.md
         uses: actions/cache@v2
         with:
           path: |
             ~/.npm
             ${{ github.workspace }}/.next/cache
+          id:
           # Generate a new cache whenever packages or source files change.
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Install npm dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci --no-audit --no-fund
       - name: Lint
         run: npm run lint:prod

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,12 +19,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-      - name: Install npm dependencies
-        run: npm ci --no-audit --no-fund
-      - name: Lint
-        run: npm run lint:prod
-      - name: Build Next.js App
-        run: npm run build
       - name: Cache npm dependencies # copied from https://github.com/vercel/next.js/blob/canary/errors/no-cache.md
         uses: actions/cache@v2
         with:
@@ -36,6 +30,12 @@ jobs:
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+      - name: Install npm dependencies
+        run: npm ci --no-audit --no-fund
+      - name: Lint
+        run: npm run lint:prod
+      - name: Build Next.js App
+        run: npm run build
     # - name: Run Tests
     #   shell: 'script -q -e -c "bash {0}"' # add support for colors in output. see: https://github.com/actions/runner/issues/241
     #   run: npm test

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,6 +25,17 @@ jobs:
         run: npm run lint:prod
       - name: Build Next.js App
         run: npm run build
+      - name: Cache npm dependencies # copied from https://github.com/vercel/next.js/blob/canary/errors/no-cache.md
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            ${{ github.workspace }}/.next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
     # - name: Run Tests
     #   shell: 'script -q -e -c "bash {0}"' # add support for colors in output. see: https://github.com/actions/runner/issues/241
     #   run: npm test

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -15,7 +15,6 @@ export default function BlocksEditorPage () {
   const [, setTitleState] = usePageTitle();
 
   function setPage (page: Partial<Page>) {
-    console.log('setPage called', page);
     const newPage = { ...pageByPath, ...page };
     setPages(pages.map(p => p.id === newPage.id ? newPage : p));
   }


### PR DESCRIPTION
Next.js warns us we are not caching our build, it should help speed up build times: https://github.com/vercel/next.js/blob/canary/errors/no-cache.md