### PR TITLE
fix state messing with page properties

### DIFF
--- a/components/editor/CharmEditor.tsx
+++ b/components/editor/CharmEditor.tsx
@@ -142,13 +142,11 @@ export default function CharmEditor (
       new Plugin({
         view: () => ({
           update: (view, prevState) => {
-            if (!view.state.doc.eq(prevState.doc)) {
-              if (onPageContentChange) {
-                onPageContentChange({
-                  doc: view.state.doc.toJSON() as PageContent,
-                  rawText: view.state.doc.textContent as string
-                });
-              }
+            if (onPageContentChange && !view.state.doc.eq(prevState.doc)) {
+              onPageContentChange({
+                doc: view.state.doc.toJSON() as PageContent,
+                rawText: view.state.doc.textContent as string
+              });
             }
           }
         })

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -48,7 +48,7 @@ function randomIntFromInterval (min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
-export function Editor ({ page, setPage }: { page: Page, setPage: (p: Page) => void }) {
+export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Page>) => void }) {
   const { isEditing, setIsEditing } = usePages();
 
   let pageControlTop = 0;
@@ -88,11 +88,21 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Page) => v
   }
 
   function updateTitle (event: ChangeEvent<HTMLInputElement>) {
-    setPage({ ...page, title: event.target.value });
+    setPage({ title: event.target.value });
+  }
+
+  function addPageHeader () {
+    const headerImage = PageCoverGalleryImageGroups['Color & Gradient'][randomIntFromInterval(0, PageCoverGalleryImageGroups['Color & Gradient'].length - 1)];
+    setPage({ headerImage });
+  }
+
+  function addPageIcon () {
+    const icon = gemojiData[randomIntFromInterval(0, gemojiData.length - 1)].emoji;
+    setPage({ icon });
   }
 
   function updatePageIcon (icon: string) {
-    setPage({ ...page, icon });
+    setPage({ icon });
   }
 
   function updatePageContent (content: ICharmEditorOutput) {
@@ -102,7 +112,7 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Page) => v
         setIsEditing(false);
       }, 1500);
     }
-    setPage({ ...page, content: content.doc, contentText: content.rawText });
+    setPage({ content: content.doc, contentText: content.rawText });
   }
 
   return (
@@ -126,10 +136,7 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Page) => v
             }}
           >
             {!page.icon && (
-              <PageControlItem onClick={() => {
-                setPage({ ...page, icon: gemojiData[randomIntFromInterval(0, gemojiData.length - 1)].emoji });
-              }}
-              >
+              <PageControlItem onClick={addPageIcon}>
                 <EmojiEmotionsIcon
                   fontSize='small'
                   sx={{ marginRight: 1 }}
@@ -138,12 +145,7 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Page) => v
               </PageControlItem>
             )}
             {!page.headerImage && (
-              <PageControlItem
-                onClick={() => {
-                  // Charmverse logo
-                  setPage({ ...page, headerImage: PageCoverGalleryImageGroups['Color & Gradient'][randomIntFromInterval(0, PageCoverGalleryImageGroups['Color & Gradient'].length - 1)] });
-                }}
-              >
+              <PageControlItem onClick={addPageHeader}>
                 <ImageIcon
                   fontSize='small'
                   sx={{ marginRight: 1 }}

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -19,7 +19,10 @@ export default function BlocksEditorPage () {
   async function setPage (updates: Partial<Page>) {
     setPages(pages.map(p => p.id === currentPage!.id ? { ...p, ...updates } : p));
     setCurrentPage(_page => ({ ..._page, ...updates }) as Page);
-    // await charmClient.updatePage({ id: currentPage!.id, ...updates } as Prisma.PageUpdateInput);
+    if (updates.title) {
+      setTitleState(updates.title);
+    }
+    await charmClient.updatePage({ id: currentPage!.id, ...updates } as Prisma.PageUpdateInput);
   }
 
   useEffect(() => {

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -7,37 +7,39 @@ import { usePages } from 'hooks/usePages';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { Page } from 'models';
 import { useRouter } from 'next/router';
-import { ReactElement, useEffect } from 'react';
+import { ReactElement, useCallback, useEffect } from 'react';
 
 export default function BlocksEditorPage () {
 
-  const { pages, setPages, setCurrentPage } = usePages();
+  const { currentPage, pages, setPages, setCurrentPage } = usePages();
   const router = useRouter();
   const { pageId } = router.query;
-  const pageByPath = pages.find(page => page.path === pageId || page.id === pageId) || pages[0];
   const [, setTitleState] = usePageTitle();
 
-  async function setPage (page: Partial<Page>) {
-    const updates = { ...pageByPath, ...page } as Prisma.PageUpdateInput;
-    const updatedPage = await charmClient.updatePage(updates);
-    setPages(pages.map(p => p.id === updatedPage.id ? updatedPage : p));
+  async function setPage (updates: Partial<Page>) {
+    setPages(pages.map(p => p.id === currentPage!.id ? { ...p, ...updates } : p));
+    setCurrentPage(_page => ({ ..._page, ...updates }) as Page);
+    // await charmClient.updatePage({ id: currentPage!.id, ...updates } as Prisma.PageUpdateInput);
   }
 
   useEffect(() => {
-    if (pageByPath) {
-      setTitleState(pageByPath.title);
-      setCurrentPage(pageByPath);
+    if (pageId && pages.length) {
+      const pageByPath = pages.find(page => page.path === pageId || page.id === pageId);
+      if (pageByPath) {
+        setTitleState(pageByPath.title);
+        setCurrentPage(pageByPath);
+      }
     }
-  }, [pageByPath]);
+  }, [pageId, pages.length > 0]);
 
-  if (!pageByPath) {
+  if (!currentPage) {
     return null;
   }
-  else if (pageByPath.type === 'board') {
-    return <DatabaseEditor page={pageByPath} setPage={setPage} />;
+  else if (currentPage.type === 'board') {
+    return <DatabaseEditor page={currentPage} setPage={setPage} />;
   }
   else {
-    return <Editor page={pageByPath} setPage={setPage} />;
+    return <Editor page={currentPage} setPage={setPage} />;
   }
 }
 


### PR DESCRIPTION
This was nuts to fix. Tells me we are doing something wrong, maybe relying on both 'currentPage' and 'pages' in context is wrong.. I just tried to reduce the amount of places we were using the 'currentPage' value. `setState()` for example can either take the new value as input, or a function which then gives you access to the current value:
```
const { currentPage, setCurrentPage } = usePages();

function setPage (updates) {
  // doesnt work
  setCurrentPage({ ...currentPage, ...updates });
  // works
  setCurrentPage(_currentPage => { ..._currentPage, ...updates });
}
```