### PR TITLE
Show pages and contributors list inside @ trigger

### DIFF
--- a/components/common/CharmEditor/components/Mention.tsx
+++ b/components/common/CharmEditor/components/Mention.tsx
@@ -181,6 +181,7 @@ export function MentionSuggest () {
     <>
       {contributors.map(contributor => (
         <MenuItem
+          component='div'
           sx={{
             background: theme.palette.background.light
           }}
@@ -201,7 +202,7 @@ export function MentionSuggest () {
 
   const pagesList = (
     <>
-      {Object.values(pages).slice(0, 10).map(page => page && (
+      {Object.values(pages).map(page => page && (
       <MenuItem
         sx={{
           background: theme.palette.background.light
@@ -236,7 +237,13 @@ export function MentionSuggest () {
         >
           {['Contributors', 'Pages'].map(sectionId => {
             return (
-              <li key={`section-${sectionId}`}>
+              <Box
+                key={`section-${sectionId}`}
+                sx={{
+                  // This is required to not show the background while scrolling
+                  backgroundColor: theme.palette.background.dark
+                }}
+              >
                 <ListSubheader>{sectionId}</ListSubheader>
                 {sectionId === 'Contributors' ? contributorsList : pagesList}
                 <hr style={{
@@ -245,7 +252,7 @@ export function MentionSuggest () {
                   marginBottom: 0
                 }}
                 />
-              </li>
+              </Box>
             );
           })}
         </List>

--- a/components/common/CharmEditor/components/Mention.tsx
+++ b/components/common/CharmEditor/components/Mention.tsx
@@ -305,7 +305,7 @@ export function Mention ({ node }: NodeViewProps) {
     );
   }
 
-  return value && (
+  return value ? (
     <Box
       component='span'
       sx={{
@@ -321,5 +321,5 @@ export function Mention ({ node }: NodeViewProps) {
     >
       {value}
     </Box>
-  );
+  ) : null;
 }

--- a/components/common/CharmEditor/components/Mention.tsx
+++ b/components/common/CharmEditor/components/Mention.tsx
@@ -183,7 +183,7 @@ export function MentionSuggest () {
         <MenuItem
           component='div'
           sx={{
-            background: theme.palette.background.light
+            background: theme.palette.background.dark
           }}
           onClick={() => onSelectMention(contributor.id, 'user')}
           key={contributor.id}
@@ -205,7 +205,7 @@ export function MentionSuggest () {
       {Object.values(pages).map(page => page && (
       <MenuItem
         sx={{
-          background: theme.palette.background.light
+          background: theme.palette.background.dark
         }}
         key={page.id}
         onClick={() => onSelectMention(page.id, 'page')}

--- a/components/common/CharmEditor/components/Resizable/HorizontalResizer.tsx
+++ b/components/common/CharmEditor/components/Resizable/HorizontalResizer.tsx
@@ -15,7 +15,6 @@ interface ResizerProps {
 
 function Resizer (props: ResizerProps) {
   const height = props.aspectRatio ? props.width / props.aspectRatio : 0;
-  console.log(props);
   return (
     <ResizableContainer>
       <ResizableBox

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -220,6 +220,15 @@ export const createThemeLightSensitive = (mode: PaletteMode) => {
           disableRipple: true
         }
       },
+      MuiDivider: {
+        styleOverrides: {
+          root: {
+            marginTop: 8,
+            height: 2,
+            marginBottom: 0
+          }
+        }
+      },
       MuiButtonGroup: {
         defaultProps: {
           disableRipple: true

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -220,15 +220,6 @@ export const createThemeLightSensitive = (mode: PaletteMode) => {
           disableRipple: true
         }
       },
-      MuiDivider: {
-        styleOverrides: {
-          root: {
-            marginTop: 8,
-            height: 2,
-            marginBottom: 0
-          }
-        }
-      },
       MuiButtonGroup: {
         defaultProps: {
           disableRipple: true


### PR DESCRIPTION
1. Show the contributors and pages of a workspace in separate sections
2. Link to a page inline
![image](https://user-images.githubusercontent.com/34683631/162579497-15c652cd-a45c-4961-8980-b27990a6c41d.png)

(Pages could be large so we might have to add support for [Virtualized List](https://mui.com/material-ui/react-list/#virtualized-list))