### PR TITLE
User roles UI

### DIFF
--- a/components/common/PageLayout/components/Account/Account.tsx
+++ b/components/common/PageLayout/components/Account/Account.tsx
@@ -19,6 +19,7 @@ import styled from '@emotion/styled';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { useRouter } from 'next/router';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import useClearParams from 'hooks/useClearParams';
 import charmClient from 'charmClient';
 
 const AccountCard = styled.div`
@@ -74,10 +75,9 @@ function Account (): JSX.Element {
 
   function postConnect () {
     setIsConnectDiscordLoading(false);
-    accountModalState.close();
     // Clean up the routes
     setTimeout(() => {
-      router.push(window.location.href.split('?')[0]);
+      router.replace(window.location.href.split('?')[0], undefined, { shallow: true });
     }, 2500);
   }
   // We might get redirected after connection with discord, so check the query param if it has a discord field
@@ -91,7 +91,6 @@ function Account (): JSX.Element {
         spaceId: space.id
       }).then(({ discordUser, username, avatar }) => {
         setUser({ ...user, username: username ?? user.username, avatar: avatar ?? user.avatar, discordUser });
-        showMessage('Successfully connected with discord', 'info');
         postConnect();
       }).catch((err) => {
         showMessage(err.error, 'error');

--- a/components/common/PageLayout/components/Account/Account.tsx
+++ b/components/common/PageLayout/components/Account/Account.tsx
@@ -19,7 +19,6 @@ import styled from '@emotion/styled';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { useRouter } from 'next/router';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import useClearParams from 'hooks/useClearParams';
 import charmClient from 'charmClient';
 
 const AccountCard = styled.div`

--- a/components/common/PageLayout/components/Account/components/AccountModal/AccountModal.tsx
+++ b/components/common/PageLayout/components/Account/components/AccountModal/AccountModal.tsx
@@ -13,8 +13,7 @@ import useENSName from 'hooks/useENSName';
 import charmClient from 'charmClient';
 import { useUser } from 'hooks/useUser';
 import styled from '@emotion/styled';
-import { CircularProgress } from '@mui/material';
-// import AccountConnections from './components/AccountConnections';
+import log from 'lib/log';
 
 const DiscordUserName = styled(Typography)`
   position: relative;
@@ -32,6 +31,8 @@ function AccountModal ({ isConnectDiscordLoading, isOpen, onClose }:
   const ENSName = useENSName(account);
   const [user, setUser] = useUser();
   const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const connectedWithDiscord = Boolean(user?.discordUser);
 
   const handleWalletProviderSwitch = () => {
     openWalletSelectorModal();
@@ -51,25 +52,20 @@ function AccountModal ({ isConnectDiscordLoading, isOpen, onClose }:
     }
   };
 
-  const connectedWithDiscord = Boolean(user?.discordUser);
+  async function connectDiscord () {
+    window.location.replace(`/api/discord/login?redirect=${encodeURIComponent(window.location.href.split('?')[0])}&type=connect`);
+  }
 
-  async function connectWithDiscord () {
-    if (!isConnectDiscordLoading) {
-      if (connectedWithDiscord) {
-        setIsDisconnecting(true);
-        try {
-          await charmClient.disconnectDiscord();
-          setUser({ ...user, discordUser: null });
-        }
-        catch (err) {
-          console.log('Error disconnecting from discord');
-        }
-        setIsDisconnecting(false);
-      }
-      else {
-        window.location.replace(`/api/discord/login?redirect=${encodeURIComponent(window.location.href.split('?')[0])}&type=connect`);
-      }
+  async function disconnectDiscord () {
+    setIsDisconnecting(true);
+    try {
+      await charmClient.disconnectDiscord();
+      setUser({ ...user, discordUser: null });
     }
+    catch (err) {
+      log.error('Error disconnecting from discord', err);
+    }
+    setIsDisconnecting(false);
   }
 
   return (
@@ -107,10 +103,8 @@ function AccountModal ({ isConnectDiscordLoading, isOpen, onClose }:
           variant={connectedWithDiscord ? 'contained' : 'outlined'}
           color={connectedWithDiscord ? 'error' : 'primary'}
           disabled={isDisconnecting || isConnectDiscordLoading}
-          onClick={connectWithDiscord}
-          endIcon={(
-            isConnectDiscordLoading && <CircularProgress size={20} />
-          )}
+          onClick={connectedWithDiscord ? disconnectDiscord : connectDiscord}
+          loading={isConnectDiscordLoading}
         >
           {connectedWithDiscord ? 'Disconnect' : 'Connect'}
         </StyledButton>

--- a/components/common/PageLayout/components/Account/components/AccountModal/AccountModal.tsx
+++ b/components/common/PageLayout/components/Account/components/AccountModal/AccountModal.tsx
@@ -100,7 +100,7 @@ function AccountModal ({ isConnectDiscordLoading, isOpen, onClose }:
         </Typography>
         <StyledButton
           size='small'
-          variant={connectedWithDiscord ? 'contained' : 'outlined'}
+          variant='outlined'
           color={connectedWithDiscord ? 'error' : 'primary'}
           disabled={isDisconnecting || isConnectDiscordLoading}
           onClick={connectedWithDiscord ? disconnectDiscord : connectDiscord}

--- a/components/settings/roles/components/RoleRow.tsx
+++ b/components/settings/roles/components/RoleRow.tsx
@@ -8,6 +8,7 @@ import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Menu from '@mui/material/Menu';
+import Chip from '@mui/material/Chip';
 import MenuItem from '@mui/material/MenuItem';
 import { ListSpaceRolesResponse } from 'charmClient';
 import Button from 'components/common/Button';
@@ -67,8 +68,8 @@ export default function RoleRow ({ role, assignRoles, unassignRole, deleteRole, 
     <Box mb={3}>
 
       <Box display='flex' justifyContent='space-between' alignItems='center'>
-        <Typography variant='h6'>
-          {role.name}
+        <Typography variant='h6' sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+          {role.name} {role.spaceRolesToRole.length > 0 && <Chip size='small' label={role.spaceRolesToRole.length} />}
         </Typography>
         <IconButton size='small' {...bindTrigger(menuState)}>
           <MoreHorizIcon />

--- a/components/settings/roles/components/RoleRow.tsx
+++ b/components/settings/roles/components/RoleRow.tsx
@@ -15,10 +15,10 @@ import { InputSearchContributorMultiple } from 'components/common/form/InputSear
 import Modal from 'components/common/Modal';
 import { bindMenu, bindPopover, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
 import { useState } from 'react';
-import useRoles from 'components/settings/roles/hooks/useRoles';
+import styled from '@emotion/styled';
+import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import RoleMemberRow from './RoleMemberRow';
 import RoleForm from './RoleForm';
-import ConfirmDeleteModal from '../../../common/Modal/ConfirmDeleteModal';
 
 interface RoleRowProps {
   role: ListSpaceRolesResponse
@@ -27,6 +27,12 @@ interface RoleRowProps {
   unassignRole: (roleId: string, userId: string) => void;
   refreshRoles: () => void
 }
+
+const ScrollableBox = styled.div<{ rows: number }>`
+  max-height: 300px; // about 5 rows * 60px
+  overflow: auto;
+  ${({ theme, rows }) => rows > 5 && `border-bottom: 1px solid ${theme.palette.divider}`};
+`;
 
 export default function RoleRow ({ role, assignRoles, unassignRole, deleteRole, refreshRoles }: RoleRowProps) {
 
@@ -60,18 +66,6 @@ export default function RoleRow ({ role, assignRoles, unassignRole, deleteRole, 
   return (
     <Box mb={3}>
 
-      <Modal {...bindPopover(popupState)} title='Add a role'>
-        <RoleForm
-          mode='edit'
-          role={role}
-          submitted={() => {
-            popupState.close();
-            refreshRoles();
-          }}
-        />
-
-      </Modal>
-
       <Box display='flex' justifyContent='space-between' alignItems='center'>
         <Typography variant='h6'>
           {role.name}
@@ -82,7 +76,9 @@ export default function RoleRow ({ role, assignRoles, unassignRole, deleteRole, 
       </Box>
       <Divider />
 
-      {contributors.map(contributor => <RoleMemberRow key={contributor.id} contributor={contributor} onRemove={removeMember} />)}
+      <ScrollableBox rows={contributors.length}>
+        {contributors.map(contributor => <RoleMemberRow key={contributor.id} contributor={contributor} onRemove={removeMember} />)}
+      </ScrollableBox>
 
       <Button onClick={showMembersPopup} variant='text' color='secondary'>+ Add members</Button>
 
@@ -115,6 +111,7 @@ export default function RoleRow ({ role, assignRoles, unassignRole, deleteRole, 
           <Typography sx={{ fontSize: 15, fontWeight: 600 }}>Delete</Typography>
         </MenuItem>
       </Menu>
+
       <Modal open={userPopupState.isOpen} onClose={userPopupState.close} title='Add members'>
         <Grid container direction='column' spacing={3}>
           <Grid item>
@@ -124,6 +121,17 @@ export default function RoleRow ({ role, assignRoles, unassignRole, deleteRole, 
             <Button onClick={addMembers}>Add</Button>
           </Grid>
         </Grid>
+      </Modal>
+
+      <Modal {...bindPopover(popupState)} title='Add a role'>
+        <RoleForm
+          mode='edit'
+          role={role}
+          submitted={() => {
+            popupState.close();
+            refreshRoles();
+          }}
+        />
       </Modal>
 
       <ConfirmDeleteModal


### PR DESCRIPTION
- limit the height of the list of members under roles to 5
- don't hide the modal immediately after connecting discord. I left in the 2.5 second timeout, but maybe we should just leave it alone. I tried unsuccessfully to remove query params in the URL without redrawing the whole page (and hiding the modal!)
- added member count to roles
- made the 'disconnect' button an outlined red. i think solid red looks pretty scary especially since we hide the modal automatically