### PR TITLE
use correct type for chainIds in connects

### DIFF
--- a/connectors.ts
+++ b/connectors.ts
@@ -34,7 +34,7 @@ const RPC = {
     rpcUrls: ['https://main-light.eth.linkpool.io']
   },
   BSC: {
-    chainId: '0x38',
+    chainId: 56,
     chainName: 'BSC',
     nativeCurrency: {
       name: 'Binance Coin',
@@ -49,7 +49,7 @@ const RPC = {
     iconUrls: ['/networkLogos/bsc.svg']
   },
   POLYGON: {
-    chainId: '0x89',
+    chainId: 137,
     chainName: 'Matic',
     nativeCurrency: {
       name: 'Polygon',


### PR DESCRIPTION
No idea why they were using the hex value in the source that I copied: https://github.com/agoraxyz/guild.xyz/blob/main/src/connectors.ts. Seems like an oversight and I'm guessing they don't really use that value