### PR TITLE
Show page controls, icon and cover on hover

### DIFF
--- a/components/editor/@bangle.dev/react-emoji-suggest/EmojiSuggest.tsx
+++ b/components/editor/@bangle.dev/react-emoji-suggest/EmojiSuggest.tsx
@@ -11,7 +11,7 @@ import Box from '@mui/material/Box';
 import { GetEmojiGroupsType, getSuggestTooltipKey, selectEmoji } from 'components/editor/@bangle.dev/react-emoji-suggest/emoji-suggest';
 import { getEmojiByAlias } from 'components/editor/EmojiSuggest';
 import GroupLabel from 'components/editor/GroupLabel';
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import reactDOM from 'react-dom';
 
 const StyledEmojiSuggest = styled(Box)`
@@ -158,7 +158,7 @@ export function EmojiSuggestContainer({
     <div
       className="bangle-emoji-suggest-container"
       style={{
-        width: containerWidth + (parseInt(theme.spacing(2).replace("px", "")) * 2),
+        width: "100%"
       }}
     >
       <Box sx={{

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -111,35 +111,47 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Page) => v
       <Container>
         <Controls sx={{
           position: 'relative',
-          top: pageControlTop
+          top: pageControlTop,
+          '&:hover .page-controls': {
+            opacity: 1
+          }
         }}
         >
-          {!page.icon && (
-            <PageControlItem onClick={() => {
-              setPage({ ...page, icon: gemojiData[randomIntFromInterval(0, gemojiData.length - 1)].emoji });
+          <Box
+            className='page-controls'
+            sx={{
+              opacity: 0,
+              display: 'flex',
+              gap: 1
             }}
-            >
-              <EmojiEmotionsIcon
-                fontSize='small'
-                sx={{ marginRight: 1 }}
-              />
-              Add icon
-            </PageControlItem>
-          )}
-          {!page.headerImage && (
-            <PageControlItem
-              onClick={() => {
-                // Charmverse logo
-                setPage({ ...page, headerImage: PageCoverGalleryImageGroups['Color & Gradient'][randomIntFromInterval(0, PageCoverGalleryImageGroups['Color & Gradient'].length - 1)] });
+          >
+            {!page.icon && (
+              <PageControlItem onClick={() => {
+                setPage({ ...page, icon: gemojiData[randomIntFromInterval(0, gemojiData.length - 1)].emoji });
               }}
-            >
-              <ImageIcon
-                fontSize='small'
-                sx={{ marginRight: 1 }}
-              />
-              Add cover
-            </PageControlItem>
-          )}
+              >
+                <EmojiEmotionsIcon
+                  fontSize='small'
+                  sx={{ marginRight: 1 }}
+                />
+                Add icon
+              </PageControlItem>
+            )}
+            {!page.headerImage && (
+              <PageControlItem
+                onClick={() => {
+                  // Charmverse logo
+                  setPage({ ...page, headerImage: PageCoverGalleryImageGroups['Color & Gradient'][randomIntFromInterval(0, PageCoverGalleryImageGroups['Color & Gradient'].length - 1)] });
+                }}
+              >
+                <ImageIcon
+                  fontSize='small'
+                  sx={{ marginRight: 1 }}
+                />
+                Add cover
+              </PageControlItem>
+            )}
+          </Box>
         </Controls>
 
         <CharmEditor


### PR DESCRIPTION
Show the page controls only on hover. Previously it was always shown.
![image](https://user-images.githubusercontent.com/34683631/155349991-8ccce0cf-418b-4669-8d85-acb1b18cd32b.png)
