### PR TITLE
Fixed image not being aligned center when resizing

### DIFF
--- a/components/editor/Resizer.tsx
+++ b/components/editor/Resizer.tsx
@@ -46,7 +46,9 @@ export default function Resizer (props: ResizerProps) {
           transition: 'opacity 250ms ease-in-out'
         },
         '& .react-resizable': {
-          display: 'flex'
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center'
         }
       }}
     >


### PR DESCRIPTION
Previously when the image was resized to its maximum size it always got aligned to the left. Below are two screenshots of the same image before and after the commit

Before:
![image](https://user-images.githubusercontent.com/34683631/155304543-b9cd70c4-a37c-41d8-93f4-b1d8b2548a10.png)

After:
![image](https://user-images.githubusercontent.com/34683631/155304317-74b6ddba-ce24-43b6-b1bd-7b87b6b1bb17.png)
