### PR TITLE
fix for emoji popup padding

### DIFF
--- a/components/editor/@bangle.dev/react-emoji-suggest/EmojiSuggest.tsx
+++ b/components/editor/@bangle.dev/react-emoji-suggest/EmojiSuggest.tsx
@@ -158,7 +158,7 @@ export function EmojiSuggestContainer({
     <div
       className="bangle-emoji-suggest-container"
       style={{
-        width: containerWidth + (parseInt(theme.spacing(2).replace("px", "")) * 2),
+        width: containerWidth + (parseInt(theme.spacing(2).replace("px", "")) * 2) + 10,
       }}
     >
       <Box sx={{


### PR DESCRIPTION
add some width to the emoji container so that there are 10 items in a row on Windows (doesnt affect mac for some reason), and the up/down keys end up moving diagonal instead of vertically