### PR TITLE
Fixed parsing yt link with timestamp

### DIFF
--- a/components/common/CharmEditor/components/ResizableIframe.tsx
+++ b/components/common/CharmEditor/components/ResizableIframe.tsx
@@ -24,20 +24,33 @@ export const
 const name = 'iframe';
 
 export function extractEmbedLink (url: string) {
-  const isYoutubeLink = url.match(/(?:https:\/\/www.youtube.com\/watch\?v=(.*)|https:\/\/youtu.be\/(.*))/);
   const isIframeEmbed = url.startsWith('<iframe ');
   let embedUrl = url;
 
-  if (isYoutubeLink) {
-    /* eslint-disable-next-line */
-    embedUrl = `https://www.youtube.com/embed/${isYoutubeLink[1] ?? isYoutubeLink[2]}`;
+  const isRegularYTLink = url.includes('youtube');
+  const isSharedYTLink = url.includes('youtu.be');
+  if (isRegularYTLink || isSharedYTLink) {
+    const { pathname, search } = new URL(url);
+    const urlSearchParams = new URLSearchParams(search);
+    if (isRegularYTLink) {
+      embedUrl = `https://www.youtube.com/embed/${urlSearchParams.get('v')}`;
+    }
+    else if (isSharedYTLink) {
+      embedUrl = `https://www.youtube.com/embed${pathname}`;
+    }
+    if (urlSearchParams.has('t')) {
+      embedUrl += `?start=${urlSearchParams.get('t')}`;
+    }
   }
+
   else if (isIframeEmbed) {
     const indexOfSrc = url.indexOf('src');
     const indexOfFirstQuote = url.indexOf('"', indexOfSrc);
     const indexOfLastQuote = url.indexOf('"', indexOfFirstQuote + 1);
     embedUrl = url.slice(indexOfFirstQuote + 1, indexOfLastQuote);
   }
+
+  console.log(embedUrl);
 
   return embedUrl;
 }

--- a/components/common/CharmEditor/components/ResizableIframe.tsx
+++ b/components/common/CharmEditor/components/ResizableIframe.tsx
@@ -50,8 +50,6 @@ export function extractEmbedLink (url: string) {
     embedUrl = url.slice(indexOfFirstQuote + 1, indexOfLastQuote);
   }
 
-  console.log(embedUrl);
-
   return embedUrl;
 }
 


### PR DESCRIPTION
Youtube links (both regular and shared) failed to generate the embed link with timestamp. This PR fixed this [card](https://app.charmverse.io/charmverse/page-49366552253645923?cardId=a2bff99f-0595-4e0d-a71a-1bcda05ccb8a&viewId=d15c9b90-8918-44da-bbd8-db8712faa723)
