### PR TITLE
Optimize rendering of sidebar components

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/sidebar/sidebarAddBoardMenu.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/sidebar/sidebarAddBoardMenu.tsx
@@ -26,7 +26,7 @@ type Props = {
     activeBoardId?: string
 }
 
-export const addBoardClicked = async (showBoard: (id: string) => void, intl: IntlShape, activeBoardId?: string) => {
+export const addBoardClicked = async (showBoard: (id: string) => void, activeBoardId?: string) => {
     const oldBoardId = activeBoardId
     const board = createBoard({addDefaultProperty: true})
     board.rootId = board.id
@@ -35,7 +35,7 @@ export const addBoardClicked = async (showBoard: (id: string) => void, intl: Int
     view.fields.viewType = 'board'
     view.parentId = board.id
     view.rootId = board.rootId
-    view.title = intl.formatMessage({id: 'View.NewBoardTitle', defaultMessage: 'Board view'})
+    view.title = 'Board view'
 
     const blocks: Card[] = [];
 
@@ -48,7 +48,7 @@ export const addBoardClicked = async (showBoard: (id: string) => void, intl: Int
       view.fields.cardOrder.push(card.id)
       blocks.push(card)
     }
-    
+
     await mutator.insertBlocks(
         [board, view, ...blocks],
         'add board',
@@ -164,7 +164,7 @@ const SidebarAddBoardMenu = (props: Props): JSX.Element => {
                         id='empty-template'
                         name={intl.formatMessage({id: 'Sidebar.empty-board', defaultMessage: 'Empty board'})}
                         icon={<BoardIcon/>}
-                        onClick={() => addBoardClicked(showBoard, intl, props.activeBoardId)}
+                        onClick={() => addBoardClicked(showBoard, props.activeBoardId)}
                     />
 
                     <Menu.Text

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -35,7 +35,7 @@ import LayoutRow from './components/columnLayout/Row';
 import { CryptoPrice, cryptoPriceSpec } from './components/CryptoPrice';
 import EmojiSuggest, { plugins as emojiPlugins, specs as emojiSpecs } from './components/emojiSuggest';
 import InlinePalette, { plugins as inlinePalettePlugins, spec as inlinePaletteSpecs } from './components/inlinePalette';
-import { Mention, mentionPlugins, mentionSpecs, MentionSuggest } from './components/Mention';
+import MentionSuggest, { Mention, mentionPlugins, mentionSpecs } from './components/Mention';
 import NestedPage, { plugins as nestedPagePlugins, NestedPagesList, spec as nestedPageSpec } from './components/nestedPage';
 import Placeholder from './components/Placeholder';
 import Quote, * as quote from './components/quote';

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPagesList.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPagesList.tsx
@@ -1,29 +1,31 @@
 
 import { useEditorViewContext, usePluginState } from '@bangle.dev/react';
-import { useTheme } from '@emotion/react';
 import { MenuItem, ListItemIcon } from '@mui/material';
 import PageIcon from 'components/common/PageLayout/components/PageIcon';
 import PageTitle from 'components/common/PageLayout/components/PageTitle';
 import { usePages } from 'hooks/usePages';
 import { Page, PageContent } from 'models';
-import { useCallback } from 'react';
+import { useCallback, memo } from 'react';
 import { isTruthy } from 'lib/utilities/types';
 import useNestedPage from '../hooks/useNestedPage';
 import { hideSuggestionsTooltip } from '../../@bangle.dev/tooltip/suggest-tooltip';
 import { NestedPagePluginKey, NestedPagePluginState } from '../nestedPage';
 import PopoverMenu, { GroupLabel } from '../../PopoverMenu';
 
-export default function NestedPagesList () {
-  const { pages } = usePages();
+function NestedPagesList () {
+
   const { addNestedPage } = useNestedPage();
+
   const view = useEditorViewContext();
+
   const {
     tooltipContentDOM,
     show: isVisible
   } = usePluginState(NestedPagePluginKey) as NestedPagePluginState;
 
-  const theme = useTheme();
-
+  function onClose () {
+    hideSuggestionsTooltip(NestedPagePluginKey)(view.state, view.dispatch, view);
+  }
   const onSelectPage = useCallback(
     (page: Page) => {
       addNestedPage(page.id);
@@ -32,39 +34,45 @@ export default function NestedPagesList () {
     [view]
   );
 
-  function onClose () {
-    hideSuggestionsTooltip(NestedPagePluginKey)(view.state, view.dispatch, view);
-  }
-
   return (
     <PopoverMenu container={tooltipContentDOM} isOpen={isVisible} onClose={onClose} width={460}>
       <GroupLabel>Select a page</GroupLabel>
-      {Object.values(pages).filter(isTruthy).map(page => {
-        const docContent = ((page.content) as PageContent)?.content;
-        const isEditorEmpty = docContent && (docContent.length <= 1
-              && (!docContent[0] || (docContent[0] as PageContent)?.content?.length === 0));
-
-        return (
-          <MenuItem
-            onClick={() => onSelectPage(page)}
-            key={page.id}
-          >
-            <>
-              <ListItemIcon>
-                <PageIcon icon={page.icon} isEditorEmpty={Boolean(isEditorEmpty)} pageType={page.type} />
-              </ListItemIcon>
-              <PageTitle
-                hasContent={page.title.length === 0}
-                sx={{
-                  fontWeight: 'bold'
-                }}
-              >
-                {page.title.length !== 0 ? page.title : 'Untitled'}
-              </PageTitle>
-            </>
-          </MenuItem>
-        );
-      })}
+      {isVisible && <PagesList onSelectPage={onSelectPage} />}
     </PopoverMenu>
   );
 }
+
+function PagesList ({ onSelectPage }: { onSelectPage: (page: Page) => void }) {
+  const { pages } = usePages();
+
+  const items = Object.values(pages).filter(isTruthy).map(page => {
+    const docContent = ((page.content) as PageContent)?.content;
+    const isEditorEmpty = docContent && (docContent.length <= 1
+          && (!docContent[0] || (docContent[0] as PageContent)?.content?.length === 0));
+
+    return (
+      <MenuItem
+        onClick={() => onSelectPage(page)}
+        key={page.id}
+      >
+        <>
+          <ListItemIcon>
+            <PageIcon icon={page.icon} isEditorEmpty={Boolean(isEditorEmpty)} pageType={page.type} />
+          </ListItemIcon>
+          <PageTitle
+            hasContent={page.title.length === 0}
+            sx={{
+              fontWeight: 'bold'
+            }}
+          >
+            {page.title.length !== 0 ? page.title : 'Untitled'}
+          </PageTitle>
+        </>
+      </MenuItem>
+    );
+  });
+
+  return items;
+}
+
+export default memo(NestedPagesList);

--- a/components/common/CharmEditor/components/nestedPage/hooks/useNestedPage.ts
+++ b/components/common/CharmEditor/components/nestedPage/hooks/useNestedPage.ts
@@ -3,18 +3,27 @@ import { rafCommandExec } from '@bangle.dev/utils/pm-helpers';
 import { Page } from '@prisma/client';
 import { useCallback } from 'react';
 import { usePages } from 'hooks/usePages';
+import { addPage } from 'lib/pages';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import { useUser } from 'hooks/useUser';
 
 export default function useNestedPage () {
-  const { currentPageId, addPage, pages } = usePages();
+  const [space] = useCurrentSpace();
+  const [user] = useUser();
+  const { currentPageId, pages } = usePages();
   const view = useEditorViewContext();
 
   const addNestedPage = useCallback(async (pageId?: string) => {
     let page: Page | undefined;
     // Creating a new page
     if (!pageId) {
-      page = await addPage({
-        parentId: currentPageId
-      });
+      if (user && space) {
+        page = await addPage({
+          createdBy: user.id,
+          parentId: currentPageId,
+          spaceId: space.id
+        });
+      }
     }
     else {
       page = pages[pageId];

--- a/components/common/PageLayout/components/NewPageMenu.tsx
+++ b/components/common/PageLayout/components/NewPageMenu.tsx
@@ -8,7 +8,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { Page } from 'models';
-import { MouseEvent, useState } from 'react';
+import { MouseEvent, useState, memo } from 'react';
 import { greyColor2 } from 'theme/colors';
 import { StyledDatabaseIcon } from './PageIcon';
 
@@ -33,7 +33,7 @@ export const StyledArticleIcon = styled(ArticleIcon)`
 
 type Props = { addPage: (p: Partial<Page>) => void, tooltip: string, sx?: any };
 
-export default function NewPageMenu ({ addPage, tooltip, ...props }: Props) {
+function NewPageMenu ({ addPage, tooltip, ...props }: Props) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
@@ -73,3 +73,5 @@ export default function NewPageMenu ({ addPage, tooltip, ...props }: Props) {
     </>
   );
 }
+
+export default memo(NewPageMenu);

--- a/components/common/PageLayout/components/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar.tsx
@@ -13,7 +13,7 @@ import IconButton from '@mui/material/IconButton';
 import MuiLink from '@mui/material/Link';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { Prisma } from '@prisma/client';
+import { Page, Prisma } from '@prisma/client';
 import charmClient from 'charmClient';
 import mutator from 'components/common/BoardEditor/focalboard/src/mutator';
 import { getSortedBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
@@ -33,7 +33,7 @@ import Link from 'components/common/Link';
 import { Modal } from 'components/common/Modal';
 import NewPageMenu from 'components/common/PageLayout/components/NewPageMenu';
 import WorkspaceAvatar from 'components/common/WorkspaceAvatar';
-import { getCards } from 'components/common/BoardEditor/focalboard/src/store/cards';
+import { addPageAndRedirect, NewPageInput } from 'lib/pages';
 import { mutate } from 'swr';
 import { headerHeight } from './Header';
 import PageNavigation from './PageNavigation';
@@ -171,7 +171,7 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
   const [space] = useCurrentSpace();
   const [spaces, setSpaces] = useSpaces();
   const boards = useAppSelector(getSortedBoards);
-  const { currentPageId, pages, addPageAndRedirect } = usePages();
+  const { currentPageId, pages } = usePages();
   const [spaceFormOpen, setSpaceFormOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const favoritePageIds = favorites.map(f => f.pageId);
@@ -240,6 +240,17 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
     }
   }, [boards]);
 
+  const addPage = useCallback((_page: Partial<Page>) => {
+    if (user && space) {
+      const newPage: NewPageInput = {
+        ..._page,
+        createdBy: user.id,
+        spaceId: space.id
+      };
+      addPageAndRedirect(newPage, router);
+    }
+  }, []);
+
   return (
     <SidebarContainer>
       <WorkspacesContainer>
@@ -304,7 +315,7 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
                 WORKSPACE
               </SectionName>
               <div className='add-a-page'>
-                <NewPageMenu tooltip='Add a page' addPage={addPageAndRedirect} />
+                <NewPageMenu tooltip='Add a page' addPage={addPage} />
               </div>
             </WorkspaceLabel>
             <Box sx={{ mb: 6 }}>

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -90,10 +90,12 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
     return newPage;
   }, [intl, pages, space, user]);
 
-  const addPageAndRedirect = async (page?: Partial<Page>) => {
-    const newPage = await addPage(page);
-    router.push(`/${space?.domain}/${newPage.path}`);
-  };
+  const addPageAndRedirect = React.useCallback(async (page?: Partial<Page>) => {
+    if (page) {
+      const newPage = await addPage(page);
+      router.push(`/${space?.domain}/${newPage.path}`);
+    }
+  }, [addPage]);
 
   /**
    * Will return permissions for the currently connected user
@@ -135,7 +137,6 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
     });
 
     return computedPermissions;
-
   }
 
   const value: IContext = useMemo(() => ({

--- a/lib/pages/addPage.ts
+++ b/lib/pages/addPage.ts
@@ -1,0 +1,50 @@
+import { Page, Prisma } from '@prisma/client';
+import { mutate } from 'swr';
+import charmClient from 'charmClient';
+import { NextRouter } from 'next/router';
+import { addBoardClicked } from 'components/common/BoardEditor/focalboard/src/components/sidebar/sidebarAddBoardMenu';
+
+export type NewPageInput = Partial<Page> & { spaceId: string, createdBy: string };
+
+export async function addPage (page: NewPageInput): Promise<Page> {
+  const spaceId = page.spaceId;
+  const id = Math.random().toString().replace('0.', '');
+  const pageProperties: Prisma.PageCreateInput = {
+    content: undefined as any,
+    contentText: '',
+    createdAt: new Date(),
+    author: {
+      connect: {
+        id: page.createdBy
+      }
+    },
+    updatedAt: new Date(),
+    updatedBy: page.createdBy,
+    path: `page-${id}`,
+    space: {
+      connect: {
+        id: spaceId
+      }
+    },
+    title: '',
+    type: 'page',
+    ...(page ?? {})
+  };
+  if (pageProperties.type === 'board') {
+    await addBoardClicked(boardId => {
+      pageProperties.boardId = boardId;
+      pageProperties.id = boardId; // use the same uuid value
+    });
+  }
+  const newPage = await charmClient.createPage(pageProperties);
+  mutate(`pages/${page.spaceId}`);
+  return newPage;
+}
+
+export async function addPageAndRedirect (page: NewPageInput, router: NextRouter) {
+  if (page) {
+    const newPage = await addPage(page);
+    router.push(`/${router.query.domain}/${newPage.path}`);
+  }
+}
+

--- a/lib/pages/index.ts
+++ b/lib/pages/index.ts
@@ -1,0 +1,1 @@
+export * from './addPage';


### PR DESCRIPTION
Ideally we shouldn't need to update the sidebar at all while someone is typing on a page, but that's not possible today. I think it's another good reason to try and split the metadata/page tree from the actual page content..

3 major improvements made:
1) memoized a lot of the inputs to components in the sidebar
2) change nested page and mentions list to only render when they are actually open - this removes watchers on the pages context being triggered.