### PR TITLE
fix max width of introduction videos

### DIFF
--- a/seedData.ts
+++ b/seedData.ts
@@ -307,7 +307,7 @@ export function gettingStartedPageContent (): PageContent {
         type: 'iframe',
         attrs: {
           src: 'https://www.youtube.com/embed/LGgi6bFRRTw',
-          width: 800,
+          width: 700,
           height: 451.9774011299435,
           type: 'video'
         }
@@ -329,7 +329,7 @@ export function gettingStartedPageContent (): PageContent {
         type: 'iframe',
         attrs: {
           src: 'https://www.youtube.com/embed/sZjggbVYGMo',
-          width: 800,
+          width: 700,
           height: 451.9774011299435,
           type: 'video'
         }


### PR DESCRIPTION
Fixes this video being too wide:
![image](https://user-images.githubusercontent.com/305398/160546632-5fd53a83-d744-445a-86e8-acefc61ed050.png)
