### PR TITLE
Fix hidden menus in Focalboard

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
@@ -180,7 +180,7 @@ const CardDetailProperties = React.memo((props: Props) => {
                                 defaultMessage='+ Add a property'
                             />
                         </Button>
-                        <Menu>
+                        <Menu position='bottom-start'>
                             <PropertyTypes
                                 label={intl.formatMessage({id: 'PropertyMenu.selectType', defaultMessage: 'Select property type'})}
                                 onTypeSelected={async (type) => {

--- a/components/common/BoardEditor/focalboard/src/components/cardDialog.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDialog.tsx
@@ -101,7 +101,7 @@ const CardDialog = (props: Props): JSX.Element | null => {
     }
 
     const menu = (
-        <Menu position='left'>
+        <Menu position='bottom-end'>
             <Menu.Text
                 id='delete'
                 icon={<DeleteIcon/>}

--- a/components/common/BoardEditor/focalboard/src/components/dialog.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.tsx
@@ -8,6 +8,7 @@ import IconButton from '../widgets/buttons/iconButton'
 import CloseIcon from '../widgets/icons/close'
 import OptionsIcon from '../widgets/icons/options'
 import MenuWrapper from '../widgets/menuWrapper'
+import Modal from '@mui/material/Modal';
 
 type Props = {
     children: React.ReactNode
@@ -31,6 +32,7 @@ const Dialog = React.memo((props: Props) => {
     useHotkeys('esc', () => props.onClose())
 
     return (
+        <Modal open={true}>
         <div className={`Dialog dialog-back ${props.className}`}>
             <div
                 className='wrapper'
@@ -68,6 +70,7 @@ const Dialog = React.memo((props: Props) => {
                 </div>
             </div>
         </div>
+        </Modal>
     )
 })
 

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/newCardButton.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/newCardButton.tsx
@@ -40,7 +40,7 @@ const NewCardButton = React.memo((props: Props): JSX.Element => {
                 />
             )}
         >
-            <Menu position='left'>
+            <Menu position='bottom-end'>
                 {cardTemplates.length > 0 && <>
                     <Menu.Label>
                         <b>

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/menu.scss
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/menu.scss
@@ -6,9 +6,9 @@
 
 .Menu {
     display: flex;
+    overflow-x: hidden;
+    overflow-y: auto;
     flex-direction: column;
-    position: absolute;
-    z-index: 15;
     background-color: rgb(var(--center-channel-bg-rgb));
     color: rgb(var(--center-channel-color-rgb));
     border-radius: var(--default-rad);

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/menu.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/menu.tsx
@@ -26,7 +26,7 @@ function Menu (props: Props) {
 
     const {position , children} = props
     const [anchorEl] = useMenuContext()
-    console.log('show menu', anchorEl)
+
     return (
         <StyledPopper anchorEl={anchorEl} open={true} placement={position || 'bottom-start'}>
         <div className={'Menu noselect ' + (position || 'bottom-start')}>

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/menu.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/menu.tsx
@@ -1,53 +1,61 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import React from 'react'
-
+import Popper from '@mui/material/Popper'
 import SeparatorOption from './separatorOption'
 import SwitchOption from './switchOption'
 import TextOption from './textOption'
 import ColorOption from './colorOption'
 import SubMenuOption from './subMenuOption'
 import LabelOption from './labelOption'
+import styled  from '@emotion/styled';
 
+
+import { useMenuContext } from './menuContext'
 
 type Props = {
     children: React.ReactNode
-    position?: 'top'|'bottom'|'left'|'right'
+    position?: 'bottom-start' | 'bottom-end' | 'top-start' | 'top' | 'bottom' | 'left' | 'right'
 }
 
-export default class Menu extends React.PureComponent<Props> {
-    static Color = ColorOption
-    static SubMenu = SubMenuOption
-    static Switch = SwitchOption
-    static Separator = SeparatorOption
-    static Text = TextOption
-    static Label = LabelOption
+const StyledPopper = styled(Popper)`
+    z-index: var(--z-index-modal);
+`;
 
-    public render(): JSX.Element {
-        const {position, children} = this.props
-        return (
-            <div className={'Menu noselect ' + (position || 'bottom')}>
-                <div className='menu-contents'>
-                    <div className='menu-options'>
-                        {children}
-                    </div>
+function Menu (props: Props) {
 
-                    <div className='menu-spacer hideOnWidescreen'/>
+    const {position , children} = props
+    const [anchorEl] = useMenuContext()
+    console.log('show menu', anchorEl)
+    return (
+        <StyledPopper anchorEl={anchorEl} open={true} placement={position || 'bottom-start'}>
+        <div className={'Menu noselect ' + (position || 'bottom-start')}>
+            <div className='menu-contents'>
+                <div className='menu-options'>
+                    {children}
+                </div>
 
-                    <div className='menu-options hideOnWidescreen'>
-                        <Menu.Text
-                            id='menu-cancel'
-                            name={'Cancel'}
-                            className='menu-cancel'
-                            onClick={this.onCancel}
-                        />
-                    </div>
+                <div className='menu-spacer hideOnWidescreen'/>
+
+                <div className='menu-options hideOnWidescreen'>
+                    <Menu.Text
+                        id='menu-cancel'
+                        name={'Cancel'}
+                        className='menu-cancel'
+                        onClick={() => void 0}
+                    />
                 </div>
             </div>
-        )
-    }
-
-    private onCancel = () => {
-        // No need to do anything, as click bubbled up to MenuWrapper, which closes
-    }
+         </div>
+        </StyledPopper>
+    )
 }
+
+Menu.Color = ColorOption
+Menu.SubMenu = SubMenuOption
+Menu.Switch = SwitchOption
+Menu.Separator = SeparatorOption
+Menu.Text = TextOption
+Menu.Label = LabelOption
+
+export default Menu

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/menu.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/menu.tsx
@@ -29,24 +29,24 @@ function Menu (props: Props) {
 
     return (
         <StyledPopper anchorEl={anchorEl} open={true} placement={position || 'bottom-start'}>
-        <div className={'Menu noselect ' + (position || 'bottom-start')}>
-            <div className='menu-contents'>
-                <div className='menu-options'>
-                    {children}
-                </div>
+            <div className={'Menu noselect ' + (position || 'bottom-start')}>
+                <div className='menu-contents'>
+                    <div className='menu-options'>
+                        {children}
+                    </div>
 
-                <div className='menu-spacer hideOnWidescreen'/>
+                    <div className='menu-spacer hideOnWidescreen'/>
 
-                <div className='menu-options hideOnWidescreen'>
-                    <Menu.Text
-                        id='menu-cancel'
-                        name={'Cancel'}
-                        className='menu-cancel'
-                        onClick={() => void 0}
-                    />
+                    <div className='menu-options hideOnWidescreen'>
+                        <Menu.Text
+                            id='menu-cancel'
+                            name={'Cancel'}
+                            className='menu-cancel'
+                            onClick={() => void 0}
+                        />
+                    </div>
                 </div>
             </div>
-         </div>
         </StyledPopper>
     )
 }

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/menu.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/menu.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Popper from '@mui/material/Popper'
 import SeparatorOption from './separatorOption'
 import SwitchOption from './switchOption'
@@ -26,10 +26,41 @@ function Menu (props: Props) {
 
     const {position , children} = props
     const [anchorEl] = useMenuContext()
+    const popperRef = useRef<HTMLDivElement>(null)
+    const [maxHeight, setMaxHeight] = useState(0)
+
+    useEffect(() => {
+        const handleResize = () => {
+            const windowHeight = window.innerHeight
+            const box = popperRef?.current?.getBoundingClientRect()
+            const padding = 10;
+            if (box) {
+                if (box.top + box.bottom + padding > windowHeight) {
+                    setMaxHeight(windowHeight - box.top - padding)
+                }
+                else {
+                    setMaxHeight(0)
+                }
+            }
+        }
+        window.addEventListener('resize', handleResize)
+
+        // run once on load, wait for menu to render
+        setTimeout(() => {
+            handleResize()
+        }, 0)
+
+        return () => {
+            window.removeEventListener('resize', handleResize)
+        }
+    }, [])
 
     return (
         <StyledPopper anchorEl={anchorEl} open={true} placement={position || 'bottom-start'}>
-            <div className={'Menu noselect ' + (position || 'bottom-start')}>
+            <div
+                ref={popperRef}
+                style={{ maxHeight: maxHeight || 'none' }}
+                className={'Menu noselect ' + (position || 'bottom-start')}>
                 <div className='menu-contents'>
                     <div className='menu-options'>
                         {children}

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/menuContext.ts
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/menuContext.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+export type Context = [HTMLDivElement | null, (ref: HTMLDivElement | null) => void]
+
+export const MenuContext = createContext<Context>([null, () => void 0]);
+
+export const useMenuContext = () => useContext(MenuContext);

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/subMenuOption.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/subMenuOption.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import React, {useState} from 'react'
+import Popper from '@mui/material/Popper'
 
 import SubmenuTriangleIcon from '../icons/submenuTriangle'
 
@@ -39,8 +40,8 @@ function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
             {props.icon ?? <div className='noicon'/>}
             <div className='menu-name'>{props.name}</div>
             {props.position !== 'left' && props.position !== 'left-bottom' && <SubmenuTriangleIcon/>}
-            {isOpen &&
-                <div className={'SubMenu Menu noselect ' + (props.position || 'bottom')}>
+            {<Popper open={isOpen}>
+                {/* <div className={'SubMenu Menu noselect ' + (props.position || 'bottom')}> */}
                     <div className='menu-contents'>
                         <div className='menu-options'>
                             {props.children}
@@ -57,7 +58,8 @@ function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
                         </div>
                     </div>
 
-                </div>
+                {/* </div> */}
+                </Popper>
             }
         </div>
     )

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/subMenuOption.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/subMenuOption.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React, {useRef,useState} from 'react'
+import React, {useEffect,useRef,useState} from 'react'
 import styled  from '@emotion/styled';
 import Popper from '@mui/material/Popper'
 
@@ -27,6 +27,35 @@ function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
 
     const openLeftClass = props.position === 'left' || props.position === 'left-bottom' ? ' open-left' : ''
 
+    const popperRef = useRef<HTMLDivElement>(null)
+    const [maxHeight, setMaxHeight] = useState(0)
+
+    useEffect(() => {
+        const handleResize = () => {
+            const windowHeight = window.innerHeight
+            const box = popperRef?.current?.getBoundingClientRect()
+            const padding = 10;
+            if (box) {
+                if (box.top + box.bottom + padding > windowHeight) {
+                    setMaxHeight(windowHeight - box.top - padding)
+                }
+                else {
+                    setMaxHeight(0)
+                }
+            }
+        }
+        window.addEventListener('resize', handleResize)
+
+        // run once on load, wait for menu to render
+        setTimeout(() => {
+            handleResize()
+        }, 0)
+
+        return () => {
+            window.removeEventListener('resize', handleResize)
+        }
+    }, [])
+
     return (
         <div
             id={props.id}
@@ -48,7 +77,10 @@ function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
             <div className='menu-name'>{props.name}</div>
             {props.position !== 'left' && props.position !== 'left-bottom' && <SubmenuTriangleIcon/>}
             {<StyledPopper anchorEl={node.current} open={isOpen} placement='right-start'>
-                <div className={'SubMenu Menu noselect ' + (props.position || 'bottom')}>
+                <div
+                    ref={popperRef}
+                    style={{ maxHeight: maxHeight || 'none' }}
+                    className={'SubMenu Menu noselect '}>
                     <div className='menu-contents'>
                         <div className='menu-options'>
                             {props.children}

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/subMenuOption.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/subMenuOption.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React, {useState} from 'react'
+import React, {useRef,useState} from 'react'
+import styled  from '@emotion/styled';
 import Popper from '@mui/material/Popper'
 
 import SubmenuTriangleIcon from '../icons/submenuTriangle'
@@ -16,14 +17,20 @@ type SubMenuOptionProps = {
     children: React.ReactNode
 }
 
+const StyledPopper = styled(Popper)`
+    z-index: var(--z-index-modal);
+`;
+
 function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
     const [isOpen, setIsOpen] = useState(false)
+    const node = useRef<HTMLDivElement>(null)
 
     const openLeftClass = props.position === 'left' || props.position === 'left-bottom' ? ' open-left' : ''
 
     return (
         <div
             id={props.id}
+            ref={node}
             className={`MenuOption SubMenuOption menu-option${openLeftClass}`}
             onMouseEnter={() => {
                 setTimeout(() => {
@@ -40,8 +47,8 @@ function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
             {props.icon ?? <div className='noicon'/>}
             <div className='menu-name'>{props.name}</div>
             {props.position !== 'left' && props.position !== 'left-bottom' && <SubmenuTriangleIcon/>}
-            {<Popper open={isOpen}>
-                {/* <div className={'SubMenu Menu noselect ' + (props.position || 'bottom')}> */}
+            {<StyledPopper anchorEl={node.current} open={isOpen} placement='right-start'>
+                <div className={'SubMenu Menu noselect ' + (props.position || 'bottom')}>
                     <div className='menu-contents'>
                         <div className='menu-options'>
                             {props.children}
@@ -58,8 +65,8 @@ function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
                         </div>
                     </div>
 
-                {/* </div> */}
-                </Popper>
+                 </div>
+            </StyledPopper>
             }
         </div>
     )

--- a/components/common/BoardEditor/focalboard/src/widgets/menuWrapper.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menuWrapper.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useRef, useState, useEffect} from 'react'
+import React, {useRef, useMemo, useState, useEffect} from 'react'
 
+import { MenuContext, useMenuContext, Context } from './menu/menuContext'
 
 type Props = {
     children?: React.ReactNode;
@@ -16,6 +17,7 @@ type Props = {
 const MenuWrapper = React.memo((props: Props) => {
     const node = useRef<HTMLDivElement>(null)
     const [open, setOpen] = useState(Boolean(props.isOpen))
+    const [, setAnchorEl] = useMenuContext()
 
     if (!Array.isArray(props.children) || props.children.length !== 2) {
         throw new Error('MenuWrapper needs exactly 2 children')
@@ -72,6 +74,12 @@ const MenuWrapper = React.memo((props: Props) => {
         }
     }, [])
 
+    useEffect(() => {
+        if (node) {
+            setAnchorEl(node.current)
+        }
+    }, [node])
+
     const {children} = props
     let className = 'MenuWrapper'
     if (props.disabled) {
@@ -95,4 +103,12 @@ const MenuWrapper = React.memo((props: Props) => {
     )
 })
 
-export default MenuWrapper
+export default function MenuWithContext (props: Props) {
+    const [anchorRef, setAnchorRef] = useState<HTMLDivElement | null>(null)
+    const value: Context = useMemo(() => [anchorRef, setAnchorRef], [anchorRef, setAnchorRef]);
+    return (
+        <MenuContext.Provider value={value}>
+            <MenuWrapper {...props} />
+        </MenuContext.Provider>
+    );
+}

--- a/components/common/BoardEditor/focalboard/src/widgets/menuWrapper.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menuWrapper.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useRef, useMemo, useState, useEffect} from 'react'
+import React, {memo, useRef, useMemo, useState, useEffect} from 'react'
+import ClickAwayListener from '@mui/material/ClickAwayListener'
 
 import { MenuContext, useMenuContext, Context } from './menu/menuContext'
 
@@ -14,7 +15,7 @@ type Props = {
     label?: string
 }
 
-const MenuWrapper = React.memo((props: Props) => {
+const MenuWrapper = (props: Props) => {
     const node = useRef<HTMLDivElement>(null)
     const [open, setOpen] = useState(Boolean(props.isOpen))
     const [, setAnchorEl] = useMenuContext()
@@ -23,29 +24,8 @@ const MenuWrapper = React.memo((props: Props) => {
         throw new Error('MenuWrapper needs exactly 2 children')
     }
 
-    const close = (): void => {
-        setOpen(false)
-    }
-
-    const closeOnBlur = (e: Event) => {
-        if (e.target && node.current?.contains(e.target as Node)) {
-            return
-        }
-
-        close()
-    }
-
-    const keyboardClose = (e: KeyboardEvent) => {
-        if (e.key === 'Escape') {
-            close()
-        }
-
-        if (e.key === 'Tab') {
-            closeOnBlur(e)
-        }
-    }
-
     const toggle = (e: React.MouseEvent<HTMLDivElement, MouseEvent>): void => {
+
         if (props.disabled) {
             return
         }
@@ -64,20 +44,41 @@ const MenuWrapper = React.memo((props: Props) => {
     }
 
     useEffect(() => {
+
+        const close = (): void => {
+            setOpen(false)
+        }
+
+        const closeOnBlur = (e: Event) => {
+
+            if (e.target && node.current?.contains(e.target as Node)) {
+                return
+            }
+
+            close()
+        }
+
+        const keyboardClose = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                close()
+            }
+
+            if (e.key === 'Tab') {
+                closeOnBlur(e)
+            }
+        }
+
+
         document.addEventListener('menuItemClicked', close, true)
-        document.addEventListener('click', closeOnBlur, true)
         document.addEventListener('keyup', keyboardClose, true)
         return () => {
             document.removeEventListener('menuItemClicked', close, true)
-            document.removeEventListener('click', closeOnBlur, true)
             document.removeEventListener('keyup', keyboardClose, true)
         }
     }, [])
 
     useEffect(() => {
-        if (node) {
-            setAnchorEl(node.current)
-        }
+        setAnchorEl(node.current)
     }, [node])
 
     const {children} = props
@@ -85,11 +86,12 @@ const MenuWrapper = React.memo((props: Props) => {
     if (props.disabled) {
         className += ' disabled'
     }
-  if (props.className) {
+    if (props.className) {
         className += ' ' + props.className
     }
 
     return (
+        <ClickAwayListener onClickAway={() => setOpen(false)}>
         <div
             role='button'
             aria-label={props.label || 'menuwrapper'}
@@ -100,10 +102,12 @@ const MenuWrapper = React.memo((props: Props) => {
             {children ? Object.values(children)[0] : null}
             {children && !props.disabled && open ? Object.values(children)[1] : null}
         </div>
+        </ClickAwayListener>
     )
-})
+}
 
-export default function MenuWithContext (props: Props) {
+// create an anchorRef to pass down as context to the menu popper
+const MenuWithContext = (props: Props) => {
     const [anchorRef, setAnchorRef] = useState<HTMLDivElement | null>(null)
     const value: Context = useMemo(() => [anchorRef, setAnchorRef], [anchorRef, setAnchorRef]);
     return (
@@ -112,3 +116,5 @@ export default function MenuWithContext (props: Props) {
         </MenuContext.Provider>
     );
 }
+
+export default memo(MenuWithContext)

--- a/components/common/BoardEditor/focalboard/src/widgets/valueSelector.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/valueSelector.tsx
@@ -83,7 +83,7 @@ const ValueSelectorLabel = React.memo((props: LabelProps): JSX.Element => {
                     title={intl.formatMessage({id: 'ValueSelectorLabel.openMenu', defaultMessage: 'Open menu'})}
                     icon={<OptionsIcon/>}
                 />
-                <Menu position='left'>
+                <Menu position='bottom'>
                     <Menu.Text
                         id='delete'
                         icon={<DeleteIcon/>}


### PR DESCRIPTION
This screenshot is an example of really bad UI:
![image](https://user-images.githubusercontent.com/305398/167505178-ca999fb7-6ca7-4194-8455-bf685880f146.png)

The dropdowns are now embedded at document.body so nothing can crop them:
![image](https://user-images.githubusercontent.com/305398/167505138-43161c61-0469-4f01-8cc3-46e3154ff83e.png)


One downside to this I noticed is that if they go past the viewport, you can't get to content. What Notion does is auto- popups to fit inside the viewport. I want to leave that for another day / another PR

The placement of menus may be a little off, I didn't go thru and update 'position' everywhere.