### PR TITLE
Lit modal fix (temporary)

### DIFF
--- a/patches/lit-share-modal+0.1.84.patch
+++ b/patches/lit-share-modal+0.1.84.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/lit-share-modal/dist/lit-share-modal.es.js b/node_modules/lit-share-modal/dist/lit-share-modal.es.js
+index cd39bbe..ce2ca77 100644
+--- a/node_modules/lit-share-modal/dist/lit-share-modal.es.js
++++ b/node_modules/lit-share-modal/dist/lit-share-modal.es.js
+@@ -13108,23 +13108,7 @@ const SelectGroup = ({
+       turnOffSearch: true
+     }), /* @__PURE__ */ jsx$1("h3", {
+       className: "lsm-select-label lsm-text-title-gray dark:lsm-text-gray lsm-font-segoe lsm-text-base lsm-font-light",
+-      children: "Select token/NFT or enter contract address:"
+-    }), !contractAddress.length && /* @__PURE__ */ jsx$1(LitTokenSelect, {
+-      option: selectedToken,
+-      label: !selectedToken || !selectedToken["label"] ? "Search for a token/NFT" : selectedToken.label,
+-      selectedToken,
+-      setSelectedToken: (e2) => {
+-        if (!!(e2 == null ? void 0 : e2["standard"])) {
+-          setContractType(e2.standard.toUpperCase());
+-        } else {
+-          setContractType(null);
+-          setErc1155TokenId(null);
+-        }
+-        setSelectedToken(e2);
+-      }
+-    }), (!selectedToken || !selectedToken["label"]) && !contractAddress.length && /* @__PURE__ */ jsx$1("p", {
+-      className: "lsm-text-sm md:lsm-text-base lsm-w-full lsm-my-1 dark:lsm-text-gray lsm-condition-spacing lsm-text-title-gray lsm-font-segoe lsm-text-base lsm-font-light",
+-      children: "OR"
++      children: "Enter contract address for a token or NFT:"
+     }), (!selectedToken || !selectedToken["label"]) && /* @__PURE__ */ jsx$1(LitInput, {
+       value: contractAddress,
+       setValue: setContractAddress,

--- a/theme/lit-share-modal/lit-share-modal.scss
+++ b/theme/lit-share-modal/lit-share-modal.scss
@@ -233,3 +233,14 @@
     background-color: var(--charm-lit-color-gray);
   }
 }
+
+
+// temporary hack to hide broken feature - hide the dropdown to select erc20 tokens
+div.lsm-w-full:nth-of-type(2) {
+  display: none;
+}
+
+// container for the word "OR"
+.lsm-text-sm.md\:lsm-text-base.lsm-w-full.lsm-my-1.dark\:lsm-text-gray.lsm-condition-spacing.lsm-text-title-gray.lsm-font-segoe.lsm-text-base.lsm-font-light {
+  display: none;
+}

--- a/theme/lit-share-modal/lit-share-modal.scss
+++ b/theme/lit-share-modal/lit-share-modal.scss
@@ -233,14 +233,3 @@
     background-color: var(--charm-lit-color-gray);
   }
 }
-
-
-// temporary hack to hide broken feature - hide the dropdown to select erc20 tokens
-.lsm-select-container div.lsm-w-full:nth-of-type(2) {
-  display: none;
-}
-
-// container for the word "OR"
-.lsm-text-sm.md\:lsm-text-base.lsm-w-full.lsm-my-1.dark\:lsm-text-gray.lsm-condition-spacing.lsm-text-title-gray.lsm-font-segoe.lsm-text-base.lsm-font-light {
-  display: none;
-}

--- a/theme/lit-share-modal/lit-share-modal.scss
+++ b/theme/lit-share-modal/lit-share-modal.scss
@@ -236,7 +236,7 @@
 
 
 // temporary hack to hide broken feature - hide the dropdown to select erc20 tokens
-div.lsm-w-full:nth-of-type(2) {
+.lsm-select-container div.lsm-w-full:nth-of-type(2) {
   display: none;
 }
 


### PR DESCRIPTION
The ERC20 token dropdown select is broken according to Lit. They are going to fix it n the next 1-2 weeks by rewriting it. In the meantime, we just want to hide it.

I tried using CSS to hide it, but  there's no way to only target the correct elements.