### PR TITLE
Fixed discord import roles of same name

### DIFF
--- a/lib/discord/createRoles.ts
+++ b/lib/discord/createRoles.ts
@@ -1,6 +1,7 @@
 import { DiscordServerRole } from 'pages/api/discord/importRoles';
 import { prisma } from 'db';
 import { Role } from '@prisma/client';
+import log from 'lib/log';
 
 type RolesRecord = Record<string, { discord: DiscordServerRole, charmverse: Role | null }>;
 
@@ -11,6 +12,7 @@ export async function findOrCreateRolesFromDiscord (
   userId: string,
   createRoles?: boolean
 ): Promise<RolesRecord> {
+  let roleWithIssue : string | null = null;
   createRoles = createRoles ?? true;
   const rolesRecord: RolesRecord = {};
   // Create all of the discord roles fist
@@ -43,7 +45,7 @@ export async function findOrCreateRolesFromDiscord (
           });
         }
         catch (_) {
-          //
+          roleWithIssue = discordServerRole.name;
         }
       }
 
@@ -52,6 +54,9 @@ export async function findOrCreateRolesFromDiscord (
         charmverse: charmVerseRole
       };
     }
+  }
+  if (roleWithIssue) {
+    log.error(`Error creating role ${roleWithIssue}. Roles: ${discordServerRoles.map(discordServerRole => discordServerRole.name).join(',')}`);
   }
   return rolesRecord;
 }

--- a/lib/discord/createRoles.ts
+++ b/lib/discord/createRoles.ts
@@ -15,9 +15,8 @@ export async function findOrCreateRolesFromDiscord (
   const rolesRecord: RolesRecord = {};
   // Create all of the discord roles fist
   for (const discordServerRole of discordServerRoles) {
-    // Skip the @everyone role, this is assigned to all the members of the workspace
+    // Skip the @everyone role, this is assigned to all the members of the server
     if (discordServerRole.name !== '@everyone') {
-      let charmVerseRole: Role | null = null;
       // First check if a role with the same name already exist in the workspace
       const existingRole = await prisma.role.findFirst({
         where: {
@@ -26,22 +25,26 @@ export async function findOrCreateRolesFromDiscord (
         }
       });
 
+      let charmVerseRole = existingRole;
+
       // Only create the role if it doesn't already exist
       if (!existingRole && createRoles) {
-        charmVerseRole = await prisma.role.create({
-          data: {
-            name: discordServerRole.name,
-            space: {
-              connect: {
-                id: spaceId
-              }
-            },
-            createdBy: userId
-          }
-        });
-      }
-      else {
-        charmVerseRole = existingRole;
+        try {
+          charmVerseRole = await prisma.role.create({
+            data: {
+              name: discordServerRole.name,
+              space: {
+                connect: {
+                  id: spaceId
+                }
+              },
+              createdBy: userId
+            }
+          });
+        }
+        catch (_) {
+          //
+        }
       }
 
       rolesRecord[discordServerRole.id] = {


### PR DESCRIPTION
Not the best solution as I couldn't figure out how to reproduce it more than one time but it will stop breaking the whole import if one role can't be imported. I've also added log to let us know which role we failed to import and all the roles the user was trying to import.