### PR TITLE
update react-dnd-scrolling lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "react-day-picker": "^7.4.10",
         "react-dnd": "^16.0.0",
         "react-dnd-html5-backend": "^16.0.0",
-        "react-dnd-scrolling": "^1.2.1",
+        "react-dnd-scrolling": "^1.2.4",
         "react-dnd-touch-backend": "^16.0.0",
         "react-dom": "^17.0.2",
         "react-hook-form": "^7.25.0",
@@ -19857,9 +19857,9 @@
       }
     },
     "node_modules/react-dnd-scrolling": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/react-dnd-scrolling/-/react-dnd-scrolling-1.2.2.tgz",
-      "integrity": "sha512-XApDQTa63433MZSMN2kRG4PyxvkDEQRepcHeFLlZMuOMX7ecfhgQxd7HXsHKmenaarp59Q/lC01zq31Ssi9o2Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/react-dnd-scrolling/-/react-dnd-scrolling-1.2.4.tgz",
+      "integrity": "sha512-twjfyP+S6cZu/ualBUAOHXiHTFATz0EmTwunP3KA4W4lNwTlp3lWJQtRWFlzPXYXY8sChRPfFb5psTgORFSVZA==",
       "dependencies": {
         "hoist-non-react-statics": "3.x",
         "lodash.throttle": "^4.1.1",
@@ -19868,9 +19868,9 @@
         "react-display-name": "^0.2.5"
       },
       "peerDependencies": {
-        "react": "16.x || 17.x",
-        "react-dnd": "10.x || 11.x || 14.x || 15.x",
-        "react-dom": "16.x || 17.x"
+        "react": "16.x || 17.x || 18.x",
+        "react-dnd": "10.x || 11.x || 14.x || 15.x || 16.x",
+        "react-dom": "16.x || 17.x || 18.x"
       }
     },
     "node_modules/react-dnd-touch-backend": {
@@ -38229,9 +38229,9 @@
       }
     },
     "react-dnd-scrolling": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/react-dnd-scrolling/-/react-dnd-scrolling-1.2.2.tgz",
-      "integrity": "sha512-XApDQTa63433MZSMN2kRG4PyxvkDEQRepcHeFLlZMuOMX7ecfhgQxd7HXsHKmenaarp59Q/lC01zq31Ssi9o2Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/react-dnd-scrolling/-/react-dnd-scrolling-1.2.4.tgz",
+      "integrity": "sha512-twjfyP+S6cZu/ualBUAOHXiHTFATz0EmTwunP3KA4W4lNwTlp3lWJQtRWFlzPXYXY8sChRPfFb5psTgORFSVZA==",
       "requires": {
         "hoist-non-react-statics": "3.x",
         "lodash.throttle": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "react-day-picker": "^7.4.10",
     "react-dnd": "^16.0.0",
     "react-dnd-html5-backend": "^16.0.0",
-    "react-dnd-scrolling": "^1.2.1",
+    "react-dnd-scrolling": "^1.2.4",
     "react-dnd-touch-backend": "^16.0.0",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.25.0",


### PR DESCRIPTION
Updating to the latest version, which doesn't complain that react-dnd is an invalid version: https://github.com/TechStark/react-dnd-scrolling/issues/15. i don't expect and breaking changes