### PR TITLE
Removed unnecessary snackbars

### DIFF
--- a/components/common/RouteGuard.tsx
+++ b/components/common/RouteGuard.tsx
@@ -8,6 +8,7 @@ import { useSpaces } from 'hooks/useSpaces';
 import { isSpaceDomain } from 'lib/spaces';
 import charmClient from 'charmClient';
 import type { UrlObject } from 'url';
+import { useSnackbar } from 'hooks/useSnackbar';
 
 // Pages shared to the public that don't require user login
 const publicPages = ['/', 'invite', 'share'];
@@ -24,7 +25,7 @@ export default function RouteGuard ({ children }: { children: ReactNode }) {
   const isWalletLoading = (!triedEager && !account);
   const isReactLoading = !router.isReady;
   const isLoading = isUserLoading || isWalletLoading || isReactLoading || !isSpacesLoaded;
-
+  const { setIsOpen } = useSnackbar();
   // console.log('isLoading', isLoading, { isReactLoading, isWalletLoading, isUserLoading, isSpacesLoaded });
 
   useEffect(() => {
@@ -49,7 +50,6 @@ export default function RouteGuard ({ children }: { children: ReactNode }) {
 
     // on route change start - hide page content by setting authorized to false
     const hideContent = () => {
-
       setAuthorized(false);
     };
     router.events.on('routeChangeStart', hideContent);

--- a/components/common/Snackbar.tsx
+++ b/components/common/Snackbar.tsx
@@ -2,25 +2,36 @@ import MuiAlert, { AlertColor, AlertProps } from '@mui/material/Alert';
 import Snackbar, { SnackbarProps } from '@mui/material/Snackbar';
 import Stack from '@mui/material/Stack';
 import { useSnackbar } from 'hooks/useSnackbar';
-import * as React from 'react';
+import { useRouter } from 'next/router';
+import { forwardRef, useEffect } from 'react';
 
-const Alert = React.forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
+const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
   return <MuiAlert elevation={6} ref={ref} variant='filled' {...props} />;
 });
 
 interface CustomizedSnackbarProps {
   autoHideDuration?: number
+  severity?: AlertColor,
+  message?: string,
+  handleClose?: SnackbarProps['onClose'],
+  isOpen?: boolean
 }
 
 export default function CustomizedSnackbar (props: CustomizedSnackbarProps) {
-  const { severity, message, handleClose, isOpen, showMessage } = useSnackbar();
+  const { setIsOpen, severity, message, handleClose, isOpen } = useSnackbar();
 
-  const { autoHideDuration = 5000 } = props;
+  // Close the snackbar if we change url
+  useEffect(() => {
+    setIsOpen(false);
+  }, [window.location.href]);
+
+  const { handleClose: handleCloseProp, isOpen: isOpenProp,
+    message: messageProp, severity: severityProp, autoHideDuration = 5000 } = props;
   return (
     <Stack spacing={2} sx={{ width: '100%' }}>
-      <Snackbar open={isOpen} autoHideDuration={autoHideDuration} onClose={handleClose}>
-        <Alert onClose={handleClose as any} severity={severity} sx={{ width: '100%' }}>
-          {message}
+      <Snackbar open={isOpenProp ?? isOpen} autoHideDuration={autoHideDuration} onClose={handleClose}>
+        <Alert onClose={handleCloseProp ?? handleClose as any} severity={severityProp ?? severity} sx={{ width: '100%' }}>
+          {messageProp ?? message}
         </Alert>
       </Snackbar>
     </Stack>

--- a/components/editor/FloatingMenu.tsx
+++ b/components/editor/FloatingMenu.tsx
@@ -17,43 +17,40 @@ export default function FloatingMenuComponent () {
   const { showMessage } = useSnackbar();
 
   return (
-    <>
-      <FloatingMenu
-        menuKey={menuKey}
-        renderMenuType={({ type }) => {
-          if (type === 'defaultMenu') {
-            return (
-              <Menu>
-                <MenuGroup>
-                  <BoldButton />
-                  <ItalicButton />
-                  <CodeButton />
-                  <StrikeButton />
-                  <UnderlineButton />
-                  <FloatingLinkButton menuKey={menuKey} />
-                </MenuGroup>
-                <MenuGroup isLastGroup>
-                  <ParagraphButton />
-                  <CalloutButton />
-                  <HeadingButton level={1} />
-                  <HeadingButton level={2} />
-                  <HeadingButton level={3} />
-                </MenuGroup>
-              </Menu>
-            );
-          }
-          if (type === 'linkSubMenu') {
-            return (
-              <Menu>
-                <LinkSubMenu showMessage={showMessage} />
-              </Menu>
-            );
-          }
-          return null;
-        }}
-      />
-      <Snackbar />
-    </>
+    <FloatingMenu
+      menuKey={menuKey}
+      renderMenuType={({ type }) => {
+        if (type === 'defaultMenu') {
+          return (
+            <Menu>
+              <MenuGroup>
+                <BoldButton />
+                <ItalicButton />
+                <CodeButton />
+                <StrikeButton />
+                <UnderlineButton />
+                <FloatingLinkButton menuKey={menuKey} />
+              </MenuGroup>
+              <MenuGroup isLastGroup>
+                <ParagraphButton />
+                <CalloutButton />
+                <HeadingButton level={1} />
+                <HeadingButton level={2} />
+                <HeadingButton level={3} />
+              </MenuGroup>
+            </Menu>
+          );
+        }
+        if (type === 'linkSubMenu') {
+          return (
+            <Menu>
+              <LinkSubMenu showMessage={showMessage} />
+            </Menu>
+          );
+        }
+        return null;
+      }}
+    />
   );
 }
 

--- a/components/editor/IFrameSelector.tsx
+++ b/components/editor/IFrameSelector.tsx
@@ -54,7 +54,6 @@ export default function IFrameSelector (props: IFrameSelectorProps) {
   )}
     >
       {children}
-      <Snackbar />
     </PopperPopup>
   );
 }

--- a/components/editor/ImageSelector.tsx
+++ b/components/editor/ImageSelector.tsx
@@ -78,7 +78,6 @@ export default function ImageSelector (props: ImageSelectorProps) {
   )}
     >
       {children}
-      <Snackbar />
     </PopperPopup>
   );
 }

--- a/components/editor/NestedPage.tsx
+++ b/components/editor/NestedPage.tsx
@@ -293,7 +293,6 @@ export function NestedPage ({ node, getPos, view }: NodeViewProps) {
           <Typography sx={{ fontSize: 15, fontWeight: 600 }}>Copy Link</Typography>
         </MenuItem>
       </Menu>
-      <Snackbar />
     </NestedPageContainer>
   );
 }

--- a/pages/[domain]/settings/workspace.tsx
+++ b/pages/[domain]/settings/workspace.tsx
@@ -55,8 +55,8 @@ export default function WorkspaceSettings () {
           setIsImportingFromNotion(false);
           showMessage('Successfully imported');
           mutate(`pages/${space.id}`);
-          showMessage('Notion workspace successfully imported');
           setNotionFailedImports(failedImports);
+          showMessage('Notion workspace successfully imported');
         })
         .catch((err) => {
           setIsImportingFromNotion(false);
@@ -192,7 +192,6 @@ export default function WorkspaceSettings () {
         </Alert>
         )}
       </Box>
-      <Snackbar />
     </>
   );
 }


### PR DESCRIPTION
1. Removed local `Snackbar` to opt for a single global `Snackbar`
2. Close the snackbar using `setIsOpen` as soon as we change route
3. Test the following places where we used local snackbars
	1. Select a text and see if the floating menu appears or not
	2. Select a text and click on link format, see if a new floating menu appears or not
	3. Iframe and image blocks
	4. Create a child page `Insert Page` and click the right-most icon (to delete, duplicate and copy link)
	5. Click on `Link to Page` and see if the dropdown appears or not