### PR TITLE
fix overlapping of icon over buttons

### DIFF
--- a/components/common/Emoji.tsx
+++ b/components/common/Emoji.tsx
@@ -14,6 +14,7 @@ const Emoji = styled(Box)`
   border-radius: ${({ theme }) => theme.spacing(0.5)};
   width: 80px;
   height: 80px;
+  overflow: hidden;
 
   display: flex;
   align-items: center;

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -117,15 +117,9 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
         >
           <EditorHeader>
             {page?.icon && (
-              <Box sx={{
-                // Moving the icon a bit upwards if the page banner is not present, otherwise the Add cover button and the icon overlaps
-                top: !page.headerImage ? -15 : 0, position: 'relative'
-              }}
-              >
-                <EmojiContainer updatePageIcon={updatePageIcon}>
-                  <Emoji sx={{ fontSize: 78 }}>{page.icon}</Emoji>
-                </EmojiContainer>
-              </Box>
+              <EmojiContainer updatePageIcon={updatePageIcon}>
+                <Emoji sx={{ fontSize: 78 }}>{page.icon}</Emoji>
+              </EmojiContainer>
             )}
             <Controls className='page-controls'>
               {!page.icon && (


### PR DESCRIPTION
I think you added the extra padding because the buttons were not accessible? adding overflow:hidden instead makes it so i can click on them again