### PR TITLE
Removed multiple prop from InputSearchContributor component

### DIFF
--- a/components/common/form/InputSearchContributor.tsx
+++ b/components/common/form/InputSearchContributor.tsx
@@ -18,7 +18,7 @@ function InputSearchContributorBase ({ defaultValue, ...props }: Partial<Compone
 
   const { cache } = useSWRConfig();
 
-  return (
+  return contributors.length !== 0 ? (
     <Autocomplete<Contributor>
       defaultValue={defaultContributor}
       loading={contributors.length === 0}
@@ -40,7 +40,7 @@ function InputSearchContributorBase ({ defaultValue, ...props }: Partial<Compone
       )}
       {...props}
     />
-  );
+  ) : null;
 }
 
 interface IInputSearchContributorProps {
@@ -55,7 +55,7 @@ export function InputSearchContributor (props: IInputSearchContributorProps) {
     }
   }
 
-  return <InputSearchContributorBase {...props} onChange={(e, value) => emitValue(value as Contributor)} multiple />;
+  return <InputSearchContributorBase {...props} onChange={(e, value) => emitValue(value as Contributor)} />;
 }
 
 interface IInputSearchContributorMultipleProps {


### PR DESCRIPTION
1. `multiple` prop was added to `InputSearchContributor`, which meant when we selected a value it was an array, and array's don't have `id` property.
2. We used to show the `Autocomplete` component even if the `contributors` list was empty. Initially it will be empty as its being fetched but once its fetched, the default values can be gathered, but by then MUI has already set the defaultValue (as undefined due to empty list) and changing it would trigger an error (MUI wont show the default value) as its being converted from an uncontrolled component (default value of undefined) to a controlled one (non undefined default value)