### PR TITLE
fix: focalboard loses scroll position when opening a card

### DIFF
--- a/components/[pageId]/BoardPage/BoardPage.tsx
+++ b/components/[pageId]/BoardPage/BoardPage.tsx
@@ -1,7 +1,7 @@
 import { generatePath } from 'lib/utilities/strings';
 import { Page } from 'models';
 import { useRouter } from 'next/router';
-import { useMemo, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import CenterPanel from 'components/common/BoardEditor/focalboard/src/components/centerPanel';
 import { sendFlashMessage } from 'components/common/BoardEditor/focalboard/src/components/flashMessages';
@@ -118,9 +118,9 @@ export default function BoardPage ({ page, setPage, readonly }: Props) {
     // router.push({ pathname: newPath, query }, undefined, { scroll: false, shallow: true });
   }, [router.query.viewId]);
 
-  const viewsToProvide = useMemo(() => readonly ? boardViews.filter(view => {
+  const viewsToProvide = readonly ? boardViews.filter(view => {
     return view.id === activeView?.id;
-  }) : boardViews, [readonly, activeView, boardViews]);
+  }) : boardViews;
 
   if (board && activeView) {
     let property = groupByProperty;
@@ -155,7 +155,7 @@ export default function BoardPage ({ page, setPage, readonly }: Props) {
               activeView={activeView}
               views={viewsToProvide}
               cards={cards}
-              key={router.query.cardId}
+              key={shownCardId}
               cardId={shownCardId}
               onClose={() => showCard(undefined)}
               showCard={(cardId) => showCard(cardId)}

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -353,7 +353,7 @@ class CenterPanel extends React.PureComponent<Props, State> {
     }
 
     private showCard = (cardId?: string) => {
-            this.setState({selectedCardIds: []})
+        this.setState({selectedCardIds: []})
         this.props.showCard(cardId)
     }
 

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -23,10 +23,8 @@ import { updateView } from '../store/views'
 import { UserSettings } from '../userSettings'
 import { Utils } from '../utils'
 import CalendarFullView from './calendar/fullCalendar'
-import CardDialog from './cardDialog'
 import Gallery from './gallery/gallery'
 import Kanban from './kanban/kanban'
-import RootPortal from './rootPortal'
 import Table from './table/table'
 import ViewHeader from './viewHeader/viewHeader'
 import ViewTitle from './viewTitle'
@@ -45,7 +43,6 @@ type Props = {
     setPage: (p: Partial<Page>) => void
     updateView: (view: BoardView) => void
     addTemplate: (template: Card) => void
-    shownCardId?: string
     showCard: (cardId?: string) => void
     showShared: boolean
 }
@@ -55,7 +52,7 @@ type State = {
     cardIdToFocusOnRender: string
 }
 
-class CenterPanel extends React.Component<Props, State> {
+class CenterPanel extends React.PureComponent<Props, State> {
     private backgroundRef = React.createRef<HTMLDivElement>()
 
     private keydownHandler = (keyName: string, e: KeyboardEvent) => {
@@ -93,14 +90,10 @@ class CenterPanel extends React.Component<Props, State> {
 
     constructor(props: Props) {
         super(props)
-        this.state = {
-            selectedCardIds: [],
-            cardIdToFocusOnRender: '',
-        }
-    }
-
-    shouldComponentUpdate(): boolean {
-        return true
+            this.state = {
+                selectedCardIds: [],
+                cardIdToFocusOnRender: '',
+            }
     }
 
     componentDidUpdate(): void {
@@ -129,20 +122,6 @@ class CenterPanel extends React.Component<Props, State> {
                     keyName='ctrl+d,del,esc,backspace'
                     onKeyDown={this.keydownHandler}
                 />
-                {this.props.shownCardId &&
-                    <RootPortal>
-                        <CardDialog
-                            board={board}
-                            activeView={activeView}
-                            views={views}
-                            cards={cards}
-                            key={this.props.shownCardId}
-                            cardId={this.props.shownCardId}
-                            onClose={() => this.showCard(undefined)}
-                            showCard={(cardId) => this.showCard(cardId)}
-                            readonly={this.props.readonly}
-                        />
-                    </RootPortal>}
                 {board.fields.headerImage && <Box className='PageBanner' width={"100%"} mb={2}>
                   <PageBanner focalBoard headerImage={board.fields.headerImage} setPage={({ headerImage }) => {
                     this.setRandomHeaderImage(board, headerImage!)
@@ -374,7 +353,7 @@ class CenterPanel extends React.Component<Props, State> {
     }
 
     private showCard = (cardId?: string) => {
-        this.setState({selectedCardIds: []})
+            this.setState({selectedCardIds: []})
         this.props.showCard(cardId)
     }
 

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -103,3 +103,9 @@ function scrollIntoViewIfNeededPolyfill (
     element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }
 }
+
+// source: https://github.com/vercel/next.js/discussions/18072
+// update URL without Next.js re-rendering the page
+export function silentlyUpdateURL (newUrl: string) {
+  window.history.replaceState({ ...window.history.state, as: newUrl, url: newUrl }, '', newUrl);
+}

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -106,7 +106,7 @@ export default function BlocksEditorPage ({ publicShare = false }: IBlocksEditor
       setPagePermissions(permissions);
     }
   }, [user, currentPageId]);
-  console.log('rerender pageId');
+
   if (pageNotFound) {
     return <ErrorPage message={'Sorry, that page doesn\'t exist'} />;
   }

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -106,7 +106,7 @@ export default function BlocksEditorPage ({ publicShare = false }: IBlocksEditor
       setPagePermissions(permissions);
     }
   }, [user, currentPageId]);
-
+  console.log('rerender pageId');
   if (pageNotFound) {
     return <ErrorPage message={'Sorry, that page doesn\'t exist'} />;
   }


### PR DESCRIPTION
It turns out, when we change the URL parameter in Next.js, it re-mounts all the components which loses the scroll position. I finally found a mechanism to update the URL without Next.js knowing it, and instead of relying on router, we just update the visible card using useState.