### PR TITLE
Reuse next.js builds in CI

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,22 @@
+
+name: "Build application"
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: "16"
+
+    - name: Cache build
+      id: cache_build
+      uses: actions/cache@v2
+      with:
+        path: .next
+        key: node-modules-${{ github.event.pull_request.head.sha }}
+
+    - name: Build
+      if: steps.cache_build.outputs.cache-hit != 'true'
+      run: npm run build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: actions/cache@v2
       with:
         path: .next
-        key: node-modules-${{ github.event.pull_request.head.sha }}
+        key: next-build-${{ github.event.pull_request.head.sha }}
 
     - name: Build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -4,11 +4,6 @@ name: "Build application"
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-node@v3
-      with:
-        node-version: "16"
 
     - name: Cache build
       id: cache_build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -18,5 +18,6 @@ runs:
         key: node-modules-${{ github.event.pull_request.head.sha }}
 
     - name: Build
+      shell: bash
       if: steps.cache_build.outputs.cache-hit != 'true'
       run: npm run build

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,13 +1,5 @@
 
-name: "Install and build application"
-
-# on:
-#   push:
-#     branches: [main]
-#   pull_request:
-#     branches: [main]
-# on:
-#   workflow_call:
+name: "Install dependencies"
 
 runs:
   using: 'composite'

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Install dependencies and build app
         uses: ./.github/actions/install
 
-      - name: Build
-        run: npm run build
+      - name: Build app
+        uses: ./.github/actions/build
 
       - name: Remove dev dependencies
         run: |

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Install dependencies and build app
         uses: ./.github/actions/install
 
-      - name: Build
-        run: npm run build
+      - name: Build app
+        uses: ./.github/actions/build
 
     # - name: Run Tests
     #   shell: 'script -q -e -c "bash {0}"' # add support for colors in output. see: https://github.com/actions/runner/issues/241
@@ -37,8 +37,8 @@ jobs:
       - name: Install dependencies and build app
         uses: ./.github/actions/install
 
-      - name: Build
-        run: npm run build
+      - name: Build app
+        uses: ./.github/actions/build
 
       - name: Remove dev dependencies
         run: |


### PR DESCRIPTION
we could probably be even more greedy by hashing all the ts, scss, etc. files but that could also backfire if we forget to include something in the cache key. for now, i tihnk this just will speed up deployment since the 'build' step fires after test