### PR TITLE
remove username from user model

### DIFF
--- a/components/bounties/BountyModal.tsx
+++ b/components/bounties/BountyModal.tsx
@@ -78,7 +78,7 @@ export default function BountyModal (props: Props) {
     defaultValues:
       modalType !== 'edit'
         ? {
-          author: user?.username || '',
+          author: user?.id,
           title: 'New Bounty',
           description: {
             type: 'doc',
@@ -87,7 +87,7 @@ export default function BountyModal (props: Props) {
           type: 'social',
           status: 'pending',
           rewardToken: 'ETH',
-          reviewer: user?.username || ''
+          reviewer: user?.id
         }
         : bounty,
     resolver: yupResolver(schema)

--- a/components/bounties/BountyModal.tsx
+++ b/components/bounties/BountyModal.tsx
@@ -79,7 +79,7 @@ export default function BountyModal (props: Props) {
     defaultValues:
       modalType !== 'edit'
         ? {
-          author: user && getDisplayName(user),
+          author: user ? getDisplayName(user) : '',
           title: 'New Bounty',
           description: {
             type: 'doc',
@@ -88,7 +88,7 @@ export default function BountyModal (props: Props) {
           type: 'social',
           status: 'pending',
           rewardToken: 'ETH',
-          reviewer: user && getDisplayName(user)
+          reviewer: user ? getDisplayName(user) : ''
         }
         : bounty,
     resolver: yupResolver(schema)

--- a/components/bounties/BountyModal.tsx
+++ b/components/bounties/BountyModal.tsx
@@ -19,7 +19,8 @@ import Select, { SelectChangeEvent } from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
 import { Bounty, BOUNTY_STATUSES, BountyStatus } from 'models/Bounty';
 import { InputSearchCrypto } from 'components/common/form/InputSearchCrypto';
-import { CryptoCurrency, CryptoCurrencyList, CryptoLogoPaths } from 'models/Currency';
+import { CryptoCurrency, CryptoCurrencyList } from 'models/Currency';
+import getDisplayName from 'lib/users/getDisplayName';
 
 interface IToken {
   symbol: string;
@@ -78,7 +79,7 @@ export default function BountyModal (props: Props) {
     defaultValues:
       modalType !== 'edit'
         ? {
-          author: user?.id,
+          author: user && getDisplayName(user),
           title: 'New Bounty',
           description: {
             type: 'doc',
@@ -87,7 +88,7 @@ export default function BountyModal (props: Props) {
           type: 'social',
           status: 'pending',
           rewardToken: 'ETH',
-          reviewer: user?.id
+          reviewer: user && getDisplayName(user)
         }
         : bounty,
     resolver: yupResolver(schema)

--- a/components/common/Avatar.tsx
+++ b/components/common/Avatar.tsx
@@ -8,7 +8,7 @@ const StyledAvatar = styled(Avatar)`
 `;
 
 export default function InitialAvatar ({ className, name, variant }: { className?: string, name?: string | null, variant?: 'circular' | 'rounded' | 'square' }) {
-  const nameStr = name || '';
+  const nameStr = (name || '').replace('0x', ''); // ignore the universal prefix of addresses
   return (
     <StyledAvatar
       className={className}

--- a/components/common/page-layout/CreateWorkspaceForm.tsx
+++ b/components/common/page-layout/CreateWorkspaceForm.tsx
@@ -11,6 +11,7 @@ import { FormValues, schema } from 'pages/[domain]/settings/workspace';
 import { ChangeEvent } from 'react';
 import { DialogTitle } from 'components/common/Modal';
 import { useForm } from 'react-hook-form';
+import getDisplayName from 'lib/users/getDisplayName';
 
 interface Props {
   onCancel: () => void;
@@ -21,7 +22,7 @@ export default function WorkspaceSettings ({ onSubmit: _onSubmit, onCancel }: Pr
 
   const [user] = useUser();
 
-  const defaultName = `${user!.username}'s Workspace`;
+  const defaultName = `${getDisplayName(user!)}'s Workspace`;
 
   const {
     register,

--- a/components/common/page-layout/Sidebar.tsx
+++ b/components/common/page-layout/Sidebar.tsx
@@ -19,7 +19,7 @@ import { usePages } from 'hooks/usePages';
 import { useSpaces } from 'hooks/useSpaces';
 import { useUser } from 'hooks/useUser';
 import { shortenHex } from 'lib/strings';
-import { ContributorUser, Page, Space } from 'models';
+import { LoggedInUser, Page, Space } from 'models';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { pages as seedPages } from 'seedData';
@@ -28,6 +28,7 @@ import { addBoardClicked } from 'components/databases/focalboard/src/components/
 import mutator from 'components/databases/focalboard/src//mutator';
 import { useAppSelector } from 'components/databases/focalboard/src/store/hooks';
 import { getSortedBoards } from 'components/databases/focalboard/src/store/boards';
+import getDisplayName from 'lib/users/getDisplayName';
 import Avatar from '../Avatar';
 import Link from '../Link';
 import { Modal } from '../Modal';
@@ -115,7 +116,7 @@ const SidebarHeader = styled.div(({ theme }) => ({
 
 interface SidebarProps {
   closeSidebar: () => void;
-  favorites: ContributorUser['favorites'];
+  favorites: LoggedInUser['favorites'];
 }
 
 export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
@@ -292,12 +293,10 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
           <Box p={1} display='flex' alignItems='center' justifyContent='space-between'>
             {user && (
               <Box display='flex' alignItems='center'>
-                <Avatar name={user.username} />
+                <Avatar name={getDisplayName(user)} />
                 <Box pl={1}>
-                  <Typography variant='caption' sx={{ display: 'block' }}>
-                    <strong>{user.username}</strong>
-                    <br />
-                    {account && shortenHex(account)}
+                  <Typography>
+                    <strong>{getDisplayName(user)}</strong>
                   </Typography>
                 </Box>
               </Box>

--- a/components/settings/ContributorRow.tsx
+++ b/components/settings/ContributorRow.tsx
@@ -3,7 +3,8 @@ import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import Avatar from 'components/common/Avatar';
-import { Contributor } from 'models';
+import { User } from 'models';
+import getDisplayName from 'lib/users/getDisplayName';
 
 const StyledRow = styled(Box)`
   border-bottom: 1px solid #ddd;
@@ -12,17 +13,16 @@ const StyledRow = styled(Box)`
   justify-content: space-between;
 `;
 
-type Props = { contributor: Contributor, spaceId: string };
+type Props = { contributor: User, spaceId: string };
 
 export default function ContributorRow ({ contributor, spaceId }: Props) {
   const role = contributor.spaceRoles.find(r => r.spaceId === spaceId);
   return (
     <StyledRow pb={2} mb={2}>
       <Box display='flex' alignItems='center'>
-        <Avatar name={contributor.username} />
+        <Avatar name={getDisplayName(contributor)} />
         <Box pl={2}>
-          <Typography variant='body1'><strong>{contributor.username}</strong></Typography>
-          <Typography color='secondary' variant='body2'>{contributor.addresses[0]}</Typography>
+          <Typography variant='body1'><strong>{getDisplayName(contributor)}</strong></Typography>
         </Box>
       </Box>
       <Typography color='secondary' variant='body2' sx={{ px: 3 }}>

--- a/hooks/useContributors.ts
+++ b/hooks/useContributors.ts
@@ -1,12 +1,12 @@
-import { Contributor } from 'models';
-import { contributors } from 'seedData';
+import { User } from 'models';
+import { users } from 'seedData';
 import { useLocalStorage } from './useLocalStorage';
 import { useCurrentSpace } from './useCurrentSpace';
 
 export function useContributors () {
   const [space] = useCurrentSpace();
-  const spaceContributors = contributors.filter(
+  const spaceContributors = users.filter(
     c => c.spaceRoles.some(({ spaceId }) => spaceId === space.id)
   );
-  return useLocalStorage<Contributor[]>(`spaces.${space.id}.contributors`, spaceContributors);
+  return useLocalStorage<User[]>(`spaces.${space.id}.contributors`, spaceContributors);
 }

--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -1,15 +1,15 @@
 import { ReactNode, createContext, useContext, useMemo } from 'react';
-import { Contributor, ContributorUser } from 'models';
+import { LoggedInUser } from 'models';
 import { activeUser } from 'seedData';
 import { useLocalStorage } from './useLocalStorage';
 
-type IContext = [user: ContributorUser | null, setUser: (user: ContributorUser | any) => void];
+type IContext = [user: LoggedInUser | null, setUser: (user: LoggedInUser | any) => void];
 
 export const UserContext = createContext<Readonly<IContext>>([null, () => undefined]);
 
 export function UserProvider ({ children }: { children: ReactNode }) {
 
-  const [user, setUser] = useLocalStorage<ContributorUser>('profile', activeUser);
+  const [user, setUser] = useLocalStorage<LoggedInUser>('profile', activeUser);
   // @ts-ignore - backwards compatibility
   user.addresses = user.addresses || [user.address];
   user.linkedAddressesCount = user.addresses.length;

--- a/lib/users/getDisplayName.ts
+++ b/lib/users/getDisplayName.ts
@@ -1,0 +1,6 @@
+import { User } from 'models/User';
+import { shortenHex } from 'lib/strings';
+
+export default function getDisplayName (user: User) {
+  return shortenHex(user.addresses[0]);
+}

--- a/models/User.ts
+++ b/models/User.ts
@@ -10,15 +10,14 @@ export interface SpaceRole {
   userId: string;
 }
 
-export interface Contributor {
+export interface User {
   id: string;
   addresses: string[];
   discordId?: string;
-  username: string;
   spaceRoles: SpaceRole[];
 }
 
-export interface ContributorUser extends Contributor {
+export interface LoggedInUser extends User {
   favorites: FavoritePage[];
   isLoading: boolean;
   linkedAddressesCount: number; // from guild.xyz

--- a/models/index.ts
+++ b/models/index.ts
@@ -1,4 +1,4 @@
-export * from './Contributor';
+export * from './User';
 export * from './Page';
 export * from './Space';
 export * from './Bounty';

--- a/pages/[domain]/settings/account.tsx
+++ b/pages/[domain]/settings/account.tsx
@@ -2,79 +2,31 @@ import SettingsLayout from 'components/settings/Layout';
 import { ReactElement } from 'react';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
-import TextField from '@mui/material/TextField';
-import { useForm } from 'react-hook-form';
-import PrimaryButton from 'components/common/PrimaryButton';
-import FieldLabel from 'components/settings/FieldLabel';
+import getDisplayName from 'lib/users/getDisplayName';
 import Avatar from 'components/settings/LargeAvatar';
 import Legend from 'components/settings/Legend';
 import { setTitle } from 'hooks/usePageTitle';
 import { useUser } from 'hooks/useUser';
-import * as yup from 'yup';
-import { yupResolver } from '@hookform/resolvers/yup';
 import WalletConnection from 'components/settings/WalletConnection';
-
-const schema = yup.object({
-  username: yup.string().ensure().trim()
-    .matches(/^[0-9a-zA-Z\s]*$/, 'Name must be only letters, numbers, and spaces')
-    .required('Username is required')
-});
-
-type FormValues = yup.InferType<typeof schema>;
 
 export default function AccountSettings () {
 
   setTitle('My Account');
   const [user, setUser] = useUser();
 
-  const {
-    register,
-    reset,
-    watch,
-    handleSubmit,
-    formState: { errors, isDirty }
-  } = useForm<FormValues>({
-    defaultValues: user!,
-    resolver: yupResolver(schema)
-  });
-
-  const watchUsername = watch('username');
-
-  function onSubmit (values: FormValues) {
-    setUser({ ...user, ...values });
-    reset(values);
-  }
-
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <Box sx={{ py: 3 }}>
-        <Avatar name={watchUsername} />
-      </Box>
-      <Grid container direction='column' spacing={3}>
-        <Grid item>
-          <FieldLabel>Username</FieldLabel>
-          <TextField
-            {...register('username')}
-            fullWidth
-            error={!!errors.username}
-            helperText={errors.username?.message}
-          />
-        </Grid>
-        <Grid item>
-        </Grid>
-        <Grid item>
-          <PrimaryButton disabled={!isDirty} type='submit'>
-            Save
-          </PrimaryButton>
-        </Grid>
-        <Grid item>
-          <Legend>Web3 Connection</Legend>
-          <WalletConnection />
-        </Grid>
+    <Grid container direction='column' spacing={3}>
+      <Grid item>
+        <Box sx={{ py: 3 }}>
+          <Avatar name={user ? getDisplayName(user) : ''} />
+        </Box>
       </Grid>
-    </form>
+      <Grid item>
+        <Legend>Web3 Connection</Legend>
+        <WalletConnection />
+      </Grid>
+    </Grid>
   );
-
 }
 
 AccountSettings.getLayout = (page: ReactElement) => {

--- a/pages/[domain]/settings/contributors.tsx
+++ b/pages/[domain]/settings/contributors.tsx
@@ -7,6 +7,7 @@ import ContributorRow from 'components/settings/ContributorRow';
 import { setTitle } from 'hooks/usePageTitle';
 import { useContributors } from 'hooks/useContributors';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import getDisplayName from 'lib/users/getDisplayName';
 
 export default function ContributorSettings () {
 
@@ -31,7 +32,7 @@ export default function ContributorSettings () {
 
       <Legend>Current Contributors</Legend>
       {contributors.map(contributor => (
-        <ContributorRow key={contributor.username} contributor={contributor} spaceId={space.id} />
+        <ContributorRow key={getDisplayName(contributor)} contributor={contributor} spaceId={space.id} />
       ))}
     </>
   );

--- a/seedData.ts
+++ b/seedData.ts
@@ -1,19 +1,19 @@
-import { Contributor, ContributorUser, Page, PageContent, Space } from 'models';
+import { User, LoggedInUser, Page, PageContent, Space } from 'models';
 
 export const spaces: Space[] = [
   { id: '0', name: 'Our Community', domain: 'demo' },
   { id: '1', name: 'My Workspace', domain: 'my-workspace' }
 ];
 
-export const contributors: Contributor[] = [
-  { id: '0', addresses: ['0x87ddfh6g435D12CE393aBbA3f81fe6C594543sdw'], username: 'dolemite', spaceRoles: [{ spaceId: spaces[0].id, type: 'admin', userId: '0' }, { spaceId: spaces[1].id, type: 'admin', userId: '0' }] },
-  { id: '1', addresses: ['0x1416d1b5435D12CE393aBbA3f81fe6C5951e4Bf4'], username: 'cerberus', spaceRoles: [{ spaceId: spaces[0].id, type: 'admin', userId: '1' }] },
-  { id: '2', addresses: ['0x626a827c90AA620CFD78A8ecda494Edb9a4225D5'], username: 'devorein', spaceRoles: [{ spaceId: spaces[0].id, type: 'contributor', userId: '2' }, { spaceId: spaces[1].id, type: 'admin', userId: '2' }] },
-  { id: '3', addresses: ['0x66525057AC951a0DB5C9fa7fAC6E056D6b8997E2'], username: 'mattopoly', spaceRoles: [{ spaceId: spaces[1].id, type: 'contributor', userId: '3' }] }
+export const users: User[] = [
+  { id: '0', addresses: ['0x87ddfh6g435D12CE393aBbA3f81fe6C594543sdw'], spaceRoles: [{ spaceId: spaces[0].id, type: 'admin', userId: '0' }, { spaceId: spaces[1].id, type: 'admin', userId: '0' }] },
+  { id: '1', addresses: ['0x1416d1b5435D12CE393aBbA3f81fe6C5951e4Bf4'], spaceRoles: [{ spaceId: spaces[0].id, type: 'admin', userId: '1' }] },
+  { id: '2', addresses: ['0x626a827c90AA620CFD78A8ecda494Edb9a4225D5'], spaceRoles: [{ spaceId: spaces[0].id, type: 'contributor', userId: '2' }, { spaceId: spaces[1].id, type: 'admin', userId: '2' }] },
+  { id: '3', addresses: ['0x66525057AC951a0DB5C9fa7fAC6E056D6b8997E2'], spaceRoles: [{ spaceId: spaces[1].id, type: 'contributor', userId: '3' }] }
 ];
 
-export const activeUser: ContributorUser = {
-  ...contributors[0],
+export const activeUser: LoggedInUser = {
+  ...users[0],
   isLoading: false,
   linkedAddressesCount: 1,
   favorites: []


### PR DESCRIPTION
We decided that allowing people to enter a custom username could be misleading - they could put in someone else's wallet address or ENS for example. In the near-term future, we should pick up ENS name, and make our avatars should be more unique because plain wallet addresses are hard to remember.