### PR TITLE
Admin status fix

### DIFF
--- a/charmClient.ts
+++ b/charmClient.ts
@@ -470,8 +470,8 @@ class CharmClient {
     return http.PUT(`/api/roles/${role.id}`, role);
   }
 
-  deleteRole (roleToDelete: {roleId: string, spaceId: string}): Promise<Role> {
-    return http.DELETE('/api/roles', roleToDelete);
+  deleteRole (roleId: string): Promise<Role> {
+    return http.DELETE(`/api/roles/${roleId}`);
   }
 
   listRoles (spaceId: string): Promise<ListSpaceRolesResponse[]> {

--- a/charmClient.ts
+++ b/charmClient.ts
@@ -93,8 +93,8 @@ class CharmClient {
     return http.GET<Contributor[]>(`/api/spaces/${spaceId}/contributors`);
   }
 
-  updateContributor ({ spaceId, userId, role }: { spaceId: string, userId: string, role: string }) {
-    return http.PUT<Contributor[]>(`/api/spaces/${spaceId}/contributors/${userId}`, { role });
+  updateContributor ({ spaceId, userId, isAdmin }: { spaceId: string, userId: string, isAdmin: boolean }) {
+    return http.PUT<Contributor[]>(`/api/spaces/${spaceId}/contributors/${userId}`, { isAdmin });
   }
 
   removeContributor ({ spaceId, userId }: { spaceId: string, userId: string }) {

--- a/components/bounties/BountyApplicantList.tsx
+++ b/components/bounties/BountyApplicantList.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from '@emotion/react';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -11,12 +12,11 @@ import Typography from '@mui/material/Typography';
 import { Application, Bounty, User } from '@prisma/client';
 import charmClient from 'charmClient';
 import { BountyStatusColours } from 'components/bounties/BountyStatusBadge';
-import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import { useUser } from 'hooks/useUser';
 import { useContributors } from 'hooks/useContributors';
+import useIsAdmin from 'hooks/useIsAdmin';
+import { useUser } from 'hooks/useUser';
 import { getDisplayName } from 'lib/users';
 import { humanFriendlyDate } from 'lib/utilities/dates';
-import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 
 /**
  * @updateApplication callback to parent [bountyId] page that implements application update logic
@@ -59,12 +59,9 @@ export function BountyApplicantList ({
   updateApplication = () => {}
 }: IBountyApplicantListProps) {
   const [user] = useUser();
-  const [space] = useCurrentSpace();
   const [contributors] = useContributors();
 
-  const isAdmin = user && user.spaceRoles.some(spaceRole => {
-    return spaceRole.spaceId === space?.id && spaceRole.role === 'admin';
-  });
+  const isAdmin = useIsAdmin();
 
   const theme = useTheme();
 

--- a/components/common/CreateSpaceForm.tsx
+++ b/components/common/CreateSpaceForm.tsx
@@ -74,7 +74,6 @@ export default function WorkspaceSettings ({ defaultValues, onSubmit: _onSubmit,
         updatedBy: user!.id,
         spaceRoles: {
           create: [{
-            role: 'admin',
             isAdmin: true,
             user: {
               connect: {

--- a/components/settings/contributors/ContributorList.tsx
+++ b/components/settings/contributors/ContributorList.tsx
@@ -1,6 +1,5 @@
 import { Contributor } from 'models';
 import { useContributors } from 'hooks/useContributors';
-import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import charmClient from 'charmClient';
 import Legend from '../Legend';
 import ContributorListItem, { RoleAction } from './ContributorListItem';
@@ -19,13 +18,13 @@ export default function ContributorList ({ isAdmin, spaceId, spaceOwner }: Props
     switch (action) {
 
       case 'makeAdmin':
-        await charmClient.updateContributor({ spaceId, userId: contributor.id, role: 'admin' });
-        setContributors(contributors.map(c => c.id === contributor.id ? { ...c, role: 'admin' } : c));
+        await charmClient.updateContributor({ spaceId, userId: contributor.id, isAdmin: true });
+        setContributors(contributors.map(c => c.id === contributor.id ? { ...c, isAdmin: true } : c));
         break;
 
       case 'makeContributor':
-        await charmClient.updateContributor({ spaceId, userId: contributor.id, role: 'contributor' });
-        setContributors(contributors.map(c => c.id === contributor.id ? { ...c, role: 'contributor' } : c));
+        await charmClient.updateContributor({ spaceId, userId: contributor.id, isAdmin: false });
+        setContributors(contributors.map(c => c.id === contributor.id ? { ...c, isAdmin: false } : c));
         break;
 
       case 'removeFromSpace':

--- a/components/settings/contributors/ContributorListItem.tsx
+++ b/components/settings/contributors/ContributorListItem.tsx
@@ -69,7 +69,7 @@ export default function ContributorRow ({ isAdmin, isSpaceOwner, contributor, on
     }
   });
 
-  const activeRoleAction = (contributor.role === 'admin') ? 'makeAdmin' : 'makeContributor';
+  const activeRoleAction = contributor.isAdmin ? 'makeAdmin' : 'makeContributor';
 
   return (
     <StyledRow pb={2} mb={2}>
@@ -90,7 +90,7 @@ export default function ContributorRow ({ isAdmin, isSpaceOwner, contributor, on
               {...bindTrigger(popupState)}
               endIcon={<KeyboardArrowDownIcon fontSize='small' />}
             >
-              {contributor.role}
+              {contributor.isAdmin ? 'admin' : 'contributor'}
             </Button>
             {/* <Typography color='secondary' variant='body2' sx={{ px: 3 }} {...bindTrigger(popupState)}>
             {contributor.role}
@@ -137,7 +137,7 @@ export default function ContributorRow ({ isAdmin, isSpaceOwner, contributor, on
         )
           : (
             <Typography color='secondary'>
-              {contributor.role}
+              {contributor.isAdmin ? 'admin' : 'contributor'}
             </Typography>
           )}
       </Box>

--- a/components/settings/payment-methods/PaymentMethods.tsx
+++ b/components/settings/payment-methods/PaymentMethods.tsx
@@ -4,17 +4,20 @@ import { usePaymentMethods } from 'hooks/usePaymentMethods';
 import Button from 'components/common/Button';
 import Typography from '@mui/material/Typography';
 import { usePopupState } from 'material-ui-popup-state/hooks';
+import useIsAdmin from 'hooks/useIsAdmin';
 import CustomERCTokenForm from './components/CustomERCTokenForm';
 import GnosisSafeForm from './components/GnosisSafeForm';
 import Legend from '../Legend';
 import PaymentMethodList from './components/PaymentMethodList';
 
-export default function PaymentMethods ({ isAdmin = true }) {
+export default function PaymentMethods () {
 
   const gnosisPopupState = usePopupState({ variant: 'popover', popupId: 'gnosis-popup' });
   const ERC20PopupState = usePopupState({ variant: 'popover', popupId: 'ERC20-popup' });
 
   const [paymentMethods] = usePaymentMethods();
+
+  const isAdmin = useIsAdmin();
 
   return (
     <>

--- a/components/settings/payment-methods/PaymentMethods.tsx
+++ b/components/settings/payment-methods/PaymentMethods.tsx
@@ -30,24 +30,24 @@ export default function PaymentMethods () {
 
       <Legend sx={{ display: 'flex', justifyContent: 'space-between' }}>
         Payment Methods
-        {isAdmin && (
-          <Stack component='span' spacing={1} direction='row'>
-            <Button
-              onClick={gnosisPopupState.open}
-              variant='outlined'
-              sx={{ float: 'right' }}
-            >
-              Add Gnosis Safe wallet
-            </Button>
-            <Button
-              onClick={ERC20PopupState.open}
-              variant='outlined'
-              sx={{ float: 'right' }}
-            >
-              Add custom token
-            </Button>
-          </Stack>
-        )}
+
+        <Stack component='span' spacing={1} direction='row'>
+          <Button
+            onClick={gnosisPopupState.open}
+            variant='outlined'
+            sx={{ float: 'right' }}
+          >
+            Add Gnosis Safe wallet
+          </Button>
+          <Button
+            onClick={ERC20PopupState.open}
+            variant='outlined'
+            sx={{ float: 'right' }}
+          >
+            Add custom token
+          </Button>
+        </Stack>
+
       </Legend>
       {paymentMethods.length > 0 && <PaymentMethodList paymentMethods={paymentMethods} />}
       {paymentMethods.length === 0 && <Typography color='secondary'>No payment methods yet</Typography>}

--- a/components/settings/payment-methods/components/PaymentMethodList.tsx
+++ b/components/settings/payment-methods/components/PaymentMethodList.tsx
@@ -3,14 +3,14 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import Tooltip from '@mui/material/Tooltip';
+import { PaymentMethod } from '@prisma/client';
+import { ElementDeleteIcon } from 'components/common/form/ElementDeleteIcon';
+import Link from 'components/common/Link';
 import TableRow from 'components/common/Table/TableRow';
 import { getChainById, getChainExplorerLink } from 'connectors';
-import { PaymentMethod } from '@prisma/client';
-import { useUser } from 'hooks/useUser';
-import { useState } from 'react';
-import { ElementDeleteIcon } from 'components/common/form/ElementDeleteIcon';
+import useIsAdmin from 'hooks/useIsAdmin';
 import { shortenHex } from 'lib/utilities/strings';
-import Link from 'components/common/Link';
+import { useState } from 'react';
 import CompositeDeletePaymentMethod from './DeletePaymentMethodModal';
 
 interface IProps {
@@ -21,10 +21,9 @@ const getGnosisSafeUrl = (address: string) => `https://gnosis-safe.io/app/rin:${
 
 export default function CompositePaymentMethodList ({ paymentMethods }: IProps) {
 
-  const [user] = useUser();
   const [paymentMethodIdToDelete, setPaymentMethodIdToDelete] = useState<string | null>(null);
 
-  const isAdmin = user?.spaceRoles.some(spaceRole => spaceRole.role === 'admin') === true;
+  const isAdmin = useIsAdmin();
 
   const sortedMethods = [...paymentMethods]
     .sort((methodA, methodB) => {

--- a/components/settings/roles/components/ImportDiscordRolesButton.tsx
+++ b/components/settings/roles/components/ImportDiscordRolesButton.tsx
@@ -1,26 +1,24 @@
 import { SvgIcon } from '@mui/material';
-import { useRouter } from 'next/router';
-import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import { useUser } from 'hooks/useUser';
-import { useState, useEffect } from 'react';
-import Button from 'components/common/Button';
-import DiscordIcon from 'public/images/discord_logo.svg';
-import { useSnackbar } from 'hooks/useSnackbar';
 import charmClient from 'charmClient';
+import Button from 'components/common/Button';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import useIsAdmin from 'hooks/useIsAdmin';
+import { useSnackbar } from 'hooks/useSnackbar';
+import { useRouter } from 'next/router';
+import DiscordIcon from 'public/images/discord_logo.svg';
+import { useEffect, useState } from 'react';
 
 export default function ImportDiscordRolesButton ({ onUpdate }: { onUpdate: () => void }) {
 
   const { showMessage } = useSnackbar();
   const [currentSpace] = useCurrentSpace();
-  const [user] = useUser();
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
 
-  const isCurrentUserAdmin = (user?.spaceRoles
-    .find(spaceRole => spaceRole.spaceId === currentSpace?.id)?.role === 'admin');
+  const isAdmin = useIsAdmin();
 
   useEffect(() => {
-    const shouldRequestServers = isCurrentUserAdmin && currentSpace && typeof router.query.guild_id === 'string' && router.query.discord === '1' && router.query.type === 'server';
+    const shouldRequestServers = isAdmin && currentSpace && typeof router.query.guild_id === 'string' && router.query.discord === '1' && router.query.type === 'server';
     if (shouldRequestServers) {
       importFromServer(router.query.guild_id as string);
     }
@@ -49,7 +47,7 @@ export default function ImportDiscordRolesButton ({ onUpdate }: { onUpdate: () =
       });
   }
 
-  if (!isCurrentUserAdmin) {
+  if (!isAdmin) {
     return null;
   }
 

--- a/components/settings/roles/hooks/useRoles.ts
+++ b/components/settings/roles/hooks/useRoles.ts
@@ -23,10 +23,8 @@ export default function useRoles () {
   }
 
   async function deleteRole (roleId: string) {
-    if (space) {
-      await charmClient.deleteRole({ roleId, spaceId: space.id });
-      refreshRoles();
-    }
+    await charmClient.deleteRole(roleId);
+    refreshRoles();
   }
 
   async function assignRoles (roleId: string, userIds: string[]) {

--- a/lib/middleware/requireApiKey.ts
+++ b/lib/middleware/requireApiKey.ts
@@ -66,7 +66,6 @@ export async function getBotUser (spaceId: string): Promise<User> {
       data: {
         spaceId,
         userId: botUser.id,
-        role: 'admin',
         isAdmin: true
       }
     });

--- a/lib/middleware/requireSpaceMembership.ts
+++ b/lib/middleware/requireSpaceMembership.ts
@@ -9,7 +9,7 @@ import { AdministratorOnlyError, UserIsNotSpaceMemberError } from '../users/erro
 /**
  * Allow an endpoint to be consumed if it originates from a share page
  */
-export function requireSpaceMembership (adminOnly: boolean = false) {
+export function requireSpaceMembership (options: {adminOnly: boolean} = { adminOnly: false }) {
   return async (req: NextApiRequest, res: NextApiResponse<ISystemError>, next: NextHandler) => {
 
     if (!req.session.user) {
@@ -50,7 +50,7 @@ export function requireSpaceMembership (adminOnly: boolean = false) {
       throw new UserIsNotSpaceMemberError();
     }
 
-    if (adminOnly && spaceRole.isAdmin !== true) {
+    if (options.adminOnly && spaceRole.isAdmin !== true) {
       throw new AdministratorOnlyError();
     }
 

--- a/lib/middleware/requireSpaceMembership.ts
+++ b/lib/middleware/requireSpaceMembership.ts
@@ -1,4 +1,3 @@
-import { Prisma, SpaceRole } from '@prisma/client';
 import { prisma } from 'db';
 import { ApiError } from 'lib/middleware';
 import { ISystemError } from 'lib/utilities/errors';
@@ -9,8 +8,11 @@ import { AdministratorOnlyError, UserIsNotSpaceMemberError } from '../users/erro
 /**
  * Allow an endpoint to be consumed if it originates from a share page
  */
-export function requireSpaceMembership (options: {adminOnly: boolean} = { adminOnly: false }) {
+export function requireSpaceMembership (options: {adminOnly: boolean, spaceIdKey?: string} = { adminOnly: false }) {
   return async (req: NextApiRequest, res: NextApiResponse<ISystemError>, next: NextHandler) => {
+
+    // Where to find the space ID
+    const spaceIdKey = 'spaceId';
 
     if (!req.session.user) {
       throw new ApiError({
@@ -19,9 +21,9 @@ export function requireSpaceMembership (options: {adminOnly: boolean} = { adminO
       });
     }
 
-    const querySpaceId = req.query?.spaceId as string;
+    const querySpaceId = req.query?.[spaceIdKey] as string;
 
-    const bodySpaceId = req.body?.spaceId as string;
+    const bodySpaceId = req.body?.[spaceIdKey] as string;
 
     const spaceId = querySpaceId ?? bodySpaceId;
 

--- a/lib/middleware/requireSpaceMembership.ts
+++ b/lib/middleware/requireSpaceMembership.ts
@@ -12,7 +12,7 @@ export function requireSpaceMembership (options: {adminOnly: boolean, spaceIdKey
   return async (req: NextApiRequest, res: NextApiResponse<ISystemError>, next: NextHandler) => {
 
     // Where to find the space ID
-    const spaceIdKey = 'spaceId';
+    const spaceIdKey = options.spaceIdKey ?? 'spaceId';
 
     if (!req.session.user) {
       throw new ApiError({

--- a/lib/permissions/pages/page-permission-compute.ts
+++ b/lib/permissions/pages/page-permission-compute.ts
@@ -70,38 +70,24 @@ function permissionsQuery (request: IPagePermissionUserRequest): Prisma.PagePerm
 
 export async function computeUserPagePermissions (request: IPagePermissionUserRequest): Promise<IPagePermissionFlags> {
 
-  const permissionWithSpaceRoleAndPermissions = await Promise.all([
+  const [foundSpaceRole, permissions] = await Promise.all([
+    // Check if user is a space admin for this page so they gain full rights
     // eslint-disable-next-line max-len
-    prisma.page.findFirst(pageWithSpaceRoleQuery(request)) as any as Promise<IPageWithNestedSpaceRole>,
+    (prisma.page.findFirst(pageWithSpaceRoleQuery(request)) as any as Promise<IPageWithNestedSpaceRole>).then(page => {
+      return page?.space?.spaceRoles?.find(spaceRole => spaceRole.spaceId === page.spaceId && spaceRole.userId === request.userId);
+    }),
     prisma.pagePermission.findMany(permissionsQuery(request))
   ]);
 
-  const page = permissionWithSpaceRoleAndPermissions[0];
-
-  // Check if user is a space admin for this page so they gain full rights
-  const foundSpaceRole = permissionWithSpaceRoleAndPermissions[0]?.space?.spaceRoles?.[0];
-
   // TODO DELETE LATER when we remove admin access to workspace
-  if (foundSpaceRole && (foundSpaceRole.role === 'admin' || foundSpaceRole.isAdmin === true)) {
+  if (foundSpaceRole && foundSpaceRole.isAdmin === true) {
 
     const fullPermissions = Object.keys(PageOperations) as PageOperationType [];
 
     return new AllowedPagePermissions(fullPermissions);
   }
 
-  const permissions = permissionWithSpaceRoleAndPermissions[1];
-
   const computedPermissions = new AllowedPagePermissions();
-
-  // Apply space level permission
-  const spaceLevelPermission = permissions.find((permission) => {
-    return foundSpaceRole && foundSpaceRole.spaceId === (permission as any as {page: Page}).page?.spaceId;
-  });
-
-  if (spaceLevelPermission) {
-    console.log('Found a space permission');
-    computedPermissions.addPermissions(permissionTemplates[spaceLevelPermission.permissionLevel]);
-  }
 
   permissions.forEach(permission => {
 
@@ -110,10 +96,6 @@ export async function computeUserPagePermissions (request: IPagePermissionUserRe
 
     computedPermissions.addPermissions(permissionsToAdd);
   });
-
-  if (request.pageId === '843e00b2-58a2-486c-92f7-dbed93123c6b') {
-    console.log('Will provide these permissions', computedPermissions);
-  }
 
   return computedPermissions;
 

--- a/lib/public-api/__tests__/getPageInBoard.spec.ts
+++ b/lib/public-api/__tests__/getPageInBoard.spec.ts
@@ -4,8 +4,9 @@ import { prisma } from 'db';
 import { ExpectedAnError } from 'testing/errors';
 import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
 import { v4 } from 'uuid';
+import { InvalidInputError } from 'lib/utilities/errors';
 import { createDatabase, createDatabaseCardPage } from '../createDatabaseCardPage';
-import { DatabasePageNotFoundError, InvalidInputError, PageNotFoundError } from '../errors';
+import { DatabasePageNotFoundError, PageNotFoundError } from '../errors';
 import { getDatabaseRoot, getPageInBoard } from '../getPageInBoard';
 import { DatabasePage, Page } from '../interfaces';
 

--- a/lib/public-api/createDatabaseCardPage.ts
+++ b/lib/public-api/createDatabaseCardPage.ts
@@ -1,7 +1,8 @@
 import { Page } from '@prisma/client';
 import { prisma } from 'db';
 import { v4, validate } from 'uuid';
-import { DatabasePageNotFoundError, InvalidInputError } from './errors';
+import { InvalidInputError } from 'lib/utilities/errors';
+import { DatabasePageNotFoundError } from './errors';
 import { PageProperty } from './interfaces';
 import { PageFromBlock } from './pageFromBlock.class';
 

--- a/lib/public-api/errors.ts
+++ b/lib/public-api/errors.ts
@@ -41,17 +41,6 @@ export class UnsupportedKeysError<D = any> extends SystemError<UnsupportedKeyDet
   }
 }
 
-export class InvalidInputError extends SystemError {
-
-  constructor (message: string) {
-    super({
-      message,
-      errorType: 'Invalid input',
-      severity: 'warning'
-    });
-  }
-}
-
 export class SpaceNotFoundError extends SystemError {
 
   constructor (id: string) {

--- a/lib/public-api/getPageInBoard.ts
+++ b/lib/public-api/getPageInBoard.ts
@@ -1,10 +1,11 @@
 import { Block } from '@prisma/client';
 import { prisma } from 'db';
+import { InvalidInputError } from 'lib/utilities/errors';
 import { filterObjectKeys } from 'lib/utilities/objects';
 import { PageContent } from 'models';
 import { validate } from 'uuid';
-import { DatabasePageNotFoundError, PageNotFoundError, SpaceNotFoundError, InvalidInputError } from './errors';
-import { Page, PageProperty, DatabasePage } from './interfaces';
+import { DatabasePageNotFoundError, PageNotFoundError, SpaceNotFoundError } from './errors';
+import { DatabasePage, Page, PageProperty } from './interfaces';
 import { PageFromBlock } from './pageFromBlock.class';
 
 export async function getPageInBoard (pageId: string): Promise<Page> {

--- a/lib/spaces/errors.ts
+++ b/lib/spaces/errors.ts
@@ -1,0 +1,12 @@
+import { SystemError } from 'lib/utilities/errors';
+
+export class MinimumOneSpaceAdminRequiredError extends SystemError {
+
+  constructor () {
+    super({
+      message: 'Spaces must have at least one administrator',
+      errorType: 'Undesirable operation',
+      severity: 'warning'
+    });
+  }
+}

--- a/lib/users/errors.ts
+++ b/lib/users/errors.ts
@@ -1,0 +1,21 @@
+import { SystemError } from 'lib/utilities/errors';
+
+export class AdministratorOnlyError extends SystemError {
+  constructor () {
+    super({
+      errorType: 'Access denied',
+      message: 'Only space administrators can perform this action',
+      severity: 'warning'
+    });
+  }
+}
+
+export class UserIsNotSpaceMemberError extends SystemError {
+  constructor () {
+    super({
+      errorType: 'Access denied',
+      message: 'User does not have access to this space',
+      severity: 'warning'
+    });
+  }
+}

--- a/lib/users/hasAccessToSpace.ts
+++ b/lib/users/hasAccessToSpace.ts
@@ -1,10 +1,11 @@
 import { prisma } from 'db';
-import { Role } from 'models';
+import { InvalidInputError } from 'lib/utilities/errors';
+import { AdministratorOnlyError, UserIsNotSpaceMemberError } from './errors';
 
 interface Input {
   userId: string;
   spaceId: string;
-  role?: Role;
+  adminOnly?: boolean;
 }
 
 interface Result {
@@ -12,10 +13,10 @@ interface Result {
   success?: boolean;
 }
 
-export async function hasAccessToSpace ({ userId, spaceId, role = 'contributor' }: Input): Promise<Result> {
+export async function hasAccessToSpace ({ userId, spaceId, adminOnly = false }: Input): Promise<Result> {
 
   if (!spaceId || !userId) {
-    return { error: 'userId and spaceId are required' };
+    return new InvalidInputError('User ID and space ID are required');
   }
 
   const spaceRole = await prisma.spaceRole.findFirst({
@@ -25,10 +26,10 @@ export async function hasAccessToSpace ({ userId, spaceId, role = 'contributor' 
     }
   });
   if (!spaceRole) {
-    return { error: 'User does not have access to space' };
+    return new UserIsNotSpaceMemberError();
   }
-  else if (role === 'admin' && spaceRole.role !== role) {
-    return { error: 'Requires admin permission' };
+  else if (adminOnly && spaceRole.isAdmin !== true) {
+    return new AdministratorOnlyError();
   }
   return { success: true };
 }

--- a/lib/users/hasAccessToSpace.ts
+++ b/lib/users/hasAccessToSpace.ts
@@ -1,5 +1,5 @@
 import { prisma } from 'db';
-import { InvalidInputError } from 'lib/utilities/errors';
+import { InvalidInputError, SystemError } from 'lib/utilities/errors';
 import { AdministratorOnlyError, UserIsNotSpaceMemberError } from './errors';
 
 interface Input {
@@ -9,14 +9,14 @@ interface Input {
 }
 
 interface Result {
-  error?: string;
+  error?: SystemError;
   success?: boolean;
 }
 
 export async function hasAccessToSpace ({ userId, spaceId, adminOnly = false }: Input): Promise<Result> {
 
   if (!spaceId || !userId) {
-    return new InvalidInputError('User ID and space ID are required');
+    return { error: new InvalidInputError('User ID and space ID are required') };
   }
 
   const spaceRole = await prisma.spaceRole.findFirst({
@@ -26,10 +26,10 @@ export async function hasAccessToSpace ({ userId, spaceId, adminOnly = false }: 
     }
   });
   if (!spaceRole) {
-    return new UserIsNotSpaceMemberError();
+    return { error: new UserIsNotSpaceMemberError() };
   }
   else if (adminOnly && spaceRole.isAdmin !== true) {
-    return new AdministratorOnlyError();
+    return { error: new AdministratorOnlyError() };
   }
   return { success: true };
 }

--- a/lib/users/isSpaceAdmin.ts
+++ b/lib/users/isSpaceAdmin.ts
@@ -1,5 +1,5 @@
 import { LoggedInUser } from 'models/User';
 
 export default function isSpaceAdmin (user?: LoggedInUser | null, spaceId?: string): boolean {
-  return !!spaceId && !!user && user.spaceRoles.some(role => role.role === 'admin' && role.spaceId === spaceId);
+  return !!spaceId && !!user && user.spaceRoles.some(role => role.isAdmin === true && role.spaceId === spaceId);
 }

--- a/lib/utilities/errors.ts
+++ b/lib/utilities/errors.ts
@@ -51,3 +51,15 @@ export class SystemError<E = any> implements ISystemError<E> {
   }
 
 }
+
+// Common Errors
+export class InvalidInputError extends SystemError {
+
+  constructor (message: string) {
+    super({
+      message,
+      errorType: 'Invalid input',
+      severity: 'warning'
+    });
+  }
+}

--- a/lib/utilities/errors.ts
+++ b/lib/utilities/errors.ts
@@ -5,6 +5,7 @@ export type ErrorSeverity = 'warning' | 'error';
 const ErrorCodes = {
   Unknown: 500,
   'Invalid input': 400,
+  'Undesirable operation': 400,
   'Data not found': 404,
   'Access denied': 401,
   'External service': 500,

--- a/lib/utilities/errors.ts
+++ b/lib/utilities/errors.ts
@@ -63,3 +63,13 @@ export class InvalidInputError extends SystemError {
     });
   }
 }
+
+export class DataNotFoundError extends SystemError {
+  constructor (message: string = 'Data not found') {
+    super({
+      message,
+      errorType: 'Data not found',
+      severity: 'warning'
+    });
+  }
+}

--- a/models/User.ts
+++ b/models/User.ts
@@ -2,10 +2,8 @@ import type { DiscordUser, FavoritePage, SpaceRole, User, Role as RoleMembership
 
 export { FavoritePage, SpaceRole, User };
 
-export type Role = 'admin' | 'contributor';
-
 export interface Contributor extends User {
-  role: Role;
+  isAdmin: boolean;
 }
 
 interface NestedMemberships {

--- a/pages/[domain]/bounties/[bountyId].tsx
+++ b/pages/[domain]/bounties/[bountyId].tsx
@@ -35,6 +35,7 @@ import { eToNumber } from 'lib/utilities/numbers';
 import { BountyWithDetails, PageContent } from 'models';
 import { useRouter } from 'next/router';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
+import useIsAdmin from 'hooks/useIsAdmin';
 
 export default function BountyDetails () {
   const [space] = useCurrentSpace();
@@ -56,9 +57,7 @@ export default function BountyDetails () {
   const isAssignee = bounty && user && bounty.assignee === user.id;
   const isReviewer = bounty && user && bounty.reviewer === user.id;
 
-  const isAdmin = space && user?.spaceRoles.some(spaceRole => {
-    return spaceRole.spaceId === space.id && spaceRole.role === 'admin';
-  });
+  const isAdmin = useIsAdmin();
 
   const isApplicant = user && applications.some(application => {
     return application.createdBy === user.id;

--- a/pages/[domain]/bounties/[bountyId].tsx
+++ b/pages/[domain]/bounties/[bountyId].tsx
@@ -36,8 +36,6 @@ import { BountyWithDetails, PageContent } from 'models';
 import { useRouter } from 'next/router';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 
-export type BountyDetailsPersona = 'applicant' | 'reviewer' | 'admin'
-
 export default function BountyDetails () {
   const [space] = useCurrentSpace();
   const [applications, setApplications] = useState([] as Application []);

--- a/pages/api/discord/importRoles.ts
+++ b/pages/api/discord/importRoles.ts
@@ -74,6 +74,6 @@ async function importRoles (req: NextApiRequest, res: NextApiResponse<ImportRole
   }
 }
 
-handler.use(requireUser).use(requireSpaceMembership('admin')).post(importRoles);
+handler.use(requireUser).use(requireSpaceMembership({ adminOnly: true })).post(importRoles);
 
 export default withSessionRoute(handler);

--- a/pages/api/invites/[id]/index.ts
+++ b/pages/api/invites/[id]/index.ts
@@ -1,7 +1,7 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
-import { onError, onNoMatch, requireUser } from 'lib/middleware';
+import { onError, onNoMatch, requireSpaceMembership, requireUser } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
 import { prisma } from 'db';
 import { SpaceRole } from '@prisma/client';
@@ -9,7 +9,11 @@ import { IEventToLog, postToDiscord } from 'lib/log/userEvents';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-handler.use(requireUser).post(acceptInvite).delete(deleteInvite);
+handler
+  .use(requireUser)
+  .post(acceptInvite)
+  .use(requireSpaceMembership({ adminOnly: true }))
+  .delete(deleteInvite);
 
 async function acceptInvite (req: NextApiRequest, res: NextApiResponse) {
 

--- a/pages/api/invites/index.ts
+++ b/pages/api/invites/index.ts
@@ -1,20 +1,21 @@
 
-import { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 import { InviteLink, User } from '@prisma/client';
 import { prisma } from 'db';
-import { onError, onNoMatch, requireUser } from 'lib/middleware';
-import { withSessionRoute } from 'lib/session/withSession';
 import { createInviteLink } from 'lib/invites';
+import { onError, onNoMatch, requireSpaceMembership } from 'lib/middleware';
+import { withSessionRoute } from 'lib/session/withSession';
+import { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
 
 export type InviteLinkPopulated = InviteLink & { author: User };
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler
-  .use(requireUser)
-  .post(createInviteLinkEndpoint)
-  .get(getInviteLinks);
+  .use(requireSpaceMembership())
+  .get(getInviteLinks)
+  .use(requireSpaceMembership({ adminOnly: true }))
+  .post(createInviteLinkEndpoint);
 
 async function createInviteLinkEndpoint (req: NextApiRequest, res: NextApiResponse) {
 

--- a/pages/api/payment-methods/[id]/index.ts
+++ b/pages/api/payment-methods/[id]/index.ts
@@ -1,8 +1,9 @@
 
 import { PaymentMethod } from '@prisma/client';
 import { prisma } from 'db';
-import { onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
+import { hasAccessToSpace, onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
+import { DataNotFoundError } from 'lib/utilities/errors';
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
@@ -13,8 +14,27 @@ handler.use(requireUser)
   .delete(deletePaymentMethod);
 
 async function deletePaymentMethod (req: NextApiRequest, res: NextApiResponse) {
-
   const { id } = req.query as any as PaymentMethod;
+
+  const paymentMethod = await prisma.paymentMethod.findUnique({
+    where: {
+      id
+    }
+  });
+
+  if (!paymentMethod) {
+    throw new DataNotFoundError(`Payment method with ID ${id} not found`);
+  }
+
+  const { error } = await hasAccessToSpace({
+    userId: req.session.user.id,
+    spaceId: paymentMethod.spaceId,
+    adminOnly: true
+  });
+
+  if (error) {
+    throw error;
+  }
 
   await prisma.paymentMethod.delete({
     where: {

--- a/pages/api/payment-methods/index.ts
+++ b/pages/api/payment-methods/index.ts
@@ -13,7 +13,6 @@ handler
   .use(requireSpaceMembership())
   .get(listPaymentMethods)
   .use(requireKeys<PaymentMethod>(['chainId', 'spaceId', 'tokenSymbol', 'tokenName', 'tokenDecimals', 'walletType'], 'body'))
-  .use(requireSpaceMembership({ adminOnly: true }))
   .post(createPaymentMethod);
 
 async function listPaymentMethods (req: NextApiRequest, res: NextApiResponse<PaymentMethod []>) {

--- a/pages/api/payment-methods/index.ts
+++ b/pages/api/payment-methods/index.ts
@@ -1,7 +1,7 @@
 
 import { PaymentMethod, Prisma } from '@prisma/client';
 import { prisma } from 'db';
-import { ApiError, onError, onNoMatch, requireKeys, requireSpaceMembership, requireUser } from 'lib/middleware';
+import { ApiError, onError, onNoMatch, requireKeys, requireSpaceMembership } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
 import { isValidChainAddress } from 'lib/tokens/validation';
 import { NextApiRequest, NextApiResponse } from 'next';
@@ -9,10 +9,11 @@ import nc from 'next-connect';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-handler.use(requireUser)
+handler
   .use(requireSpaceMembership())
   .get(listPaymentMethods)
   .use(requireKeys<PaymentMethod>(['chainId', 'spaceId', 'tokenSymbol', 'tokenName', 'tokenDecimals', 'walletType'], 'body'))
+  .use(requireSpaceMembership({ adminOnly: true }))
   .post(createPaymentMethod);
 
 async function listPaymentMethods (req: NextApiRequest, res: NextApiResponse<PaymentMethod []>) {

--- a/pages/api/roles/[id]/index.ts
+++ b/pages/api/roles/[id]/index.ts
@@ -1,17 +1,61 @@
 
-import { Role } from '@prisma/client';
+import { Role, SpaceRoleToRole } from '@prisma/client';
 import { prisma } from 'db';
-import { ApiError, onError, onNoMatch, requireUser } from 'lib/middleware';
+import { ApiError, hasAccessToSpace, onError, onNoMatch, requireUser } from 'lib/middleware';
 import { requireSpaceMembership } from 'lib/middleware/requireSpaceMembership';
 import { withSessionRoute } from 'lib/session/withSession';
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
+import { DataNotFoundError } from 'lib/utilities/errors';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler.use(requireUser)
-  .use(requireSpaceMembership())
+  // Delete role performs the check for whether the user can delete it
+  .delete(deleteRole)
+  .use(requireSpaceMembership({ adminOnly: true }))
   .put(updateRole);
+
+async function deleteRole (req: NextApiRequest, res: NextApiResponse) {
+  const roleId = req.query.id as string;
+
+  if (!roleId) {
+    throw new ApiError({
+      message: 'Please provide a valid role id',
+      errorType: 'Invalid input'
+    });
+  }
+
+  const role = await prisma.role.findUnique({
+    where: {
+      id: roleId
+    }
+  });
+
+  if (!role) {
+    throw new DataNotFoundError(`Could not find role with id ${roleId}`);
+  }
+
+  // Check user can delete role
+  const { error } = await hasAccessToSpace({
+    userId: req.session.user.id,
+    spaceId: role.spaceId,
+    adminOnly: true
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  // Use space ID assertion to prevent role deletion
+  await prisma.role.delete({
+    where: {
+      id: roleId
+    }
+  });
+
+  return res.status(200).json({ success: true });
+}
 
 async function updateRole (req: NextApiRequest, res: NextApiResponse) {
   const { name } = req.body as Role;

--- a/pages/api/roles/assignment/index.ts
+++ b/pages/api/roles/assignment/index.ts
@@ -10,7 +10,7 @@ import nc from 'next-connect';
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler.use(requireUser)
-  .use(requireSpaceMembership())
+  .use(requireSpaceMembership({ adminOnly: true }))
   .use(requireKeys<SpaceRoleToRole & SpaceRole>(['spaceId', 'roleId', 'userId'], 'body'))
   .post(assignRole)
   .delete(removeRole);

--- a/pages/api/spaces/[id]/contributors/[userId].ts
+++ b/pages/api/spaces/[id]/contributors/[userId].ts
@@ -10,9 +10,9 @@ const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 const requireAdmin = async (req: NextApiRequest, res: NextApiResponse, next: NextHandler) => {
   const userId = req.session.user.id;
-  const { error } = await hasAccessToSpace({ userId, spaceId: req.query.id as string, role: 'admin' });
+  const { error } = await hasAccessToSpace({ userId, spaceId: req.query.id as string, adminOnly: true });
   if (error) {
-    return res.status(401).json({ error });
+    throw error;
   }
   next();
 };

--- a/pages/api/spaces/[id]/contributors/[userId].ts
+++ b/pages/api/spaces/[id]/contributors/[userId].ts
@@ -1,23 +1,50 @@
 
 import { prisma } from 'db';
-import { onError, onNoMatch, requireSpaceMembership, requireUser } from 'lib/middleware';
+import { onError, onNoMatch, requireKeys, requireSpaceMembership, requireUser } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
+import { AdministratorOnlyError, UserIsNotSpaceMemberError } from 'lib/users/errors';
+import { MinimumOneSpaceAdminRequiredError } from 'lib/spaces/errors';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler.use(requireUser)
-  .use(requireSpaceMembership(true))
-  .put(updateContributor)
-  .delete(deleteContributor);
+  .use(requireSpaceMembership({ adminOnly: false, spaceIdKey: 'id' }))
+  .delete(deleteContributor)
+  .use(requireSpaceMembership({ adminOnly: true, spaceIdKey: 'id' }))
+  .use(requireKeys(['isAdmin'], 'body'))
+  .put(updateContributor);
 
 async function updateContributor (req: NextApiRequest, res: NextApiResponse) {
+
+  const userId = req.query.userId as string;
+  const spaceId = req.query.id as string;
+
+  const newAdminStatus = req.body.isAdmin;
+
+  // Check the space won't end up with 0 admins
+  if (newAdminStatus === false) {
+    const otherAdmins = await prisma.spaceRole.count({
+      where: {
+        isAdmin: true,
+        spaceId,
+        userId: {
+          not: req.session.user.id
+        }
+      }
+    });
+
+    if (otherAdmins === 0) {
+      throw new MinimumOneSpaceAdminRequiredError();
+    }
+  }
+
   await prisma.spaceRole.update({
     where: {
       spaceUser: {
-        userId: req.query.userId as string,
-        spaceId: req.query.id as string
+        userId,
+        spaceId
       }
     },
     data: {
@@ -28,11 +55,48 @@ async function updateContributor (req: NextApiRequest, res: NextApiResponse) {
 }
 
 async function deleteContributor (req: NextApiRequest, res: NextApiResponse) {
+
+  const userId = req.query.userId as string;
+  const spaceId = req.query.id as string;
+
+  const existingRole = await prisma.spaceRole.findUnique({
+    where: {
+      spaceUser: {
+        spaceId,
+        userId
+      }
+    }
+  });
+
+  if (!existingRole) {
+    throw new UserIsNotSpaceMemberError();
+  }
+
+  // Non admin user trying to delete another user
+  if (existingRole.isAdmin !== true && userId !== req.session.user.id) {
+    throw new AdministratorOnlyError();
+  }
+  else if (existingRole.isAdmin) {
+    const otherAdmins = await prisma.spaceRole.count({
+      where: {
+        isAdmin: true,
+        spaceId,
+        userId: {
+          not: req.session.user.id
+        }
+      }
+    });
+
+    if (otherAdmins === 0) {
+      throw new MinimumOneSpaceAdminRequiredError();
+    }
+  }
+
   await prisma.spaceRole.delete({
     where: {
       spaceUser: {
-        userId: req.query.userId as string,
-        spaceId: req.query.id as string
+        userId,
+        spaceId
       }
     }
   });

--- a/pages/api/spaces/[id]/contributors/[userId].ts
+++ b/pages/api/spaces/[id]/contributors/[userId].ts
@@ -1,23 +1,14 @@
 
-import { NextApiRequest, NextApiResponse } from 'next';
-import nc, { NextHandler } from 'next-connect';
-import { onError, onNoMatch, requireUser, hasAccessToSpace } from 'lib/middleware';
-import { withSessionRoute } from 'lib/session/withSession';
 import { prisma } from 'db';
+import { onError, onNoMatch, requireSpaceMembership, requireUser } from 'lib/middleware';
+import { withSessionRoute } from 'lib/session/withSession';
+import { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-const requireAdmin = async (req: NextApiRequest, res: NextApiResponse, next: NextHandler) => {
-  const userId = req.session.user.id;
-  const { error } = await hasAccessToSpace({ userId, spaceId: req.query.id as string, adminOnly: true });
-  if (error) {
-    throw error;
-  }
-  next();
-};
-
 handler.use(requireUser)
-  .use(requireAdmin)
+  .use(requireSpaceMembership(true))
   .put(updateContributor)
   .delete(deleteContributor);
 

--- a/pages/api/spaces/[id]/contributors/[userId].ts
+++ b/pages/api/spaces/[id]/contributors/[userId].ts
@@ -3,7 +3,6 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import nc, { NextHandler } from 'next-connect';
 import { onError, onNoMatch, requireUser, hasAccessToSpace } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
-import { Role } from 'models';
 import { prisma } from 'db';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
@@ -31,7 +30,7 @@ async function updateContributor (req: NextApiRequest, res: NextApiResponse) {
       }
     },
     data: {
-      role: req.body.role as Role
+      isAdmin: req.body.isAdmin
     }
   });
   res.status(200).json({ ok: true });

--- a/pages/api/spaces/[id]/contributors/index.ts
+++ b/pages/api/spaces/[id]/contributors/index.ts
@@ -1,10 +1,10 @@
 
-import { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
+import { prisma } from 'db';
 import { onError, onNoMatch, requireUser } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
-import { Contributor, Role } from 'models';
-import { prisma } from 'db';
+import { Contributor } from 'models';
+import { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
@@ -22,7 +22,7 @@ async function getContributors (req: NextApiRequest, res: NextApiResponse<Contri
   const contributors = spaceRoles.map((spaceRole): Contributor => {
     return {
       ...spaceRole.user,
-      role: spaceRole.role as Role
+      isAdmin: spaceRole.isAdmin
     };
   });
   return res.status(200).json(contributors);

--- a/pages/api/spaces/[id]/index.ts
+++ b/pages/api/spaces/[id]/index.ts
@@ -9,7 +9,7 @@ import nc from 'next-connect';
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler
-  .use(requireSpaceMembership({ adminOnly: true }))
+  .use(requireSpaceMembership({ adminOnly: true, spaceIdKey: 'id' }))
   .put(updateSpace)
   .delete(deleteSpace);
 

--- a/pages/api/spaces/[id]/index.ts
+++ b/pages/api/spaces/[id]/index.ts
@@ -1,14 +1,17 @@
 
-import { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
-import { onError, onNoMatch, requireUser } from 'lib/middleware';
-import { withSessionRoute } from 'lib/session/withSession';
 import { Space } from '@prisma/client';
 import { prisma } from 'db';
+import { onError, onNoMatch, requireSpaceMembership } from 'lib/middleware';
+import { withSessionRoute } from 'lib/session/withSession';
+import { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-handler.use(requireUser).put(updateSpace).delete(deleteSpace);
+handler
+  .use(requireSpaceMembership({ adminOnly: true }))
+  .put(updateSpace)
+  .delete(deleteSpace);
 
 async function updateSpace (req: NextApiRequest, res: NextApiResponse<Space>) {
 

--- a/pages/api/spaces/[id]/pages.ts
+++ b/pages/api/spaces/[id]/pages.ts
@@ -51,13 +51,8 @@ async function getPages (req: NextApiRequest, res: NextApiResponse<Page[]>) {
             id: spaceId,
             spaceRoles: {
               some: {
-                OR: [{
-                  userId,
-                  isAdmin: true
-                }, {
-                  userId,
-                  role: 'admin'
-                }]
+                userId,
+                isAdmin: true
               }
             }
           }

--- a/pages/api/token-gates/[id]/index.ts
+++ b/pages/api/token-gates/[id]/index.ts
@@ -26,10 +26,10 @@ async function deleteTokenGate (req: NextApiRequest, res: NextApiResponse) {
   const { error } = await hasAccessToSpace({
     userId: req.session.user.id,
     spaceId: gate.spaceId,
-    role: 'admin'
+    adminOnly: true
   });
   if (error) {
-    return res.status(401).json({ error });
+    throw error;
   }
   await prisma.tokenGate.delete({
     where: {

--- a/pages/api/token-gates/[id]/index.ts
+++ b/pages/api/token-gates/[id]/index.ts
@@ -1,7 +1,6 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
-import { TokenGate } from '@prisma/client';
 import { prisma } from 'db';
 import { onError, onNoMatch, requireUser, hasAccessToSpace } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';

--- a/pages/api/token-gates/[id]/verify.ts
+++ b/pages/api/token-gates/[id]/verify.ts
@@ -42,7 +42,7 @@ async function verifyWallet (req: NextApiRequest, res: NextApiResponse) {
       if (!spaceRole) {
         await prisma.spaceRole.create({
           data: {
-            role: tokenGate.userRole || undefined,
+            isAdmin: false,
             userId: user.id,
             spaceId: tokenGate.spaceId,
             tokenGateId: tokenGate.id,
@@ -51,7 +51,7 @@ async function verifyWallet (req: NextApiRequest, res: NextApiResponse) {
         });
         console.log('Gave user access to workspace', { tokenGateId: tokenGate.id, userId: user.id });
       }
-      else if (spaceRole.tokenGateId || spaceRole.role !== 'admin') {
+      else if (spaceRole.tokenGateId || spaceRole.isAdmin !== true) {
         await prisma.spaceRole.update({
           where: {
             spaceUser: {
@@ -60,7 +60,7 @@ async function verifyWallet (req: NextApiRequest, res: NextApiResponse) {
             }
           },
           data: {
-            role: tokenGate.userRole || undefined,
+            isAdmin: false,
             tokenGateId: tokenGate.id,
             tokenGateConnectedDate: new Date()
           }

--- a/pages/api/token-gates/index.ts
+++ b/pages/api/token-gates/index.ts
@@ -1,16 +1,16 @@
 
+import { Space, TokenGate } from '@prisma/client';
+import { prisma } from 'db';
+import { hasAccessToSpace, onError, onNoMatch, requireSpaceMembership } from 'lib/middleware';
+import { withSessionRoute } from 'lib/session/withSession';
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
-import { TokenGate, Space } from '@prisma/client';
-import { prisma } from 'db';
-import { onError, onNoMatch, requireUser, hasAccessToSpace } from 'lib/middleware';
-import { withSessionRoute } from 'lib/session/withSession';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler
   .get(getTokenGates)
-  .use(requireUser)
+  .use(requireSpaceMembership({ adminOnly: true }))
   .post(saveTokenGate);
 
 async function saveTokenGate (req: NextApiRequest, res: NextApiResponse) {

--- a/pages/api/token-gates/index.ts
+++ b/pages/api/token-gates/index.ts
@@ -18,10 +18,10 @@ async function saveTokenGate (req: NextApiRequest, res: NextApiResponse) {
   const { error } = await hasAccessToSpace({
     userId: req.session.user.id,
     spaceId: req.body.spaceId,
-    role: 'admin'
+    adminOnly: true
   });
   if (error) {
-    return res.status(401).json({ error });
+    throw error;
   }
 
   const result = await prisma.tokenGate.create({

--- a/prisma/migrations/20220502213040_remove_spacerole_name/migration.sql
+++ b/prisma/migrations/20220502213040_remove_spacerole_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `role` on the `SpaceRole` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "SpaceRole" DROP COLUMN "role";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -162,7 +162,6 @@ model FavoritePage {
 
 model SpaceRole {
   id                     String            @id @default(uuid()) @db.Uuid
-  role                   String            @default("contributor")
   isAdmin                Boolean           @default(false)
   spaceId                String            @db.Uuid
   space                  Space             @relation(fields: [spaceId], references: [id], onDelete: Cascade)

--- a/scripts/setAdminStatus.ts
+++ b/scripts/setAdminStatus.ts
@@ -3,6 +3,9 @@
 import { RPCList } from 'connectors';
 import { prisma } from 'db';
 
+/**
+ * Restore admin status
+ */
 function setAdminStatus (): Promise<any> {
 
   return new Promise((resolve, reject) => {
@@ -35,3 +38,27 @@ setAdminStatus()
   });
 */
 
+/**
+ * Moving away from role names
+ */
+async function migrateAdminStatus () {
+  prisma.spaceRole.updateMany({
+    where: {
+      role: 'admin'
+    },
+    data: {
+      isAdmin: true
+    }
+  }).then(data => {
+    console.log(data.count, ' space roles affected');
+
+    return true;
+  });
+}
+
+/*
+migrateAdminStatus()
+  .then(() => {
+    console.log('Job complete');
+  });
+*/


### PR DESCRIPTION
1. Create/Update/Delete roles
- Only admin can delete, create and update roles
- Only admin can assign or unassign roles
- If discord roles are imported, and I connect my discord account as a non admin user, I will still auto-receive my Discord roles

2. Create/Update/Delete invites
- Any user (including non space members) can accept invites
- Any space member can see invites
- Only admin can create or delete invites

3. Update/Delete space
- Only admin can update or delete space

4. Update contributors (admin or contributor role)
- admin can delete any space membership
- user can only delete their own space membership
- only admin can change contributor / admin status
- if the last admin will be made a contributor, reject this operation so the space has at least 1 admin
- if the last admin will be deleted, reject this operation so the space has at least 1 admin

5. Add/Remove token gates
- anyone can get token gates (useful for connecting to a space)
- only admin can add or remove token gates

6. Add/Remove/Update payment methods
- Any space member can list or add payment methods
- Only admin can delete payment methods