### PR TITLE
check for image nodes in charmeditor

### DIFF
--- a/components/databases/focalboard/src/components/gallery/galleryCard.tsx
+++ b/components/databases/focalboard/src/components/gallery/galleryCard.tsx
@@ -80,7 +80,7 @@ const GalleryCard = React.memo((props: Props) => {
           }
           else if (item.type === 'image') {
             if (item.attrs?.src) {
-                galleryImageUrl = item.attrs?.src
+                galleryImageUrl = item.attrs.src
                 break;
               }
           }

--- a/components/databases/focalboard/src/components/gallery/galleryCard.tsx
+++ b/components/databases/focalboard/src/components/gallery/galleryCard.tsx
@@ -70,13 +70,19 @@ const GalleryCard = React.memo((props: Props) => {
         for (let index = 0; index < content.content.length; index++) {
           const item = content.content[index];
           if (item.type === "paragraph") {
-            const imageNode = item?.content?.[0]
+            const imageNode = item.content?.[0]
             if (imageNode?.type === "image") {
               if (imageNode.attrs?.src) {
                 galleryImageUrl = imageNode.attrs.src
                 break;
               }
             }
+          }
+          else if (item.type === 'image') {
+            if (item.attrs?.src) {
+                galleryImageUrl = item.attrs?.src
+                break;
+              }
           }
         }
       }


### PR DESCRIPTION
this is based on my own local example, the image node was not nested inside a paragraph node. not sure if this was what the original user was seeing though