### PR TITLE
Delete all child blocks of a block when deleting

### DIFF
--- a/pages/api/blocks/[id]/index.ts
+++ b/pages/api/blocks/[id]/index.ts
@@ -17,9 +17,36 @@ async function deleteBlock (req: NextApiRequest, res: NextApiResponse<Block>) {
     }
   });
 
+  const blockIds = (await prisma.block.findMany({
+    where: {
+      OR: [
+        {
+          rootId: req.query.id as string
+        },
+        {
+          parentId: req.query.id as string
+        }
+      ]
+    },
+    select: {
+      id: true
+    }
+  })).map(block => block.id);
+
   await prisma.block.deleteMany({
     where: {
-      rootId: req.query.id as string
+      OR: [
+        {
+          id: {
+            in: blockIds
+          }
+        },
+        {
+          parentId: {
+            in: blockIds
+          }
+        }
+      ]
     }
   });
 

--- a/pages/api/blocks/[id]/index.ts
+++ b/pages/api/blocks/[id]/index.ts
@@ -17,7 +17,7 @@ async function deleteBlock (req: NextApiRequest, res: NextApiResponse<Block>) {
     }
   });
 
-  const blockIds = (await prisma.block.findMany({
+  await prisma.block.deleteMany({
     where: {
       OR: [
         {
@@ -25,26 +25,6 @@ async function deleteBlock (req: NextApiRequest, res: NextApiResponse<Block>) {
         },
         {
           parentId: req.query.id as string
-        }
-      ]
-    },
-    select: {
-      id: true
-    }
-  })).map(block => block.id);
-
-  await prisma.block.deleteMany({
-    where: {
-      OR: [
-        {
-          id: {
-            in: blockIds
-          }
-        },
-        {
-          parentId: {
-            in: blockIds
-          }
         }
       ]
     }


### PR DESCRIPTION
Turns out we only deleted blocks via their rootId. This works only when we delete the whole board, but not when deleting a single card. If I delete a card now only the card page and card block get deleted, the charm_text and comment blocks associated with it still remain.

**Strategy**
1. Retrieve all the blocks whose `rootId` or `parentId` is the same as the deleted block id
2. Delete all the blocks whose id is from 1 or whose `parentId` is from 1