### PR TITLE
Allow making pages public

### DIFF
--- a/charmClient.ts
+++ b/charmClient.ts
@@ -97,6 +97,10 @@ class CharmClient {
     return http.DELETE('/api/profile/favorites', { pageId });
   }
 
+  getPublicPage (pageId: string) {
+    return http.GET<Page>(`/api/public/pages/${pageId}`);
+  }
+
   createInviteLink (link: Partial<InviteLink>) {
     return http.POST<InviteLinkPopulated[]>('/api/invites', link);
   }

--- a/charmClient.ts
+++ b/charmClient.ts
@@ -101,6 +101,10 @@ class CharmClient {
     return http.GET<Page>(`/api/public/pages/${pageId}`);
   }
 
+  togglePagePublicAccess (pageId: string, publiclyAccessible: boolean) {
+    return http.PUT<Page>(`/api/pages/${pageId}`, { isPublic: publiclyAccessible });
+  }
+
   createInviteLink (link: Partial<InviteLink>) {
     return http.POST<InviteLinkPopulated[]>('/api/invites', link);
   }

--- a/components/common/RouteGuard.tsx
+++ b/components/common/RouteGuard.tsx
@@ -8,6 +8,8 @@ import { useUser } from 'hooks/useUser';
 const walletConnectPages = ['/login', '/invite'];
 // Pages to create a user account
 const signupPages = ['/signup', '/invite'];
+// Pages shared to the public that don't require user login
+const publicPages = ['/share'];
 
 /**
  * Page loading:
@@ -58,8 +60,11 @@ export default function RouteGuard ({ children }: { children: ReactNode }) {
   function authCheck (url: string) {
     // redirect to login page if accessing a private page and not logged in
     const path = url.split('?')[0];
-    // redirect to connect wallet
-    if (!account && !walletConnectPages.some(basePath => path.startsWith(basePath))) {
+
+    if (publicPages.some(basePath => path.startsWith(basePath))) {
+      setAuthorized(true);
+    }// redirect to connect wallet
+    else if (!account && !walletConnectPages.some(basePath => path.startsWith(basePath))) {
       setAuthorized(false);
       console.log('[RouteGuard]: redirect to login');
       router.push({

--- a/components/common/page-layout/Header.tsx
+++ b/components/common/page-layout/Header.tsx
@@ -21,6 +21,7 @@ import { useColorMode } from 'context/color-mode';
 import { usePages } from 'hooks/usePages';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { useUser } from 'hooks/useUser';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useRouter } from 'next/router';
 
 export const headerHeight = 56;
@@ -37,8 +38,13 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
   const [pageTitle] = usePageTitle();
   const { currentPage, isEditing } = usePages();
   const [user, setUser] = useUser();
+  const [space] = useCurrentSpace();
   const [isPublic, setIsPublic] = useState(currentPage?.isPublic === true);
   const theme = useTheme();
+
+  const isAdmin = user?.spaceRoles.some(spaceRole => {
+    return spaceRole.spaceId === space?.id && spaceRole.role === 'admin';
+  });
 
   const isFavorite = currentPage && user?.favorites.some(({ pageId }) => pageId === currentPage.id);
 
@@ -116,22 +122,25 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
         <Box>
           {isPage && (
           <>
-            <Tooltip title={isPublic ? 'Make private' : 'Make public'} arrow placement='bottom'>
-              <FormControlLabel
-                control={(
-                  <Switch
-                    defaultChecked={isPublic}
-                    onChange={ev => {
-                      togglePublic(ev.target.checked);
-                    }}
-                    inputProps={{ 'aria-label': 'toggle public access' }}
-                  />
-                )}
-                label={isPublic === true ? 'Public' : 'Private'}
-              />
-
-            </Tooltip>
             {
+            isAdmin === true && (
+              <>
+                <Tooltip title={isPublic ? 'Make private' : 'Make public'} arrow placement='bottom'>
+                  <FormControlLabel
+                    control={(
+                      <Switch
+                        defaultChecked={isPublic}
+                        onChange={ev => {
+                          togglePublic(ev.target.checked);
+                        }}
+                        inputProps={{ 'aria-label': 'toggle public access' }}
+                      />
+                )}
+                    label={isPublic === true ? 'Public' : 'Private'}
+                  />
+
+                </Tooltip>
+                {
               isPublic === true && (
                 <Tooltip title='Copy sharing link' arrow placement='bottom'>
 
@@ -146,6 +155,10 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
                 </Tooltip>
               )
             }
+              </>
+            )
+          }
+
             <Tooltip title={isFavorite ? 'Remove from Favorites' : 'Add to Favorites'} arrow placement='bottom'>
               <IconButton sx={{ ml: 1 }} onClick={toggleFavorite} color='inherit'>
                 {isFavorite ? <FavoritedIcon color='secondary' /> : <NotFavoritedIcon color='secondary' />}

--- a/components/common/page-layout/Header.tsx
+++ b/components/common/page-layout/Header.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
@@ -7,10 +9,14 @@ import FavoritedIcon from '@mui/icons-material/Star';
 import NotFavoritedIcon from '@mui/icons-material/StarBorder';
 import { Box, CircularProgress } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import Toolbar from '@mui/material/Toolbar';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import charmClient from 'charmClient';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import LinkIcon from '@mui/icons-material/Link';
 import { useColorMode } from 'context/color-mode';
 import { usePages } from 'hooks/usePages';
 import { usePageTitle } from 'hooks/usePageTitle';
@@ -31,9 +37,11 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
   const [pageTitle] = usePageTitle();
   const { currentPage, isEditing } = usePages();
   const [user, setUser] = useUser();
+  const [isPublic, setIsPublic] = useState(currentPage?.isPublic === true);
   const theme = useTheme();
 
   const isFavorite = currentPage && user?.favorites.some(({ pageId }) => pageId === currentPage.id);
+
   const isPage = router.route.includes('pageId');
 
   async function toggleFavorite () {
@@ -43,6 +51,19 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
       ? await charmClient.unfavoritePage(pageId)
       : await charmClient.favoritePage(pageId);
     setUser(newUser);
+  }
+
+  async function togglePublic (newPublicStatus: boolean) {
+    const updatedPage = await charmClient.togglePagePublicAccess(currentPage!.id, newPublicStatus);
+    setIsPublic(updatedPage.isPublic);
+  }
+
+  function generateShareLink () {
+
+    const baseUrl = window.location.origin;
+    const shareLink = `${baseUrl}/share/${currentPage?.id}`;
+    navigator.clipboard.writeText(shareLink);
+    return shareLink;
   }
 
   return (
@@ -94,11 +115,43 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
         {/** favorite toggle */}
         <Box>
           {isPage && (
-          <Tooltip title={isFavorite ? 'Remove from Favorites' : 'Add to Favorites'} arrow placement='bottom'>
-            <IconButton sx={{ ml: 1 }} onClick={toggleFavorite} color='inherit'>
-              {isFavorite ? <FavoritedIcon color='secondary' /> : <NotFavoritedIcon color='secondary' />}
-            </IconButton>
-          </Tooltip>
+          <>
+            <Tooltip title={isPublic ? 'Make private' : 'Make public'} arrow placement='bottom'>
+              <FormControlLabel
+                control={(
+                  <Switch
+                    defaultChecked={isPublic}
+                    onChange={ev => {
+                      togglePublic(ev.target.checked);
+                    }}
+                    inputProps={{ 'aria-label': 'toggle public access' }}
+                  />
+                )}
+                label={isPublic === true ? 'Public' : 'Private'}
+              />
+
+            </Tooltip>
+            {
+              isPublic === true && (
+                <Tooltip title='Copy sharing link' arrow placement='bottom'>
+
+                  <IconButton
+                    sx={{ ml: 1 }}
+                    color='inherit'
+                    onClick={generateShareLink}
+                  >
+                    {isPublic ? <LinkIcon color='secondary' /> : <LinkIcon color='secondary' />}
+                  </IconButton>
+
+                </Tooltip>
+              )
+            }
+            <Tooltip title={isFavorite ? 'Remove from Favorites' : 'Add to Favorites'} arrow placement='bottom'>
+              <IconButton sx={{ ml: 1 }} onClick={toggleFavorite} color='inherit'>
+                {isFavorite ? <FavoritedIcon color='secondary' /> : <NotFavoritedIcon color='secondary' />}
+              </IconButton>
+            </Tooltip>
+          </>
           )}
           {/** dark mode toggle */}
           <Tooltip title={theme.palette.mode === 'dark' ? 'Light mode' : 'Dark mode'} arrow placement='bottom'>

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -122,7 +122,7 @@ export function Editor ({ page, setPage, readOnly = false }: IEditorProps) {
               </EmojiContainer>
             )}
             <Controls className='page-controls'>
-              {!page.icon && (
+              {!readOnly && !page.icon && (
                 <PageControlItem onClick={addPageIcon}>
                   <EmojiEmotionsIcon
                     fontSize='small'
@@ -131,7 +131,7 @@ export function Editor ({ page, setPage, readOnly = false }: IEditorProps) {
                   Add icon
                 </PageControlItem>
               )}
-              {!page.headerImage && (
+              {!readOnly && !page.headerImage && (
                 <PageControlItem onClick={addPageHeader}>
                   <ImageIcon
                     fontSize='small'
@@ -143,6 +143,7 @@ export function Editor ({ page, setPage, readOnly = false }: IEditorProps) {
             </Controls>
           </EditorHeader>
           <PageTitle
+            readOnly={readOnly}
             value={page.title}
             onChange={updateTitle}
           />

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -61,7 +61,10 @@ const EditorHeader = styled.div`
   }
 `;
 
-export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Page>) => void }) {
+export interface IEditorProps {
+  page: Page, setPage: (p: Partial<Page>) => void, readOnly?: boolean }
+
+export function Editor ({ page, setPage, readOnly = false }: IEditorProps) {
 
   let pageTop = 100;
   if (page.headerImage) {
@@ -110,6 +113,7 @@ export function Editor ({ page, setPage }: { page: Page, setPage: (p: Partial<Pa
           key={page.id}
           content={page.content as PageContent}
           onPageContentChange={updatePageContent}
+          readOnly={readOnly}
         >
           <EditorHeader>
             {page?.icon && (

--- a/components/editor/Page/PageTitle.tsx
+++ b/components/editor/Page/PageTitle.tsx
@@ -1,6 +1,6 @@
 import { EditorViewContext } from '@bangle.dev/react';
 import styled from '@emotion/styled';
-import { TextField } from '@mui/material';
+import { TextField, Typography } from '@mui/material';
 import { TextSelection } from 'prosemirror-state';
 import { ChangeEvent, useContext } from 'react';
 
@@ -33,19 +33,28 @@ const StyledPageTitle = styled(TextField)`
   }
 `;
 
+const StyledReadOnlyTitle = styled(Typography)`
+  font-size: 40px;
+  font-weight: 700;
+`;
+
 interface PageTitleProps {
-  value: string
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void
+  value: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  readOnly?: boolean;
 }
 
-export default function PageTitle ({ value, onChange }: PageTitleProps) {
+export default function PageTitle ({ value, onChange, readOnly }: PageTitleProps) {
   const view = useContext(EditorViewContext);
+  if (readOnly) {
+    return <StyledReadOnlyTitle>{value}</StyledReadOnlyTitle>;
+  }
   return (
     <StyledPageTitle
       value={value}
       onChange={onChange}
       placeholder='Untitled'
-      autoFocus
+      autoFocus={!readOnly}
       multiline
       variant='standard'
       onKeyDown={(e) => {

--- a/models/Space.ts
+++ b/models/Space.ts
@@ -2,4 +2,4 @@ import type { Space } from '@prisma/client';
 
 export { Space };
 
-export const DOMAIN_BLACKLIST = ['api', 'invite', 'login', 'signup', 'createWorkspace'];
+export const DOMAIN_BLACKLIST = ['api', 'invite', 'login', 'signup', 'createWorkspace', 'share'];

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -49,7 +49,7 @@ export default function BlocksEditorPage ({ publicShare = false }: IBlocksEditor
 
   async function loadPublicPage (publicPageId: string) {
     const page = await charmClient.getPublicPage(publicPageId);
-    setTitleState(page.id);
+    setTitleState(page.title);
     setCurrentPage(page);
   }
 

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -74,7 +74,7 @@ export default function BlocksEditorPage ({ publicShare = false }: IBlocksEditor
     return <DatabaseEditor page={currentPage} setPage={setPage} />;
   }
   else {
-    return <Editor page={currentPage} setPage={setPage} />;
+    return <Editor page={currentPage} setPage={setPage} readOnly={publicShare} />;
   }
 }
 

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -10,7 +10,11 @@ import { useRouter } from 'next/router';
 import { ReactElement, useEffect, useMemo } from 'react';
 import debouncePromise from 'lib/utilities/debouncePromise';
 
-export default function BlocksEditorPage () {
+interface IBlocksEditorPage {
+  publicShare?: boolean
+}
+
+export default function BlocksEditorPage ({ publicShare = false }: IBlocksEditorPage) {
 
   const { currentPage, setIsEditing, pages, setPages, setCurrentPage } = usePages();
   const router = useRouter();
@@ -25,6 +29,9 @@ export default function BlocksEditorPage () {
   }, []);
 
   async function setPage (updates: Partial<Page>) {
+    if (publicShare === true) {
+      return;
+    }
     setPages(pages.map(p => p.id === currentPage!.id ? { ...p, ...updates } : p));
     setCurrentPage(_page => ({ ..._page, ...updates }) as Page);
     if (updates.hasOwnProperty('title')) {
@@ -40,8 +47,18 @@ export default function BlocksEditorPage () {
       });
   }
 
+  async function loadPublicPage (publicPageId: string) {
+    const page = await charmClient.getPublicPage(publicPageId);
+    setTitleState(page.id);
+    setCurrentPage(page);
+  }
+
   useEffect(() => {
-    if (pageId && pages.length) {
+
+    if (publicShare === true && pageId) {
+      loadPublicPage(pageId as string);
+    }
+    else if (pageId && pages.length) {
       const pageByPath = pages.find(page => page.path === pageId || page.id === pageId);
       if (pageByPath) {
         setTitleState(pageByPath.title);

--- a/pages/api/public/pages/[pageId]/index.ts
+++ b/pages/api/public/pages/[pageId]/index.ts
@@ -1,0 +1,34 @@
+
+import { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
+import { onError, onNoMatch, requireUser } from 'lib/middleware';
+import { withSessionRoute } from 'lib/session/withSession';
+import { Page } from '@prisma/client';
+import { prisma } from 'db';
+
+const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+
+handler.get(getPublicPage);
+
+async function getPublicPage (req: NextApiRequest, res: NextApiResponse<Page>) {
+
+  const { pageId } = req.query;
+
+  if (pageId === undefined) {
+    return res.status(400).json({ error: 'Please provide a valid page ID' } as any);
+  }
+
+  const page = await prisma.page.findUnique({
+    where: {
+      id: pageId as string
+    }
+  });
+
+  if (page === null || page.isPublic !== true) {
+    return res.status(404).json({ error: 'Page not found' } as any);
+  }
+
+  return res.status(200).json(page);
+}
+
+export default withSessionRoute(handler);

--- a/pages/share/[pageId].tsx
+++ b/pages/share/[pageId].tsx
@@ -1,0 +1,7 @@
+import BlocksEditorPage from 'pages/[domain]/[pageId]';
+import router from 'next/router';
+
+export default function PublicPage () {
+
+  return <BlocksEditorPage publicShare={true} />;
+}


### PR DESCRIPTION
Provides a toggle which admin users can enable.

If so, a publicly shareable link can be copied and sent to others.

![image](https://user-images.githubusercontent.com/18669748/155744639-1d0340ea-37b8-4e6c-83af-038b62a47aeb.png)
