### PR TITLE
Show breadcrumb of pages on header

### DIFF
--- a/components/common/PageLayout/components/Header.tsx
+++ b/components/common/PageLayout/components/Header.tsx
@@ -158,7 +158,7 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
       }
     }
     return currentPageParentChain.reverse();
-  }, [pages]);
+  }, [pages, currentPage]);
 
   const isFavorite = currentPage && user?.favorites.some(({ pageId }) => pageId === currentPage.id);
 

--- a/components/common/PageLayout/components/Header.tsx
+++ b/components/common/PageLayout/components/Header.tsx
@@ -119,7 +119,7 @@ function PageBreadcrumbs ({ pages }: {pages: Page[]}) {
     id: '123'
   }, pages[pages.length - 2], pages[pages.length - 1]] : pages).map(page => ({
     title: page.title,
-    link: `/${router.query.domain}/${page.path}`,
+    link: page.path ? `/${router.query.domain}/${page.path}` : null,
     icon: page.icon,
     id: page.id
   }));
@@ -130,7 +130,7 @@ function PageBreadcrumbs ({ pages }: {pages: Page[]}) {
 export default function Header ({ open, openSidebar }: { open: boolean, openSidebar: () => void }) {
   const router = useRouter();
   const colorMode = useColorMode();
-  const { pages, linkedPages, currentPageId, isEditing } = usePages();
+  const { pages, currentPageId, isEditing } = usePages();
   const [user, setUser] = useUser();
   const theme = useTheme();
   const [pageMenuOpen, setPageMenuOpen] = useState(false);
@@ -141,13 +141,18 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
 
   const currentPageChain = useMemo(() => {
     const currentPageParentChain: Page[] = [];
-    let currentPageInChain: LinkedPage | null = linkedPages[currentPageId];
+    let currentPageInChain: Page | null | undefined = pages[currentPageId];
     while (currentPageInChain) {
       currentPageParentChain.push(currentPageInChain);
-      currentPageInChain = currentPageInChain.parent;
+      if (currentPageInChain.parentId) {
+        currentPageInChain = pages[currentPageInChain.parentId];
+      }
+      else {
+        currentPageInChain = null;
+      }
     }
     return currentPageParentChain.reverse();
-  }, [currentPage]);
+  }, [pages]);
 
   const isFavorite = currentPage && user?.favorites.some(({ pageId }) => pageId === currentPage.id);
 

--- a/components/common/PageLayout/components/Header.tsx
+++ b/components/common/PageLayout/components/Header.tsx
@@ -26,11 +26,10 @@ import charmClient from 'charmClient';
 import { charmEditorPlugins, specRegistry } from 'components/common/CharmEditor/CharmEditor';
 import { useColorMode } from 'context/color-mode';
 import { LinkedPage, usePages } from 'hooks/usePages';
-import { usePageTitle } from 'hooks/usePageTitle';
 import { useUser } from 'hooks/useUser';
 import { PageContent } from 'models';
 import { useRouter } from 'next/router';
-import { useMemo, useRef, useState } from 'react';
+import { Fragment, useMemo, useRef, useState } from 'react';
 import Account from './Account';
 import ShareButton from './ShareButton';
 import { StyledPageIcon } from './PageNavigation';
@@ -76,11 +75,13 @@ function PageBreadcrumbs ({ pages }: {pages: Page[]}) {
   const trailsInfo = (trimTrails ? [pages[0], {
     title: '...',
     path: null,
-    icon: null
+    icon: null,
+    id: '123'
   }, pages[pages.length - 2], pages[pages.length - 1]] : pages).map(page => ({
     title: page.title,
     path: page.path,
-    icon: page.icon
+    icon: page.icon,
+    id: page.id
   }));
 
   return (
@@ -89,21 +90,21 @@ function PageBreadcrumbs ({ pages }: {pages: Page[]}) {
         const trailTitle = trailInfo.title ?? 'Untitled';
         const pageDeco = (
           <Box display='flex'>
-            {trailInfo.icon && <StyledPageIcon icon={<span>{trailInfo.icon}</span>} />}
+            {trailInfo.icon && <StyledPageIcon icon={trailInfo.icon} />}
             {trailTitle}
           </Box>
         );
 
         return trailInfoIndex !== trailsInfo.length - 1 ? (
-          <>
+          <Fragment key={trailInfo.id}>
             {trailInfo.path ? (
               <Link href={`/${router.query.domain}/${trailInfo.path}`}>
                 {pageDeco}
               </Link>
             ) : <div>{pageDeco}</div>}
             <span>/</span>
-          </>
-        ) : <div>{pageDeco}</div>;
+          </Fragment>
+        ) : <div key={trailInfo.id}>{pageDeco}</div>;
       })}
     </Box>
   );
@@ -129,7 +130,7 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
       currentPageInChain = currentPageInChain.parent;
     }
     return currentPageParentChain.reverse();
-  }, [currentPageId]);
+  }, [currentPage]);
 
   const isFavorite = currentPage && user?.favorites.some(({ pageId }) => pageId === currentPage.id);
 

--- a/components/common/PageLayout/components/Header.tsx
+++ b/components/common/PageLayout/components/Header.tsx
@@ -33,6 +33,7 @@ import { useRouter } from 'next/router';
 import { useMemo, useRef, useState } from 'react';
 import Account from './Account';
 import ShareButton from './ShareButton';
+import { StyledPageIcon } from './PageNavigation';
 
 export const headerHeight = 56;
 
@@ -74,26 +75,36 @@ function PageBreadcrumbs ({ pages }: {pages: Page[]}) {
   const trimTrails = pages.length > 3;
   const trailsInfo = (trimTrails ? [pages[0], {
     title: '...',
-    path: null
+    path: null,
+    icon: null
   }, pages[pages.length - 2], pages[pages.length - 1]] : pages).map(page => ({
     title: page.title,
-    path: page.path
+    path: page.path,
+    icon: page.icon
   }));
 
   return (
     <Box gap={1} display='flex'>
-      {trailsInfo.map((trailInfo, trailInfoIndex) => (
-        trailInfoIndex !== trailsInfo.length - 1 ? (
+      {trailsInfo.map((trailInfo, trailInfoIndex) => {
+        const trailTitle = trailInfo.title ?? 'Untitled';
+        const pageDeco = (
+          <Box display='flex'>
+            {trailInfo.icon && <StyledPageIcon icon={<span>{trailInfo.icon}</span>} />}
+            {trailTitle}
+          </Box>
+        );
+
+        return trailInfoIndex !== trailsInfo.length - 1 ? (
           <>
             {trailInfo.path ? (
               <Link href={`/${router.query.domain}/${trailInfo.path}`}>
-                {trailInfo.title ?? 'Untitled'}
+                {pageDeco}
               </Link>
-            ) : <div>{trailInfo.title ?? 'Untitled'}</div>}
+            ) : <div>{pageDeco}</div>}
             <span>/</span>
           </>
-        ) : <div>{trailInfo.title ?? 'Untitled'}</div>
-      ))}
+        ) : <div>{pageDeco}</div>;
+      })}
     </Box>
   );
 }

--- a/components/common/PageLayout/components/Header.tsx
+++ b/components/common/PageLayout/components/Header.tsx
@@ -65,23 +65,28 @@ function BreadCrumbs ({ items }: {items: {
     <BreadCrumb>
       {items.map((item, itemIndex) => {
         const itemTitle = item.title ?? 'Untitled';
-        const pageDeco = (
+        const currentPageCrumb = (
           <Box display='flex'>
             {item.icon && <StyledPageIcon icon={item.icon} />}
             {itemTitle}
           </Box>
         );
 
-        return itemIndex !== items.length - 1 ? (
-          <Fragment key={item.id}>
-            {item.link ? (
-              <Link href={item.link}>
-                {pageDeco}
-              </Link>
-            ) : <div>{pageDeco}</div>}
-            <span className='breadcrumb-slash'>/</span>
-          </Fragment>
-        ) : <div key={item.id}>{pageDeco}</div>;
+        // Last item doesn't have any /
+        if (itemIndex !== items.length - 1) {
+          return (
+            <Fragment key={item.id}>
+              {item.link ? (
+                <Link href={item.link}>
+                  {currentPageCrumb}
+                </Link>
+              ) : <div>{currentPageCrumb}</div>}
+              <span className='breadcrumb-slash'>/</span>
+            </Fragment>
+          );
+        }
+
+        return <div key={item.id}>{currentPageCrumb}</div>;
       })}
     </BreadCrumb>
   );
@@ -112,19 +117,20 @@ function BountyBreadcrumbs () {
 function PageBreadcrumbs ({ pages }: {pages: Page[]}) {
   const router = useRouter();
   const trimTrails = pages.length > 3;
-  const breadcrumbItems = (trimTrails ? [pages[0], {
+  const collapsedCrumb = {
     title: '...',
     path: null,
     icon: null,
     id: '123'
-  }, pages[pages.length - 2], pages[pages.length - 1]] : pages).map(page => ({
+  };
+  const displayedCrumbs = (trimTrails ? [pages[0], collapsedCrumb, pages[pages.length - 2], pages[pages.length - 1]] : pages).map(page => ({
     title: page.title,
     link: page.path ? `/${router.query.domain}/${page.path}` : null,
     icon: page.icon,
     id: page.id
   }));
 
-  return <BreadCrumbs items={breadcrumbItems} />;
+  return <BreadCrumbs items={displayedCrumbs} />;
 }
 
 export default function Header ({ open, openSidebar }: { open: boolean, openSidebar: () => void }) {

--- a/components/common/PageLayout/components/Header.tsx
+++ b/components/common/PageLayout/components/Header.tsx
@@ -73,7 +73,7 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
   const router = useRouter();
   const colorMode = useColorMode();
   const [pageTitle] = usePageTitle();
-  const { pages, currentPageId, isEditing } = usePages();
+  const { pages, linkedPages, currentPageId, isEditing } = usePages();
   const [user, setUser] = useUser();
   const theme = useTheme();
   const [pageMenuOpen, setPageMenuOpen] = useState(false);
@@ -81,7 +81,6 @@ export default function Header ({ open, openSidebar }: { open: boolean, openSide
   const pageMenuAnchor = useRef();
 
   const currentPage = currentPageId && pages[currentPageId];
-
   const isFavorite = currentPage && user?.favorites.some(({ pageId }) => pageId === currentPage.id);
 
   const isPage = router.route.includes('pageId');

--- a/components/common/PageLayout/components/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation.tsx
@@ -525,6 +525,7 @@ function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, a
             label={view.title}
             href={`${pathPrefix}/${item.path}${item.type === 'board' ? `?viewId=${view.id}` : ''}`}
             id={view.id}
+            nodeId={view.id}
             pageType='view'
           />
       ))}

--- a/components/common/PageLayout/components/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation.tsx
@@ -126,7 +126,7 @@ const PageAnchor = styled.a`
   }
 `;
 
-const StyledPageIcon = styled(EmojiIcon)`
+export const StyledPageIcon = styled(EmojiIcon)`
   height: 24px;
   width: 24px;
   margin-right: 4px;

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -24,7 +24,6 @@ type IContext = {
   addPage: AddPageFn,
   addPageAndRedirect: (page?: Partial<Page>) => void
   getPagePermissions: (pageId: string) => IPagePermissionFlags,
-  linkedPages: Record<string, LinkedPage>
 };
 
 const refreshInterval = 1000 * 5 * 60; // 5 minutes
@@ -38,8 +37,7 @@ export const PagesContext = createContext<Readonly<IContext>>({
   setIsEditing: () => { },
   addPage: null as any,
   addPageAndRedirect: null as any,
-  getPagePermissions: () => new AllowedPagePermissions(),
-  linkedPages: {}
+  getPagePermissions: () => new AllowedPagePermissions()
 });
 
 export function PagesProvider ({ children }: { children: ReactNode }) {
@@ -55,39 +53,6 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
   useEffect(() => {
     setPages(data?.reduce((acc, page) => ({ ...acc, [page.id]: page }), {}) || {});
   }, [data]);
-
-  const linkedPages = useMemo(() => {
-    const _linkedPages: Record<string, LinkedPage> = {};
-    Object.values(pages as unknown as LinkedPage[]).forEach((page) => {
-      if (page) {
-        const linkedPage: LinkedPage = _linkedPages[page.id] ?? {
-          ...page,
-          children: []
-        };
-
-        // If parentId exists, it wont exist for root pages
-        if (linkedPage.parentId && pages[linkedPage.parentId]) {
-          const parentPage = _linkedPages[linkedPage.parentId] ?? {
-            ...pages[linkedPage.parentId]
-          };
-
-          if (!parentPage.children) {
-            parentPage.children = [];
-          }
-          parentPage.children.push(linkedPage);
-          linkedPage.parent = parentPage;
-          _linkedPages[linkedPage.parentId] = parentPage;
-        }
-        else {
-          linkedPage.parent = null;
-        }
-
-        _linkedPages[page.id] = linkedPage;
-      }
-    });
-
-    return _linkedPages;
-  }, [pages]);
 
   const addPage: AddPageFn = React.useCallback(async (page) => {
     const spaceId = space?.id;
@@ -186,8 +151,7 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
     setPages,
     addPage,
     addPageAndRedirect,
-    getPagePermissions,
-    linkedPages
+    getPagePermissions
   }), [currentPageId, isEditing, router, pages, user]);
 
   return (

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -12,7 +12,7 @@ import { useCurrentSpace } from './useCurrentSpace';
 import { useUser } from './useUser';
 import { IPagePermissionFlags, IPageWithPermissions, PageOperationType } from '../lib/permissions/pages/page-permission-interfaces';
 
-export type LinkedPage = (Page & {children: Page[], parent: null | Page});
+export type LinkedPage = (Page & {children: LinkedPage[], parent: null | LinkedPage});
 type AddPageFn = (page?: Partial<Page>) => Promise<Page>;
 type IContext = {
   currentPageId: string,

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -60,25 +60,29 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
     const _linkedPages: Record<string, LinkedPage> = {};
     Object.values(pages as unknown as LinkedPage[]).forEach((page) => {
       if (page) {
-        const updatedPage: LinkedPage = {
-          ...page
+        const linkedPage: LinkedPage = _linkedPages[page.id] ?? {
+          ...page,
+          children: []
         };
 
         // If parentId exists, it wont exist for root pages
-        if (updatedPage.parentId && pages[updatedPage.parentId]) {
-          const parentPage = _linkedPages[updatedPage.parentId] ?? {
-            ...pages[updatedPage.parentId]
+        if (linkedPage.parentId && pages[linkedPage.parentId]) {
+          const parentPage = _linkedPages[linkedPage.parentId] ?? {
+            ...pages[linkedPage.parentId]
           };
 
           if (!parentPage.children) {
             parentPage.children = [];
           }
-          parentPage.children.push(page);
-          updatedPage.parent = parentPage;
+          parentPage.children.push(linkedPage);
+          linkedPage.parent = parentPage;
+          _linkedPages[linkedPage.parentId] = parentPage;
+        }
+        else {
+          linkedPage.parent = null;
         }
 
-        updatedPage.children = [];
-        _linkedPages[page.id] = page;
+        _linkedPages[page.id] = linkedPage;
       }
     });
 


### PR DESCRIPTION
1. Each link is separated by a / (backslash)
2. If there are more than 3 links, just show the first, the one before the last and the last one (current page), the rest are shown via an ... (ellipsis)
3. Otherwise show all of them (for 1, 2, and 3 levels of nesting)
4. Each of the previous links can be navigated by clicking on them
5. We show the icon and title of each link and it kept up to date with the state
