### PR TITLE
better error from metamask

### DIFF
--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/utils/processConnectionError.ts
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/utils/processConnectionError.ts
@@ -33,7 +33,13 @@ const processConnectionError = (error: Error): ErrorInfo => {
         description: error.message
       };
     default:
-      console.error(error);
+      if ((<any> error).code === -32002) {
+        return {
+          title: 'Sign in to MetaMask',
+          description:
+            'Please make sure you are signed in.'
+        };
+      }
       return {
         title: 'An unknown error occurred',
         description: 'Check the console for more details.'


### PR DESCRIPTION
Currently it says 'an unknown error occurred' if you are signed out of metamask. I think checking for the error code is enough to guess it's metamask

<img width="487" alt="image" src="https://user-images.githubusercontent.com/305398/156327742-ea46766d-6d2e-47d2-8116-ec3b5722fb33.png">
