### PR TITLE
add some padding around properties on kanban cards

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.scss
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.scss
@@ -50,6 +50,10 @@
             padding: 0;
             margin: 0;
         }
+    
+        &:empty {
+          display: none;
+        }
     }
 
     .octo-icontitle {

--- a/components/common/BoardEditor/focalboard/src/styles/main.scss
+++ b/components/common/BoardEditor/focalboard/src/styles/main.scss
@@ -125,9 +125,14 @@ html {
   .octo-propertyvalue {
     font-size: 12px;
     color: rgb(var(--center-channel-color-rgb));
+    margin: 2px 0;
 
     &.empty {
       color: rgba(var(--center-channel-color-rgb), 0.4);
+    }
+
+    &:empty {
+      display: none;
     }
 
     .IconButton.delete-value {

--- a/components/common/BoardEditor/focalboard/src/styles/main.scss
+++ b/components/common/BoardEditor/focalboard/src/styles/main.scss
@@ -125,14 +125,9 @@ html {
   .octo-propertyvalue {
     font-size: 12px;
     color: rgb(var(--center-channel-color-rgb));
-    margin: 2px 0;
 
     &.empty {
       color: rgba(var(--center-channel-color-rgb), 0.4);
-    }
-
-    &:empty {
-      display: none;
     }
 
     .IconButton.delete-value {

--- a/theme/focalboard/focalboard.main.scss
+++ b/theme/focalboard/focalboard.main.scss
@@ -112,6 +112,7 @@ html {
   .octo-propertyvalue {
     font-size: 12px;
     color: rgb(var(--center-channel-color-rgb));
+    margin: 2px 0;
 
     &.empty {
       color: rgba(var(--center-channel-color-rgb), 0.4);


### PR DESCRIPTION
Bug fix: https://app.charmverse.io/charmverse/page-49366552253645923?cardId=bf1e756c-99cc-4dab-bac4-478b87cfd6e8&viewId=d15c9b90-8918-44da-bbd8-db8712faa723

Now:
![image](https://user-images.githubusercontent.com/305398/165262476-8537c0aa-094d-4de3-90f9-ed6043dc77cb.png)
