### PR TITLE
remove black bar on images and other components

### DIFF
--- a/components/editor/BangleEditor.tsx
+++ b/components/editor/BangleEditor.tsx
@@ -175,7 +175,11 @@ export default function BangleEditor (
         containerDOM: ['div']
       })
     ],
-    initialValue: Node.fromJSON(specRegistry.schema, content)
+    initialValue: Node.fromJSON(specRegistry.schema, content),
+    // hide the black bar when dragging items - we dont even support dragging most components
+    dropCursorOpts: {
+      color: 'transparent'
+    }
   });
 
   let pageTitleTop = 50; let bangleEditorTop = 75; let

--- a/components/editor/Image.tsx
+++ b/components/editor/Image.tsx
@@ -74,7 +74,6 @@ const StyledImage = styled.img`
   &:hover {
     cursor: initial;
   }
-  box-shadow: ${({ theme }) => theme.shadows[3]};
   border-radius: ${({ theme }) => theme.spacing(1)};
 `;
 
@@ -213,7 +212,7 @@ export function Image ({ node, updateAttrs }: NodeViewProps) {
     >
       <div className='content' style={{ position: 'relative' }}>
         { /* eslint-disable-next-line */}
-        <Box 
+        <Box
           sx={{
             position: 'relative',
             cursor: 'col-resize',


### PR DESCRIPTION
I found the culprit: https://github.com/ProseMirror/prosemirror-dropcursor. This cursor is to show you where a component will be dropped if it is draggable. Bangle.dev enables this plugin all the time even if an element is not draggable. I don't think we support any draggable components at the moment? Just hiding it for now.

Also, no need to add a drop shadow on images.. I think that could mess up people's abilities to fully customize their content. They can always add a drop shadow themselves, or we could give them some options one day .. but i think by default we should leave it up to them, since a drop shadow might look ugly say if you have a transparent picture.