### PR TITLE
Show a visible box when the permission is hovered

### DIFF
--- a/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import Box from '@mui/material/Box';
+import { useTheme } from '@emotion/react';
 import Button from '@mui/material/Button';
 import InputAdornment from '@mui/material/InputAdornment';
 import Input from '@mui/material/OutlinedInput';
@@ -89,6 +90,7 @@ interface Props {
 export default function PagePermissions ({ pageId }: Props) {
 
   const [pagePermissions, setPagePermissions] = useState<IPagePermissionWithAssignee []>([]);
+  const theme = useTheme();
   const { pages } = usePages();
   const [space] = useCurrentSpace();
   const { getPagePermissions } = usePages();
@@ -201,7 +203,11 @@ export default function PagePermissions ({ pageId }: Props) {
                 }
               }}
               >
-                <Typography color='secondary' variant='caption'>
+                <Typography
+                  color='secondary'
+                  variant='caption'
+                  sx={{ ':hover': { borderWidth: 2, borderColor: theme.palette.gray, borderRadius: 1, borderStyle: 'solid', px: 3, py: 1 } }}
+                >
                   {spaceLevelPermission ? permissionsWithoutCustom[spaceLevelPermission.permissionLevel] : (permissionsLoaded ? 'No access' : '')}
                 </Typography>
               </div>
@@ -248,7 +254,7 @@ export default function PagePermissions ({ pageId }: Props) {
                       }
                     }}
                     >
-                      <Typography color='secondary' variant='caption'>
+                      <Typography color='secondary' variant='caption' sx={{ ':hover': { borderWidth: 2, borderColor: theme.palette.gray, borderRadius: 1, borderStyle: 'solid', px: 3, py: 1 } }}>
                         {permissionLevels[permission.permissionLevel]}
                       </Typography>
                     </div>

--- a/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -195,6 +195,7 @@ export default function PagePermissions ({ pageId }: Props) {
                 onChange={level => updateSpacePagePermissionLevel(level as PagePermissionLevelType)}
                 keyAndLabel={permissionsWithRemove}
                 defaultValue={spaceLevelPermission?.permissionLevel}
+                autoExpand
               />
             ) : (
               <div onClick={() => {
@@ -234,7 +235,7 @@ export default function PagePermissions ({ pageId }: Props) {
       {
         sortedPermissions.map(permission => {
           return (
-            <Box display='block' py={0.5}>
+            <Box display='block' py={0.5} onMouseLeave={() => setSelectedPermissionId(null)}>
               <Box display='flex' justifyContent='space-between' alignItems='center' key={permission.displayName}>
                 <Typography variant='body2'>
                   {permission.displayName}
@@ -246,6 +247,7 @@ export default function PagePermissions ({ pageId }: Props) {
                       onChange={level => updatePagePermissionLevel(permission, level as PagePermissionLevelType)}
                       keyAndLabel={permissionsWithRemove}
                       defaultValue={permission.permissionLevel}
+                      autoExpand
                     />
                   ) : (
                     <div onClick={() => {

--- a/components/common/form/InputEnumToOptions.tsx
+++ b/components/common/form/InputEnumToOptions.tsx
@@ -9,9 +9,10 @@ export interface Props {
   defaultValue?: string,
   title?: string
   keyAndLabel: Record<string | any, string | number>
+  autoExpand?: boolean
 }
 
-export default function InputEnumToOptions ({ onChange = () => {}, defaultValue, title, keyAndLabel }: Props) {
+export default function InputEnumToOptions ({ onChange = () => {}, defaultValue, title, keyAndLabel, autoExpand = false }: Props) {
 
   const options = Object.entries(keyAndLabel);
 
@@ -31,6 +32,7 @@ export default function InputEnumToOptions ({ onChange = () => {}, defaultValue,
 
       <Select
         value={value}
+        defaultOpen={autoExpand}
         onChange={(ev) => {
           setValue(ev.target.value as string);
           if (ev.target.value) {


### PR DESCRIPTION
This PR is in response to an issue reported by a user who thought they couldn't change their permissions.

It displays a box when a permission level is hovered.

![highlight-permission](https://user-images.githubusercontent.com/18669748/168181495-3e17282e-4b5a-4f5e-b9a3-25e109fcd868.png)
