### PR TITLE
save content for focalboard blocks from charm editor

### DIFF
--- a/components/databases/focalboard/src/blocks/block.ts
+++ b/components/databases/focalboard/src/blocks/block.ts
@@ -5,7 +5,7 @@ import difference from 'lodash/difference'
 
 import {Utils} from '../utils'
 
-const contentBlockTypes = ['text', 'image', 'divider', 'checkbox'] as const
+const contentBlockTypes = ['text', 'image', 'divider', 'checkbox', 'charm_text'] as const
 const blockTypes = [...contentBlockTypes, 'board', 'view', 'card', 'comment', 'unknown'] as const
 type ContentBlockTypes = typeof contentBlockTypes[number]
 type BlockTypes = typeof blockTypes[number]

--- a/components/databases/focalboard/src/blocks/charmBlock.ts
+++ b/components/databases/focalboard/src/blocks/charmBlock.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {ContentBlock} from './contentBlock'
+import {Block, createBlock} from './block'
+
+export type CharmTextBlock = ContentBlock & {
+    type: 'charm_text'
+}
+
+function createCharmTextBlock(block?: Block): CharmTextBlock {
+    return {
+        ...createBlock(block),
+        type: 'charm_text',
+    }
+}
+
+export {createCharmTextBlock}

--- a/components/databases/focalboard/src/components/cardDetail/cardDetailContents.tsx
+++ b/components/databases/focalboard/src/components/cardDetail/cardDetailContents.tsx
@@ -172,7 +172,7 @@ const CardDetailContents = React.memo((props: Props) => {
     }
     return (
         <div className='octo-content CardDetailContents'>
-            <div className='octo-block'>
+            <div className='octo-block' style={{ position: 'relative', zIndex: 1 }}>
                 <CharmEditor editorTop={-70} content={content} onPageContentChange={updatePageContent} />
                 <Box mb={6} />
             </div>

--- a/components/databases/focalboard/src/components/cardDetail/cardDetailContents.tsx
+++ b/components/databases/focalboard/src/components/cardDetail/cardDetailContents.tsx
@@ -4,6 +4,7 @@ import CharmEditor, { ICharmEditorOutput } from 'components/editor/CharmEditor'
 import { PageContent } from 'models'
 import React from 'react'
 import { IntlShape } from 'react-intl'
+import Box from '@mui/material/Box'
 import { Card } from '../../blocks/card'
 import { ContentBlock as ContentBlockType, IContentBlockWithCords } from '../../blocks/contentBlock'
 import { CharmTextBlock, createCharmTextBlock } from '../../blocks/charmBlock'
@@ -44,7 +45,6 @@ function addTextBlock(card: Card, intl: IntlShape, text: string): void {
 function updateCharmTextBlock(block: CharmTextBlock, content: PageContent) {
     const newBlock = createCharmTextBlock(block)
     newBlock.fields.content = content
-    console.log('update charm text block', newBlock)
     return mutator.updateBlock(newBlock, block, 'Updated description')
 }
 
@@ -173,7 +173,8 @@ const CardDetailContents = React.memo((props: Props) => {
     return (
         <div className='octo-content CardDetailContents'>
             <div className='octo-block'>
-                <CharmEditor content={content} onPageContentChange={updatePageContent} />
+                <CharmEditor editorTop={-70} content={content} onPageContentChange={updatePageContent} />
+                <Box mb={6} />
             </div>
         </div>
     )

--- a/components/databases/focalboard/src/components/centerPanel.tsx
+++ b/components/databases/focalboard/src/components/centerPanel.tsx
@@ -13,6 +13,7 @@ import {BlockIcons} from '../blockIcons'
 import {Card, createCard} from '../blocks/card'
 import {Board, IPropertyTemplate, IPropertyOption, BoardGroup} from '../blocks/board'
 import {BoardView} from '../blocks/boardView'
+import { createCharmTextBlock } from '../blocks/charmBlock'
 import {CardFilter} from '../cardFilter'
 import mutator from '../mutator'
 import {Utils} from '../utils'
@@ -272,11 +273,18 @@ class CenterPanel extends React.Component<Props, State> {
             card.fields.icon = BlockIcons.shared.randomIcon()
         }
 
+        const charmTextBlock = createCharmTextBlock()
+        charmTextBlock.parentId = card.id
+        charmTextBlock.rootId = card.rootId
+        card.fields.contentOrder = [charmTextBlock.id];
+
         mutator.performAsUndoGroup(async () => {
             const newCard = await mutator.insertBlock(
                 card,
                 'add card',
                 async (block: Block) => {
+                    await mutator.insertBlock(charmTextBlock, 'add card description')
+                    console.log(charmTextBlock)
                     if (show) {
                         this.props.addCard(createCard(block))
                         this.props.updateView({...activeView, fields: {...activeView.fields, cardOrder: [...activeView.fields.cardOrder, block.id]}})

--- a/components/databases/focalboard/src/components/centerPanel.tsx
+++ b/components/databases/focalboard/src/components/centerPanel.tsx
@@ -284,7 +284,6 @@ class CenterPanel extends React.Component<Props, State> {
                 'add card',
                 async (block: Block) => {
                     await mutator.insertBlock(charmTextBlock, 'add card description')
-                    console.log(charmTextBlock)
                     if (show) {
                         this.props.addCard(createCard(block))
                         this.props.updateView({...activeView, fields: {...activeView.fields, cardOrder: [...activeView.fields.cardOrder, block.id]}})

--- a/components/databases/focalboard/src/octoUtils.tsx
+++ b/components/databases/focalboard/src/octoUtils.tsx
@@ -10,6 +10,7 @@ import {IPropertyTemplate, createBoard} from './blocks/board'
 import {BoardView, createBoardView} from './blocks/boardView'
 import {Card, createCard} from './blocks/card'
 import {createCommentBlock} from './blocks/commentBlock'
+import {createCharmTextBlock} from './blocks/charmBlock'
 import {createCheckboxBlock} from './blocks/checkboxBlock'
 import {createDividerBlock} from './blocks/dividerBlock'
 import {createImageBlock} from './blocks/imageBlock'
@@ -85,6 +86,7 @@ class OctoUtils {
         case 'view': { return createBoardView(block) }
         case 'card': { return createCard(block) }
         case 'text': { return createTextBlock(block) }
+        case 'charm_text': { return createCharmTextBlock(block) }
         case 'image': { return createImageBlock(block) }
         case 'divider': { return createDividerBlock(block) }
         case 'comment': { return createCommentBlock(block) }

--- a/components/editor/CharmEditor.tsx
+++ b/components/editor/CharmEditor.tsx
@@ -115,7 +115,6 @@ function PlaceHolder ({ top }: {top?: number}) {
   const docTextContent = view.state.doc.textContent as string;
   const theme = useTheme();
   const color = useMemo(() => alpha(theme.palette.text.secondary, 0.35), [theme]);
-  console.log('placeholder', docTextContent);
   // Only show placeholder if the editor content is empty
   return docTextContent.length === 0 ? (
     <Box sx={{

--- a/components/editor/CharmEditor.tsx
+++ b/components/editor/CharmEditor.tsx
@@ -115,7 +115,7 @@ function PlaceHolder ({ top }: {top?: number}) {
   const docTextContent = view.state.doc.textContent as string;
   const theme = useTheme();
   const color = useMemo(() => alpha(theme.palette.text.secondary, 0.35), [theme]);
-
+  console.log('placeholder', docTextContent);
   // Only show placeholder if the editor content is empty
   return docTextContent.length === 0 ? (
     <Box sx={{

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -65,8 +65,9 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Page) => v
     pageControlTop = 50;
   }
 
-  let pageTitleTop = 50; let bangleEditorTop = 75; let
-    pageIconTop = 50;
+  let pageTitleTop = 50;
+  let bangleEditorTop = 75;
+  let pageIconTop = 50;
 
   if (page) {
     if (page.icon && !page.headerImage) {
@@ -151,9 +152,9 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Page) => v
         >
           <>
             {page?.icon && (
-            <EmojiContainer top={pageIconTop} updatePageIcon={updatePageIcon}>
-              <Emoji sx={{ fontSize: 78 }}>{page.icon}</Emoji>
-            </EmojiContainer>
+              <EmojiContainer top={pageIconTop} updatePageIcon={updatePageIcon}>
+                <Emoji sx={{ fontSize: 78 }}>{page.icon}</Emoji>
+              </EmojiContainer>
             )}
             {page && (
             <Box sx={{

--- a/theme/focalboard/focalboard.main.scss
+++ b/theme/focalboard/focalboard.main.scss
@@ -198,12 +198,9 @@ html {
   }
 
   .octo-block {
+    position: relative;
+    z-index: 1;
     width: 100%;
-
-    &:hover {
-      position: relative;
-      z-index: 1;
-    }
 
     > * {
       flex: 1 1 auto;

--- a/theme/focalboard/focalboard.main.scss
+++ b/theme/focalboard/focalboard.main.scss
@@ -198,9 +198,12 @@ html {
   }
 
   .octo-block {
-    position: relative;
-    z-index: 1;
     width: 100%;
+
+    &:hover {
+      position: relative;
+      z-index: 1;
+    }
 
     > * {
       flex: 1 1 auto;


### PR DESCRIPTION
This fix is to create a single "content block" of type: 'charm_text' for focalboard tasks. there might be a more elegant solution but it would require more changes outside the card details view