### PR TITLE
fix flash of login page on first load

### DIFF
--- a/components/common/base-layout/getLayout.tsx
+++ b/components/common/base-layout/getLayout.tsx
@@ -10,3 +10,15 @@ export default function getLayout (page: ReactElement) {
     </PageWrapper>
   );
 }
+
+/**
+ * Use as an alternative to getLayout when you need to control if the whole page should appear
+ */
+export function BaseLayout ({ children }: {children: ReactElement []}) {
+  return (
+    <PageWrapper>
+      <Header />
+      {children}
+    </PageWrapper>
+  );
+}

--- a/components/common/base-layout/getLayout.tsx
+++ b/components/common/base-layout/getLayout.tsx
@@ -10,15 +10,3 @@ export default function getLayout (page: ReactElement) {
     </PageWrapper>
   );
 }
-
-/**
- * Use as an alternative to getLayout when you need to control if the whole page should appear
- */
-export function BaseLayout ({ children }: {children: ReactElement []}) {
-  return (
-    <PageWrapper>
-      <Header />
-      {children}
-    </PageWrapper>
-  );
-}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useWeb3React } from '@web3-react/core';
 import { useRouter } from 'next/router';
 import getBaseLayout from 'components/common/base-layout/getLayout';
@@ -17,8 +17,9 @@ export default function LoginPage () {
   const [, setTitleState] = usePageTitle();
   const [user, setUser, isUserLoaded] = useUser();
   const [spaces, setSpaces, isSpacesLoaded] = useSpaces();
+  const [isLoaded, setIsLoaded] = useState(false); // capture isLoaded state to prevent render on route change
 
-  const isLoading = !triedEager || !isSpacesLoaded || !isUserLoaded;
+  const isDataLoaded = triedEager && isSpacesLoaded && isUserLoaded;
 
   useEffect(() => {
     setTitleState('Welcome');
@@ -27,24 +28,26 @@ export default function LoginPage () {
   useEffect(() => {
 
     // redirect user once wallet is connected
-    if (account) {
-      if (typeof router.query.returnUrl === 'string') {
-        router.push(router.query.returnUrl);
-      }
-      else if (!isLoading) {
-        console.log('spaces', isSpacesLoaded, spaces);
-        if (spaces.length > 0) {
+    if (isDataLoaded) {
+      // redirect once account exists (user has connected wallet)
+      if (account) {
+        if (typeof router.query.returnUrl === 'string') {
+          router.push(router.query.returnUrl);
+        }
+        else if (spaces.length > 0) {
           router.push(`/${spaces[0]!.domain}`);
         }
         else {
           router.push('/signup');
         }
       }
+      else {
+        setIsLoaded(true);
+      }
     }
+  }, [account, isDataLoaded]);
 
-  }, [account, isLoading]);
-
-  if (isLoading) {
+  if (!isLoaded) {
     return null;
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,7 +17,7 @@ export default function LoginPage () {
   const [, setTitleState] = usePageTitle();
   const [user, setUser, isUserLoaded] = useUser();
   const [spaces, setSpaces, isSpacesLoaded] = useSpaces();
-  const [isLoaded, setIsLoaded] = useState(false); // capture isLoaded state to prevent render on route change
+  const [showLogin, setShowLogin] = useState(false); // capture isLoaded state to prevent render on route change
 
   const isDataLoaded = triedEager && isSpacesLoaded && isUserLoaded;
 
@@ -42,12 +42,12 @@ export default function LoginPage () {
         }
       }
       else {
-        setIsLoaded(true);
+        setShowLogin(true);
       }
     }
   }, [account, isDataLoaded]);
 
-  if (!isLoaded) {
+  if (!showLogin) {
     return null;
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from 'react';
 import { useWeb3React } from '@web3-react/core';
 import { useRouter } from 'next/router';
-import getBaseLayout from 'components/common/base-layout/getLayout';
+import { BaseLayout } from 'components/common/base-layout/getLayout';
 import LoginPageContent from 'components/login/LoginPageContent';
 import { usePageTitle } from 'hooks/usePageTitle';
 import Footer from 'components/login/Footer';
@@ -52,11 +52,9 @@ export default function LoginPage () {
   }
 
   return (
-    <>
+    <BaseLayout>
       <LoginPageContent account={account} />
       <Footer />
-    </>
+    </BaseLayout>
   );
 }
-
-LoginPage.getLayout = getBaseLayout;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from 'react';
 import { useWeb3React } from '@web3-react/core';
 import { useRouter } from 'next/router';
-import { BaseLayout } from 'components/common/base-layout/getLayout';
+import getLayout from 'components/common/base-layout/getLayout';
 import LoginPageContent from 'components/login/LoginPageContent';
 import { usePageTitle } from 'hooks/usePageTitle';
 import Footer from 'components/login/Footer';
@@ -52,9 +52,11 @@ export default function LoginPage () {
   }
 
   return (
-    <BaseLayout>
-      <LoginPageContent account={account} />
-      <Footer />
-    </BaseLayout>
+    getLayout(
+      <>
+        <LoginPageContent account={account} />
+        <Footer />
+      </>
+    )
   );
 }


### PR DESCRIPTION
There's a flash of the login page when you go to https://app.charmverse directly, that's because the redirect inside `useEffect()` is happening after the component mounts. The fix is to rely on a different value to trigger the login view which is set in the useEffect method