### PR TITLE
fix emoji picker in charmeditor

### DIFF
--- a/components/common/CharmEditor/components/EmojiSuggest/EmojiSuggest.tsx
+++ b/components/common/CharmEditor/components/EmojiSuggest/EmojiSuggest.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@mui/material';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import { BaseEmoji, Picker } from 'emoji-mart';
 import { useCallback } from 'react';
-import { createPortal } from 'react-dom';
+import Portal from '@mui/material/Portal';
 import { selectEmoji } from './EmojiSuggest.plugin';
 
 export function EmojiSuggest ({
@@ -25,7 +25,7 @@ export function EmojiSuggest ({
   const theme = useTheme();
 
   function closeTooltip () {
-    if (view.dispatch!) {
+    if (view.dispatch) {
       view.dispatch(
         // Chain transactions together
         view.state.tr.setMeta(suggestTooltipKey, { type: 'HIDE_TOOLTIP' }).setMeta('addToHistory', false)
@@ -41,15 +41,16 @@ export function EmojiSuggest ({
     [view, emojiSuggestKey]
   );
 
-  return isVisible && createPortal(
+  return isVisible && (
     <ClickAwayListener onClickAway={closeTooltip}>
-      <Picker
-        theme={theme.palette.mode}
-        onSelect={(emoji: BaseEmoji) => {
-          onSelectEmoji(emoji.native);
-        }}
-      />
-    </ClickAwayListener>,
-    tooltipContentDOM
+      <Portal container={tooltipContentDOM}>
+        <Picker
+          theme={theme.palette.mode}
+          onSelect={(emoji: BaseEmoji) => {
+            onSelectEmoji(emoji.native);
+          }}
+        />
+      </Portal>
+    </ClickAwayListener>
   );
 }


### PR DESCRIPTION
this must have never worked since i added the clickawaylistener component? but apparently it's smart enough to not close when a child component is clicked. i had to use react's portal component as well