### PR TITLE
Fixed not being able to detect content emptyness

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -258,7 +258,7 @@ export function convertPageContentToMarkdown (content: PageContent, title?: stri
   return markdown;
 }
 
-export function checkForEmpty (content: PageContent) {
+export function checkForEmpty (content: PageContent | null) {
   return !content?.content
   || content.content.length === 0
   || (content.content.length === 1

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -260,12 +260,12 @@ export function convertPageContentToMarkdown (content: PageContent, title?: stri
 }
 
 function checkForEmpty (content: PageContent) {
-  return content === null || !content?.content
+  return !content?.content
   || content.content.length === 0
   || (content.content.length === 1
       // These nodes dont contain any content so there is no content field
       && !content.content[0]?.type.match(/(cryptoPrice|columnLayout|image|iframe|mention|page)/)
-      && !content.content[0].content?.length);
+      && (!content.content[0].content?.length));
 }
 
 function CharmEditor (
@@ -273,9 +273,10 @@ function CharmEditor (
 ) {
 
   // check empty state of page on first load
-  const _isEmpty = checkForEmpty(content);
+  const _isEmpty = checkForEmpty(defaultContent);
 
   const [isEmpty, setIsEmpty] = useState(_isEmpty);
+
   const onContentChangeDebounced = onContentChange ? debounce((view: EditorView) => {
     const doc = view.state.doc.toJSON() as PageContent;
     const rawText = view.state.doc.textContent as string;
@@ -284,8 +285,7 @@ function CharmEditor (
 
   function _onContentChange (view: EditorView) {
     // @ts-ignore missing types from the @bangle.dev/react package
-    setIsEmpty(checkForEmpty(view.state.doc as PageContent));
-    console.log({ content: view.state.doc.toJSON() });
+    setIsEmpty(checkForEmpty(view.state.doc.toJSON() as PageContent));
     if (onContentChangeDebounced) {
       onContentChangeDebounced(view);
     }

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -222,8 +222,7 @@ const defaultContent: PageContent = {
   type: 'doc',
   content: [
     {
-      type: 'paragraph',
-      content: []
+      type: 'paragraph'
     }
   ]
 };
@@ -259,7 +258,7 @@ export function convertPageContentToMarkdown (content: PageContent, title?: stri
   return markdown;
 }
 
-function checkForEmpty (content: PageContent) {
+export function checkForEmpty (content: PageContent) {
   return !content?.content
   || content.content.length === 0
   || (content.content.length === 1
@@ -273,7 +272,7 @@ function CharmEditor (
 ) {
 
   // check empty state of page on first load
-  const _isEmpty = checkForEmpty(defaultContent);
+  const _isEmpty = checkForEmpty(content);
 
   const [isEmpty, setIsEmpty] = useState(_isEmpty);
 

--- a/components/common/PageLayout/components/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation.tsx
@@ -35,6 +35,7 @@ import EmojiIcon from 'components/common/Emoji';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import { iconForViewType } from 'components/common/BoardEditor/focalboard/src/components/viewMenu';
 import { IViewType } from 'components/common/BoardEditor/focalboard/src/blocks/boardView';
+import { checkForEmpty } from 'components/common/CharmEditor/CharmEditor';
 import NewPageMenu, { StyledDatabaseIcon } from './NewPageMenu';
 import AddNewCard from './AddNewCard';
 // based off https://codesandbox.io/s/dawn-resonance-pgefk?file=/src/Demo.js
@@ -490,9 +491,7 @@ function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, a
 
   const { focalboardViewsRecord } = useFocalboardViews();
 
-  const docContent = (item.content as PageContent)?.content;
-  const isEmptyContent = docContent && (docContent.length <= 1
-    && (!docContent[0] || (docContent[0] as PageContent)?.content?.length === 0));
+  const isEmptyContent = checkForEmpty(item.content as PageContent);
 
   const viewsRecord = useAppSelector((state) => state.views.views);
   const views = Object.values(viewsRecord).filter(view => view.parentId === item.boardId);


### PR DESCRIPTION
We couldn't detect page content emptiness if there was a non-content node. See below (a page node). I encountered this while testing out the notion import
![image](https://user-images.githubusercontent.com/34683631/162628895-299ef405-7c5e-41f3-9182-4ff0fbc9542a.png)
1. Correctly detect content emptiness for non-content nodes (mention, pages, cryptoPrice and so on)
2. Show the correct icon in the sidebar if the page is empty (couldn't detect correctly earlier)

