### PR TITLE
Get viewId from the query, let DatabaseEditor access it from the query

### DIFF
--- a/components/databases/DatabasePage.tsx
+++ b/components/databases/DatabasePage.tsx
@@ -23,14 +23,13 @@ interface Props {
   page: Page;
   readonly?: boolean;
   setPage: (p: Partial<Page>) => void;
-  viewId?: string
 }
 
-export function DatabaseEditor ({ page, setPage, readonly, viewId }: Props) {
+export function DatabaseEditor ({ page, setPage, readonly }: Props) {
   const router = useRouter();
   const board = useAppSelector(getCurrentBoard);
   const cards = useAppSelector(getCurrentViewCardsSortedFilteredAndGrouped);
-  const activeView = useAppSelector(getView(viewId ?? router.query.viewId as string));
+  const activeView = useAppSelector(getView(router.query.viewId as string));
   const boardViews = useAppSelector(getCurrentBoardViews);
   const groupByProperty = useAppSelector(getCurrentViewGroupBy);
   const dateDisplayProperty = useAppSelector(getCurrentViewDisplayBy);
@@ -43,7 +42,8 @@ export function DatabaseEditor ({ page, setPage, readonly, viewId }: Props) {
 
     // Ensure boardViews is for our boardId before redirecting
     const isCorrectBoardView = boardViews.length > 0 && boardViews[0].parentId === boardId;
-    if (!viewId && !urlViewId && isCorrectBoardView) {
+
+    if (!urlViewId && isCorrectBoardView) {
       const newPath = generatePath(router.pathname, { ...router.query, boardId });
       router.replace({
         pathname: newPath,
@@ -53,7 +53,7 @@ export function DatabaseEditor ({ page, setPage, readonly, viewId }: Props) {
     }
 
     dispatch(setCurrentBoard(boardId));
-    dispatch(setCurrentView(viewId || ''));
+    dispatch(setCurrentView(urlViewId || ''));
 
   }, [page.boardId, router.query.viewId, boardViews]);
 

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -16,13 +16,13 @@ import debouncePromise from 'lib/utilities/debouncePromise';
  */
 interface IBlocksEditorPage {
   publicShare?: boolean
-  viewId?: string
 }
 
-export default function BlocksEditorPage ({ publicShare = false, viewId }: IBlocksEditorPage) {
+export default function BlocksEditorPage ({ publicShare = false }: IBlocksEditorPage) {
 
   const { currentPage, setIsEditing, pages, setPages, setCurrentPage } = usePages();
   const router = useRouter();
+  const { viewId } = router.query;
   const { pageId } = router.query;
   const [, setTitleState] = usePageTitle();
   const [pageNotFound, setPageNotFound] = useState(false);
@@ -67,12 +67,11 @@ export default function BlocksEditorPage ({ publicShare = false, viewId }: IBloc
   }
 
   useEffect(() => {
-
     if (publicShare === true && pageId) {
       loadPublicPage(pageId as string);
     }
     else if (publicShare === true && viewId) {
-      loadPublicBoardView(viewId);
+      loadPublicBoardView(viewId as string);
     }
     else if (pageId && pages.length) {
       const pageByPath = pages.find(page => page.path === pageId || page.id === pageId);
@@ -94,7 +93,7 @@ export default function BlocksEditorPage ({ publicShare = false, viewId }: IBloc
     return null;
   }
   else if (currentPage.type === 'board') {
-    return <DatabaseEditor page={currentPage} setPage={setPage} readonly={publicShare} viewId={viewId} />;
+    return <DatabaseEditor page={currentPage} setPage={setPage} readonly={publicShare} />;
   }
   else {
     return <Editor page={currentPage} setPage={setPage} readOnly={publicShare} />;

--- a/pages/share/view/[sharedViewId].tsx
+++ b/pages/share/view/[sharedViewId].tsx
@@ -1,10 +1,22 @@
 import BlocksEditorPage from 'pages/[domain]/[pageId]';
 import { useRouter } from 'next/router';
+import { generatePath } from 'lib/utilities/strings';
 
 export default function PublicBoardView () {
   const router = useRouter();
 
   const { sharedViewId } = router.query;
 
-  return <BlocksEditorPage publicShare={true} viewId={sharedViewId as string} />;
+  const { viewId } = router.query;
+
+  if (!viewId) {
+    const newPath = generatePath(router.pathname, { ...router.query, sharedViewId });
+    router.replace({
+      pathname: newPath,
+      query: { viewId: sharedViewId }
+    });
+    return null;
+  }
+
+  return <BlocksEditorPage publicShare={true} />;
 }


### PR DESCRIPTION
Revert to previous behaviour of letting focalboard load its view from the url query