### PR TITLE
Fix conflict between different @emotion instances

### DIFF
--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -73,7 +73,7 @@ function WalletSelectorModal ({
       <DialogTitle onClose={closeModal}>Connect to a wallet</DialogTitle>
       <Error error={error} processError={processConnectionError} />
       <Grid container spacing={2}>
-        <Grid item xs>
+        <Grid item xs={12}>
           <ConnectorButton
             name={
               typeof window !== 'undefined'
@@ -93,7 +93,7 @@ function WalletSelectorModal ({
             isLoading={activatingConnector === injected}
           />
         </Grid>
-        <Grid item xs>
+        <Grid item xs={12}>
           <ConnectorButton
             name='WalletConnect'
             onClick={() => handleConnect(walletConnect)}
@@ -103,7 +103,7 @@ function WalletSelectorModal ({
             isLoading={activatingConnector === walletConnect}
           />
         </Grid>
-        <Grid item xs>
+        <Grid item xs={12}>
           <ConnectorButton
             name='Coinbase Wallet'
             onClick={() => handleConnect(walletLink)}

--- a/components/common/base-layout/PageWrapper.tsx
+++ b/components/common/base-layout/PageWrapper.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 const PageWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-height: 100%;
   background-color: ${({ theme }) => theme.palette.background.light};
 `;
 

--- a/components/settings/TokenGates.tsx
+++ b/components/settings/TokenGates.tsx
@@ -6,7 +6,6 @@ import { usePopupState, bindTrigger } from 'material-ui-popup-state/hooks';
 import useLitProtocol from 'adapters/litProtocol/hooks/useLitProtocol';
 import Prisma, { TokenGate } from '@prisma/client';
 import charmClient from 'charmClient';
-import { useEffect, useState } from 'react';
 import Legend from './Legend';
 import Button from '../common/Button';
 import TokenGatesTable from './TokenGatesTable';
@@ -31,7 +30,6 @@ export default function TokenGates ({ isAdmin, spaceId }: { isAdmin: boolean, sp
   };
 
   async function onSubmit (conditions: ConditionsModalResult) {
-    console.log('onAccessControlConditionsSelected', conditions);
     await saveTokenGate(conditions);
     popupState.close();
   }
@@ -41,14 +39,12 @@ export default function TokenGates ({ isAdmin, spaceId }: { isAdmin: boolean, sp
     const authSig = await checkAndSignAuthMessage({
       chain
     });
-    console.log('authsig', authSig);
     const success = await litClient?.saveSigningCondition({
       ...conditions,
       authSig,
       chain,
       resourceId: spaceResourceId
     });
-    console.log('success', success);
     await charmClient.saveTokenGate({
       conditions: conditions as any,
       resourceId: spaceResourceId,

--- a/components/settings/TokenGatesTable.tsx
+++ b/components/settings/TokenGatesTable.tsx
@@ -14,18 +14,7 @@ import DeleteIcon from '@mui/icons-material/Close';
 import ButtonChip from 'components/common/ButtonChip';
 import Tooltip from '@mui/material/Tooltip';
 import useLitProtocol from 'adapters/litProtocol/hooks/useLitProtocol';
-import Button from 'components/common/Button';
-import CheckIcon from '@mui/icons-material/Check';
 import Chip from '@mui/material/Chip';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import ListItemText from '@mui/material/ListItemText';
-import MenuItem from '@mui/material/MenuItem';
-import Menu from '@mui/material/Menu';
-import { usePopupState, bindMenu, bindTrigger } from 'material-ui-popup-state/hooks';
-import Avatar from 'components/common/Avatar';
-import { Contributor } from 'models';
-import getDisplayName from 'lib/users/getDisplayName';
-import useENSName from 'hooks/useENSName';
 import charmClient from 'charmClient';
 
 export const StyledRow = styled(TableRow)`

--- a/next.config.js
+++ b/next.config.js
@@ -16,23 +16,6 @@ const config = {
       test: /\.svg$/,
       use: ['@svgr/webpack']
     });
-    // const oneOf = _config.module.rules.find(
-    //   (rule) => typeof rule.oneOf === 'object'
-    // );
-
-    // if (oneOf) {
-    //   const moduleCssRule = oneOf.oneOf.find(
-    //     (rule) => regexEqual(rule.test, /\.module\.(scss|sass)$/)
-    //     // regexEqual(rule.test, /\.module\.(scss|sass)$/)
-    //   );
-
-    //   if (moduleCssRule) {
-    //     const cssLoader = moduleCssRule.use.find(({ loader }) => loader.includes('css-loader'));
-    //     if (cssLoader) {
-    //       cssLoader.options.modules.mode = 'local';
-    //     }
-    //   }
-    // }
     return _config;
   }
 };
@@ -54,21 +37,6 @@ const isSerializableProps = next.isSerializableProps;
 next.isSerializableProps = function _isSerializableProps (page, method, input) {
   return isSerializableProps(page, method, removeUndefined(input));
 };
-
-/** Allow CSS modules in dependencies: https://github.com/vercel/next.js/issues/10142 */
-/**
- * Stolen from https://stackoverflow.com/questions/10776600/testing-for-equality-of-regular-expressions
- */
-function regexEqual (x, y) {
-  return (
-    x instanceof RegExp
-    && y instanceof RegExp
-    && x.source === y.source
-    && x.global === y.global
-    && x.ignoreCase === y.ignoreCase
-    && x.multiline === y.multiline
-  );
-}
 
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true'

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -162,6 +162,8 @@ import {
   lightTheme
 } from 'theme/focalboard/theme';
 import 'theme/styles.scss';
+import { CacheProvider } from '@emotion/react'; // create a cache so we dont conflict with emotion from react-windowed-select
+import createCache from '@emotion/cache';
 
 const getLibrary = (provider: ExternalProvider | JsonRpcFetchFunc) => new Web3Provider(provider);
 
@@ -227,43 +229,45 @@ export default function App ({ Component, pageProps }: AppPropsWithLayout) {
     return null;
   }
   return (
-    <ColorModeContext.Provider value={colorMode}>
-      <ThemeProvider theme={theme}>
-        <Web3ReactProvider getLibrary={getLibrary}>
-          <Web3ConnectionManager>
-            <LitProtocolProvider>
-              <ReduxProvider store={store}>
-                <FocalBoardProviders>
-                  <DataProviders>
-                    <TitleContext.Consumer>
-                      {([title]) => (
-                        <Head>
-                          <title>
-                            {title ? `${title} | CharmVerse` : 'CharmVerse - the all-in-one web3 workspace'}
-                          </title>
-                        </Head>
-                      )}
-                    </TitleContext.Consumer>
-                    <Head>
-                      <meta name='description' content='The Notion of Web3' />
-                      <meta name='viewport' content='minimum-scale=1, initial-scale=1, width=device-width' />
-                    </Head>
-                    <CssBaseline enableColorScheme={true} />
-                    <RouteGuard>
-                      <ErrorBoundary>
-                        {getLayout(<Component {...pageProps} />)}
-                      </ErrorBoundary>
-                    </RouteGuard>
-                  </DataProviders>
-                </FocalBoardProviders>
-                {/** include the root portal for focalboard's popup */}
-                <FocalBoardPortal />
-              </ReduxProvider>
-            </LitProtocolProvider>
-          </Web3ConnectionManager>
-        </Web3ReactProvider>
-      </ThemeProvider>
-    </ColorModeContext.Provider>
+    <CacheProvider value={createCache({ key: 'app' })}>
+      <ColorModeContext.Provider value={colorMode}>
+        <ThemeProvider theme={theme}>
+          <Web3ReactProvider getLibrary={getLibrary}>
+            <Web3ConnectionManager>
+              <LitProtocolProvider>
+                <ReduxProvider store={store}>
+                  <FocalBoardProviders>
+                    <DataProviders>
+                      <TitleContext.Consumer>
+                        {([title]) => (
+                          <Head>
+                            <title>
+                              {title ? `${title} | CharmVerse` : 'CharmVerse - the all-in-one web3 workspace'}
+                            </title>
+                          </Head>
+                        )}
+                      </TitleContext.Consumer>
+                      <Head>
+                        <meta name='description' content='The Notion of Web3' />
+                        <meta name='viewport' content='minimum-scale=1, initial-scale=1, width=device-width' />
+                      </Head>
+                      <CssBaseline enableColorScheme={true} />
+                      <RouteGuard>
+                        <ErrorBoundary>
+                          {getLayout(<Component {...pageProps} />)}
+                        </ErrorBoundary>
+                      </RouteGuard>
+                    </DataProviders>
+                  </FocalBoardProviders>
+                  {/** include the root portal for focalboard's popup */}
+                  <FocalBoardPortal />
+                </ReduxProvider>
+              </LitProtocolProvider>
+            </Web3ConnectionManager>
+          </Web3ReactProvider>
+        </ThemeProvider>
+      </ColorModeContext.Provider>
+    </CacheProvider>
   );
 }
 

--- a/theme/styles.scss
+++ b/theme/styles.scss
@@ -28,3 +28,8 @@ div[role="presentation"] {
 .react-select__menu-portal {
   z-index: 99999;
 }
+
+button {
+  appearance: none;
+  -webkit-appearance: none;
+}

--- a/theme/styles.scss
+++ b/theme/styles.scss
@@ -23,3 +23,8 @@ body {
 div[role="presentation"] {
   z-index: 2500;
 }
+
+/** react-select is used by lit-modal-vite */
+.react-select__menu-portal {
+  z-index: 99999;
+}

--- a/theme/styles.scss
+++ b/theme/styles.scss
@@ -28,8 +28,3 @@ div[role="presentation"] {
 .react-select__menu-portal {
   z-index: 99999;
 }
-
-button {
-  appearance: none;
-  -webkit-appearance: none;
-}


### PR DESCRIPTION
This was hard to track down.. In only our production build, the lit modal component was destroying our CSS styles. I realized the class definitions from @emotion/react were disappearing. I have a hunch thi sis because react-windows-select also uses @emotion and it was overriding our own. I added a cache for our Emotion styles with its own name (so the classes are all prefixed with "app" now). This seems to work on my laptop and hoping for the best in production!


Related issues:
https://github.com/JedWatson/react-select/issues/3309
https://github.com/emotion-js/emotion/issues/2210
