### PR TITLE
Delete card pages and card blocks when deleting board

### DIFF
--- a/components/common/PageLayout/components/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation.tsx
@@ -560,9 +560,7 @@ function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, a
 }
 
 function mapTree (items: Page[], key: 'parentId', rootPageIds?: string[]): MenuNode[] {
-  const pagesRecord: Record<string, Page> = {};
   const tempItems = items.map((item): MenuNode => {
-    pagesRecord[item.id] = item;
     return {
       ...item,
       children: []
@@ -585,7 +583,7 @@ function mapTree (items: Page[], key: 'parentId', rootPageIds?: string[]): MenuN
         sortArrayByObjectProperty(tempItems[index].children, 'index');
       }
     }
-    else if (!rootPageIds) {
+    else if (!rootPageIds && node.type !== 'card') {
       roots.push(node);
     }
     if (rootPageIds?.includes(node.id)) {

--- a/components/common/PageLayout/components/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation.tsx
@@ -583,7 +583,7 @@ function mapTree (items: Page[], key: 'parentId', rootPageIds?: string[]): MenuN
         sortArrayByObjectProperty(tempItems[index].children, 'index');
       }
     }
-    else if (!rootPageIds && node.type !== 'card') {
+    else if (!rootPageIds) {
       roots.push(node);
     }
     if (rootPageIds?.includes(node.id)) {

--- a/components/common/PageLayout/components/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar.tsx
@@ -33,6 +33,7 @@ import Link from 'components/common/Link';
 import { Modal } from 'components/common/Modal';
 import NewPageMenu from 'components/common/PageLayout/components/NewPageMenu';
 import WorkspaceAvatar from 'components/common/WorkspaceAvatar';
+import { getCards } from 'components/common/BoardEditor/focalboard/src/store/cards';
 import { headerHeight } from './Header';
 import PageNavigation from './PageNavigation';
 
@@ -169,6 +170,7 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
   const [space] = useCurrentSpace();
   const [spaces, setSpaces] = useSpaces();
   const boards = useAppSelector(getSortedBoards);
+  const cards = useAppSelector(getCards);
   const { currentPageId, pages, setPages, addPageAndRedirect } = usePages();
   const [spaceFormOpen, setSpaceFormOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
@@ -210,9 +212,11 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
         newPages = { [newPage.id]: newPage };
       }
     }
-    setPages(newPages);
     if (page?.boardId) {
       const board = boards.find(b => b.id === page.boardId);
+      const deletedCards = board ? Object.values(cards).filter(card => card.parentId === board.id) : [];
+      // Delete the page associated with the card
+      deletedCards.forEach(deletedCard => delete newPages[deletedCard.id]);
       if (board) {
         mutator.deleteBlock(
           board,
@@ -226,7 +230,7 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
         );
       }
     }
-
+    setPages(newPages);
     const currentPage = pages[currentPageId];
     // Redirect from current page
     if (page && currentPage && page.id === currentPage.id) {

--- a/pages/api/blocks/[id]/index.ts
+++ b/pages/api/blocks/[id]/index.ts
@@ -22,6 +22,7 @@ async function deleteBlock (req: NextApiRequest, res: NextApiResponse<Block>) {
       rootId: req.query.id as string
     }
   });
+
   return res.status(200).json(deleted);
 }
 

--- a/pages/api/blocks/[id]/index.ts
+++ b/pages/api/blocks/[id]/index.ts
@@ -1,7 +1,7 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
-import { Prisma, Block } from '@prisma/client';
+import { Block } from '@prisma/client';
 import { prisma } from 'db';
 import { onError, onNoMatch, requireUser } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
@@ -14,6 +14,12 @@ async function deleteBlock (req: NextApiRequest, res: NextApiResponse<Block>) {
   const deleted = await prisma.block.delete({
     where: {
       id: req.query.id as string
+    }
+  });
+
+  await prisma.block.deleteMany({
+    where: {
+      rootId: req.query.id as string
     }
   });
   return res.status(200).json(deleted);


### PR DESCRIPTION
Right now if we delete the focalboard page, all the card pages get moved to the root level of the navigation
![image](https://user-images.githubusercontent.com/34683631/163430435-cd8d89f4-24c8-4475-860b-40b5a459797b.png)
