### PR TITLE
Description for focalboard card

### DIFF
--- a/components/databases/focalboard/src/blocks/board.ts
+++ b/components/databases/focalboard/src/blocks/board.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+import { PageContent } from 'models'
 import { IDType, Utils } from '../utils'
 import { Block, createBlock } from './block'
 import { Card } from './card'
@@ -23,7 +24,7 @@ interface IPropertyTemplate {
 
 type BoardFields = {
     icon: string
-    description: string
+    description: PageContent
     showDescription?: boolean
     isTemplate?: boolean
     cardProperties: IPropertyTemplate[]

--- a/components/databases/focalboard/src/components/centerPanel.scss
+++ b/components/databases/focalboard/src/components/centerPanel.scss
@@ -26,7 +26,7 @@
             padding: 0 40px;
         }
 
-        &:first-child {
+        &:nth-child(1) {
             padding-top: 24px;
             @media screen and (max-width: 768px) {
                 padding: 0 8px;
@@ -46,7 +46,7 @@
         z-index: 100;
     }
 
-    > div:nth-child(2) {
+    > div:nth-child(3) {
         padding: 0 0 0 1px;
         margin-left: 80px;
 

--- a/components/databases/focalboard/src/components/viewHeader/viewHeader.scss
+++ b/components/databases/focalboard/src/components/viewHeader/viewHeader.scss
@@ -41,4 +41,6 @@
             background: rgba(var(--center-channel-color-rgb), 0.1);
         }
     }
+
+  margin-top: 0px;
 }

--- a/components/databases/focalboard/src/components/viewTitle.scss
+++ b/components/databases/focalboard/src/components/viewTitle.scss
@@ -1,13 +1,7 @@
 .ViewTitle {
-    > div {
-        flex: 0 0 auto;
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        min-width: 300px;
-    }
-
     > .add-buttons {
+        display: flex;
+        align-items: center;
         flex-direction: row;
         min-height: 36px;
         color: rgba(var(--center-channel-color-rgb), 0.4);
@@ -42,6 +36,11 @@
     .Editable {
         margin-bottom: 0;
         flex-grow: 1;
+        margin-bottom: 0px;
+    }
+
+    .description {
+      padding-left: 4px;
     }
 
     >.description>* {

--- a/components/databases/focalboard/src/components/viewTitle.tsx
+++ b/components/databases/focalboard/src/components/viewTitle.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import ImageIcon from '@mui/icons-material/Image'
-import CharmEditor from 'components/editor/CharmEditor'
+import CharmEditor, { ICharmEditorOutput } from 'components/editor/CharmEditor'
 import { PageCoverGalleryImageGroups } from 'components/editor/Page/PageBanner'
 import { randomIntFromInterval } from 'lib/utilities/random'
-import { Page } from 'models'
+import { Page, PageContent } from 'models'
 import React, { useCallback, useState } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { BlockIcons } from '../blockIcons'
@@ -36,7 +36,7 @@ const ViewTitle = React.memo((props: Props) => {
         setTitle(board.title)
         props.setPage({ title: board.title })
     }, [board.title])
-    const onDescriptionBlur = useCallback((text) => mutator.changeDescription(board.id, board.fields.description, text), [board.id, board.fields.description])
+    const onDescriptionChange = useCallback((text: PageContent) => mutator.changeDescription(board.id, board.fields.description, text), [board.id, board.fields.description])
     const onAddRandomIcon = useCallback(() => {
         const newIcon = BlockIcons.shared.randomIcon()
         mutator.changeIcon(board.id, board.fields.icon, newIcon)
@@ -121,7 +121,9 @@ const ViewTitle = React.memo((props: Props) => {
 
             {board.fields.showDescription &&
                 <div className='description'>
-                    <CharmEditor />
+                    <CharmEditor content={board.fields.description} onPageContentChange={(content: ICharmEditorOutput) => {
+                      onDescriptionChange(content.doc)
+                    }} />
                 </div>
             }
         </div>

--- a/components/databases/focalboard/src/mutator.ts
+++ b/components/databases/focalboard/src/mutator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import charmClient from 'charmClient'
+import { PageContent } from 'models'
 import { publishIncrementalUpdate } from '../../publisher'
 import { BlockIcons } from './blockIcons'
 import { Block, BlockPatch, createPatchesFromBlocks } from './blocks/block'
@@ -212,7 +213,7 @@ class Mutator {
       )
   }
 
-    async changeDescription(blockId: string, oldBlockDescription: string|undefined, blockDescription: string, description = 'change description') {
+    async changeDescription(blockId: string, oldBlockDescription: PageContent|undefined, blockDescription: PageContent, description = 'change description') {
         await undoManager.perform(
             async () => {
                 await charmClient.patchBlock(blockId, {updatedFields: {description: blockDescription}}, publishIncrementalUpdate)

--- a/components/databases/focalboard/src/styles/_typography.scss
+++ b/components/databases/focalboard/src/styles/_typography.scss
@@ -10,7 +10,6 @@ h3,
   .title {
     font-size: 40px;
     line-height: 40px;
-    margin: 0 0 10px;
   }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34683631/156603509-8af2df0d-cfd2-4c77-8d16-c95b6f07f584.png)

1. Fixed the layout of the CharmEditor
2. Updated the data model (client side) to be `PageContent` type
3. Persisting board description to database
4. Fixing styling issues arising from board cover