### PR TITLE
Prevent pages from being returned on workspace creation

### DIFF
--- a/pages/api/spaces/index.ts
+++ b/pages/api/spaces/index.ts
@@ -58,7 +58,11 @@ async function createSpace (req: NextApiRequest, res: NextApiResponse<Space>) {
   });
 
   logSpaceCreation(space);
-  return res.status(200).json(space);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { pages, ...spaceResponse } = space;
+
+  return res.status(200).json(spaceResponse);
 }
 
 export default withSessionRoute(handler);


### PR DESCRIPTION
The workspace update was throwing a 500 when editing just after it was created. The reason was that the pages were also sent in the PUT request.
