### PR TITLE
Fixed image resize issue on toggle dark/light modes

### DIFF
--- a/components/editor/BlockAligner.tsx
+++ b/components/editor/BlockAligner.tsx
@@ -7,7 +7,7 @@ import { ReactNode } from 'react';
 interface BlockAlignerProps {
   children: ReactNode
   onDelete: () => void
-  imageSize: number
+  size?: number
 }
 
 const StyledBlockAligner = styled.div`
@@ -32,7 +32,7 @@ const Controls = styled.div`
 `;
 
 export default function BlockAligner (props: BlockAlignerProps) {
-  const { imageSize, children, onDelete } = props;
+  const { size = 250, children, onDelete } = props;
   const theme = useTheme();
 
   return (
@@ -49,12 +49,12 @@ export default function BlockAligner (props: BlockAlignerProps) {
               onDelete();
             }}
             sx={{
-              padding: imageSize < 150 ? theme.spacing(0.5) : theme.spacing(1),
+              padding: size < 150 ? theme.spacing(0.5) : theme.spacing(1),
               backgroundColor: 'inherit'
             }}
           >
             <DeleteIcon sx={{
-              fontSize: imageSize < 150 ? 12 : 14
+              fontSize: size < 150 ? 12 : 14
             }}
             />
           </ListItem>

--- a/components/editor/BlockAligner.tsx
+++ b/components/editor/BlockAligner.tsx
@@ -2,16 +2,17 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { ListItem } from '@mui/material';
-import { ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 
 interface BlockAlignerProps {
   children: ReactNode
   onDelete: () => void
+  imageSize: number
 }
 
-const StyledBlockAligner = styled.div<{ align?: string }>`
+const StyledBlockAligner = styled.div`
   display: flex;
-  justify-content: ${props => props.align};
+  justify-content:center;
   &:hover .controls {
     opacity: 1;
     transition: opacity 250ms ease-in-out;
@@ -31,13 +32,11 @@ const Controls = styled.div`
 `;
 
 export default function BlockAligner (props: BlockAlignerProps) {
-  const { children, onDelete } = props;
-  const [align, setAlign] = useState('center');
+  const { imageSize, children, onDelete } = props;
   const theme = useTheme();
 
   return (
     <StyledBlockAligner
-      align={align}
       draggable={false}
     >
       <div className='content' style={{ position: 'relative' }}>
@@ -50,12 +49,12 @@ export default function BlockAligner (props: BlockAlignerProps) {
               onDelete();
             }}
             sx={{
-              padding: theme.spacing(1),
+              padding: imageSize < 150 ? theme.spacing(0.5) : theme.spacing(1),
               backgroundColor: 'inherit'
             }}
           >
             <DeleteIcon sx={{
-              fontSize: 14
+              fontSize: imageSize < 150 ? 12 : 14
             }}
             />
           </ListItem>

--- a/components/editor/ColumnLayout.tsx
+++ b/components/editor/ColumnLayout.tsx
@@ -29,7 +29,6 @@ const StyledColumnLayout = styled(Box)<{colCount: number}>`
   border-radius: ${({ theme }) => theme.spacing(0.5)};
   padding: ${({ theme }) => theme.spacing(1)};
   margin: ${({ theme }) => theme.spacing(2, 0)};
-  box-shadow: ${({ theme }) => theme.shadows[1]};
 
   & > .bangle-nv-child-container {
     height: 100%;

--- a/components/editor/Image.tsx
+++ b/components/editor/Image.tsx
@@ -10,7 +10,7 @@ import ImageSelector from './ImageSelector';
 import Resizer from './Resizer';
 
 const MAX_IMAGE_SIZE = 750; const
-  MIN_IMAGE_SIZE = 250;
+  MIN_IMAGE_SIZE = 100;
 
 const StyledEmptyImageContainer = styled(Box)`
   display: flex;
@@ -114,11 +114,13 @@ export function Image ({ node, updateAttrs }: NodeViewProps) {
       flexDirection: 'column'
     }}
     >
-      <BlockAligner onDelete={() => {
-        updateAttrs({
-          src: null
-        });
-      }}
+      <BlockAligner
+        onDelete={() => {
+          updateAttrs({
+            src: null
+          });
+        }}
+        imageSize={size}
       >
         <Resizer
           size={size}

--- a/components/editor/Image.tsx
+++ b/components/editor/Image.tsx
@@ -120,7 +120,7 @@ export function Image ({ node, updateAttrs }: NodeViewProps) {
             src: null
           });
         }}
-        imageSize={size}
+        size={size}
       >
         <Resizer
           size={size}

--- a/components/editor/Image.tsx
+++ b/components/editor/Image.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import ImageIcon from '@mui/icons-material/Image';
 import { Box, ListItem, Typography } from '@mui/material';
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, useState } from 'react';
 import BlockAligner from './BlockAligner';
 import ImageSelector from './ImageSelector';
 import Resizer from './Resizer';
@@ -92,7 +92,7 @@ const StyledImage = styled.img`
 
 export function Image ({ node, updateAttrs }: NodeViewProps) {
   const theme = useTheme();
-
+  const [size, setSize] = useState(MIN_IMAGE_SIZE);
   // If there are no source for the node, return the image select component
   if (!node.attrs.src) {
     return (
@@ -120,7 +120,14 @@ export function Image ({ node, updateAttrs }: NodeViewProps) {
         });
       }}
       >
-        <Resizer maxSize={MAX_IMAGE_SIZE} minSize={MIN_IMAGE_SIZE}>
+        <Resizer
+          size={size}
+          onResize={(_, data) => {
+            setSize(data.size.width);
+          }}
+          maxSize={MAX_IMAGE_SIZE}
+          minSize={MIN_IMAGE_SIZE}
+        >
           <StyledImage
             draggable={false}
             src={node.attrs.src}

--- a/components/editor/Resizer.tsx
+++ b/components/editor/Resizer.tsx
@@ -15,7 +15,7 @@ interface ResizerProps {
 
 export const StyledResizeHandle = styled(Box)`
   width: 7.5px;
-  height: calc(100% - 15px);
+  height: calc(100% - 25px);
   max-height: 75px;
   border-radius: ${({ theme }) => theme.spacing(2)};
   background-color: ${({ theme }) => theme.palette.background.dark};

--- a/components/editor/Resizer.tsx
+++ b/components/editor/Resizer.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import { ResizableBox, ResizableProps } from 'react-resizable';
 
 interface ResizerProps {
+  size?: number
   maxSize?: number
   minSize?: number
   children: ReactNode
@@ -35,7 +36,7 @@ export const StyledResizeHandle = styled(Box)`
 `;
 
 export default function Resizer (props: ResizerProps) {
-  const { onResize, minConstraints, maxConstraints, minSize = 250, maxSize = 750, children } = props;
+  const { size = 250, onResize, minConstraints, maxConstraints, minSize = 250, maxSize = 750, children } = props;
 
   return (
     <Box
@@ -51,8 +52,8 @@ export default function Resizer (props: ResizerProps) {
     >
       <ResizableBox
         onResize={onResize}
-        width={maxConstraints?.[0] ?? maxSize}
-        height={maxConstraints?.[1] ?? maxSize}
+        width={maxConstraints?.[0] ?? size ?? maxSize}
+        height={maxConstraints?.[1] ?? size ?? maxSize}
         resizeHandles={['w', 'e']}
         lockAspectRatio
         minConstraints={minConstraints ?? [minSize, minSize]}


### PR DESCRIPTION
1. Dropped column drop shadows
2. Images can be resize beyond the width of a column
3. Toggling dark/light theme doesn't reset image size