### PR TITLE
Put link to settings at top of sidebar like Notion

### DIFF
--- a/components/common/page-layout/PageNavigation.tsx
+++ b/components/common/page-layout/PageNavigation.tsx
@@ -37,6 +37,8 @@ export type MenuNode = Page & {
   children: MenuNode[];
 }
 
+// export const NonTreeItemLink = styled
+
 export const StyledTreeItem = styled(TreeItem)(({ theme }) => ({
 
   position: 'relative',
@@ -113,7 +115,7 @@ export const StyledIconButton = styled(IconButton)`
   }
 `;
 
-const PageAnchor = styled.a`
+export const PageAnchor = styled.a`
   color: inherit;
   text-decoration: none;
   display: flex;
@@ -134,14 +136,14 @@ const PageAnchor = styled.a`
   }
 `;
 
-const PageIcon = styled(EmojiCon)`
+export const PageIcon = styled(EmojiCon)`
   height: 24px;
   width: 24px;
   margin-right: 4px;
   color: ${({ theme }) => theme.palette.secondary.light};
 `;
 
-export const PageTitle = styled(Typography)<{isempty: number}>`
+export const PageTitle = styled(Typography)<{ isempty?: number }>`
   color: inherit;
   display: flex;
   align-items: center;
@@ -179,61 +181,63 @@ export function PageLink ({ children, href, label, labelIcon, pageId }: PageLink
   });
 
   return (
-    <PageAnchor onClick={stopPropagation}>
-      {labelIcon && (
-        <PageIcon {...bindTrigger(popupState)}>
-          {labelIcon}
-        </PageIcon>
-      )}
-      <Link href={href} passHref>
-        <PageTitle isempty={isempty ? 1 : 0}>
-          {isempty ? 'Untitled' : label}
-        </PageTitle>
-      </Link>
-      {children}
-      <Menu {...bindMenu(popupState)}>
-        <EmojiPicker onSelect={async (emoji) => {
-          if (pageId) {
-            await charmClient.updatePage({
-              id: pageId,
-              icon: emoji
-            });
-            let isCurrentPageEdited = false;
-            let boardId: null | string = null;
-            // Update the state
-            setPages((pages) => pages.map(page => {
-              if (page.id === pageId) {
-                if (page.id === currentPage?.id) {
-                  isCurrentPageEdited = true;
-                }
-
-                if (page.boardId !== null) {
-                  boardId = page.boardId;
-                }
-                return {
-                  ...page,
-                  icon: emoji
-                };
-              }
-              return page;
-            }));
-
-            if (currentPage && isCurrentPageEdited) {
-              setCurrentPage({
-                ...currentPage,
+    <Link href={href} passHref>
+      <PageAnchor onClick={stopPropagation}>
+        {labelIcon && (
+          <PageIcon {...bindTrigger(popupState)}>
+            {labelIcon}
+          </PageIcon>
+        )}
+        <Link href={href}>
+          <PageTitle isempty={isempty ? 1 : 0}>
+            {isempty ? 'Untitled' : label}
+          </PageTitle>
+        </Link>
+        {children}
+        <Menu {...bindMenu(popupState)}>
+          <EmojiPicker onSelect={async (emoji) => {
+            if (pageId) {
+              await charmClient.updatePage({
+                id: pageId,
                 icon: emoji
               });
-            }
+              let isCurrentPageEdited = false;
+              let boardId: null | string = null;
+              // Update the state
+              setPages((pages) => pages.map(page => {
+                if (page.id === pageId) {
+                  if (page.id === currentPage?.id) {
+                    isCurrentPageEdited = true;
+                  }
 
-            if (boardId) {
-              await mutator.changeIcon(boardId, emoji, emoji);
+                  if (page.boardId !== null) {
+                    boardId = page.boardId;
+                  }
+                  return {
+                    ...page,
+                    icon: emoji
+                  };
+                }
+                return page;
+              }));
+
+              if (currentPage && isCurrentPageEdited) {
+                setCurrentPage({
+                  ...currentPage,
+                  icon: emoji
+                });
+              }
+
+              if (boardId) {
+                await mutator.changeIcon(boardId, emoji, emoji);
+              }
+              popupState.close();
             }
-            popupState.close();
-          }
-        }}
-        />
-      </Menu>
-    </PageAnchor>
+          }}
+          />
+        </Menu>
+      </PageAnchor>
+    </Link>
   );
 }
 

--- a/components/common/page-layout/PageNavigation.tsx
+++ b/components/common/page-layout/PageNavigation.tsx
@@ -37,8 +37,6 @@ export type MenuNode = Page & {
   children: MenuNode[];
 }
 
-// export const NonTreeItemLink = styled
-
 export const StyledTreeItem = styled(TreeItem)(({ theme }) => ({
 
   position: 'relative',
@@ -115,7 +113,7 @@ export const StyledIconButton = styled(IconButton)`
   }
 `;
 
-export const PageAnchor = styled.a`
+const PageAnchor = styled.a`
   color: inherit;
   text-decoration: none;
   display: flex;
@@ -136,14 +134,14 @@ export const PageAnchor = styled.a`
   }
 `;
 
-export const PageIcon = styled(EmojiCon)`
+const PageIcon = styled(EmojiCon)`
   height: 24px;
   width: 24px;
   margin-right: 4px;
   color: ${({ theme }) => theme.palette.secondary.light};
 `;
 
-export const PageTitle = styled(Typography)<{ isempty?: number }>`
+const PageTitle = styled(Typography)<{ isempty?: number }>`
   color: inherit;
   display: flex;
   align-items: center;

--- a/components/common/page-layout/Sidebar.tsx
+++ b/components/common/page-layout/Sidebar.tsx
@@ -37,7 +37,7 @@ import { Modal } from '../Modal';
 import NewPageMenu from '../NewPageMenu';
 import WorkspaceAvatar from '../WorkspaceAvatar';
 import { headerHeight } from './Header';
-import PageNavigation, { PageAnchor, PageIcon, PageTitle } from './PageNavigation';
+import PageNavigation from './PageNavigation';
 
 const AvatarLink = styled(NextLink)`
   cursor: pointer;

--- a/components/common/page-layout/Sidebar.tsx
+++ b/components/common/page-layout/Sidebar.tsx
@@ -297,12 +297,14 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
                 />
               </Box>
             </Box>
-            <SidebarLink
-              href={`/${space.domain}/bounties`}
-              active={router.pathname.startsWith('/[domain]/bounties')}
-              icon={<BountyIcon fontSize='small' />}
-              label='Bounties'
-            />
+            <Box sx={{ mt: 3 }}>
+              <SidebarLink
+                href={`/${space.domain}/bounties`}
+                active={router.pathname.startsWith('/[domain]/bounties')}
+                icon={<BountyIcon fontSize='small' />}
+                label='Bounties'
+              />
+            </Box>
           </Box>
           <Box>
             <Divider />

--- a/components/common/page-layout/Sidebar.tsx
+++ b/components/common/page-layout/Sidebar.tsx
@@ -217,7 +217,6 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
       router.push(newPath);
     }
   }
-  console.log(router.pathname);
 
   return (
     <SidebarContainer>

--- a/components/common/page-layout/Sidebar.tsx
+++ b/components/common/page-layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 
 import styled from '@emotion/styled';
+import { css, Theme } from '@emotion/react';
 import AddIcon from '@mui/icons-material/Add';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import BountyIcon from '@mui/icons-material/RequestPage';
@@ -36,7 +37,7 @@ import { Modal } from '../Modal';
 import NewPageMenu from '../NewPageMenu';
 import WorkspaceAvatar from '../WorkspaceAvatar';
 import { headerHeight } from './Header';
-import PageNavigation, { PageLink, StyledTreeItem } from './PageNavigation';
+import PageNavigation, { PageAnchor, PageIcon, PageTitle } from './PageNavigation';
 
 const AvatarLink = styled(NextLink)`
   cursor: pointer;
@@ -76,14 +77,41 @@ const SidebarContainer = styled.div`
   }
 `;
 
+const sidebarItemStyles = ({ theme }: { theme: Theme }) => css`
+  padding-left: ${theme.spacing(2)};
+  padding-right: ${theme.spacing(2)};
+  margin-bottom: ${theme.spacing(0.5)};
+`;
+
 const SectionName = styled(Typography)`
+  ${sidebarItemStyles}
   color: ${greyColor2};
   font-size: 12px;
   letter-spacing: 0.03em;
   font-weight: 600;
-  padding-left: ${({ theme }) => theme.spacing(2)};
-  padding-right: ${({ theme }) => theme.spacing(2)};
-  margin-bottom: ${({ theme }) => theme.spacing(0.5)};
+`;
+
+const MenuItem = styled(Link)<{ active: boolean }>`
+  ${sidebarItemStyles}
+  align-items: center;
+  color: ${({ theme }) => theme.palette.text.secondary};
+  display: flex;
+  font-size: 14px;
+  font-weight: 500;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  :hover {
+    background-color: ${({ theme }) => theme.palette.action.hover};
+    color: inherit;
+  }
+  ${({ active, theme }) => active ? `
+    background-color: ${theme.palette.action.selected};
+    color: ${theme.palette.text.primary};
+  ` : ''}
+  svg {
+    font-size: 1.2em;
+    margin-right: ${({ theme }) => theme.spacing(1)};
+  }
 `;
 
 const SidebarHeader = styled.div(({ theme }) => ({
@@ -104,6 +132,15 @@ const SidebarHeader = styled.div(({ theme }) => ({
   // necessary for content to be below app bar
   minHeight: headerHeight
 }));
+
+function SidebarLink ({ active, href, icon, label }: { active: boolean, href: string, icon: any, label: string }) {
+  return (
+    <MenuItem href={href} active={active}>
+      {icon}
+      {label}
+    </MenuItem>
+  );
+}
 
 interface SidebarProps {
   closeSidebar: () => void;
@@ -180,6 +217,7 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
       router.push(newPath);
     }
   }
+  console.log(router.pathname);
 
   return (
     <SidebarContainer>
@@ -224,7 +262,15 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
                     <ChevronLeftIcon />
                   </IconButton>
                 </SidebarHeader>
-                <Divider sx={{ mb: 3 }} />
+                <Divider sx={{ mb: 2 }} />
+                <Box mb={2}>
+                  <SidebarLink
+                    active={router.pathname.startsWith('/[domain]/settings')}
+                    href={`/${space.domain}/settings/account`}
+                    icon={<SettingsIcon color='secondary' fontSize='small' />}
+                    label='Settings & Members'
+                  />
+                </Box>
                 {favoritePageIds.length > 0 && (
                   <Box mb={2}>
                     <SectionName>
@@ -251,16 +297,11 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
                 />
               </Box>
             </Box>
-            <StyledTreeItem
-              sx={{ mt: 3 }}
-              nodeId='bounties'
+            <SidebarLink
+              href={`/${space.domain}/bounties`}
+              active={router.pathname.startsWith('/[domain]/bounties')}
               icon={<BountyIcon fontSize='small' />}
-              label={
-                <PageLink href={`/${space.domain}/bounties`} label='Bounties' />
-              }
-              ContentProps={{
-                className: router.pathname.includes('bounties') ? 'Mui-selected' : ''
-              }}
+              label='Bounties'
             />
           </Box>
           <Box>
@@ -276,11 +317,6 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
                   </Box>
                 </Box>
               )}
-              <Link href={`/${space.domain}/settings/account`}>
-                <IconButton>
-                  <SettingsIcon color='secondary' />
-                </IconButton>
-              </Link>
             </Box>
           </Box>
         </Box>

--- a/components/settings/Layout.tsx
+++ b/components/settings/Layout.tsx
@@ -8,12 +8,14 @@ import Box from '@mui/material/Box';
 import AccountIcon from '@mui/icons-material/AccountCircle';
 import SettingsIcon from '@mui/icons-material/WorkOutline';
 import PersonIcon from '@mui/icons-material/Group';
+import LockIcon from '@mui/icons-material/LockOpen';
 import { PageLayout } from '../common/page-layout';
 
 const SETTINGS_TABS = [
   { icon: <AccountIcon fontSize='small' />, path: 'account', label: 'My account' },
   { icon: <SettingsIcon fontSize='small' />, path: 'workspace', label: 'Workspace' },
-  { icon: <PersonIcon fontSize='small' />, path: 'contributors', label: 'Contributors' }
+  { icon: <PersonIcon fontSize='small' />, path: 'contributors', label: 'Contributors' },
+  { icon: <LockIcon fontSize='small' />, path: 'token-gates', label: 'Token Gates' }
 ];
 
 const ScrollableWindow = styled.div`

--- a/pages/[domain]/settings/token-gates.tsx
+++ b/pages/[domain]/settings/token-gates.tsx
@@ -3,8 +3,7 @@ import { ReactElement } from 'react';
 import { setTitle } from 'hooks/usePageTitle';
 import { useUser } from 'hooks/useUser';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import InviteLinkList from 'components/settings/InviteLinks';
-import ContributorList from 'components/settings/ContributorList';
+import TokenGateList from 'components/settings/TokenGates';
 import isSpaceAdmin from 'lib/users/isSpaceAdmin';
 
 export default function ContributorSettings () {
@@ -14,15 +13,12 @@ export default function ContributorSettings () {
 
   const isAdmin = isSpaceAdmin(user, space?.id);
 
-  setTitle('Contributors');
+  setTitle('Token Gates');
   if (!space) {
     return null;
   }
   return (
-    <>
-      <InviteLinkList isAdmin={isAdmin} spaceId={space.id} />
-      <ContributorList isAdmin={isAdmin} spaceId={space.id} spaceOwner={space.createdBy} />
-    </>
+    <TokenGateList isAdmin={isAdmin} spaceId={space.id} />
   );
 }
 


### PR DESCRIPTION
Some users were not sure where to go to add users, and i wanted to highlight we have token gates. This also fixes the bug when clicking on Bounties in dev mode. We can use the extra space at the bottom of the sidebar for showing the network you're on, maybe allowing u to reconnect too

![image](https://user-images.githubusercontent.com/305398/157763007-3fd20ed7-bb14-4f78-bb44-67a7ac80be33.png)
