### PR TITLE
remember extensions when using Chrome debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tsconfig.tsbuildinfo
 
 # user data
 *.csv
+.vscode/vscode-chrome-debug-userdatadir/
 
 # debug
 npm-debug.log*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
       "request": "launch",
       "name": "Launch Chrome against localhost",
       "url": "http://localhost:3000",
-      "webRoot": "${workspaceFolder}"
+      "webRoot": "${workspaceFolder}",
+      "userDataDir": "${workspaceFolder}/.vscode/vscode-chrome-debug-userdatadir"
     }
   ]
 }


### PR DESCRIPTION
Currently the Chrome debugger starts with a new profile each time you run it, but it's a pain to reinstall the Metamask extension each time. One option is to set the user directory to "false" and it will use your personal profile, but with this update we save it inside `.vscode` so that it just remembers what you did the last time, and we only have to install Metamask once.
https://stackoverflow.com/questions/51725854/run-vscode-chrome-debugger-with-its-extensions