### PR TITLE
more viewport meta tag to _app.tsx

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -250,6 +250,8 @@ export default function App ({ Component, pageProps }: AppPropsWithLayout) {
                             <title>
                               {title ? `${title} | CharmVerse` : 'CharmVerse - the all-in-one web3 workspace'}
                             </title>
+                            {/* viewport meta tag goes in _app.tsx - https://nextjs.org/docs/messages/no-document-viewport-meta */}
+                            <meta name='viewport' content='minimum-scale=1, initial-scale=1, width=device-width' />
                           </Head>
                         )}
                       </TitleContext.Consumer>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -13,7 +13,6 @@ class MyDocument extends Document {
           <meta name='theme-color' content={blueColor} />
           <link rel='icon' href='/favicon.png' />
           <meta name='description' content='The First Web 3 Native All-in-one Workspace' />
-          <meta name='viewport' content='minimum-scale=1, initial-scale=1, width=device-width' />
           <meta property='og:title' content='CharmVerse' />
           <meta property='og:image' content='https://app.charmverse.io/images/charmverse_logo_sm_black.png' />
           <meta property='twitter:title' content='CharmVerse' />


### PR DESCRIPTION
Fixes a warning when starting Next.js:
```
Warning: viewport meta tags should not be used in _document.js's <Head>. https://nextjs.org/docs/messages/no-document-viewport-meta
```