### PR TITLE
small tweaks for bangle dev editor

### DIFF
--- a/components/bounties_v2/BountyIntegration.tsx
+++ b/components/bounties_v2/BountyIntegration.tsx
@@ -1,4 +1,4 @@
-import { Button, Typography } from '@mui/material';
+import { Button } from '@mui/material';
 import { Box } from '@mui/system';
 import { useBounties } from 'hooks/useBounties';
 import { useState } from 'react';
@@ -19,24 +19,11 @@ export function BountyIntegration (props: BountyIntegrationProps) {
 
   return (
     <Box sx={{
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      gap: 1
+      whiteSpace: 'nowrap'
     }}
     >
       {linkedBounty ? <BountyBadge bounty={linkedBounty} /> : (
         <>
-          <Typography
-            variant='h5'
-            sx={{
-              textTransform: 'uppercase',
-              fontWeight: 'bold',
-              textAlign: 'center'
-            }}
-          >
-            No bounties assigned
-          </Typography>
           <Button onClick={() => {
             setIsModalOpen(true);
           }}
@@ -60,7 +47,6 @@ export function BountyIntegration (props: BountyIntegrationProps) {
           )}
         </>
       )}
-
     </Box>
   );
 }

--- a/components/common/Emoji.tsx
+++ b/components/common/Emoji.tsx
@@ -11,10 +11,9 @@ const Emoji = styled(Box)`
   white-space: nowrap;
   user-select: none;
   cursor: pointer;
-  padding: ${({ theme }) => theme.spacing(1)};
   border-radius: ${({ theme }) => theme.spacing(0.5)};
-  width: 100px;
-  height: 100px;
+  width: 80px;
+  height: 80px;
 
   display: flex;
   align-items: center;
@@ -32,7 +31,7 @@ export default function EmojiCon ({ children, ...props }: ComponentProps<typeof 
 }
 
 export function EmojiContainer (
-  { updatePageIcon, top, children }: { updatePageIcon: (icon: string) => void, children: ReactNode, top: number }
+  { updatePageIcon, children }: { updatePageIcon: (icon: string) => void, children: ReactNode }
 ) {
   const view = useContext(EditorViewContext);
   const ref = useRef<HTMLDivElement>(null);
@@ -41,9 +40,7 @@ export function EmojiContainer (
     <Box
       sx={{
         width: 'fit-content',
-        display: 'flex',
-        position: 'absolute',
-        top
+        display: 'flex'
       }}
       ref={ref}
       onClick={() => {

--- a/components/common/Emoji.tsx
+++ b/components/common/Emoji.tsx
@@ -18,9 +18,23 @@ const Emoji = styled(Box)`
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+  z-index: 1;
 
-  &:hover {
+  &:before {
+    border-radius: 4px;
+    content: " ";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 0;
+    z-index: -1;
     background-color: ${({ theme }) => theme.palette.background.light}
+  }
+  &:hover:before {
+    opacity: 0.5;
   }
 `;
 

--- a/components/databases/focalboard/src/components/cardDetail/cardDetailContents.tsx
+++ b/components/databases/focalboard/src/components/cardDetail/cardDetailContents.tsx
@@ -173,7 +173,7 @@ const CardDetailContents = React.memo((props: Props) => {
     return (
         <div className='octo-content CardDetailContents'>
             <div className='octo-block' style={{ position: 'relative', zIndex: 1 }}>
-                <CharmEditor editorTop={-70} content={content} onPageContentChange={updatePageContent} />
+                <CharmEditor content={content} onPageContentChange={updatePageContent} />
                 <Box mb={6} />
             </div>
         </div>

--- a/components/editor/CharmEditor.tsx
+++ b/components/editor/CharmEditor.tsx
@@ -19,7 +19,6 @@ import { NodeView, Plugin, SpecRegistry } from '@bangle.dev/core';
 import { columnResizing, DOMOutputSpecArray, Node } from '@bangle.dev/pm';
 import { BangleEditor as ReactBangleEditor, useEditorState, useEditorViewContext } from '@bangle.dev/react';
 import { table, tableCell, tableHeader, tablePlugins, tableRow } from '@bangle.dev/table';
-import '@bangle.dev/tooltip/style.css';
 import styled from '@emotion/styled';
 import { alpha, Box, useTheme } from '@mui/material';
 import { plugins as imagePlugins, spec as imageSpec } from 'components/editor/@bangle.dev/base-components/image';
@@ -132,9 +131,9 @@ function PlaceHolder ({ top }: {top?: number}) {
 }
 
 export default function CharmEditor (
-  { editorTop, content = defaultContent, children, onPageContentChange, style }:
+  { content = defaultContent, children, onPageContentChange, style }:
   { content?: PageContent, children?: ReactNode, onPageContentChange?: UpdatePageContent,
-    style?: CSSProperties, editorTop?: number }
+    style?: CSSProperties }
 ) {
   const state = useEditorState({
     specRegistry,
@@ -214,8 +213,6 @@ export default function CharmEditor (
       color: 'transparent'
     }
   });
-
-  const docTextContent = state.pmState.doc.textContent as string;
 
   return (
     <StyledReactBangleEditor

--- a/components/editor/CharmEditor.tsx
+++ b/components/editor/CharmEditor.tsx
@@ -18,7 +18,7 @@ import {
 import { NodeView, Plugin, SpecRegistry } from '@bangle.dev/core';
 import { columnResizing, DOMOutputSpecArray, Node } from '@bangle.dev/pm';
 import { BangleEditor as ReactBangleEditor, useEditorState } from '@bangle.dev/react';
-import { table, tableCell, tableHeader, tablePlugins, tableRow } from '@bangle.dev/table';
+import { table, tableCell, tableHeader, tableRow } from '@bangle.dev/table';
 import styled from '@emotion/styled';
 import { plugins as imagePlugins, spec as imageSpec } from 'components/editor/@bangle.dev/base-components/image';
 import FloatingMenu, { floatingMenuPlugin } from 'components/editor/FloatingMenu';
@@ -182,7 +182,7 @@ export default function CharmEditor (
         name: 'iframe',
         containerDOM: ['div', { class: 'iframe-container' }]
       })
-      // TODO: Pasting iframe or image link shouldn't create those blocks. Maybe in the future we might allow this behavior and adjust it to that of Notion's
+      // TODO: Pasting iframe or image link shouldn't create those blocks for now
       // iframePlugin,
       // pasteImagePlugin
     ],

--- a/components/editor/CharmEditor.tsx
+++ b/components/editor/CharmEditor.tsx
@@ -17,15 +17,14 @@ import {
 } from '@bangle.dev/base-components';
 import { NodeView, Plugin, SpecRegistry } from '@bangle.dev/core';
 import { columnResizing, DOMOutputSpecArray, Node } from '@bangle.dev/pm';
-import { BangleEditor as ReactBangleEditor, useEditorState, useEditorViewContext } from '@bangle.dev/react';
+import { BangleEditor as ReactBangleEditor, useEditorState } from '@bangle.dev/react';
 import { table, tableCell, tableHeader, tablePlugins, tableRow } from '@bangle.dev/table';
 import styled from '@emotion/styled';
-import { alpha, Box, useTheme } from '@mui/material';
 import { plugins as imagePlugins, spec as imageSpec } from 'components/editor/@bangle.dev/base-components/image';
 import FloatingMenu, { floatingMenuPlugin } from 'components/editor/FloatingMenu';
 import { PageContent } from 'models';
 import { CryptoCurrency, FiatCurrency } from 'models/Currency';
-import { CSSProperties, ReactNode, useMemo } from 'react';
+import { CSSProperties, ReactNode } from 'react';
 import { BlockQuote, blockQuoteSpec } from './BlockQuote';
 import { Code } from './Code';
 import ColumnBlock, { spec as columnBlockSpec } from './ColumnBlock';
@@ -35,6 +34,7 @@ import EmojiSuggest, { emojiPlugins, emojiSpecs } from './EmojiSuggest';
 import IFrame, { iframeSpec } from './Iframe';
 import { Image } from './Image';
 import InlinePalette, { inlinePalettePlugins, inlinePaletteSpecs } from './InlinePalette';
+import Placeholder from './Placeholder';
 
 export interface ICharmEditorOutput {
   doc: PageContent,
@@ -108,27 +108,6 @@ const defaultContent: PageContent = {
 };
 
 export type UpdatePageContent = (content: ICharmEditorOutput) => any;
-
-function PlaceHolder ({ top }: {top?: number}) {
-  const view = useEditorViewContext();
-  const docTextContent = view.state.doc.textContent as string;
-  const theme = useTheme();
-  const color = useMemo(() => alpha(theme.palette.text.secondary, 0.35), [theme]);
-  // Only show placeholder if the editor content is empty
-  return docTextContent.length === 0 ? (
-    <Box sx={{
-      // This weird calculation is required to place the placeholder on the same position as the editor
-      top: top ? top - 31 : 30,
-      position: 'relative',
-      color,
-      // Place it beneath the actual editor
-      zIndex: -20
-    }}
-    >
-      Type '/' for commands
-    </Box>
-  ) : null;
-}
 
 export default function CharmEditor (
   { content = defaultContent, children, onPageContentChange, style }:
@@ -289,7 +268,7 @@ export default function CharmEditor (
       {EmojiSuggest}
       {InlinePalette}
       {children}
-      <PlaceHolder top={style?.top as number ?? 20} />
+      <Placeholder />
     </StyledReactBangleEditor>
   );
 }

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 import EmojiEmotionsIcon from '@mui/icons-material/EmojiEmotions';
 import ImageIcon from '@mui/icons-material/Image';
-import { ListItemButton, ListItemProps } from '@mui/material';
+import { ListItemButton } from '@mui/material';
 import Box from '@mui/material/Box';
 import Emoji, { EmojiContainer } from 'components/common/Emoji';
 import gemojiData from 'emoji-lookup-data/data/gemoji.json';
 import { usePages } from 'hooks/usePages';
 import { Page, PageContent } from 'models';
-import React, { ChangeEvent, ReactNode } from 'react';
+import { ChangeEvent } from 'react';
 import CharmEditor, { ICharmEditorOutput } from './CharmEditor';
 import PageBanner, { PageCoverGalleryImageGroups } from './Page/PageBanner';
 import PageTitle from './Page/PageTitle';
@@ -117,9 +117,15 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
         >
           <EditorHeader>
             {page?.icon && (
-            <EmojiContainer updatePageIcon={updatePageIcon}>
-              <Emoji sx={{ fontSize: 78 }}>{page.icon}</Emoji>
-            </EmojiContainer>
+              <Box sx={{
+                // Moving the icon a bit upwards if the page banner is not present, otherwise the Add cover button and the icon overlaps
+                top: !page.headerImage ? -15 : 0, position: 'relative'
+              }}
+              >
+                <EmojiContainer updatePageIcon={updatePageIcon}>
+                  <Emoji sx={{ fontSize: 78 }}>{page.icon}</Emoji>
+                </EmojiContainer>
+              </Box>
             )}
             <Controls className='page-controls'>
               {!page.icon && (

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -26,7 +26,7 @@ const PageControlItem = styled(ListItemButton)`
   opacity: 0.5;
   display: flex;
   padding: 0 ${({ theme }) => theme.spacing(0.75)};
-  width: fit-content;
+  flex-grow: 0;
 `;
 
 const Controls = styled(Box)`

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -64,45 +64,9 @@ const EditorHeader = styled.div`
 export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Page>) => void }) {
   const { isEditing, setIsEditing } = usePages();
 
-  let pageControlTop = 0;
-
-  if (page.icon && !page.headerImage) {
-    pageControlTop = 50;
-  }
-
-  if (!page.icon && page.headerImage) {
-    pageControlTop = 10;
-  }
-
-  if (page.icon && page.headerImage) {
-    pageControlTop = 50;
-  }
-
-  let pageTitleTop = 50;
-  let bangleEditorTop = 75;
-  let pageIconTop = 50;
-
   let pageTop = 100;
   if (page.icon) {
     pageTop = 130;
-  }
-
-  if (page) {
-    if (page.icon && !page.headerImage) {
-      pageTitleTop = 100;
-      bangleEditorTop = 125;
-      pageIconTop = -75;
-    }
-
-    if (!page.icon && page.headerImage) {
-      pageTitleTop = 50;
-    }
-
-    if (page.icon && page.headerImage) {
-      pageTitleTop = 50;
-      bangleEditorTop = 125;
-      pageIconTop = -60;
-    }
   }
 
   function updateTitle (event: ChangeEvent<HTMLInputElement>) {
@@ -137,7 +101,6 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
     <Box>
       <PageBanner page={page} setPage={setPage} />
       <Container top={pageTop}>
-
         <CharmEditor
           key={page.id}
           content={page.content as PageContent}

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -161,7 +161,6 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
           style={{
             top: bangleEditorTop
           }}
-          editorTop={bangleEditorTop}
           content={page.content as PageContent}
           onPageContentChange={updatePageContent}
         >

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import EmojiEmotionsIcon from '@mui/icons-material/EmojiEmotions';
 import ImageIcon from '@mui/icons-material/Image';
-import { ListItem, ListItemProps } from '@mui/material';
+import { ListItemButton, ListItemProps } from '@mui/material';
 import Box from '@mui/material/Box';
 import Emoji, { EmojiContainer } from 'components/common/Emoji';
 import gemojiData from 'emoji-lookup-data/data/gemoji.json';
@@ -12,34 +12,25 @@ import CharmEditor, { ICharmEditorOutput } from './CharmEditor';
 import PageBanner, { PageCoverGalleryImageGroups } from './Page/PageBanner';
 import PageTitle from './Page/PageTitle';
 
-const Container = styled(Box)`
+const Container = styled(Box)<{ top: number }>`
   width: 860px;
   max-width: 100%;
   margin: 0 auto 5px;
   padding: 0 20px 0 40px;
   position: relative;
+  top: ${({ top }) => top}px;
 `;
 
-const StyledListItem = styled(ListItem)`
+const PageControlItem = styled(ListItemButton)`
   border-radius: ${({ theme }) => theme.spacing(0.5)};
   opacity: 0.5;
   display: flex;
-  gap: 1;
   padding: ${({ theme }) => theme.spacing(0.75)};
   width: fit-content;
-` as React.FC<{ disableRipple: boolean, button: boolean, children: ReactNode }>;
-
-function PageControlItem (props: { children: ReactNode } & ListItemProps) {
-  const { children, ...rest } = props;
-  return (
-    <StyledListItem {...rest} disableRipple button>
-      {children}
-    </StyledListItem>
-  );
-}
+`;
 
 const Controls = styled(Box)`
-  margin-bottom: 4px;
+  position: relative;
   display: flex;
   gap: ${({ theme }) => theme.spacing(0.5)};
 `;
@@ -47,6 +38,28 @@ const Controls = styled(Box)`
 function randomIntFromInterval (min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
+
+const EditorHeader = styled.div`
+  position: absolute;
+  top: 0;
+  height: 0;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  justify-content: flex-end;
+  overflow: visible;
+
+  .page-controls {
+    height: 36px;
+    opacity: 0;
+    display: flex;
+    gap: 1;
+  }
+
+  &:hover .page-controls {
+    opacity: 1
+  }
+`;
 
 export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Page>) => void }) {
   const { isEditing, setIsEditing } = usePages();
@@ -68,6 +81,11 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
   let pageTitleTop = 50;
   let bangleEditorTop = 75;
   let pageIconTop = 50;
+
+  let pageTop = 100;
+  if (page.icon) {
+    pageTop = 130;
+  }
 
   if (page) {
     if (page.icon && !page.headerImage) {
@@ -118,71 +136,48 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
   return (
     <Box>
       <PageBanner page={page} setPage={setPage} />
-      <Container>
-        <Controls sx={{
-          position: 'relative',
-          top: pageControlTop,
-          '&:hover .page-controls': {
-            opacity: 1
-          }
-        }}
-        >
-          <Box
-            className='page-controls'
-            sx={{
-              opacity: 0,
-              display: 'flex',
-              gap: 1
-            }}
-          >
-            {!page.icon && (
-              <PageControlItem onClick={addPageIcon}>
-                <EmojiEmotionsIcon
-                  fontSize='small'
-                  sx={{ marginRight: 1 }}
-                />
-                Add icon
-              </PageControlItem>
-            )}
-            {!page.headerImage && (
-              <PageControlItem onClick={addPageHeader}>
-                <ImageIcon
-                  fontSize='small'
-                  sx={{ marginRight: 1 }}
-                />
-                Add cover
-              </PageControlItem>
-            )}
-          </Box>
-        </Controls>
+      <Container top={pageTop}>
 
         <CharmEditor
           key={page.id}
-          style={{
-            top: bangleEditorTop
-          }}
           content={page.content as PageContent}
           onPageContentChange={updatePageContent}
         >
-          <>
+          <EditorHeader>
             {page?.icon && (
-              <EmojiContainer top={pageIconTop} updatePageIcon={updatePageIcon}>
-                <Emoji sx={{ fontSize: 78 }}>{page.icon}</Emoji>
-              </EmojiContainer>
+            <EmojiContainer updatePageIcon={updatePageIcon}>
+              <Emoji sx={{ fontSize: 78 }}>{page.icon}</Emoji>
+            </EmojiContainer>
             )}
-            {page && (
-            <Box sx={{
-              position: 'absolute',
-              top: pageTitleTop
-            }}
-            >
-              <PageTitle
-                value={page.title}
-                onChange={updateTitle}
-              />
-            </Box>
-            )}
-          </>
+            <Controls>
+              <Box
+                className='page-controls'
+              >
+                {!page.icon && (
+                <PageControlItem onClick={addPageIcon}>
+                  <EmojiEmotionsIcon
+                    fontSize='small'
+                    sx={{ marginRight: 1 }}
+                  />
+                  Add icon
+                </PageControlItem>
+                )}
+                {!page.headerImage && (
+                <PageControlItem onClick={addPageHeader}>
+                  <ImageIcon
+                    fontSize='small'
+                    sx={{ marginRight: 1 }}
+                  />
+                  Add cover
+                </PageControlItem>
+                )}
+              </Box>
+            </Controls>
+            <PageTitle
+              value={page.title}
+              onChange={updateTitle}
+            />
+          </EditorHeader>
         </CharmEditor>
       </Container>
     </Box>

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -25,7 +25,7 @@ const PageControlItem = styled(ListItemButton)`
   border-radius: ${({ theme }) => theme.spacing(0.5)};
   opacity: 0.5;
   display: flex;
-  padding: ${({ theme }) => theme.spacing(0.75)};
+  padding: 0 ${({ theme }) => theme.spacing(0.75)};
   width: fit-content;
 `;
 
@@ -50,10 +50,9 @@ const EditorHeader = styled.div`
   overflow: visible;
 
   .page-controls {
-    height: 36px;
+    min-height: 32px;
     opacity: 0;
     display: flex;
-    gap: 1;
   }
 
   &:hover .page-controls {
@@ -64,9 +63,15 @@ const EditorHeader = styled.div`
 export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Page>) => void }) {
   const { isEditing, setIsEditing } = usePages();
 
-  let pageTop = 100;
+  let pageTop = 200;
   if (page.icon) {
-    pageTop = 130;
+    pageTop = 280;
+  }
+  if (page.headerImage) {
+    pageTop = 100;
+    if (page.icon) {
+      pageTop = 120;
+    }
   }
 
   function updateTitle (event: ChangeEvent<HTMLInputElement>) {
@@ -75,6 +80,10 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
 
   function addPageHeader () {
     const headerImage = PageCoverGalleryImageGroups['Color & Gradient'][randomIntFromInterval(0, PageCoverGalleryImageGroups['Color & Gradient'].length - 1)];
+    setPage({ headerImage });
+  }
+
+  function updatePageHeader (headerImage: string | null) {
     setPage({ headerImage });
   }
 
@@ -99,7 +108,7 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
 
   return (
     <Box>
-      <PageBanner page={page} setPage={setPage} />
+      {page.headerImage && <PageBanner image={page.headerImage} setImage={updatePageHeader} />}
       <Container top={pageTop}>
         <CharmEditor
           key={page.id}
@@ -112,11 +121,8 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
               <Emoji sx={{ fontSize: 78 }}>{page.icon}</Emoji>
             </EmojiContainer>
             )}
-            <Controls>
-              <Box
-                className='page-controls'
-              >
-                {!page.icon && (
+            <Controls className='page-controls'>
+              {!page.icon && (
                 <PageControlItem onClick={addPageIcon}>
                   <EmojiEmotionsIcon
                     fontSize='small'
@@ -124,8 +130,8 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
                   />
                   Add icon
                 </PageControlItem>
-                )}
-                {!page.headerImage && (
+              )}
+              {!page.headerImage && (
                 <PageControlItem onClick={addPageHeader}>
                   <ImageIcon
                     fontSize='small'
@@ -133,8 +139,7 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
                   />
                   Add cover
                 </PageControlItem>
-                )}
-              </Box>
+              )}
             </Controls>
             <PageTitle
               value={page.title}

--- a/components/editor/Page/PageBanner.tsx
+++ b/components/editor/Page/PageBanner.tsx
@@ -9,6 +9,7 @@ import { ImageSelectorGallery } from '../ImageSelectorGallery';
 const StyledPageBanner = styled(Box)`
   display: flex;
   align-items: center;
+  height: 200px;
   justify-content: center;
   position: relative;
 
@@ -46,19 +47,13 @@ export const PageCoverGalleryImageGroups = {
   ]
 };
 
-export default function PageBanner ({ page, setPage }: { page: Page, setPage: (p: Page) => void }) {
+export default function PageBanner ({ image, setImage }: { image: string, setImage: (_: string | null) => void }) {
   const theme = useTheme();
 
   return (
-    <StyledPageBanner sx={{
-      height: page.headerImage ? 200 : 100
-    }}
-    >
-      {page.headerImage
-    && (
-    <>
+    <StyledPageBanner>
       {/* eslint-disable-next-line */}
-      <img src={page.headerImage} alt='Page Banner' />
+      <img src={image} alt='Page Banner' />
       <Box
         sx={{
           background: theme.palette.background.light,
@@ -74,13 +69,13 @@ export default function PageBanner ({ page, setPage }: { page: Page, setPage: (p
             'Gallery',
             <ImageSelectorGallery
               onImageClick={(imageSrc) => {
-                setPage({ ...page, headerImage: imageSrc });
+                setImage(imageSrc);
               }}
               items={PageCoverGalleryImageGroups}
             />
           ]]}
           onImageSelect={(imageSrc) => {
-            setPage({ ...page, headerImage: imageSrc });
+            setImage(imageSrc);
           }}
         >
           <ListItem
@@ -111,15 +106,13 @@ export default function PageBanner ({ page, setPage }: { page: Page, setPage: (p
           <Typography
             variant='subtitle1'
             onClick={() => {
-              setPage({ ...page, headerImage: null });
+              setImage(null);
             }}
           >
             Remove
           </Typography>
         </ListItem>
       </Box>
-    </>
-    )}
     </StyledPageBanner>
   );
 }

--- a/components/editor/Placeholder.tsx
+++ b/components/editor/Placeholder.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { alpha, Box, useTheme } from '@mui/material';
+import { useEditorViewContext } from '@bangle.dev/react';
+
+export default function PlaceHolder () {
+  const view = useEditorViewContext();
+  const theme = useTheme();
+  const color = useMemo(() => alpha(theme.palette.text.secondary, 0.35), [theme]);
+  // @ts-ignore missing types from the @bangle.dev/react package
+  const docContent: { content: { size: number } }[] = view.state.doc.content.content;
+  console.log(docContent);
+  const isEmpty = docContent.length <= 1
+    && (!docContent[0] || docContent[0].content.size === 0);
+  // Only show placeholder if the editor content is empty
+  return isEmpty ? (
+    <Box sx={{
+      top: '-2.1em',
+      position: 'relative',
+      color,
+      // Place it beneath the actual editor
+      zIndex: -20
+    }}
+    >
+      Type '/' for commands
+    </Box>
+  ) : null;
+}

--- a/components/editor/Placeholder.tsx
+++ b/components/editor/Placeholder.tsx
@@ -13,7 +13,7 @@ export default function PlaceHolder () {
   // Only show placeholder if the editor content is empty
   return isEmpty ? (
     <Box sx={{
-      top: '-2.1em',
+      top: '-2em',
       position: 'relative',
       color,
       // Place it beneath the actual editor

--- a/components/editor/Placeholder.tsx
+++ b/components/editor/Placeholder.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
-import { alpha, Box, useTheme } from '@mui/material';
 import { useEditorViewContext } from '@bangle.dev/react';
+import { alpha, Box, useTheme } from '@mui/material';
+import { useMemo } from 'react';
 
 export default function PlaceHolder () {
   const view = useEditorViewContext();
@@ -9,7 +9,7 @@ export default function PlaceHolder () {
   // @ts-ignore missing types from the @bangle.dev/react package
   const docContent: { content: { size: number } }[] = view.state.doc.content.content;
   const isEmpty = docContent.length <= 1
-    && (!docContent[0] || docContent[0].content.size === 0);
+  && (!docContent[0] || docContent[0].content.size === 0);
   // Only show placeholder if the editor content is empty
   return isEmpty ? (
     <Box sx={{

--- a/components/editor/Placeholder.tsx
+++ b/components/editor/Placeholder.tsx
@@ -8,7 +8,6 @@ export default function PlaceHolder () {
   const color = useMemo(() => alpha(theme.palette.text.secondary, 0.35), [theme]);
   // @ts-ignore missing types from the @bangle.dev/react package
   const docContent: { content: { size: number } }[] = view.state.doc.content.content;
-  console.log(docContent);
   const isEmpty = docContent.length <= 1
     && (!docContent[0] || docContent[0].content.size === 0);
   // Only show placeholder if the editor content is empty

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -151,6 +151,7 @@ import { IntlProvider } from 'react-intl';
 import { Provider as ReduxProvider } from 'react-redux';
 import 'react-resizable/css/styles.css';
 import { createThemeLightSensitive } from 'theme';
+import '@bangle.dev/tooltip/style.css';
 import 'theme/@bangle.dev/styles.scss';
 import 'theme/focalboard/styles.scss';
 import {

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -24,7 +24,7 @@
 }
 
 :root {
-  --window-tooltip-zIndex: 4;
+  --window-tooltip-zIndex: 5;
   --inlineUniversalPalette-height: 400px;
 }
 

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -1,3 +1,4 @@
+
 .bangle-heading-collapsed {
   border-radius: 8px;
 }
@@ -23,8 +24,12 @@
 }
 
 :root {
-  --window-tooltip-zIndex: 5;
+  --window-tooltip-zIndex: 4;
   --inlineUniversalPalette-height: 400px;
+}
+
+.bangle-tooltip {
+  z-index: 3000;
 }
 
 .bangle-editor a {

--- a/theme/focalboard/focalboard.main.scss
+++ b/theme/focalboard/focalboard.main.scss
@@ -20,7 +20,6 @@ html {
 }
 
 .focalboard-body {
-  --cursor-color: rgb(var(--center-channel-color-rgb));
 
   padding: 0;
   margin: 0;
@@ -31,7 +30,6 @@ html {
   * {
     box-sizing: border-box;
     outline: 0;
-    user-select: none;
   }
 
   input,
@@ -50,15 +48,6 @@ html {
     user-select: text;
   }
 
-  a {
-    text-decoration: none;
-    color: var(--link-color-rgb);
-
-    &:hover {
-      background-color: rgba(192, 192, 255, 0.2);
-    }
-  }
-
   hr {
     width: 100%;
     height: 1px;
@@ -69,9 +58,6 @@ html {
   }
 
   #focalboard-app {
-    a:visited {
-      color: var(--link-visited-color-rgb);
-    }
 
     button {
       &.style--none {

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -218,6 +218,11 @@ export const createThemeLightSensitive = (mode: PaletteMode) => createTheme({
         }
       }
     },
+    MuiListItemButton: {
+      defaultProps: {
+        disableRipple: true
+      }
+    },
     MuiPaper: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
Some cleanup items/bug fixes:
- Simplified CSS for page title and controls, reducing the need to set multiple 'top' offsets - now we just have an offset whether there's an icon set or not.
- made placeholder  its own component, and now it appears in the correct spot wherever it is used
- the text style cursor was disabled when looking at editor inside focalboard