### PR TITLE
Fix focalboard modal CSS on mobile

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -19,10 +19,14 @@ export const Container = styled(Box)<{ top: number }>`
   width: 860px;
   max-width: 100%;
   margin: 0 auto ${({ top }) => top + 100}px;
-  padding: 0 80px;
   position: relative;
   top: ${({ top }) => top}px;
   padding-bottom: ${({ theme }) => theme.spacing(5)};
+
+  padding: 0 40px;
+  @media (min-width: 975px) {
+    padding: 0 80px;
+  }
 `;
 
 export interface IEditorProps {

--- a/components/common/BoardEditor/focalboard/src/components/dialog.scss
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.scss
@@ -9,8 +9,8 @@
     }
 
     .toolbar div[role="button"].MenuWrapper {
-      position: absolute;
-      right: 10px;
+        position: absolute;
+        right: 10px;
     }
 
     .wrapper {
@@ -19,6 +19,7 @@
         height: 100%;
         background-color: rgba(var(--center-channel-color-rgb), 0.5);
     }
+
     @media (prefers-color-scheme: dark) {
         .wrapper {
             background-color: rgba(15, 15, 15, 0.8);
@@ -38,55 +39,61 @@
         overflow-y: auto;
 
         width: fit-content;
-        min-width: 500px;
 
-        position: absolute;
-        transform: translate(-50%, -50%);
-        left: 50%;
-        top: 50%;
-        width: 100%;
-        max-height: 75%;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        margin: 72px auto;
+        max-width: 100%;
+
+        @media screen and (min-width: 975px) {
+            right: unset;
+            bottom: unset;
+            position: absolute;
+            transform: translate(-50%, -50%);
+            left: 50%;
+            top: 50%;
+            width: 100%;
+            margin: 0;
+            max-height: 75%;
+            min-width: 500px;
+            max-width: 975px;
+        }
 
         @media not screen and (max-width: 975px) {
-            max-width: 975px;
 
             .hideOnWidescreen {
                 /* Hide elements on larger screens */
                 display: none !important;
             }
         }
-        @media screen and (max-width: 975px) {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-        }
 
-        > * {
+        >* {
             flex-shrink: 0;
             overflow-x: hidden;
         }
 
-        > .banner {
+        >.banner {
             background-color: rgba(230, 220, 192, 0.9);
             text-align: center;
             padding: 10px;
             color: #222;
         }
 
-        > .banner.error {
+        >.banner.error {
             background-color: rgba(230, 192, 192, 0.9);
         }
 
-        > .toolbar {
+        >.toolbar {
             display: flex;
             flex-direction: row;
             padding: 16px;
             justify-content: space-between;
         }
 
-        > .content {
+        >.content {
             display: flex;
             flex-direction: column;
             align-items: flex-start;
@@ -94,12 +101,13 @@
             @media not screen and (max-width: 975px) {
                 padding: 10px 126px;
             }
+
             @media screen and (max-width: 975px) {
                 padding: 10px;
             }
         }
 
-        > .content.fullwidth {
+        >.content.fullwidth {
             padding: 10px 126px;
         }
     }

--- a/components/common/BoardEditor/focalboard/src/components/dialog.scss
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.scss
@@ -70,30 +70,30 @@
             }
         }
 
-        >* {
+        > * {
             flex-shrink: 0;
             overflow-x: hidden;
         }
 
-        >.banner {
+        > .banner {
             background-color: rgba(230, 220, 192, 0.9);
             text-align: center;
             padding: 10px;
             color: #222;
         }
 
-        >.banner.error {
+        > .banner.error {
             background-color: rgba(230, 192, 192, 0.9);
         }
 
-        >.toolbar {
+        > .toolbar {
             display: flex;
             flex-direction: row;
             padding: 16px;
             justify-content: space-between;
         }
 
-        >.content {
+        > .content {
             display: flex;
             flex-direction: column;
             align-items: flex-start;
@@ -107,7 +107,7 @@
             }
         }
 
-        >.content.fullwidth {
+        > .content.fullwidth {
             padding: 10px 126px;
         }
     }


### PR DESCRIPTION
it now stretches across the page < 975px: 

![image](https://user-images.githubusercontent.com/305398/165255522-03dad5d3-8fdf-4fb4-a09d-8e707f239749.png)
