### PR TITLE
convert pages state to a map for performance

### DIFF
--- a/components/common/page-layout/PageNavigation.tsx
+++ b/components/common/page-layout/PageNavigation.tsx
@@ -163,11 +163,12 @@ interface PageLinkProps {
   href: string;
   label?: string;
   labelIcon?: React.ReactNode;
-  pageId?: string
+  boardId?: string;
+  pageId?: string;
 }
 
-export function PageLink ({ children, href, label, labelIcon, pageId }: PageLinkProps) {
-  const { currentPage, setCurrentPage, setPages } = usePages();
+export function PageLink ({ children, href, label, labelIcon, boardId, pageId }: PageLinkProps) {
+  const { setPages } = usePages();
   const isempty = !label;
 
   function stopPropagation (event: SyntheticEvent) {
@@ -200,33 +201,13 @@ export function PageLink ({ children, href, label, labelIcon, pageId }: PageLink
                 id: pageId,
                 icon: emoji
               });
-              let isCurrentPageEdited = false;
-              let boardId: null | string = null;
-              // Update the state
-              setPages((pages) => pages.map(page => {
-                if (page.id === pageId) {
-                  if (page.id === currentPage?.id) {
-                    isCurrentPageEdited = true;
-                  }
-
-                  if (page.boardId !== null) {
-                    boardId = page.boardId;
-                  }
-                  return {
-                    ...page,
-                    icon: emoji
-                  };
-                }
-                return page;
-              }));
-
-              if (currentPage && isCurrentPageEdited) {
-                setCurrentPage({
-                  ...currentPage,
+              setPages(_pages => ({
+                ..._pages,
+                [pageId]: {
+                  ..._pages[pageId],
                   icon: emoji
-                });
-              }
-
+                }
+              }));
               if (boardId) {
                 await mutator.changeIcon(boardId, emoji, emoji);
               }
@@ -251,7 +232,6 @@ const TreeItemComponent = React.forwardRef<React.Ref<HTMLDivElement>, TreeItemCo
 
 // eslint-disable-next-line react/function-component-definition
 const PageTreeItem = forwardRef((props: any, ref) => {
-  const { pages } = usePages();
   const theme = useTheme();
   const {
     addSubPage,
@@ -259,19 +239,14 @@ const PageTreeItem = forwardRef((props: any, ref) => {
     color,
     href,
     isAdjacent,
+    isEmptyContent,
     labelIcon,
     label,
+    boardId,
     pageType,
     pageId,
     ...other
   } = props;
-
-  const referencedPage = pages.find(_page => _page.id === pageId);
-
-  const docContent = ((referencedPage?.content) as PageContent)?.content;
-
-  const isEditorEmpty = docContent && (docContent.length <= 1
-  && (!docContent[0] || (docContent[0] as PageContent)?.content?.length === 0));
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
@@ -291,7 +266,7 @@ const PageTreeItem = forwardRef((props: any, ref) => {
     if (pageType === 'board') {
       Icon = (<StyledDatabaseIcon />);
     }
-    else if (isEditorEmpty) {
+    else if (isEmptyContent) {
       Icon = (
         <InsertDriveFileOutlinedIcon sx={{
           opacity: theme.palette.mode !== 'light' ? 0.5 : 1
@@ -317,7 +292,8 @@ const PageTreeItem = forwardRef((props: any, ref) => {
             href={href}
             label={label}
             labelIcon={Icon}
-            pageId={referencedPage?.id}
+            pageId={pageId}
+            boardId={boardId}
           >
             <div className='page-actions'>
               <IconButton size='small' onClick={showMenu}>
@@ -384,12 +360,11 @@ function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, a
   const ref = useRef<HTMLDivElement>(null);
   const theme = useTheme();
   const [isAdjacent, isAdjacentRef, setIsAdjacent] = useRefState(false);
-  const [{ handlerId, isDragging }, drag, dragPreview] = useDrag(() => ({
+  const [{ handlerId }, drag, dragPreview] = useDrag(() => ({
     type: 'item',
     item,
     collect: (monitor) => ({
-      handlerId: monitor.getHandlerId(),
-      isDragging: monitor.isDragging()
+      handlerId: monitor.getHandlerId()
     })
   }));
   const [{ canDrop, isOverCurrent }, drop] = useDrop(() => ({
@@ -464,9 +439,10 @@ function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, a
   }
 
   const { focalboardViewsRecord } = useFocalboardViews();
-  const { pagesRecord } = usePages();
 
-  const page = pagesRecord[item.id];
+  const docContent = (item.content as PageContent)?.content;
+  const isEmptyContent = docContent && (docContent.length <= 1
+    && (!docContent[0] || (docContent[0] as PageContent)?.content?.length === 0));
 
   return (
     <PageTreeItem
@@ -478,8 +454,10 @@ function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, a
       key={item.id}
       nodeId={item.id}
       label={item.title}
-      href={`${pathPrefix}/${item.path}${page.type === 'board' && page.boardId && focalboardViewsRecord[page.boardId] ? `?viewId=${focalboardViewsRecord[page.boardId]}` : ''}`}
+      href={`${pathPrefix}/${item.path}${item.type === 'board' && item.boardId && focalboardViewsRecord[item.boardId] ? `?viewId=${focalboardViewsRecord[item.boardId]}` : ''}`}
       isAdjacent={isAdjacentActive}
+      isEmptyContent={isEmptyContent}
+      boardId={item.boardId}
       labelIcon={item.icon || undefined}
       pageType={item.type as 'page'}
       sx={{
@@ -546,7 +524,7 @@ function mapTree (items: Page[], key: 'parentId', rootPageIds?: string[]): MenuN
 type TreeRootProps = {
   children: ReactNode,
   isFavorites?: boolean,
-  setPages: Dispatch<SetStateAction<Page[]>>
+  setPages: Dispatch<SetStateAction<Record<string, Page>>>
 } & ComponentProps<typeof TreeView>;
 
 function TreeRoot ({ children, setPages, isFavorites, ...rest }: TreeRootProps) {
@@ -557,15 +535,11 @@ function TreeRoot ({ children, setPages, isFavorites, ...rest }: TreeRootProps) 
       if (didDrop || !item.parentId) {
         return;
       }
-      setPages((stateNodes) => stateNodes.map((stateNode) => {
-        if (stateNode.id === item.id) {
-          return {
-            ...stateNode,
-            parentId: null
-          };
-        }
-        else {
-          return stateNode;
+      setPages(_pages => ({
+        ..._pages,
+        [item.id]: {
+          ..._pages[item.id],
+          parentId: null
         }
       }));
     },
@@ -604,7 +578,11 @@ export default function PageNavigation ({
 }: NavProps) {
   const { pages, currentPage, setPages, addPageAndRedirect } = usePages();
   const [expanded, setExpanded] = useLocalStorage<string[]>(`${space.id}.expanded-pages`, []);
-  const mappedItems = useMemo(() => mapTree(pages, 'parentId', rootPageIds), [pages, rootPageIds]);
+
+  const mappedItems = useMemo(() => {
+    const pagesArray = Object.keys(pages).map(pageId => pages[pageId]);
+    return mapTree(pagesArray, 'parentId', rootPageIds);
+  }, [pages, rootPageIds]);
 
   const onDropAdjacent = (droppedItem: MenuNode, containerItem: MenuNode) => {
 
@@ -614,7 +592,7 @@ export default function PageNavigation ({
     const parentId = containerItem.parentId;
     // console.log('onDropAdjacent:', droppedItem.title, 'to', containerItem.title);
     setPages(_pages => {
-      const siblings = _pages.filter((page) => page.parentId === parentId && page.id !== droppedItem.id);
+      const siblings = Object.values(_pages).filter((page) => page.parentId === parentId && page.id !== droppedItem.id);
       const originIndex = siblings.findIndex((page) => page.id === containerItem.id);
       siblings.splice(originIndex, 0, droppedItem);
       siblings.forEach((page, _index) => {
@@ -627,10 +605,9 @@ export default function PageNavigation ({
         });
       });
       siblings.forEach(page => {
-        const _pageIndex = _pages.findIndex(stateNode => stateNode.id === page.id);
-        if (_pageIndex > -1) {
-          _pages[_pageIndex] = {
-            ..._pages[_pageIndex],
+        if (_pages[page.id]) {
+          _pages[page.id] = {
+            ..._pages[page.id],
             index: page.index,
             parentId: page.parentId
           };
@@ -638,7 +615,7 @@ export default function PageNavigation ({
           // _page.parentId = parentId;
         }
       });
-      return [..._pages];
+      return { ..._pages };
     });
   };
 
@@ -655,34 +632,24 @@ export default function PageNavigation ({
       index, // send it to the end
       parentId
     });
-    setPages(stateNodes => {
-      return stateNodes.map(stateNode => {
-        if (stateNode.id === droppedItem.id) {
-          return {
-            ...stateNode,
-            index,
-            parentId
-          };
-        }
-        else {
-          return stateNode;
-        }
-      });
-    });
+    setPages(_pages => ({
+      ..._pages,
+      [droppedItem.id]: {
+        ..._pages[droppedItem.id],
+        index,
+        parentId
+      }
+    }));
   };
 
   useEffect(() => {
-    for (const page of pages) {
-      if (currentPage?.id === page.id) {
-        // expand the parent of the active page
-        if (!isFavorites && page.parentId) {
-          if (!expanded.includes(page.parentId)) {
-            setExpanded(expanded.concat(page.parentId));
-          }
-        }
+    // expand the parent of the active page
+    if (currentPage?.parentId && !isFavorites) {
+      if (!expanded.includes(currentPage.parentId)) {
+        setExpanded(expanded.concat(currentPage.parentId));
       }
     }
-  }, [currentPage]);
+  }, [currentPage, isFavorites]);
 
   function onNodeToggle (event: SyntheticEvent, nodeIds: string[]) {
     setExpanded(nodeIds);

--- a/components/common/page-layout/ShareButton.tsx
+++ b/components/common/page-layout/ShareButton.tsx
@@ -52,7 +52,13 @@ export default function ShareButton ({ headerHeight }: { headerHeight: number })
     const updatedPage = await charmClient.togglePagePublicAccess(currentPage!.id, !isPublic);
     setIsPublic(updatedPage.isPublic);
     const updates = { isPublic: updatedPage.isPublic };
-    setPages(pages => pages.map(p => p.id === currentPage!.id ? { ...p, ...updates } : p));
+    setPages(_pages => ({
+      ..._pages,
+      [currentPage!.id]: {
+        ..._pages[currentPage!.id],
+        ...updates
+      }
+    }));
   }
 
   async function updateShareLink () {

--- a/components/common/page-layout/Sidebar.tsx
+++ b/components/common/page-layout/Sidebar.tsx
@@ -196,16 +196,17 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
   }
 
   async function deletePage (pageId: string) {
-    const page = pages.find(p => p.id === pageId);
-    let newPages = pages.filter(p => p.id !== pageId);
+    const page = pages[pageId];
+    let newPages = { ...pages };
+    delete newPages[pageId];
     if (page) {
       await charmClient.deletePage(page.id);
-      if (pages.length === 1) {
+      if (Object.keys(newPages).length === 0) {
         const newPage = await charmClient.createPage(untitledPage({
           userId: user!.id,
           spaceId: space!.id
         }));
-        newPages = [newPage];
+        newPages = { [newPage.id]: newPage };
       }
     }
     setPages(newPages);
@@ -229,7 +230,7 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
     if (page && currentPage && page.id === currentPage.id) {
       let newPath = `/${space!.domain}`;
       if (currentPage.parentId) {
-        const parent = pages.find(p => p.id === currentPage.parentId);
+        const parent = pages[currentPage.parentId];
         if (parent) {
           newPath += `/${parent.path}`;
         }

--- a/components/editor/NestedPage.tsx
+++ b/components/editor/NestedPage.tsx
@@ -50,7 +50,7 @@ export function NestedPage ({ node, getPos, view }: NodeViewProps) {
   const { pages } = usePages();
   const { addNestedPage } = useNestedPage();
   const { message, handleClose, isOpen: isSnackbarOpen, showMessage } = useSnackbar();
-  const nestedPage = pages.find(page => page.id === node.attrs.id);
+  const nestedPage = pages[node.attrs.id];
   const popupState = usePopupState({ variant: 'popover', popupId: 'nested-page' });
 
   const docContent = ((nestedPage?.content) as PageContent)?.content;

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -12,32 +12,30 @@ import { useUser } from './useUser';
 type AddPageFn = (page?: Partial<Page>) => Promise<Page>;
 type IContext = {
   currentPage: Page | null,
-  pages: Page[],
+  pages: Record<string, Page>,
   setCurrentPage: Dispatch<SetStateAction<Page | null>>,
-  setPages: Dispatch<SetStateAction<Page[]>>,
+  setPages: Dispatch<SetStateAction<Record<string, Page>>>,
   isEditing: boolean
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>
   addPage: AddPageFn,
-  addPageAndRedirect: (page?: Partial<Page>) => void,
-  pagesRecord: Record<string, Page>
+  addPageAndRedirect: (page?: Partial<Page>) => void
 };
 
 export const PagesContext = createContext<Readonly<IContext>>({
   currentPage: null,
-  pages: [],
+  pages: {},
   setCurrentPage: () => undefined,
   setPages: () => undefined,
   isEditing: true,
   setIsEditing: () => { },
   addPage: null as any,
-  addPageAndRedirect: null as any,
-  pagesRecord: {}
+  addPageAndRedirect: null as any
 });
 
 export function PagesProvider ({ children }: { children: ReactNode }) {
   const [isEditing, setIsEditing] = useState(false);
   const [space] = useCurrentSpace();
-  const [pages, setPages] = useState<Page[]>([]);
+  const [pages, setPages] = useState<Record<string, Page>>({});
   const [currentPage, setCurrentPage] = useState<Page | null>(null);
   const router = useRouter();
   const intl = useIntl();
@@ -45,10 +43,14 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (space) {
-      setPages([]);
+      setPages({});
       charmClient.getPages(space.id)
         .then(_pages => {
-          setPages(sortArrayByObjectProperty(_pages, 'index'));
+          const state: { [key: string]: Page } = {};
+          for (const page of _pages) {
+            state[page.id] = page;
+          }
+          setPages(state);
         });
     }
   }, [space?.id]);
@@ -89,7 +91,7 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
       }, intl);
     }
     const newPage = await charmClient.createPage(pageProperties);
-    setPages([newPage, ...pages]);
+    setPages({ ...pages, [newPage.id]: newPage });
     return newPage;
   }, [intl, pages, space, user]);
 
@@ -97,14 +99,7 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
     const newPage = await addPage(page);
     router.push(`/${(space!).domain}/${newPage.path}`);
   };
-
-  const pagesRecord = useMemo(() => {
-    const _pagesRecord: Record<string, Page> = {};
-    pages.forEach(page => {
-      _pagesRecord[page.id] = page;
-    });
-    return _pagesRecord;
-  }, [pages]);
+  console.log('pages provider');
 
   const value: IContext = useMemo(() => ({
     currentPage,
@@ -114,8 +109,7 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
     setCurrentPage,
     setPages,
     addPage,
-    addPageAndRedirect,
-    pagesRecord
+    addPageAndRedirect
   }), [currentPage, isEditing, router, pages, user]);
 
   return (

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -99,7 +99,6 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
     const newPage = await addPage(page);
     router.push(`/${(space!).domain}/${newPage.path}`);
   };
-  console.log('pages provider');
 
   const value: IContext = useMemo(() => ({
     currentPage,


### PR DESCRIPTION
Editor is still a bit slow but we should try to avoid array loops in general. Should probably move the rest of our data state to maps, but I think this is the one we use most commonly and that could impact editor speed.

I think this turned out to be a good change because it reduced the amount of code we needed to update a single page in various places