### PR TITLE
fix up and down arrow key direction on command palette

### DIFF
--- a/components/editor/@bangle.dev/react-emoji-suggest/EmojiSuggest.tsx
+++ b/components/editor/@bangle.dev/react-emoji-suggest/EmojiSuggest.tsx
@@ -48,10 +48,11 @@ export function EmojiSuggest({
     triggerText,
     show: isVisible,
   } = usePluginState(suggestTooltipKey);
-  const width = rowWidth + (parseInt(theme.spacing(1).replace("px", "")) * 2);
+
+  const width = rowWidth + (parseInt(theme.spacing(2).replace("px", "")) * 2);
 
   return reactDOM.createPortal(
-    <StyledEmojiSuggest className="bangle-emoji-suggest">
+    <StyledEmojiSuggest className="bangle-emoji-suggest" id='inline-palette-wrapper'>
       <div
         style={{
           width,
@@ -63,7 +64,7 @@ export function EmojiSuggest({
           <EmojiSuggestContainer
             view={view}
             insideCallout={insideCallout}
-            rowWidth={width}
+            rowWidth={rowWidth}
             squareMargin={squareMargin}
             squareSide={squareSide}
             maxItems={maxItems}
@@ -262,7 +263,7 @@ const StyledEmojiSquare = styled.button<{ isSelected: boolean }>`
   ${props => props.isSelected && `background-color: rgb(0, 0, 0, 0.125);`};
   transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   border-radius: ${({ theme }) => theme.spacing(0.5)};
-  
+
   &:hover {
     cursor: pointer;
     background-color: ${({ theme }) => theme.palette.emoji.hoverBackground};

--- a/components/editor/@bangle.dev/react-emoji-suggest/emoji-suggest.ts
+++ b/components/editor/@bangle.dev/react-emoji-suggest/emoji-suggest.ts
@@ -137,7 +137,6 @@ function pluginsFactory({
           rowCount,
           namedEmojiGroups,
         );
-        console.log('row count', { rowWidth, squareMargin, squareSide, rowCount });
 
         if (newCounter == null) {
           return false;

--- a/components/editor/@bangle.dev/react-emoji-suggest/emoji-suggest.ts
+++ b/components/editor/@bangle.dev/react-emoji-suggest/emoji-suggest.ts
@@ -10,6 +10,7 @@ import {
 } from '@bangle.dev/utils';
 import * as suggestTooltip from "components/editor/@bangle.dev/tooltip/suggest-tooltip";
 import { emojiSuggestKey, getEmojiByAlias } from 'components/editor/EmojiSuggest';
+import { safeScrollIntoViewIfNeeded } from 'components/editor/utility';
 
 const {
   decrementSuggestTooltipCounter,
@@ -101,11 +102,7 @@ function pluginsFactory({
         requestAnimationFrame(() => {
           const selectedEmoji = document.getElementById(selectedEmojiSquareId);
           if (selectedEmoji) {
-            if ('scrollIntoViewIfNeeded' in document.body) {
-              (selectedEmoji as any).scrollIntoViewIfNeeded(false);
-            } else if (selectedEmoji.scrollIntoView) {
-              selectedEmoji.scrollIntoView(false);
-            }
+            safeScrollIntoViewIfNeeded(selectedEmoji);
           }
           view?.focus();
         });
@@ -140,6 +137,7 @@ function pluginsFactory({
           rowCount,
           namedEmojiGroups,
         );
+        console.log('row count', { rowWidth, squareMargin, squareSide, rowCount });
 
         if (newCounter == null) {
           return false;
@@ -255,7 +253,7 @@ function pluginsFactory({
           const emojiAlias = activeItem[0];
           view &&
             rafCommandExec(view, resetSuggestTooltipCounter(suggestTooltipKey));
-          
+
           if (!insideCallout) {
             return selectEmoji(key, emojiAlias)(state, dispatch, view);
           } else {

--- a/components/editor/@bangle.io/extensions/inline-command-palette/InlineCommandPalette.tsx
+++ b/components/editor/@bangle.io/extensions/inline-command-palette/InlineCommandPalette.tsx
@@ -134,20 +134,23 @@ export function InlineCommandPalette() {
     if (!paletteGroupItemsRecord[item.group]) {
       paletteGroupItemsRecord[item.group] = []
     }
-    paletteGroupItemsRecord[item.group].push(<ListItem key={item.uid} disabled={item._isItemDisabled} button component="div" sx={{ py: 0, px: 0 }}>
-      <InlinePaletteRow
-        dataId={item.uid}
-        disabled={item._isItemDisabled}
-        title={item.title}
-        description={item.description}
-        icon={item.icon}
-        {...itemProps}
-      />
-    </ListItem>)
+    paletteGroupItemsRecord[item.group].push(
+      <ListItem key={item.uid} disabled={item._isItemDisabled} button component="div" sx={{ py: 0, px: 0 }}>
+        <InlinePaletteRow
+          dataId={item.uid}
+          key={item.uid}
+          disabled={item._isItemDisabled}
+          title={item.title}
+          description={item.description}
+          icon={item.icon}
+          {...itemProps}
+        />
+      </ListItem>
+    )
   })
 
   return reactDOM.createPortal(
-    <InlinePaletteWrapper sx={{width: 200}}>
+    <InlinePaletteWrapper sx={{width: 200}} id='inline-palette-wrapper'>
       {Object.entries(paletteGroupItemsRecord).map(([group, paletteItems]) => (
         <InlinePaletteGroup key={group}>
           <GroupLabel label={group} />

--- a/components/editor/@bangle.io/js-lib/inline-palette/inline-palette.ts
+++ b/components/editor/@bangle.io/js-lib/inline-palette/inline-palette.ts
@@ -65,7 +65,7 @@ function pluginsFactory({
         safeRequestAnimationFrame(() => {
           view?.focus();
         });
-        if (key === 'UP' ? !getIsTop() : getIsTop()) {
+        if (key === 'UP') {
           return decrementSuggestTooltipCounter(suggestTooltipKey)(
             state,
             dispatch,

--- a/components/editor/@bangle.io/lib/ui-components/InlinePaletteRow/InlinePaletteRow.tsx
+++ b/components/editor/@bangle.io/lib/ui-components/InlinePaletteRow/InlinePaletteRow.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   isTouchDevice,
   safeScrollIntoViewIfNeeded
-} from '../../utils/utility';
+} from 'components/editor/utility';
 
 const BASE_PADDING = 10;
 

--- a/components/editor/@bangle.io/lib/ui-components/UniversalPalette/PaletteItem.tsx
+++ b/components/editor/@bangle.io/lib/ui-components/UniversalPalette/PaletteItem.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { ReactNode, useEffect, useRef } from 'react';
-import { safeScrollIntoViewIfNeeded } from '../../utils';
+import { safeScrollIntoViewIfNeeded } from 'components/editor/utility';
 
 
 export interface ItemType {

--- a/components/editor/@bangle.io/lib/utils/utility.ts
+++ b/components/editor/@bangle.io/lib/utils/utility.ts
@@ -38,68 +38,6 @@ export function isTouchDevice() {
   return hasTouchScreen;
 }
 
-export const safeScrollIntoViewIfNeeded = (
-  element: HTMLElement,
-  centerIfNeeded?: boolean,
-) => {
-  if (typeof window !== 'undefined') {
-    return 'scrollIntoViewIfNeeded' in document.body
-      ? (element as any).scrollIntoViewIfNeeded(centerIfNeeded)
-      : scrollIntoViewIfNeededPolyfill(element, centerIfNeeded);
-  }
-  return () => {};
-};
-
-function scrollIntoViewIfNeededPolyfill(
-  element: HTMLElement,
-  centerIfNeeded?: boolean,
-) {
-  centerIfNeeded = arguments.length === 0 ? true : !!centerIfNeeded;
-
-  const parent = (element.closest('#inline-palette-wrapper') || element.parentNode)! as HTMLElement;
-  const elementCoords = element.getBoundingClientRect();
-  const parentCoords = parent.getBoundingClientRect();
-  const elementOffsetTop = elementCoords.top - parentCoords.top;
-  const elementOffsetBottom = elementCoords.bottom - parentCoords.top;
-  const parentComputedStyle = window.getComputedStyle(parent, null),
-    parentBorderTopWidth = parseInt(
-      parentComputedStyle.getPropertyValue('border-top-width'),
-    ),
-    parentBorderLeftWidth = parseInt(
-      parentComputedStyle.getPropertyValue('border-left-width'),
-    ),
-    overTop = elementOffsetTop < 0,//element.offsetTop - parent.offsetTop < parent.scrollTop,
-    overBottom = elementOffsetBottom > parentCoords.height,
-    overLeft = element.offsetLeft - parent.offsetLeft < parent.scrollLeft,
-    overRight =
-      element.offsetLeft -
-        parent.offsetLeft +
-        element.clientWidth -
-        parentBorderLeftWidth >
-      parent.scrollLeft + parent.clientWidth,
-    alignWithTop = overTop && !overBottom;
-  if ((overTop || overBottom) && centerIfNeeded) {
-    parent.scrollTop =
-      element.offsetTop -
-      parent.offsetTop -
-      parent.clientHeight / 2 -
-      parentBorderTopWidth +
-      element.clientHeight / 2;
-  }
-
-  if ((overLeft || overRight) && centerIfNeeded) {
-    parent.scrollLeft =
-      element.offsetLeft -
-      parent.offsetLeft -
-      parent.clientWidth / 2 -
-      parentBorderLeftWidth +
-      element.clientWidth / 2;
-  }
-  if ((overTop || overBottom || overLeft || overRight) && !centerIfNeeded) {
-    element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  }
-}
-
 export function makeSafeForCSS(name: string) {
   return name.replace(/[^a-z0-9]/g, function (s: string) {
     let c = s.charCodeAt(0);

--- a/components/editor/@bangle.io/lib/utils/utility.ts
+++ b/components/editor/@bangle.io/lib/utils/utility.ts
@@ -56,21 +56,20 @@ function scrollIntoViewIfNeededPolyfill(
 ) {
   centerIfNeeded = arguments.length === 0 ? true : !!centerIfNeeded;
 
-  const parent = element.parentNode! as HTMLElement,
-    parentComputedStyle = window.getComputedStyle(parent, null),
+  const parent = (element.closest('#inline-palette-wrapper') || element.parentNode)! as HTMLElement;
+  const elementCoords = element.getBoundingClientRect();
+  const parentCoords = parent.getBoundingClientRect();
+  const elementOffsetTop = elementCoords.top - parentCoords.top;
+  const elementOffsetBottom = elementCoords.bottom - parentCoords.top;
+  const parentComputedStyle = window.getComputedStyle(parent, null),
     parentBorderTopWidth = parseInt(
       parentComputedStyle.getPropertyValue('border-top-width'),
     ),
     parentBorderLeftWidth = parseInt(
       parentComputedStyle.getPropertyValue('border-left-width'),
     ),
-    overTop = element.offsetTop - parent.offsetTop < parent.scrollTop,
-    overBottom =
-      element.offsetTop -
-        parent.offsetTop +
-        element.clientHeight -
-        parentBorderTopWidth >
-      parent.scrollTop + parent.clientHeight,
+    overTop = elementOffsetTop < 0,//element.offsetTop - parent.offsetTop < parent.scrollTop,
+    overBottom = elementOffsetBottom > parentCoords.height,
     overLeft = element.offsetLeft - parent.offsetLeft < parent.scrollLeft,
     overRight =
       element.offsetLeft -
@@ -79,7 +78,6 @@ function scrollIntoViewIfNeededPolyfill(
         parentBorderLeftWidth >
       parent.scrollLeft + parent.clientWidth,
     alignWithTop = overTop && !overBottom;
-
   if ((overTop || overBottom) && centerIfNeeded) {
     parent.scrollTop =
       element.offsetTop -
@@ -97,9 +95,8 @@ function scrollIntoViewIfNeededPolyfill(
       parentBorderLeftWidth +
       element.clientWidth / 2;
   }
-
   if ((overTop || overBottom || overLeft || overRight) && !centerIfNeeded) {
-    element.scrollIntoView(alignWithTop);
+    element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }
 }
 

--- a/components/editor/utility.ts
+++ b/components/editor/utility.ts
@@ -1,0 +1,88 @@
+// This file was moved from bangle.io `lib/utils/utility.ts` so we can also use it in bangle.dev
+
+/** Based on https://developer.mozilla.org/docs/Web/HTTP/Browser_detection_using_the_user_agent */
+export function isTouchDevice () {
+  let hasTouchScreen = false;
+  if ('maxTouchPoints' in navigator) {
+    hasTouchScreen = navigator.maxTouchPoints > 0;
+  }
+  else if ('msMaxTouchPoints' in navigator) {
+    // @ts-ignore
+    hasTouchScreen = navigator.msMaxTouchPoints > 0;
+  }
+  else {
+    const mQ = typeof window !== 'undefined'
+      && window.matchMedia
+      && matchMedia('(pointer:coarse)');
+    if (mQ && mQ.media === '(pointer:coarse)') {
+      hasTouchScreen = !!mQ.matches;
+    }
+    else if ('orientation' in window) {
+      hasTouchScreen = true; // deprecated, but good fallback
+    }
+    else {
+      // Only as a last resort, fall back to user agent sniffing
+      // @ts-ignore
+      const UA = navigator.userAgent;
+      hasTouchScreen = /\b(BlackBerry|webOS|iPhone|IEMobile)\b/i.test(UA)
+        || /\b(Android|Windows Phone|iPad|iPod)\b/i.test(UA);
+    }
+  }
+  return hasTouchScreen;
+}
+
+export const safeScrollIntoViewIfNeeded = (
+  element: HTMLElement,
+  centerIfNeeded?: boolean
+) => {
+  if (typeof window !== 'undefined') {
+    return 'scrollIntoViewIfNeeded' in document.body
+      ? (element as any).scrollIntoViewIfNeeded(centerIfNeeded)
+      : scrollIntoViewIfNeededPolyfill(element, centerIfNeeded);
+  }
+  return () => {};
+};
+
+function scrollIntoViewIfNeededPolyfill (
+  element: HTMLElement,
+  centerIfNeeded?: boolean
+) {
+  centerIfNeeded = arguments.length === 0 ? true : !!centerIfNeeded;
+
+  const parent = (element.closest('#inline-palette-wrapper') || element.parentNode)! as HTMLElement;
+  const elementCoords = element.getBoundingClientRect();
+  const parentCoords = parent.getBoundingClientRect();
+  const elementOffsetTop = elementCoords.top - parentCoords.top;
+  const elementOffsetBottom = elementCoords.bottom - parentCoords.top;
+  const parentComputedStyle = window.getComputedStyle(parent, null);
+  const parentBorderTopWidth = parseInt(parentComputedStyle.getPropertyValue('border-top-width'), 10);
+  const parentBorderLeftWidth = parseInt(parentComputedStyle.getPropertyValue('border-left-width'), 10);
+  const overTop = elementOffsetTop < 0; const // element.offsetTop - parent.offsetTop < parent.scrollTop,
+    overBottom = elementOffsetBottom > parentCoords.height;
+  const overLeft = element.offsetLeft - parent.offsetLeft < parent.scrollLeft;
+  const overRight = element.offsetLeft
+        - parent.offsetLeft
+        + element.clientWidth
+        - parentBorderLeftWidth
+      > parent.scrollLeft + parent.clientWidth;
+  const alignWithTop = overTop && !overBottom;
+  if ((overTop || overBottom) && centerIfNeeded) {
+    parent.scrollTop = element.offsetTop
+      - parent.offsetTop
+      - parent.clientHeight / 2
+      - parentBorderTopWidth
+      + element.clientHeight / 2;
+  }
+
+  if ((overLeft || overRight) && centerIfNeeded) {
+    parent.scrollLeft = element.offsetLeft
+      - parent.offsetLeft
+      - parent.clientWidth / 2
+      - parentBorderLeftWidth
+      + element.clientWidth / 2;
+  }
+  console.log('parent', parent, parentCoords, elementOffsetBottom, overTop, overBottom);
+  if ((overTop || overBottom || overLeft || overRight) && !centerIfNeeded) {
+    element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+}


### PR DESCRIPTION
Two problems I fixed, tested in Chrome and Firefox:
- up/down arrows go in reverse direction if the command pallete opened above instead of below the cursor.
- even if the element you are keying down to is still in view, we were scrolling the parent each time.
- same issue was happening on the emoji container, and pressing up/down arrow would go diagonally up/down rather than straight up and  down

The bug stemmed from the fact our elements are embedded inside of a couple parent items (List, ListItem) so `parent` was actually a button, and not the scrolling container as it is on bangle.io.