### PR TITLE
Fix API docs, enforce light mode in the API

### DIFF
--- a/lib/public-api/interfaces.ts
+++ b/lib/public-api/interfaces.ts
@@ -60,7 +60,7 @@ export interface PageProperty {
  *          type: string
  *          format: uuid
  *          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
-*         spaceId:
+ *        spaceId:
  *          type: string
  *          format: uuid
  *          example: 12c419f4-017e-4696-b8e9-ca3079b32428
@@ -135,14 +135,13 @@ export interface PageContentFormats {
  *          format: date-time
  *          example: 2022-04-02T07:22:31.097Z
  *        title:
- *          type: object
- *            properties
+ *          type: string
  *          example: Finalise community guidelines
  *        content:
  *          type: object
  *          $ref: '#/components/schemas/PageContentFormats'
  *        isTemplate:
- *          type: string
+ *          type: boolean
  *          example: false
  *        properties:
  *           type: object

--- a/pages/api-docs.tsx
+++ b/pages/api-docs.tsx
@@ -1,7 +1,8 @@
+import { useTheme } from '@emotion/react';
+import { useColorMode } from 'context/darkMode';
 import { GetStaticProps, InferGetStaticPropsType } from 'next';
-import { useEffect, useState } from 'react';
-
 import { createSwaggerSpec } from 'next-swagger-doc';
+import { useEffect } from 'react';
 import SwaggerUI from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
 
@@ -32,6 +33,16 @@ export const getStaticProps: GetStaticProps = async ctx => {
 };
 
 export default function ApiDoc ({ spec }: InferGetStaticPropsType<typeof getStaticProps>) {
+
+  const theme = useTheme();
+
+  const colorMode = useColorMode();
+  useEffect(() => {
+    if (theme.palette.mode === 'dark') {
+      colorMode.toggleColorMode();
+    }
+
+  }, []);
 
   return (<SwaggerUI spec={spec}></SwaggerUI>);
 //  ;

--- a/pages/api-docs.tsx
+++ b/pages/api-docs.tsx
@@ -35,8 +35,8 @@ export const getStaticProps: GetStaticProps = async ctx => {
 export default function ApiDoc ({ spec }: InferGetStaticPropsType<typeof getStaticProps>) {
 
   const theme = useTheme();
-
   const colorMode = useColorMode();
+
   useEffect(() => {
     if (theme.palette.mode === 'dark') {
       colorMode.toggleColorMode();


### PR DESCRIPTION
This ensures the Open API docs show in light mode only, and fixes a small bug on the Database Page