### PR TITLE
speed up build by fixing mui imports

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,6 @@
 
+const PluginTransformImport = require('swc-plugin-transform-import').default;
+
 const config = {
   poweredByHeader: false,
   webpack5: true,
@@ -16,6 +18,24 @@ const config = {
       test: /\.svg$/,
       use: ['@svgr/webpack']
     });
+    const swcRule = _config.module.rules.find(rule => rule.use?.loader === 'next-swc-loader');
+    swcRule.use.options.plugin = (m) => new PluginTransformImport({
+      '@mui/material': {
+        // eslint-disable-next-line no-template-curly-in-string
+        transform: '@mui/material/${member}',
+        preventFullImport: true
+      },
+      '@mui/icons-material': {
+        // eslint-disable-next-line no-template-curly-in-string
+        transform: '@mui/icons-material/${member}',
+        preventFullImport: true
+      },
+      '@mui/lab': {
+        // eslint-disable-next-line no-template-curly-in-string
+        transform: '@mui/lab/${member}',
+        preventFullImport: true
+      }
+    }).visitProgram(m);
     return _config;
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "react-resizable": "^3.0.4",
         "react-select": "^5.2.1",
         "reselect": "^4.0.0",
+        "swc-plugin-transform-import": "^1.1.2",
         "swr": "^1.2.1",
         "uuid": "^8.3.2",
         "yup": "^0.32.11"
@@ -6476,6 +6477,231 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@swc/core": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.151.tgz",
+      "integrity": "sha512-oHgqKwK/Djv765zUHPiGqfMCaKIxXTgQyyCUBKLBQfAJwe/7FVobQ2fghBp4FsZA/NE1LZBmMPpRZNQwlGjeHw==",
+      "bin": {
+        "swcx": "run_swcx.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-android-arm-eabi": "1.2.151",
+        "@swc/core-android-arm64": "1.2.151",
+        "@swc/core-darwin-arm64": "1.2.151",
+        "@swc/core-darwin-x64": "1.2.151",
+        "@swc/core-freebsd-x64": "1.2.151",
+        "@swc/core-linux-arm-gnueabihf": "1.2.151",
+        "@swc/core-linux-arm64-gnu": "1.2.151",
+        "@swc/core-linux-arm64-musl": "1.2.151",
+        "@swc/core-linux-x64-gnu": "1.2.151",
+        "@swc/core-linux-x64-musl": "1.2.151",
+        "@swc/core-win32-arm64-msvc": "1.2.151",
+        "@swc/core-win32-ia32-msvc": "1.2.151",
+        "@swc/core-win32-x64-msvc": "1.2.151"
+      }
+    },
+    "node_modules/@swc/core-android-arm-eabi": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.151.tgz",
+      "integrity": "sha512-Suk3IcHdha33K4hq9tfBCwkXJsENh7kjXCseLqL8Yvy8QobqkXjf1fcoJxX9BdCmPwsKmIw0ZgCBYR+Hl83M2w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-android-arm64": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.151.tgz",
+      "integrity": "sha512-HZVy69dVWT5RgrMJMRK5aiicPmhzkyCHAexApYAHYLgAIhsxL7uoAIPmuRKRkrKNJjrwsWL7H27bBH5bddRDvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.151.tgz",
+      "integrity": "sha512-Ql7rXMu+IC76TemRtkt+opl5iSpX2ApAXVSfvf6afNVTrfTKLpDwiR3ySRRlG0FnNIv6TfOCJpHf655xp01S/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.151.tgz",
+      "integrity": "sha512-N1OBIB7xatR5eybLo91ZhvMJMxT0zxRQURV/a9I8o5CyP4iLd1k8gmrYvBbtj08ohS8F9z7k/dFjxk/9ve5Drw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-freebsd-x64": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.151.tgz",
+      "integrity": "sha512-WVIRiDzuz+/W7BMjVtg1Cmk1+zmDT18Qq+Ygr9J6aFQ1JQUkLEE1pvtkGD3JIEa6Jhz/VwM6AFHtY5o1CrZ21w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.151.tgz",
+      "integrity": "sha512-pfBrIUwu3cR/M7DzDCUJAw9jFKXvJ/Ge8auFk07lRb+JcDnPm0XxLyrLqGvNQWdcHgXeXfmnS4fMQxdb9GUN1w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.151.tgz",
+      "integrity": "sha512-M+BTkTdPY7gteM+0dYz9wrU/j9taL4ccqPEHkDEKP21lS24y99UtuKsvdBLzDm/6ShBVLFAkgIBPu5cEb7y6ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.151.tgz",
+      "integrity": "sha512-7A+yTtSvPJVwO8X1cxUbD/PVCx8G9MKn83G9pH/r+9sQMBXqxyw6/NR0DG6nMMiyOmJkmYWgh5mO47BN7WC4dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.151.tgz",
+      "integrity": "sha512-ORlbN3wf1w0IQGjGToYYC/hV/Vwfcs88Ohfxc4X+IQaw/VxKG6/XT65c0btK640F2TVhvhH1MbYFJJlsycsW7g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.151.tgz",
+      "integrity": "sha512-r6odKE3+9+ReVdnNTZnICt5tscyFFtP4GFcmPQzBSlVoD9LZX6O4WeOlFXn77rVK/+205n2ag/KkKgZH+vdPuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.151.tgz",
+      "integrity": "sha512-jnjJTNHpLhBaPwRgiKv1TdrMljL88ePqMCdVMantyd7yl4lP0D2e5/xR9ysR9S4EGcUnOyo9w8WUYhx/TioMZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.151.tgz",
+      "integrity": "sha512-hSCxAiyDDXKvdUExj4jSIhzWFePqoqak1qdNUjlhEhEinDG8T8PTRCLalyW6fqZDcLf6Tqde7H79AqbfhRlYGQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.151.tgz",
+      "integrity": "sha512-HOkqcJWCChps83Maj0M5kifPDuZ2sGPqpLM67poawspTFkBh0QJ9TMmxW1doQw+74cqsTpRi1ewr/KhsN18i5g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@testing-library/cypress": {
@@ -22392,6 +22618,14 @@
       "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.5.0.tgz",
       "integrity": "sha512-o/vohwqjUO9nDAh4rcjE3KaW/v//At8UJu2LJMybXidf5QLQLVA4bxH0//4YCsr+1H4Gw1Wi/Jc62ynzSBYidw=="
     },
+    "node_modules/swc-plugin-transform-import": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swc-plugin-transform-import/-/swc-plugin-transform-import-1.1.2.tgz",
+      "integrity": "sha512-e19iA7X9Jj2M2vpoyhZ6cYvqC+G3iduNipoyJ1jTfeRAGOUVe9/BdZzSqlNXXieRfpVCE8I58cjmONTBxwx1dg==",
+      "dependencies": {
+        "@swc/core": "^1.2.136"
+      }
+    },
     "node_modules/swr": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/swr/-/swr-1.2.2.tgz",
@@ -28406,6 +28640,104 @@
         "@svgr/plugin-jsx": "^6.2.1",
         "@svgr/plugin-svgo": "^6.2.0"
       }
+    },
+    "@swc/core": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.151.tgz",
+      "integrity": "sha512-oHgqKwK/Djv765zUHPiGqfMCaKIxXTgQyyCUBKLBQfAJwe/7FVobQ2fghBp4FsZA/NE1LZBmMPpRZNQwlGjeHw==",
+      "requires": {
+        "@swc/core-android-arm-eabi": "1.2.151",
+        "@swc/core-android-arm64": "1.2.151",
+        "@swc/core-darwin-arm64": "1.2.151",
+        "@swc/core-darwin-x64": "1.2.151",
+        "@swc/core-freebsd-x64": "1.2.151",
+        "@swc/core-linux-arm-gnueabihf": "1.2.151",
+        "@swc/core-linux-arm64-gnu": "1.2.151",
+        "@swc/core-linux-arm64-musl": "1.2.151",
+        "@swc/core-linux-x64-gnu": "1.2.151",
+        "@swc/core-linux-x64-musl": "1.2.151",
+        "@swc/core-win32-arm64-msvc": "1.2.151",
+        "@swc/core-win32-ia32-msvc": "1.2.151",
+        "@swc/core-win32-x64-msvc": "1.2.151"
+      }
+    },
+    "@swc/core-android-arm-eabi": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.151.tgz",
+      "integrity": "sha512-Suk3IcHdha33K4hq9tfBCwkXJsENh7kjXCseLqL8Yvy8QobqkXjf1fcoJxX9BdCmPwsKmIw0ZgCBYR+Hl83M2w==",
+      "optional": true
+    },
+    "@swc/core-android-arm64": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.151.tgz",
+      "integrity": "sha512-HZVy69dVWT5RgrMJMRK5aiicPmhzkyCHAexApYAHYLgAIhsxL7uoAIPmuRKRkrKNJjrwsWL7H27bBH5bddRDvg==",
+      "optional": true
+    },
+    "@swc/core-darwin-arm64": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.151.tgz",
+      "integrity": "sha512-Ql7rXMu+IC76TemRtkt+opl5iSpX2ApAXVSfvf6afNVTrfTKLpDwiR3ySRRlG0FnNIv6TfOCJpHf655xp01S/g==",
+      "optional": true
+    },
+    "@swc/core-darwin-x64": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.151.tgz",
+      "integrity": "sha512-N1OBIB7xatR5eybLo91ZhvMJMxT0zxRQURV/a9I8o5CyP4iLd1k8gmrYvBbtj08ohS8F9z7k/dFjxk/9ve5Drw==",
+      "optional": true
+    },
+    "@swc/core-freebsd-x64": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.151.tgz",
+      "integrity": "sha512-WVIRiDzuz+/W7BMjVtg1Cmk1+zmDT18Qq+Ygr9J6aFQ1JQUkLEE1pvtkGD3JIEa6Jhz/VwM6AFHtY5o1CrZ21w==",
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.151.tgz",
+      "integrity": "sha512-pfBrIUwu3cR/M7DzDCUJAw9jFKXvJ/Ge8auFk07lRb+JcDnPm0XxLyrLqGvNQWdcHgXeXfmnS4fMQxdb9GUN1w==",
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.151.tgz",
+      "integrity": "sha512-M+BTkTdPY7gteM+0dYz9wrU/j9taL4ccqPEHkDEKP21lS24y99UtuKsvdBLzDm/6ShBVLFAkgIBPu5cEb7y6ig==",
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.151.tgz",
+      "integrity": "sha512-7A+yTtSvPJVwO8X1cxUbD/PVCx8G9MKn83G9pH/r+9sQMBXqxyw6/NR0DG6nMMiyOmJkmYWgh5mO47BN7WC4dQ==",
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.151.tgz",
+      "integrity": "sha512-ORlbN3wf1w0IQGjGToYYC/hV/Vwfcs88Ohfxc4X+IQaw/VxKG6/XT65c0btK640F2TVhvhH1MbYFJJlsycsW7g==",
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.151.tgz",
+      "integrity": "sha512-r6odKE3+9+ReVdnNTZnICt5tscyFFtP4GFcmPQzBSlVoD9LZX6O4WeOlFXn77rVK/+205n2ag/KkKgZH+vdPuQ==",
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.151.tgz",
+      "integrity": "sha512-jnjJTNHpLhBaPwRgiKv1TdrMljL88ePqMCdVMantyd7yl4lP0D2e5/xR9ysR9S4EGcUnOyo9w8WUYhx/TioMZw==",
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.151.tgz",
+      "integrity": "sha512-hSCxAiyDDXKvdUExj4jSIhzWFePqoqak1qdNUjlhEhEinDG8T8PTRCLalyW6fqZDcLf6Tqde7H79AqbfhRlYGQ==",
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.2.151",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.151.tgz",
+      "integrity": "sha512-HOkqcJWCChps83Maj0M5kifPDuZ2sGPqpLM67poawspTFkBh0QJ9TMmxW1doQw+74cqsTpRi1ewr/KhsN18i5g==",
+      "optional": true
     },
     "@testing-library/cypress": {
       "version": "8.0.2",
@@ -40910,6 +41242,14 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.5.0.tgz",
       "integrity": "sha512-o/vohwqjUO9nDAh4rcjE3KaW/v//At8UJu2LJMybXidf5QLQLVA4bxH0//4YCsr+1H4Gw1Wi/Jc62ynzSBYidw=="
+    },
+    "swc-plugin-transform-import": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swc-plugin-transform-import/-/swc-plugin-transform-import-1.1.2.tgz",
+      "integrity": "sha512-e19iA7X9Jj2M2vpoyhZ6cYvqC+G3iduNipoyJ1jTfeRAGOUVe9/BdZzSqlNXXieRfpVCE8I58cjmONTBxwx1dg==",
+      "requires": {
+        "@swc/core": "^1.2.136"
+      }
     },
     "swr": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react-resizable": "^3.0.4",
     "react-select": "^5.2.1",
     "reselect": "^4.0.0",
+    "swc-plugin-transform-import": "^1.1.2",
     "swr": "^1.2.1",
     "uuid": "^8.3.2",
     "yup": "^0.32.11"


### PR DESCRIPTION
You're supposed to import MUI components individually, but I know this is had to remember, it's ugly, and hard to enforce:
```
import Box from '@mui/material/Box';
vs
import { Box } from '@mui/material';

```
See: https://mui.com/guides/minimizing-bundle-size/

The next.js maintainers believe this is part of why dev can take so long: https://github.com/vercel/next.js/issues/29559. THey suggest using a special babel plugin, however that means you can't use the SWC compiler (written in Rust and much faster). So I found someone created a similar plugin and implemented that instead. Seems to be working, although the final build size has not changed, I Noticed that mentions of "@mui/icons-material" went from almost 10,000 to about 150 in the '.next/trace' file.

Another alternative is to use babel compiler with this config: https://mui.com/guides/minimizing-bundle-size/#option-2. I haven't tried it yet, but we'd be have do swap the Rust compiler (SWC) with babel, which is slower.