### PR TITLE
more optimizations

### DIFF
--- a/components/[pageId]/BoardPage/BoardPage.tsx
+++ b/components/[pageId]/BoardPage/BoardPage.tsx
@@ -41,7 +41,7 @@ export default function BoardPage ({ page, setPage, readonly }: Props) {
   const dispatch = useAppDispatch();
   const [shownCardId, setShownCardId] = useState(router.query.cardId);
   const { pages } = usePages();
-  const accessibleCards = useMemo(() => cards.filter(card => pages[card.id]), [Object.keys(pages).toString()]);
+  const accessibleCards = useMemo(() => cards.filter(card => pages[card.id]), [cards, Object.keys(pages).toString()]);
 
   useEffect(() => {
     const boardId = page.boardId!;

--- a/components/[pageId]/BoardPage/BoardPage.tsx
+++ b/components/[pageId]/BoardPage/BoardPage.tsx
@@ -1,7 +1,7 @@
 import { generatePath } from 'lib/utilities/strings';
 import { Page } from 'models';
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import CenterPanel from 'components/common/BoardEditor/focalboard/src/components/centerPanel';
 import { sendFlashMessage } from 'components/common/BoardEditor/focalboard/src/components/flashMessages';
@@ -41,7 +41,7 @@ export default function BoardPage ({ page, setPage, readonly }: Props) {
   const dispatch = useAppDispatch();
   const [shownCardId, setShownCardId] = useState(router.query.cardId);
   const { pages } = usePages();
-  const accessibleCards = cards.filter(card => pages[card.id]);
+  const accessibleCards = useMemo(() => cards.filter(card => pages[card.id]), [Object.keys(pages).toString()]);
 
   useEffect(() => {
     const boardId = page.boardId!;

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -4,8 +4,6 @@
 import { Box } from '@mui/system'
 import PageBanner, { randomBannerImage } from 'components/[pageId]/DocumentPage/components/PageBanner'
 import { useCurrentSpace } from 'hooks/useCurrentSpace'
-import { usePages } from 'hooks/usePages'
-import { randomIntFromInterval } from 'lib/utilities/random'
 import { Page } from 'models'
 import React, { useState } from 'react'
 import Hotkeys from 'react-hot-keys'
@@ -60,7 +58,6 @@ function CenterPanel(props: Props) {
     selectedCardIds: []
   })
 
-  const { pages } = usePages()
   const [space] = useCurrentSpace()
 
   const backgroundRef = React.createRef<HTMLDivElement>()
@@ -83,13 +80,6 @@ function CenterPanel(props: Props) {
         e.stopPropagation()
       }
 
-      // TODO: Might need a different hotkey, as Cmd+D is save bookmark on Chrome
-      if (keyName === 'ctrl+d') {
-        // CTRL+D: Duplicate selected cards
-        duplicateSelectedCards()
-        e.stopPropagation()
-        e.preventDefault()
-      }
     }
   }
 
@@ -106,31 +96,31 @@ function CenterPanel(props: Props) {
     }
   }
 
-  const addCardFromTemplate = async (cardTemplateId: string) => {
-    const { activeView, board } = props
+  // const addCardFromTemplate = async (cardTemplateId: string) => {
+  //   const { activeView, board } = props
 
-    mutator.performAsUndoGroup(async () => {
-      if (pages[cardTemplateId]) {
-        const [, newCardId] = await mutator.duplicateCard({
-          cardId: cardTemplateId,
-          board,
-          description: props.intl.formatMessage({ id: 'Mutator.new-card-from-template', defaultMessage: 'new card from template' }),
-          asTemplate: false,
-          afterRedo: async (cardId) => {
-            props.updateView({ ...activeView, fields: { ...activeView.fields, cardOrder: [...activeView.fields.cardOrder, cardId] } })
-            // TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.CreateCardViaTemplate, {board: props.board.id, view: props.activeView.id, card: cardId, cardTemplateId})
-            showCard(cardId)
-          },
-          beforeUndo: async () => {
-            showCard(undefined)
-          },
-          cardPage: pages[cardTemplateId]!
-        }
-        )
-        await mutator.changeViewCardOrder(activeView, [...activeView.fields.cardOrder, newCardId], 'add-card')
-      }
-    })
-  }
+  //   mutator.performAsUndoGroup(async () => {
+  //     if (pages[cardTemplateId]) {
+  //       const [, newCardId] = await mutator.duplicateCard({
+  //         cardId: cardTemplateId,
+  //         board,
+  //         description: props.intl.formatMessage({ id: 'Mutator.new-card-from-template', defaultMessage: 'new card from template' }),
+  //         asTemplate: false,
+  //         afterRedo: async (cardId) => {
+  //           props.updateView({ ...activeView, fields: { ...activeView.fields, cardOrder: [...activeView.fields.cardOrder, cardId] } })
+  //           // TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.CreateCardViaTemplate, {board: props.board.id, view: props.activeView.id, card: cardId, cardTemplateId})
+  //           showCard(cardId)
+  //         },
+  //         beforeUndo: async () => {
+  //           showCard(undefined)
+  //         },
+  //         cardPage: pages[cardTemplateId]!
+  //       }
+  //       )
+  //       await mutator.changeViewCardOrder(activeView, [...activeView.fields.cardOrder, newCardId], 'add-card')
+  //     }
+  //   })
+  // }
 
   const addCard = async (groupByOptionId?: string, show = false, properties: Record<string, string> = {}, insertLast = false): Promise<void> => {
     const { activeView, board, groupByProperty } = props
@@ -169,7 +159,6 @@ function CenterPanel(props: Props) {
             await mutate(`pages/${space.id}`)
           }
           if (show) {
-            console.log('add card', props.addCard.toString());
             props.addCard(createCard(block))
             props.updateView({ ...activeView, fields: { ...activeView.fields, cardOrder: newCardOrder } })
             showCard(block.id)
@@ -273,32 +262,6 @@ function CenterPanel(props: Props) {
     setState({ ...state, selectedCardIds: [] })
   }
 
-  async function duplicateSelectedCards() {
-    const { board } = props
-    const { selectedCardIds } = state
-    if (selectedCardIds.length < 1) {
-      return
-    }
-    mutator.performAsUndoGroup(async () => {
-      for (const cardId of selectedCardIds) {
-        const card = props.cards.find((o) => o.id === cardId)
-        if (card && pages[cardId] && space) {
-          mutator.duplicateCard({
-            cardId,
-            board,
-            cardPage: pages[cardId]!,
-            afterRedo: async () => {
-              mutate(`pages/${space.id}`)
-            }
-          })
-        } else {
-          Utils.assertFailure(`Selected card not found: ${cardId}`)
-        }
-      }
-    })
-
-    setState({ ...state, selectedCardIds: [] })
-  }
 
   function groupCardsByOptions(cards: Card[], optionIds: string[], groupByProperty?: IPropertyTemplate): BoardGroup[] {
     const groups = []
@@ -383,7 +346,7 @@ function CenterPanel(props: Props) {
           groupByProperty={props.groupByProperty}
           dateDisplayProperty={props.dateDisplayProperty}
           addCard={() => addCard('', true)}
-          addCardFromTemplate={addCardFromTemplate}
+          //addCardFromTemplate={addCardFromTemplate}
           addCardTemplate={addCardTemplate}
           editCardTemplate={editCardTemplate}
           readonly={props.readonly}

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/newCardButton.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/newCardButton.tsx
@@ -15,7 +15,7 @@ import EmptyCardButton from './emptyCardButton'
 
 type Props = {
     addCard: () => void
-    addCardFromTemplate: (cardTemplateId: string) => void
+    //addCardFromTemplate: (cardTemplateId: string) => void
     addCardTemplate: () => void
     editCardTemplate: (cardTemplateId: string) => void
 }
@@ -28,7 +28,7 @@ const NewCardButton = React.memo((props: Props): JSX.Element => {
         <ButtonWithMenu
             onClick={() => {
                 if (currentView.fields.defaultTemplateId) {
-                    props.addCardFromTemplate(currentView.fields.defaultTemplateId)
+                    //props.addCardFromTemplate(currentView.fields.defaultTemplateId)
                 } else {
                     props.addCard()
                 }

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
@@ -33,7 +33,7 @@ type Props = {
     cards: Card[]
     groupByProperty?: IPropertyTemplate
     addCard: () => void
-    addCardFromTemplate: (cardTemplateId: string) => void
+    //addCardFromTemplate: (cardTemplateId: string) => void
     addCardTemplate: () => void
     editCardTemplate: (cardTemplateId: string) => void
     readonly: boolean
@@ -167,7 +167,7 @@ const ViewHeader = React.memo((props: Props) => {
 
                 <NewCardButton
                     addCard={props.addCard}
-                    addCardFromTemplate={props.addCardFromTemplate}
+                   // addCardFromTemplate={props.addCardFromTemplate}
                     addCardTemplate={props.addCardTemplate}
                     editCardTemplate={props.editCardTemplate}
                 />

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -17,7 +17,7 @@ import debounce from 'lodash/debounce';
 import { NodeView, Plugin, SpecRegistry, BangleEditorState } from '@bangle.dev/core';
 import { EditorView, Node } from '@bangle.dev/pm';
 import { useEditorState } from '@bangle.dev/react';
-import { useState, CSSProperties, ReactNode, memo } from 'react';
+import { useState, CSSProperties, ReactNode, memo, useCallback } from 'react';
 import styled from '@emotion/styled';
 import ErrorBoundary from 'components/common/errors/ErrorBoundary';
 import { plugins as imagePlugins } from 'components/common/CharmEditor/components/@bangle.dev/base-components/image';
@@ -301,6 +301,13 @@ function CharmEditor (
     }
   });
 
+  const onResizeStop = useCallback((view: EditorView<any>) => {
+    if (onContentChangeDebounced) {
+      // Save the current embed size on the backend after we are done resizing
+      onContentChangeDebounced(view);
+    }
+  }, [onContentChangeDebounced]);
+
   return (
     <StyledReactBangleEditor
       style={{
@@ -316,6 +323,7 @@ function CharmEditor (
       postEditorComponents={<Placeholder show={isEmpty} />}
       state={state}
       renderNodeViews={({ children: _children, ...props }) => {
+
         switch (props.node.type.name) {
           case 'quote':
             return <Quote {...props}>{_children}</Quote>;
@@ -357,12 +365,7 @@ function CharmEditor (
             return (
               <ResizableImage
                 readOnly={readOnly}
-                onResizeStop={(view: EditorView<any>) => {
-                  if (onContentChangeDebounced) {
-                    // Save the current image size on the backend after we are done resizing
-                    onContentChangeDebounced(view);
-                  }
-                }}
+                onResizeStop={onResizeStop}
                 {...props}
               />
             );
@@ -371,12 +374,7 @@ function CharmEditor (
             return (
               <ResizableIframe
                 readOnly={readOnly}
-                onResizeStop={(view) => {
-                  if (onContentChangeDebounced) {
-                    // Save the current embed size on the backend after we are done resizing
-                    onContentChangeDebounced(view);
-                  }
-                }}
+                onResizeStop={onResizeStop}
                 {...props}
               />
             );

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -83,13 +83,13 @@ export default function PageLayout ({ children }: { children: React.ReactNode })
   const { currentPageId, pages } = usePages();
   const currentPage = pages[currentPageId];
 
-  const handleDrawerOpen = () => {
+  const handleDrawerOpen = React.useCallback(() => {
     setOpen(true);
-  };
+  }, []);
 
-  const handleDrawerClose = () => {
+  const handleDrawerClose = React.useCallback(() => {
     setOpen(false);
-  };
+  }, []);
 
   return (
     <>

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -77,11 +77,14 @@ const HeaderSpacer = styled.div`
   min-height: ${headerHeight}px;
 `;
 
-export default function PageLayout ({ children }: { children: React.ReactNode }) {
+const LayoutContainer = styled.div`
+  display: flex;
+  height: 100%;
+`;
+
+function PageLayout ({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = React.useState(true);
   const [user] = useUser();
-  const { currentPageId, pages } = usePages();
-  const currentPage = pages[currentPageId];
 
   const handleDrawerOpen = React.useCallback(() => {
     setOpen(true);
@@ -94,9 +97,9 @@ export default function PageLayout ({ children }: { children: React.ReactNode })
   return (
     <>
       <Head>
-        <Favicon pageIcon={currentPage?.icon} />
+        <CurrentPageFavicon />
       </Head>
-      <Box sx={{ display: 'flex', height: '100%' }}>
+      <LayoutContainer>
         <AppBar position='fixed' open={open}>
           <Header open={open} openSidebar={handleDrawerOpen} />
         </AppBar>
@@ -107,7 +110,15 @@ export default function PageLayout ({ children }: { children: React.ReactNode })
           <HeaderSpacer />
           {children}
         </PageContainer>
-      </Box>
+      </LayoutContainer>
     </>
   );
 }
+
+function CurrentPageFavicon () {
+  const { currentPageId, pages } = usePages();
+  const currentPage = pages[currentPageId];
+  return <Favicon pageIcon={currentPage?.icon} />;
+}
+
+export default PageLayout;

--- a/components/common/PageLayout/components/AddNewCard.tsx
+++ b/components/common/PageLayout/components/AddNewCard.tsx
@@ -9,8 +9,9 @@ import { StyledIconButton } from 'components/common/PageLayout/components/NewPag
 import { useAppDispatch } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import { addCard } from 'components/common/BoardEditor/focalboard/src/store/cards';
 import { mutate } from 'swr';
+import { memo } from 'react';
 
-export default function AddNewCard ({ pageId }: {pageId: string}) {
+function AddNewCard ({ pageId }: {pageId: string}) {
   const router = useRouter();
   const [space] = useCurrentSpace();
   const { pages } = usePages();
@@ -38,3 +39,5 @@ export default function AddNewCard ({ pageId }: {pageId: string}) {
     </Tooltip>
   );
 }
+
+export default memo(AddNewCard);

--- a/components/common/PageLayout/components/PageNavigation/components/BoardViewTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/BoardViewTreeItem.tsx
@@ -1,5 +1,5 @@
 
-import { forwardRef } from 'react';
+import { forwardRef, memo } from 'react';
 import { iconForViewType } from 'components/common/BoardEditor/focalboard/src/components/viewMenu';
 import { IViewType } from 'components/common/BoardEditor/focalboard/src/blocks/boardView';
 import { StyledTreeItem, PageLink } from './PageTreeItem';
@@ -38,4 +38,4 @@ const BoardViewTreeItem = forwardRef<HTMLDivElement, BoardViewTreeItemProps>((pr
   );
 });
 
-export default BoardViewTreeItem;
+export default memo(BoardViewTreeItem);

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -248,13 +248,7 @@ const TreeItemComponent = React.forwardRef<React.Ref<HTMLDivElement>, TreeItemCo
   )
 );
 
-function MoreIconButton ({ onClick }: { onClick: (e: any) => void }) {
-  return (
-    <IconButton size='small' onClick={onClick}>
-      <MoreHorizIcon color='secondary' fontSize='small' />
-    </IconButton>
-  );
-}
+const MemoizedIconButton = memo(IconButton);
 
 const PageMenuItem = styled(MenuItem)`
   padding: 3px 12px;
@@ -295,14 +289,15 @@ const PageTreeItem = forwardRef<any, PageTreeItemProps>((props, ref) => {
     setAnchorEl(null);
   }
 
-  let Icon: null | ReactNode = labelIcon;
-
-  if (!labelIcon) {
-    if (pageType === 'board') {
-      Icon = (<StyledDatabaseIcon />);
+  const icon = useMemo(() => {
+    if (labelIcon) {
+      return labelIcon;
+    }
+    else if (pageType === 'board') {
+      return (<StyledDatabaseIcon />);
     }
     else if (isEmptyContent) {
-      Icon = (
+      return (
         <InsertDriveFileOutlinedIcon sx={{
           opacity: theme.palette.mode !== 'light' ? 0.5 : 1
         }}
@@ -310,14 +305,14 @@ const PageTreeItem = forwardRef<any, PageTreeItemProps>((props, ref) => {
       );
     }
     else {
-      Icon = (
+      return (
         <DescriptionOutlinedIcon sx={{
           opacity: theme.palette.mode !== 'light' ? 0.5 : 1
         }}
         />
       );
     }
-  }
+  }, [labelIcon, pageType]);
 
   const ContentProps = useMemo(() => ({ isAdjacent, className: hasSelectedChildView ? 'Mui-selected' : undefined }), [isAdjacent, hasSelectedChildView]);
   const TransitionProps = useMemo(() => ({ timeout: 50 }), []);
@@ -328,12 +323,14 @@ const PageTreeItem = forwardRef<any, PageTreeItemProps>((props, ref) => {
     <PageLink
       href={href}
       label={label}
-      labelIcon={Icon}
+      labelIcon={icon}
       pageId={pageId}
       pageType={pageType}
     >
       <div className='page-actions'>
-        <MoreIconButton onClick={showMenu} />
+        <MemoizedIconButton size='small' onClick={showMenu}>
+          <MoreHorizIcon color='secondary' fontSize='small' />
+        </MemoizedIconButton>
         {pageType === 'board' ? (
           <AddNewCard pageId={pageId} />
         ) : (
@@ -341,7 +338,7 @@ const PageTreeItem = forwardRef<any, PageTreeItemProps>((props, ref) => {
         )}
       </div>
     </PageLink>
-  ), [href, label, pageId, Icon, addSubPage, pageType]);
+  ), [href, label, pageId, icon, addSubPage, pageType]);
 
   return (
     <>

--- a/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
@@ -27,7 +27,7 @@ type NodeProps = {
   selectedNodeId: string | null;
 }
 
-function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, addPage, deletePage, selectedNodeId }: NodeProps) {
+function DraggableTreeNode ({ item, onDropAdjacent, onDropChild, pathPrefix, addPage, deletePage, selectedNodeId }: NodeProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [isAdjacent, isAdjacentRef, setIsAdjacent] = useRefState(false);
   const [{ handlerId }, drag, dragPreview] = useDrag(() => ({
@@ -127,39 +127,41 @@ function RenderDraggableNode ({ item, onDropAdjacent, onDropChild, pathPrefix, a
       labelIcon={item.icon || undefined}
       pageType={item.type as 'page'}
     >
-      {hideChildren ? <div>{/* empty div to trick TreeView into showing expand icon */}</div> : (
-        item.type === 'board' ? (
-          views.map(view => (
-            <BoardViewTreeItem
-              key={view.id}
-              href={`${pathPrefix}/${item.path}?viewId=${view.id}`}
-              label={view.title}
-              nodeId={view.id}
-              viewType={view.fields.viewType}
-            />
-          ))
-        ) : (
-          item.children.length > 0
-            ? item.children.map((childItem) => (
-              // eslint-disable-next-line no-use-before-define
-              <MemoizedRenderDraggableNode
-                onDropAdjacent={onDropAdjacent}
-                onDropChild={onDropChild}
-                pathPrefix={pathPrefix}
-                key={childItem.id}
-                item={childItem}
-                addPage={addPage}
-                selectedNodeId={selectedNodeId}
-                deletePage={deletePage}
+      {hideChildren
+        ? <div>{/* empty div to trick TreeView into showing expand icon */}</div>
+        : (
+          item.type === 'board' ? (
+            views.map(view => (
+              <BoardViewTreeItem
+                key={view.id}
+                href={`${pathPrefix}/${item.path}?viewId=${view.id}`}
+                label={view.title}
+                nodeId={view.id}
+                viewType={view.fields.viewType}
               />
             ))
-            : (
-              <Typography variant='caption' className='MuiTreeItem-content' sx={{ display: 'flex', alignItems: 'center', color: `${greyColor2} !important`, ml: 3 }}>
-                No pages inside
-              </Typography>
-            )
-        )
-      )}
+          ) : (
+            item.children.length > 0
+              ? item.children.map((childItem) => (
+              // eslint-disable-next-line no-use-before-define
+                <MemoizedTreeNode
+                  onDropAdjacent={onDropAdjacent}
+                  onDropChild={onDropChild}
+                  pathPrefix={pathPrefix}
+                  key={childItem.id}
+                  item={childItem}
+                  addPage={addPage}
+                  selectedNodeId={selectedNodeId}
+                  deletePage={deletePage}
+                />
+              ))
+              : (
+                <Typography variant='caption' className='MuiTreeItem-content' sx={{ display: 'flex', alignItems: 'center', color: `${greyColor2} !important`, ml: 3 }}>
+                  No pages inside
+                </Typography>
+              )
+          )
+        )}
     </PageTreeItem>
   );
 }
@@ -178,6 +180,6 @@ function mergeRefs (refs: any) {
   };
 }
 
-const MemoizedRenderDraggableNode = memo(RenderDraggableNode);
+const MemoizedTreeNode = memo(DraggableTreeNode);
 
-export default MemoizedRenderDraggableNode;
+export default MemoizedTreeNode;

--- a/components/common/PageLayout/components/PageTitle.tsx
+++ b/components/common/PageLayout/components/PageTitle.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import styled from '@emotion/styled';
 import Typography from '@mui/material/Typography';
 
@@ -19,4 +20,4 @@ const PageTitle = styled(({ hasContent, ...props }: any) => <Typography {...prop
   width: calc(80%); // hack to get ellipsis to appear
 `;
 
-export default PageTitle;
+export default memo(PageTitle);

--- a/components/common/PageLayout/components/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar.tsx
@@ -253,7 +253,6 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
               </SectionName>
               <PageNavigation
                 isFavorites={true}
-                spaceId={space.id}
                 rootPageIds={favoritePageIds}
               />
             </Box>
@@ -266,10 +265,10 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
                 <NewPageMenu tooltip='Add a page' addPage={addPage} />
               </div>
             </WorkspaceLabel>
-            <Box sx={{ mb: 6 }}>
-              <PageNavigation spaceId={space.id} />
+            <Box mb={6}>
+              <PageNavigation />
             </Box>
-            <Box sx={{ mb: 2 }}>
+            <Box mb={2}>
               <SidebarLink
                 href={`/${space.domain}/bounties`}
                 active={router.pathname.startsWith('/[domain]/bounties')}

--- a/pages/api/pages/[id]/index.ts
+++ b/pages/api/pages/[id]/index.ts
@@ -1,6 +1,5 @@
 
 import { ActionNotPermittedError, onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
-import { requirePagePermissions } from 'lib/middleware/requirePagePermissions';
 import { computeUserPagePermissions, setupPermissionsAfterPageRepositioned } from 'lib/permissions/pages';
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';


### PR DESCRIPTION
My approach was again to profile the React components while typing in the focalboard title input. most of it now looks like it's inside the MUI TreeView component. the only way we can get away w/o rendering all of that would be to separate the page content state from the page tree info, both of which we store in the PageProvider currently..