### PR TITLE
fix scrolling in focalboard cards

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetail.scss
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetail.scss
@@ -1,5 +1,4 @@
 .CardDetail {
-    overflow-x: hidden;
     
     .title {
         width: 100%;


### PR DESCRIPTION
This fixes a bug: https://app.charmverse.io/charmverse/page-49366552253645923?cardId=370458ce-83d1-4f52-aeb5-2fb06d2ba257&viewId=d15c9b90-8918-44da-bbd8-db8712faa723.

