### PR TITLE
Fixed card content being reset after closing it

### DIFF
--- a/components/[pageId]/BoardPage/BoardPage.tsx
+++ b/components/[pageId]/BoardPage/BoardPage.tsx
@@ -146,7 +146,7 @@ export default function BoardPage ({ page, setPage, readonly }: Props) {
           views={boardViews}
           showShared={clientConfig?.enablePublicSharedBoards || false}
         />
-        {typeof shownCardId === 'string' && (
+        {typeof shownCardId === 'string' && shownCardId.length !== 0 && shownCardId !== 'undefined' && (
           <RootPortal>
             <CardDialog
               board={board}


### PR DESCRIPTION
Turns out we were calling the `debouncedPageUpdate` function even after the `cardDetail` component was unmounted. Added a ref to make sure we don't call it if the component has been unmounted.