### PR TITLE
fix error related to board page items in sidebar menu

### DIFF
--- a/components/common/PageLayout/components/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation.tsx
@@ -346,15 +346,24 @@ const PageTreeItem = forwardRef((props: any, ref) => {
   );
 });
 
-const BoardViewTreeItem = forwardRef((_props: any, ref) => {
+interface BoardViewTreeItemProps {
+  href: string;
+  label: string;
+  labelIcon: string;
+  boardId: string;
+  pageId: string;
+  nodeId: string;
+}
+
+const BoardViewTreeItem = forwardRef<HTMLDivElement, BoardViewTreeItemProps>((props, ref) => {
   const {
     href,
     label,
     labelIcon,
     boardId,
     pageId,
-    ...props
-  } = _props;
+    nodeId
+  } = props;
 
   return (
     <StyledTreeItem
@@ -367,10 +376,9 @@ const BoardViewTreeItem = forwardRef((_props: any, ref) => {
           boardId={boardId}
         />
       )}
-      ContentComponent={TreeItemComponent}
-      {...props}
-      TransitionProps={{ timeout: 50 }}
+      nodeId={nodeId}
       ref={ref}
+      TransitionProps={{ timeout: 50 }}
     />
   );
 });

--- a/components/common/PageLayout/components/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation.tsx
@@ -298,7 +298,6 @@ const PageTreeItem = forwardRef((props: any, ref) => {
       );
     }
   }
-  console.log(hasSelectedChildView);
 
   return (
     <>

--- a/components/common/PageLayout/components/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation.tsx
@@ -403,10 +403,10 @@ type NodeProps = {
   pathPrefix: string;
   addPage?: (p: Partial<Page>) => void;
   deletePage?: (id: string) => void;
-  selectedId: string | null;
+  selectedNodeId: string | null;
 }
 
-function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, addPage, deletePage, selectedId }: NodeProps) {
+function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, addPage, deletePage, selectedNodeId }: NodeProps) {
   const ref = useRef<HTMLDivElement>(null);
   const theme = useTheme();
   const [isAdjacent, isAdjacentRef, setIsAdjacent] = useRefState(false);
@@ -497,7 +497,7 @@ function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, a
   const viewsRecord = useAppSelector((state) => state.views.views);
   const views = Object.values(viewsRecord).filter(view => view.parentId === item.boardId);
 
-  const hasSelectedChildView = views.some(view => view.id === selectedId);
+  const hasSelectedChildView = views.some(view => view.id === selectedNodeId);
 
   return (
     <PageTreeItem
@@ -532,7 +532,7 @@ function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, a
               key={childItem.id}
               item={childItem}
               addPage={addPage}
-              selectedId={selectedId}
+              selectedNodeId={selectedNodeId}
               deletePage={deletePage}
             />
           ))
@@ -723,11 +723,11 @@ export default function PageNavigation ({
     setExpanded(nodeIds);
   }
 
-  let selectedId: string | null = null;
+  let selectedNodeId: string | null = null;
   if (currentPageId) {
-    selectedId = currentPageId;
+    selectedNodeId = currentPageId;
     if (typeof router.query.viewId === 'string') {
-      selectedId = router.query.viewId;
+      selectedNodeId = router.query.viewId;
     }
   }
 
@@ -736,7 +736,7 @@ export default function PageNavigation ({
       setPages={setPages}
       expanded={expanded}
       // @ts-ignore - we use null instead of undefined to control the element
-      selected={selectedId}
+      selected={selectedNodeId}
       onNodeToggle={onNodeToggle}
       aria-label='items navigator'
       defaultCollapseIcon={<ExpandMoreIcon fontSize='large' />}
@@ -756,7 +756,7 @@ export default function PageNavigation ({
           onDropAdjacent={onDropAdjacent}
           pathPrefix={`/${space.domain}`}
           // pass down so parent databases can highlight themselves
-          selectedId={selectedId}
+          selectedNodeId={selectedNodeId}
           addPage={page => addPageAndRedirect(page)}
           deletePage={deletePage}
         />

--- a/components/common/PageLayout/components/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation.tsx
@@ -34,6 +34,7 @@ import NewPageMenu, { StyledDatabaseIcon } from 'components/common/NewPageMenu';
 import EmojiIcon from 'components/common/Emoji';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import { iconForViewType } from 'components/common/BoardEditor/focalboard/src/components/viewMenu';
+import { IViewType } from 'components/common/BoardEditor/focalboard/src/blocks/boardView';
 import AddNewCard from './AddNewCard';
 // based off https://codesandbox.io/s/dawn-resonance-pgefk?file=/src/Demo.js
 
@@ -349,21 +350,19 @@ const PageTreeItem = forwardRef((props: any, ref) => {
 interface BoardViewTreeItemProps {
   href: string;
   label: string;
-  labelIcon: string;
-  boardId: string;
-  pageId: string;
   nodeId: string;
+  viewType: IViewType;
 }
 
 const BoardViewTreeItem = forwardRef<HTMLDivElement, BoardViewTreeItemProps>((props, ref) => {
   const {
     href,
     label,
-    labelIcon,
-    boardId,
-    pageId,
+    viewType,
     nodeId
   } = props;
+
+  const labelIcon = iconForViewType(viewType);
 
   return (
     <StyledTreeItem
@@ -372,8 +371,6 @@ const BoardViewTreeItem = forwardRef<HTMLDivElement, BoardViewTreeItemProps>((pr
           href={href}
           label={label}
           labelIcon={labelIcon}
-          pageId={pageId}
-          boardId={boardId}
         />
       )}
       nodeId={nodeId}
@@ -540,10 +537,10 @@ function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, a
       ) : views.map(view => (
         <BoardViewTreeItem
           key={view.id}
-          labelIcon={iconForViewType(view.fields.viewType)}
-          label={view.title}
           href={`${pathPrefix}/${item.path}?viewId=${view.id}`}
+          label={view.title}
           nodeId={view.id}
+          viewType={view.fields.viewType}
         />
       ))}
     </PageTreeItem>


### PR DESCRIPTION
- There was an error from MUI because we were not passing a 'nodeId' property to the TreeItem used for board views. I also split it into its own component from PageTreeItem because they don't really need to share the same code.
```
Warning: Failed prop type: The prop `nodeId` is marked as required in `ForwardRef(TreeItem)`, but its value is `undefined`
```
- Also: highlight the view row when you're on the page (see screenshot)
![image](https://user-images.githubusercontent.com/305398/161616954-e285a82f-946a-45a4-9f99-6dda171a31b0.png)
