### PR TITLE
add kanban cards to bottom of column when using "+ Add" at bottom

### DIFF
--- a/components/databases/focalboard/src/components/cardDialog.tsx
+++ b/components/databases/focalboard/src/components/cardDialog.tsx
@@ -81,7 +81,7 @@ const CardDialog = (props: Props): JSX.Element => {
     }
 
     const confirmDialogProps: ConfirmationDialogBoxProps = {
-        heading: intl.formatMessage({id: 'CardDialog.delete-confirmation-dialog-heading', defaultMessage: 'Confirm card delete!'}),
+        heading: intl.formatMessage({id: 'CardDialog.delete-confirmation-dialog-heading', defaultMessage: 'Confirm card delete?'}),
         confirmButtonText: intl.formatMessage({id: 'CardDialog.delete-confirmation-dialog-button-text', defaultMessage: 'Delete'}),
         onConfirm: handleDeleteCard,
         onClose: () => {

--- a/components/databases/focalboard/src/components/kanban/kanban.tsx
+++ b/components/databases/focalboard/src/components/kanban/kanban.tsx
@@ -74,7 +74,7 @@ type Props = {
     intl: IntlShape
     readonly: boolean
     onCardClicked: (e: React.MouseEvent, card: Card) => void
-    addCard: (groupByOptionId?: string, show?:boolean) => Promise<void>
+    addCard: (groupByOptionId?: string, show?:boolean, props?: any, insertLast?: boolean) => Promise<void>
     showCard: (cardId?: string) => void
 }
 
@@ -334,7 +334,7 @@ const Kanban = (props: Props) => {
                               color='secondary'
                               sx={{ justifyContent: 'flex-start' }}
                               onClick={() => {
-                                  props.addCard(group.option.id, true)
+                                  props.addCard(group.option.id, true, {}, true)
                               }}
                           >
                               <FormattedMessage

--- a/components/databases/focalboard/src/components/kanban/kanbanCard.tsx
+++ b/components/databases/focalboard/src/components/kanban/kanbanCard.tsx
@@ -70,7 +70,7 @@ const KanbanCard = React.memo((props: Props) => {
         await mutator.deleteBlock(card, 'delete card')
     }
     const confirmDialogProps: ConfirmationDialogBoxProps = {
-        heading: intl.formatMessage({id: 'CardDialog.delete-confirmation-dialog-heading', defaultMessage: 'Confirm card delete!'}),
+        heading: intl.formatMessage({id: 'CardDialog.delete-confirmation-dialog-heading', defaultMessage: 'Confirm card delete?'}),
         confirmButtonText: intl.formatMessage({id: 'CardDialog.delete-confirmation-dialog-button-text', defaultMessage: 'Delete'}),
         onConfirm: handleDeleteCard,
         onClose: () => {


### PR DESCRIPTION
You can add a card from the top or bottom of a column. If you use the bottom Add button, it should add the card to the bottom of the column as well.
![image](https://user-images.githubusercontent.com/305398/157198485-8d84236b-db92-4b01-a837-d6ce4e246190.png)
