### PR TITLE
Shouldn't show picker for focalboard views

### DIFF
--- a/components/common/PageLayout/components/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation.tsx
@@ -164,9 +164,10 @@ interface PageLinkProps {
   labelIcon?: React.ReactNode;
   boardId?: string;
   pageId?: string;
+  showPicker?: boolean
 }
 
-export function PageLink ({ children, href, label, labelIcon, boardId, pageId }: PageLinkProps) {
+export function PageLink ({ showPicker = true, children, href, label, labelIcon, boardId, pageId }: PageLinkProps) {
   const { setPages } = usePages();
   const isempty = !label;
 
@@ -179,10 +180,12 @@ export function PageLink ({ children, href, label, labelIcon, boardId, pageId }:
     variant: 'popover'
   });
 
+  const triggerState = bindTrigger(popupState);
   return (
     <PageAnchor onClick={stopPropagation}>
       {labelIcon && (
-        <StyledPageIcon icon={labelIcon} {...bindTrigger(popupState)} />
+        // No need to show hover style if we are not showing the picker when the icon is clicked
+        <StyledPageIcon icon={labelIcon} {...triggerState} onClick={showPicker ? triggerState.onClick : undefined} />
       )}
       <Link passHref href={href}>
         <PageTitle isempty={isempty ? 1 : 0}>
@@ -190,6 +193,7 @@ export function PageLink ({ children, href, label, labelIcon, boardId, pageId }:
         </PageTitle>
       </Link>
       {children}
+      {showPicker && (
       <Menu {...bindMenu(popupState)}>
         <EmojiPicker onSelect={async (emoji) => {
           if (pageId) {
@@ -217,6 +221,7 @@ export function PageLink ({ children, href, label, labelIcon, boardId, pageId }:
         }}
         />
       </Menu>
+      )}
     </PageAnchor>
   );
 }
@@ -374,6 +379,7 @@ const BoardViewTreeItem = forwardRef<HTMLDivElement, BoardViewTreeItemProps>((pr
           href={href}
           label={label}
           labelIcon={labelIcon}
+          showPicker={false}
         />
       )}
       nodeId={nodeId}


### PR DESCRIPTION
We shouldn't be allowing the user to change the focalboard view icons since they are static. This is a misleading UX. This PR:-
1. Removes showing the picker for focalboard views
2. Removes the hover style to let the user know its not clickable (at least nothing will happen if they click it)
![image](https://user-images.githubusercontent.com/34683631/162957370-b42b5925-dc8e-4ccb-9817-0c8e8399c616.png)
