### PR TITLE
fix script to run patch-package

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -34,4 +34,3 @@ runs:
       if: steps.cache_node_modules.outputs.cache-hit != 'true'
       run: |
         npm ci --no-audit --no-fund
-        npx patch-package

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "destroy:staging": "npx cdk destroy \"CharmVerse-staging-${STAGE}\" --force",
     "lint": "eslint -c .eslintrc.json . --ext .ts --ext .tsx",
     "lint:prod": "npm run lint -- --quiet",
+    "postinstall": "patch-package",
     "start": "next dev",
     "start:test": "dotenv -e .env.test.local -- npm start",
     "start:test:ci": "npx react-env --path .env.test.local -- npx next start",
@@ -25,7 +26,6 @@
     "test:server": "NODE_OPTIONS=\"--max_old_space_size=4096\" dotenv -e .env.test.local --override -- npx jest --config='./jest.config-server.ts' --verbose",
     "test:server-integration": "dotenv -e .env.test.local --override -- npx jest --config='./jest.config-server-integration.ts' --verbose"
   },
-  "postinstall": "patch-package",
   "prepare": "husky install",
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
The 'postinstall' script was in the wrong place in package.json, so it didn't get triggered! I have a feeling this happened while I was fixing a merge conflict.. after this, we should no longer have to run npx patch-package locally :)