### PR TITLE
strip out fields from user profile when saving the session cookie

### DIFF
--- a/pages/api/discord/callback.ts
+++ b/pages/api/discord/callback.ts
@@ -25,7 +25,9 @@ handler.get(async (req, res) => {
   if (type === 'login') {
     try {
       const user = await loginByDiscord({ code: tempAuthCode, hostName: req.headers.host });
-      req.session.user = user;
+      // strip out large fields so we dont break the cookie
+      const { discordUser, spaceRoles, ...userData } = user;
+      req.session.user = userData;
     }
     catch (error) {
       log.warn('Error while connecting to Discord', error);

--- a/pages/api/profile/index.ts
+++ b/pages/api/profile/index.ts
@@ -40,7 +40,9 @@ async function createUser (req: NextApiRequest, res: NextApiResponse<LoggedInUse
   });
 
   if (user) {
-    req.session.user = user;
+    // strip out large fields so we dont break the cookie
+    const { discordUser, spaceRoles, ...userData } = user;
+    req.session.user = userData;
     await req.session.save();
     res.status(200).json(user);
   }

--- a/pages/api/session/login.ts
+++ b/pages/api/session/login.ts
@@ -37,7 +37,9 @@ async function login (req: NextApiRequest, res: NextApiResponse<LoggedInUser | {
     return res.status(401).send({ error: 'No user has been associated with this wallet address' });
   }
 
-  req.session.user = user;
+  // strip out large fields so we dont break the cookie
+  const { discordUser, spaceRoles, ...userData } = user;
+  req.session.user = userData;
   await req.session.save();
 
   return res.status(200).json(user);


### PR DESCRIPTION
Alex can't log in, i believe it's because his cookie is too large. I think it's because we are writing the whole discord user profile to the cookie. It looks like we only really need to save the userId to the sessino, but i'm going to wait till i have more time to do that