### PR TITLE
Fix notion cookies

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -124,8 +124,7 @@ export function getCookie (name: string): string {
 export function setCookie (name: string, value: string, expiresInDays: number = 10 * 365) {
   const expires = new Date();
   expires.setDate(expires.getDate() + expiresInDays);
-  const domainString = window.location.hostname === 'localhost' ? '' : 'domain=app.charmverse.io; ';
-  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires.toUTCString()}; ${domainString}path=/; SameSite=Lax; secure`;
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires.toUTCString()}; path=/; secure`;
 }
 
 export function deleteCookie (name: string) {

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -121,12 +121,12 @@ export function getCookie (name: string): string {
 }
 
 // cookies reference: https://developer.mozilla.org/en-US/docs/Web/API/document/cookie
-export function setCookie (name: string, value: string, expiresInDays: number = 10 * 365) {
+export function setCookie ({ name, value, expiresInDays = 10 * 365 }: { name: string, value: string, expiresInDays: number }) {
   const expires = new Date();
   expires.setDate(expires.getDate() + expiresInDays);
   document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires.toUTCString()}; path=/; secure`;
 }
 
 export function deleteCookie (name: string) {
-  setCookie(name, '', 0);
+  setCookie({ name, value: '', expiresInDays: 0 });
 }

--- a/lib/session/config.ts
+++ b/lib/session/config.ts
@@ -11,6 +11,7 @@ export const ironOptions = {
   password: process.env.AUTH_SECRET as string,
   // secure: true should be used in production (HTTPS) but can't be used in development (HTTP)
   cookieOptions: {
+    sameSite: 'strict',
     secure: typeof process.env.DOMAIN === 'string' && process.env.DOMAIN.includes('https')
   }
 };

--- a/lib/session/config.ts
+++ b/lib/session/config.ts
@@ -11,7 +11,7 @@ export const ironOptions = {
   password: process.env.AUTH_SECRET as string,
   // secure: true should be used in production (HTTPS) but can't be used in development (HTTP)
   cookieOptions: {
-    sameSite: 'strict',
+    sameSite: 'strict' as const,
     secure: typeof process.env.DOMAIN === 'string' && process.env.DOMAIN.includes('https')
   }
 };

--- a/pages/api/notion/callback.ts
+++ b/pages/api/notion/callback.ts
@@ -27,11 +27,11 @@ handler.get(async (req, res) => {
   const cookies = new Cookies(req, res);
 
   if (typeof tempAuthCode === 'string') {
-    cookies.set(AUTH_CODE_COOKIE, tempAuthCode, { httpOnly: false });
+    cookies.set(AUTH_CODE_COOKIE, tempAuthCode, { httpOnly: false, sameSite: 'strict' });
   }
   else {
     log.warn('Error importing from notion', req.query);
-    cookies.set(AUTH_ERROR_COOKIE, 'There was an error from Notion. Please try again', { httpOnly: false });
+    cookies.set(AUTH_ERROR_COOKIE, 'There was an error from Notion. Please try again', { httpOnly: false, sameSite: 'strict' });
   }
 
   res.redirect(redirect);


### PR DESCRIPTION
it wasn't working because code in the browser would set a domain on the cookie, but the cookies from the server dont have an explicit domain. I removed the setting of domain, we don't have a need for that now. It could be useful if we want to support cross-domain cookies