### PR TITLE
Link to page using `/` shortcut

### DIFF
--- a/components/common/page-layout/PageNavigation.tsx
+++ b/components/common/page-layout/PageNavigation.tsx
@@ -135,14 +135,14 @@ const PageAnchor = styled.a`
   }
 `;
 
-const PageIcon = styled(EmojiCon)`
+const StyledPageIcon = styled(EmojiCon)`
   height: 24px;
   width: 24px;
   margin-right: 4px;
   color: ${({ theme }) => theme.palette.secondary.light};
 `;
 
-const PageTitle = styled(Typography)<{ isempty?: number }>`
+export const PageTitle = styled(Typography)<{ isempty?: number }>`
   color: inherit;
   display: flex;
   align-items: center;
@@ -183,9 +183,9 @@ export function PageLink ({ children, href, label, labelIcon, pageId }: PageLink
     <Link href={href} passHref>
       <PageAnchor onClick={stopPropagation}>
         {labelIcon && (
-          <PageIcon {...bindTrigger(popupState)}>
+          <div {...bindTrigger(popupState)}>
             {labelIcon}
-          </PageIcon>
+          </div>
         )}
         <Link passHref href={href}>
           <PageTitle isempty={isempty ? 1 : 0}>
@@ -249,6 +249,29 @@ const TreeItemComponent = React.forwardRef<React.Ref<HTMLDivElement>, TreeItemCo
   )
 );
 
+export function PageIcon ({ isEditorEmpty, pageType }: {pageType: Page['type'], isEditorEmpty: boolean}) {
+  let Icon: null | ReactNode = null;
+  if (pageType === 'board') {
+    Icon = (<StyledDatabaseIcon />);
+  }
+  else if (isEditorEmpty) {
+    Icon = (
+      <InsertDriveFileOutlinedIcon />
+    );
+  }
+  else {
+    Icon = (
+      <DescriptionOutlinedIcon />
+    );
+  }
+
+  return (
+    <StyledPageIcon>
+      {Icon}
+    </StyledPageIcon>
+  );
+}
+
 // eslint-disable-next-line react/function-component-definition
 const PageTreeItem = forwardRef((props: any, ref) => {
   const { pages } = usePages();
@@ -285,30 +308,6 @@ const PageTreeItem = forwardRef((props: any, ref) => {
     setAnchorEl(null);
   }
 
-  let Icon: null | ReactNode = labelIcon;
-
-  if (!labelIcon) {
-    if (pageType === 'board') {
-      Icon = (<StyledDatabaseIcon />);
-    }
-    else if (isEditorEmpty) {
-      Icon = (
-        <InsertDriveFileOutlinedIcon sx={{
-          opacity: theme.palette.mode !== 'light' ? 0.5 : 1
-        }}
-        />
-      );
-    }
-    else {
-      Icon = (
-        <DescriptionOutlinedIcon sx={{
-          opacity: theme.palette.mode !== 'light' ? 0.5 : 1
-        }}
-        />
-      );
-    }
-  }
-
   return (
     <>
       <StyledTreeItem
@@ -316,7 +315,7 @@ const PageTreeItem = forwardRef((props: any, ref) => {
           <PageLink
             href={href}
             label={label}
-            labelIcon={Icon}
+            labelIcon={labelIcon ?? <PageIcon isEditorEmpty={Boolean(isEditorEmpty)} pageType={pageType} />}
             pageId={referencedPage?.id}
           >
             <div className='page-actions'>

--- a/components/common/page-layout/PageNavigation.tsx
+++ b/components/common/page-layout/PageNavigation.tsx
@@ -180,63 +180,61 @@ export function PageLink ({ children, href, label, labelIcon, pageId }: PageLink
   });
 
   return (
-    <Link href={href} passHref>
-      <PageAnchor onClick={stopPropagation}>
-        {labelIcon && (
-          <div {...bindTrigger(popupState)}>
-            {labelIcon}
-          </div>
-        )}
-        <Link passHref href={href}>
-          <PageTitle isempty={isempty ? 1 : 0}>
-            {isempty ? 'Untitled' : label}
-          </PageTitle>
-        </Link>
-        {children}
-        <Menu {...bindMenu(popupState)}>
-          <EmojiPicker onSelect={async (emoji) => {
-            if (pageId) {
-              await charmClient.updatePage({
-                id: pageId,
+    <PageAnchor onClick={stopPropagation}>
+      {labelIcon && (
+      <StyledPageIcon {...bindTrigger(popupState)}>
+        {labelIcon}
+      </StyledPageIcon>
+      )}
+      <Link passHref href={href}>
+        <PageTitle isempty={isempty ? 1 : 0}>
+          {isempty ? 'Untitled' : label}
+        </PageTitle>
+      </Link>
+      {children}
+      <Menu {...bindMenu(popupState)}>
+        <EmojiPicker onSelect={async (emoji) => {
+          if (pageId) {
+            await charmClient.updatePage({
+              id: pageId,
+              icon: emoji
+            });
+            let isCurrentPageEdited = false;
+            let boardId: null | string = null;
+            // Update the state
+            setPages((pages) => pages.map(page => {
+              if (page.id === pageId) {
+                if (page.id === currentPage?.id) {
+                  isCurrentPageEdited = true;
+                }
+
+                if (page.boardId !== null) {
+                  boardId = page.boardId;
+                }
+                return {
+                  ...page,
+                  icon: emoji
+                };
+              }
+              return page;
+            }));
+
+            if (currentPage && isCurrentPageEdited) {
+              setCurrentPage({
+                ...currentPage,
                 icon: emoji
               });
-              let isCurrentPageEdited = false;
-              let boardId: null | string = null;
-              // Update the state
-              setPages((pages) => pages.map(page => {
-                if (page.id === pageId) {
-                  if (page.id === currentPage?.id) {
-                    isCurrentPageEdited = true;
-                  }
-
-                  if (page.boardId !== null) {
-                    boardId = page.boardId;
-                  }
-                  return {
-                    ...page,
-                    icon: emoji
-                  };
-                }
-                return page;
-              }));
-
-              if (currentPage && isCurrentPageEdited) {
-                setCurrentPage({
-                  ...currentPage,
-                  icon: emoji
-                });
-              }
-
-              if (boardId) {
-                await mutator.changeIcon(boardId, emoji, emoji);
-              }
-              popupState.close();
             }
-          }}
-          />
-        </Menu>
-      </PageAnchor>
-    </Link>
+
+            if (boardId) {
+              await mutator.changeIcon(boardId, emoji, emoji);
+            }
+            popupState.close();
+          }
+        }}
+        />
+      </Menu>
+    </PageAnchor>
   );
 }
 

--- a/components/editor/@bangle.dev/tooltip/suggest-tooltip.ts
+++ b/components/editor/@bangle.dev/tooltip/suggest-tooltip.ts
@@ -74,9 +74,9 @@ export type SuggestTooltipRenderOpts = Omit<
 
 interface PluginsOptions {
   key?: PluginKey;
+  tooltipRenderOpts: SuggestTooltipRenderOpts;
   markName: string;
   trigger: string;
-  tooltipRenderOpts: SuggestTooltipRenderOpts;
   keybindings?: any;
   onEnter?: Command;
   onArrowDown?: Command;
@@ -204,7 +204,7 @@ function pluginsFactory({
   };
 }
 
-function referenceElement(
+export function referenceElement(
   getActiveMarkPos: (state: EditorState) => { start: number; end: number },
 ): GetReferenceElementFunction {
   return (view) => {
@@ -333,7 +333,7 @@ function doesQueryHaveTrigger(
   return textContent.includes(trigger);
 }
 
-function renderSuggestionsTooltip(key: PluginKey): Command {
+export function renderSuggestionsTooltip(key: PluginKey): Command {
   return (state, dispatch, _view) => {
     if (dispatch) {
       dispatch(
@@ -346,7 +346,7 @@ function renderSuggestionsTooltip(key: PluginKey): Command {
   };
 }
 
-function hideSuggestionsTooltip(key: PluginKey): Command {
+export function hideSuggestionsTooltip(key: PluginKey): Command {
   return (state, dispatch, _view) => {
     if (dispatch) {
       dispatch(

--- a/components/editor/@bangle.io/extensions/inline-command-palette/use-editor-items.tsx
+++ b/components/editor/@bangle.io/extensions/inline-command-palette/use-editor-items.tsx
@@ -19,6 +19,8 @@ import TableChartIcon from '@mui/icons-material/TableChart';
 import TextFieldsIcon from '@mui/icons-material/TextFields';
 import VideoLibraryIcon from '@mui/icons-material/VideoLibrary';
 import ViewColumnIcon from '@mui/icons-material/ViewColumn';
+import { renderSuggestionsTooltip } from 'components/editor/@bangle.dev/tooltip/suggest-tooltip';
+import { NestedPagePluginKey } from 'components/editor/NestedPage';
 import { MAX_EMBED_WIDTH, MIN_EMBED_HEIGHT, MIN_EMBED_WIDTH, VIDEO_ASPECT_RATIO } from 'components/editor/ResizableIframe';
 import useNestedPage from 'hooks/useNestedPage';
 import { useMemo } from 'react';
@@ -112,7 +114,6 @@ function createColumnPaletteItem(colCount: number): Omit<PaletteItemType, "group
 
 const paletteGroupItemsRecord: Record<string, Omit<PaletteItemType, "group">[]> = {
   other: [
-    
     {
       uid: 'price',
       title: 'Crypto price',
@@ -503,6 +504,19 @@ export function useEditorItems() {
               dispatch,
               view,
             );
+          }) as PromisedCommand;
+        }),
+      },
+      {
+        uid: 'page',
+        title: 'Link to page',
+        icon: <DescriptionOutlinedIcon sx={{
+          fontSize: 16
+        }}/>,
+        description: 'Link to a new page',
+        editorExecuteCommand: (() => {
+          return (async (state, dispatch, view) => {
+            return renderSuggestionsTooltip(NestedPagePluginKey)(state, dispatch, view);
           }) as PromisedCommand;
         }),
       }

--- a/components/editor/@bangle.io/extensions/inline-command-palette/use-editor-items.tsx
+++ b/components/editor/@bangle.io/extensions/inline-command-palette/use-editor-items.tsx
@@ -490,7 +490,7 @@ export function useEditorItems() {
     Object.entries({...paletteGroupItemsRecord, other: [
       ...paletteGroupItemsRecord.other,
       {
-        uid: 'page',
+        uid: 'insert-page',
         title: 'Insert page',
         icon: <DescriptionOutlinedIcon sx={{
           fontSize: 16
@@ -508,7 +508,7 @@ export function useEditorItems() {
         }),
       },
       {
-        uid: 'page',
+        uid: 'link-to-page',
         title: 'Link to page',
         icon: <DescriptionOutlinedIcon sx={{
           fontSize: 16
@@ -516,7 +516,12 @@ export function useEditorItems() {
         description: 'Link to a new page',
         editorExecuteCommand: (() => {
           return (async (state, dispatch, view) => {
-            return renderSuggestionsTooltip(NestedPagePluginKey)(state, dispatch, view);
+            renderSuggestionsTooltip(NestedPagePluginKey)(state, dispatch, view);
+            return replaceSuggestionMarkWith(NestedPagePluginKey, '')(
+              state,
+              dispatch,
+              view
+            );
           }) as PromisedCommand;
         }),
       }

--- a/components/editor/@bangle.io/extensions/inline-command-palette/use-editor-items.tsx
+++ b/components/editor/@bangle.io/extensions/inline-command-palette/use-editor-items.tsx
@@ -517,7 +517,7 @@ export function useEditorItems() {
         editorExecuteCommand: (() => {
           return (async (state, dispatch, view) => {
             renderSuggestionsTooltip(NestedPagePluginKey)(state, dispatch, view);
-            return replaceSuggestionMarkWith(NestedPagePluginKey, '')(
+            return replaceSuggestionMarkWith(palettePluginKey, '')(
               state,
               dispatch,
               view

--- a/components/editor/CharmEditor.tsx
+++ b/components/editor/CharmEditor.tsx
@@ -35,7 +35,7 @@ import { CryptoPrice, cryptoPriceSpec } from './CryptoPrice';
 import EmojiSuggest, { emojiPlugins, emojiSpecs } from './EmojiSuggest';
 import InlinePalette, { inlinePalettePlugins, inlinePaletteSpecs } from './InlinePalette';
 import { Mention, mentionPlugins, mentionSpecs, MentionSuggest } from './Mention';
-import { NestedPage, nestedPageSpec } from './NestedPage';
+import { NestedPage, nestedPagePlugins, NestedPagesList, nestedPageSpec } from './NestedPage';
 import Placeholder from './Placeholder';
 import { Quote, quoteSpec } from './Quote';
 import ResizableIframe, { iframeSpec } from './ResizableIframe';
@@ -157,6 +157,11 @@ function CharmEditor (
             }
           }
         })
+      }),
+      nestedPagePlugins({
+        tooltipRenderOpts: {
+          placement: 'bottom'
+        }
       }),
       imagePlugins(),
       inlinePalettePlugins(),
@@ -347,6 +352,7 @@ function CharmEditor (
     >
       <FloatingMenu />
       <MentionSuggest />
+      <NestedPagesList />
       {EmojiSuggest}
       {InlinePalette}
       {children}

--- a/components/editor/Mention.tsx
+++ b/components/editor/Mention.tsx
@@ -7,6 +7,7 @@ import { Box, ClickAwayListener, Typography } from '@mui/material';
 import MenuItem from '@mui/material/MenuItem';
 import Avatar from 'components/common/Avatar';
 import * as suggestTooltip from 'components/editor/@bangle.dev/tooltip/suggest-tooltip';
+import { hideSuggestionsTooltip } from 'components/editor/@bangle.dev/tooltip/suggest-tooltip';
 import { useContributors } from 'hooks/useContributors';
 import useENSName from 'hooks/useENSName';
 import { getDisplayName } from 'lib/users';
@@ -161,26 +162,20 @@ export function MentionSuggest () {
 
   const theme = useTheme();
 
-  function closeTooltip () {
-    if (view.dispatch!) {
-      view.dispatch(
-        // Chain transactions together
-        view.state.tr.setMeta(suggestTooltipKey, { type: 'HIDE_TOOLTIP' }).setMeta('addToHistory', false)
-      );
-    }
-  }
-
   const onSelectMention = useCallback(
     (value: string, type: string) => {
       selectMention(mentionSuggestKey, value, type)(view.state, view.dispatch, view);
-      closeTooltip();
+      hideSuggestionsTooltip(suggestTooltipKey)(view.state, view.dispatch, view);
     },
     [view, mentionSuggestKey]
   );
 
   if (isVisible) {
     return createPortal(
-      <ClickAwayListener onClickAway={closeTooltip}>
+      <ClickAwayListener onClickAway={() => {
+        hideSuggestionsTooltip(suggestTooltipKey)(view.state, view.dispatch, view);
+      }}
+      >
         <Box>
           {contributors.map(contributor => (
             <MenuItem

--- a/components/editor/NestedPage.tsx
+++ b/components/editor/NestedPage.tsx
@@ -10,6 +10,7 @@ import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutl
 import LinkIcon from '@mui/icons-material/Link';
 import { Box, ClickAwayListener, ListItemIcon, Menu, MenuItem, Typography } from '@mui/material';
 import ActionsMenu from 'components/common/ActionsMenu';
+import { PageIcon, PageTitle } from 'components/common/page-layout/PageNavigation';
 import Snackbar from 'components/common/Snackbar';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import useNestedPage from 'hooks/useNestedPage';
@@ -158,17 +159,35 @@ export function NestedPagesList () {
       }}
       >
         <Box>
-          {pages.map(page => (
-            <MenuItem
-              sx={{
-                background: theme.palette.background.light
-              }}
-              onClick={() => onSelectPage(page)}
-              key={page.id}
-            >
-              <div>{page.title}</div>
-            </MenuItem>
-          ))}
+          {pages.map(page => {
+            const docContent = ((page?.content) as PageContent)?.content;
+            const isEditorEmpty = docContent && (docContent.length <= 1
+              && (!docContent[0] || (docContent[0] as PageContent)?.content?.length === 0));
+
+            return (
+              <MenuItem
+                sx={{
+                  background: theme.palette.background.light
+                }}
+                onClick={() => onSelectPage(page)}
+                key={page.id}
+              >
+                <>
+                  <div>
+                    {page.icon ?? <PageIcon isEditorEmpty={Boolean(isEditorEmpty)} pageType={page.type} />}
+                  </div>
+                  <PageTitle
+                    isempty={page.title.length === 0 ? 1 : 0}
+                    sx={{
+                      fontWeight: 'bold'
+                    }}
+                  >
+                    {page.title.length !== 0 ? page.title : 'Untitled'}
+                  </PageTitle>
+                </>
+              </MenuItem>
+            );
+          })}
         </Box>
       </ClickAwayListener>,
       tooltipContentDOM

--- a/components/editor/NestedPage.tsx
+++ b/components/editor/NestedPage.tsx
@@ -159,7 +159,7 @@ export function NestedPagesList () {
       }}
       >
         <Box>
-          {pages.map(page => {
+          {Object.values(pages).map(page => {
             const docContent = ((page?.content) as PageContent)?.content;
             const isEditorEmpty = docContent && (docContent.length <= 1
               && (!docContent[0] || (docContent[0] as PageContent)?.content?.length === 0));

--- a/components/editor/NestedPage.tsx
+++ b/components/editor/NestedPage.tsx
@@ -34,7 +34,7 @@ export function nestedPageSpec (): RawSpecs {
     type: 'node',
     name,
     schema: {
-      inline: true,
+      inline: false,
       attrs: {
         path: {
           default: null
@@ -44,7 +44,7 @@ export function nestedPageSpec (): RawSpecs {
           default: null
         }
       },
-      group: 'inline',
+      group: 'block',
       draggable: false,
       parseDOM: [{ tag: 'div' }],
       toDOM: (): DOMOutputSpec => {
@@ -149,7 +149,7 @@ export function NestedPagesList () {
       addNestedPage(page.id);
       hideSuggestionsTooltip(NestedPagePluginKey)(view.state, view.dispatch, view);
     },
-    [view, mentionSuggestKey]
+    [view]
   );
 
   if (isVisible) {
@@ -263,18 +263,24 @@ export function NestedPage ({ node, getPos, view }: NodeViewProps) {
             view.dispatch(view.state.tr.deleteSelection());
           }}
         >
-          <ListItemIcon><DeleteIcon fontSize='small' /></ListItemIcon>
+          <DeleteIcon
+            fontSize='small'
+            sx={{
+              mr: 1
+            }}
+          />
           <Typography sx={{ fontSize: 15, fontWeight: 600 }}>Delete</Typography>
         </MenuItem>
         <MenuItem
           sx={{ padding: '3px 12px' }}
           onClick={() => addNestedPage()}
         >
-          <ListItemIcon>
-            <ContentPasteIcon
-              fontSize='small'
-            />
-          </ListItemIcon>
+          <ContentPasteIcon
+            fontSize='small'
+            sx={{
+              mr: 1
+            }}
+          />
           <Typography sx={{ fontSize: 15, fontWeight: 600 }}>Duplicate</Typography>
         </MenuItem>
         <MenuItem
@@ -285,11 +291,12 @@ export function NestedPage ({ node, getPos, view }: NodeViewProps) {
             showMessage('Link copied');
           }}
         >
-          <ListItemIcon>
-            <LinkIcon
-              fontSize='small'
-            />
-          </ListItemIcon>
+          <LinkIcon
+            fontSize='small'
+            sx={{
+              mr: 1
+            }}
+          />
           <Typography sx={{ fontSize: 15, fontWeight: 600 }}>Copy Link</Typography>
         </MenuItem>
       </Menu>

--- a/hooks/useNestedPage.ts
+++ b/hooks/useNestedPage.ts
@@ -1,18 +1,26 @@
 import { Fragment } from '@bangle.dev/pm';
 import { useEditorViewContext } from '@bangle.dev/react';
 import { rafCommandExec } from '@bangle.dev/utils/pm-helpers';
+import { Page } from '@prisma/client';
 import { insertNode } from 'components/editor/@bangle.io/extensions/inline-command-palette/use-editor-items';
 import { useCallback } from 'react';
 import { usePages } from './usePages';
 
 export default function useNestedPage () {
-  const { currentPage, addPage } = usePages();
+  const { currentPage, addPage, pagesRecord } = usePages();
   const view = useEditorViewContext();
 
-  const addNestedPage = useCallback(async () => {
-    const page = await addPage({
-      parentId: currentPage?.id
-    });
+  const addNestedPage = useCallback(async (pageLink?: string) => {
+    let page: Page = null as any;
+    // Creating a new page
+    if (!pageLink) {
+      page = await addPage({
+        parentId: currentPage?.id
+      });
+    }
+    else {
+      page = pagesRecord[pageLink];
+    }
 
     rafCommandExec(view!, (state, dispatch) => {
       return insertNode(state, dispatch, state.schema.nodes.paragraph.create(

--- a/hooks/useNestedPage.ts
+++ b/hooks/useNestedPage.ts
@@ -10,16 +10,16 @@ export default function useNestedPage () {
   const { currentPage, addPage, pagesRecord } = usePages();
   const view = useEditorViewContext();
 
-  const addNestedPage = useCallback(async (pageLink?: string) => {
+  const addNestedPage = useCallback(async (pageId?: string) => {
     let page: Page = null as any;
     // Creating a new page
-    if (!pageLink) {
+    if (!pageId) {
       page = await addPage({
         parentId: currentPage?.id
       });
     }
     else {
-      page = pagesRecord[pageLink];
+      page = pagesRecord[pageId];
     }
 
     rafCommandExec(view!, (state, dispatch) => {

--- a/hooks/useNestedPage.ts
+++ b/hooks/useNestedPage.ts
@@ -6,7 +6,7 @@ import { useCallback } from 'react';
 import { usePages } from './usePages';
 
 export default function useNestedPage () {
-  const { currentPage, addPage, pagesRecord } = usePages();
+  const { currentPage, addPage, pages } = usePages();
   const view = useEditorViewContext();
 
   const addNestedPage = useCallback(async (pageId?: string) => {
@@ -18,7 +18,7 @@ export default function useNestedPage () {
       });
     }
     else {
-      page = pagesRecord[pageId];
+      page = pages[pageId];
     }
 
     rafCommandExec(view!, (state, dispatch) => {

--- a/hooks/useNestedPage.ts
+++ b/hooks/useNestedPage.ts
@@ -1,4 +1,3 @@
-import { Fragment } from '@bangle.dev/pm';
 import { useEditorViewContext } from '@bangle.dev/react';
 import { rafCommandExec } from '@bangle.dev/utils/pm-helpers';
 import { Page } from '@prisma/client';
@@ -23,15 +22,10 @@ export default function useNestedPage () {
     }
 
     rafCommandExec(view!, (state, dispatch) => {
-      return insertNode(state, dispatch, state.schema.nodes.paragraph.create(
-        undefined,
-        Fragment.fromArray([
-          state.schema.nodes.page.create({
-            path: page.path,
-            id: page.id
-          })
-        ])
-      ));
+      return insertNode(state, dispatch, state.schema.nodes.page.create({
+        path: page.path,
+        id: page.id
+      }));
     });
   }, [currentPage, addPage, view]);
 


### PR DESCRIPTION
1. Type `/` to view the `Link to Page` option
2. Click on the option to view a list of all pages in the workspace
3. Click on any of the pages to see it get embedded in the editor

I tried to implement @motechFR suggestion to allow navigation via arrow key and select page on pressing enter and was almost close to completing it, but just couldn't seem to get it working. I've added that to the backlog as that's quite important for UX