### PR TITLE
remove etags to force page reloading

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 const config = {
+  generateEtags: false,
   poweredByHeader: false,
   webpack5: true,
   experimental: {


### PR DESCRIPTION
Alex has said a few times that he's had to hard-refresh the page to get updates, using Chrome. This is hard to reproduce but it looks like Next.js uses ETags to tell browsers when to refresh the page. Perhaps the Etags are not always updated properly - by removing them, we force the browser to always load the first page. With Etags, I get a 304 Status code after the first load, without them, it's a 200 each time (re-download the page). I believe this only affects the first request and not our other static assets.

https://stackoverflow.com/questions/69838808/next-js-is-caching-my-server-side-pages-how-to-disable-that