### PR TITLE
fix logic to not show "0" on focalboards

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -327,7 +327,7 @@ function CenterPanel(props: Props) {
         keyName='ctrl+d,del,esc,backspace'
         onKeyDown={keydownHandler}
       />
-      {board.deletedAt && <PageDeleteBanner pageId={board.id}/>}
+      {!!board.deletedAt && <PageDeleteBanner pageId={board.id}/>}
       {board.fields.headerImage && <Box className='PageBanner' width={"100%"} mb={2}>
         <PageBanner focalBoard headerImage={board.fields.headerImage} setPage={({ headerImage }) => {
           setRandomHeaderImage(board, headerImage!)


### PR DESCRIPTION
Apparently, 'card.deletedAt' can be 0 sometimes, but it then appears on our UI. I wonder if there's a lint rule or something to prevent non-boolean types from being used in React templates

<img width="797" alt="image" src="https://user-images.githubusercontent.com/305398/167541118-7ecc5478-e40b-43a1-8791-be7e22722fc2.png">
