### PR TITLE
Review markdown

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -79,7 +79,7 @@ export const specRegistry = new SpecRegistry([
   orderedList.spec(), // OK
   strike.spec(), // OK
   underline.spec(), // OK
-  emojiSpecs(), // ??
+  emojiSpecs(), // OK
   mentionSpecs(), // NO
   code.spec(), // OK
   codeBlock.spec(), // OK

--- a/components/common/CharmEditor/components/emojiSuggest/emojiSuggest.specs.ts
+++ b/components/common/CharmEditor/components/emojiSuggest/emojiSuggest.specs.ts
@@ -38,6 +38,16 @@ function emojiSpec ({ defaultEmoji = '😃' }: { defaultEmoji?: string } = {}): 
       toDOM,
       parseDOM,
       selectable: true
+    },
+    markdown: {
+      toMarkdown: (state, node) => {
+        try {
+          state.text(node.attrs.emoji);
+        }
+        catch (err) {
+          console.log('Conversion err', err);
+        }
+      }
     }
   };
 }

--- a/components/common/CharmEditor/components/table/table.ts
+++ b/components/common/CharmEditor/components/table/table.ts
@@ -13,7 +13,10 @@ export function spec (): RawSpecs {
   const specs = Object.entries(schemas).map(([name, schema]): RawSpecs => ({
     name,
     schema,
-    type: 'node'
+    type: 'node',
+    markdown: {
+      toMarkdown: () => null
+    }
   }));
   return specs;
 }


### PR DESCRIPTION
Prevent markdown export from blowing up
- Adds support for inline emojis
- Provides empty renderer function for tables