### PR TITLE
Updated crypto price format

### DIFF
--- a/lib/utilities/__tests__/formatting.spec.ts
+++ b/lib/utilities/__tests__/formatting.spec.ts
@@ -1,0 +1,16 @@
+import { formatMoney } from '../formatting';
+
+describe('amount formating', () => {
+
+  it('should be correct for values larger than 1', () => {
+    const amount = formatMoney(2932.12345, 'USD');
+
+    expect(amount).toBe('$2,932.12');
+  });
+
+  it('should be correct for values less than 1', () => {
+    const amount = formatMoney(0.12345, 'USD');
+
+    expect(amount).toBe('$0.1234');
+  });
+});

--- a/lib/utilities/formatting.ts
+++ b/lib/utilities/formatting.ts
@@ -6,9 +6,11 @@ export function formatMoney (amount: number, currency: FiatCurrency): string {
 
   const formatter = new Intl.NumberFormat(userLocale, {
     style: 'currency',
-    currency
+    currency,
+    ...(amount < 1 && {
+      minimumFractionDigits: 4
+    })
   });
 
   return formatter.format(amount);
-
 }


### PR DESCRIPTION
Updated the format in which the crypto price is displayed in the crypto module. The two scenarios are:

- if price > 0 : display two digits after the decimal point
- if price < 0: display four digits after the decimal point

![image](https://user-images.githubusercontent.com/12700927/166918753-79026a4d-c90f-4b3b-863a-b3e710aef322.png)

![image](https://user-images.githubusercontent.com/12700927/166918635-1fa0e7b3-b9e8-4495-afa3-6e63e110f682.png)
 