### PR TITLE
Scroll to the correct item in page navigation

### DIFF
--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -12,7 +12,7 @@ import { useUser } from 'hooks/useUser';
 import { sortArrayByObjectProperty } from 'lib/utilities/array';
 import { isTruthy } from 'lib/utilities/types';
 import { Page, PageContent } from 'models';
-import { ComponentProps, Dispatch, ReactNode, SetStateAction, SyntheticEvent, useCallback, useEffect, useMemo, memo } from 'react';
+import { ComponentProps, Dispatch, ReactNode, SetStateAction, SyntheticEvent, useCallback, useEffect, useMemo, memo, useRef } from 'react';
 import { useDrop } from 'react-dnd';
 import { checkForEmpty } from 'components/common/CharmEditor/utils';
 import { addPageAndRedirect, NewPageInput } from 'lib/pages';
@@ -121,6 +121,18 @@ function PageNavigation ({
   const [space] = useCurrentSpace();
   const [user] = useUser();
   const [expanded, setExpanded] = useLocalStorage<string[]>(`${space!.id}.expanded-pages`, []);
+
+  useEffect(() => {
+    const currentPageNode = document.getElementById(`page-navigation-${currentPageId}`);
+
+    if (currentPageNode) {
+      setTimeout(() => {
+        currentPageNode.scrollIntoView({
+          behavior: 'smooth'
+        });
+      });
+    }
+  }, [currentPageId]);
 
   const pagesArray: MenuNode[] = Object.values(pages)
     .filter((page): page is Page => Boolean(isTruthy(page) && (page.type === 'board' || page.type === 'page' || rootPageIds?.includes(page.id))))

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -125,11 +125,18 @@ function PageNavigation ({
   useEffect(() => {
     const currentPageNode = document.getElementById(`page-navigation-${currentPageId}`);
 
-    if (currentPageNode) {
+    if (currentPageNode && currentPageId) {
       setTimeout(() => {
-        currentPageNode.scrollIntoView({
-          behavior: 'smooth'
-        });
+        const rect = currentPageNode.getBoundingClientRect();
+        const isInViewport = rect.top >= 0
+            && rect.left >= 0
+            && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
+            && rect.right <= (window.innerWidth || document.documentElement.clientWidth);
+        if (!isInViewport) {
+          currentPageNode.scrollIntoView({
+            behavior: 'smooth'
+          });
+        }
       });
     }
   }, [currentPageId]);

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -193,22 +193,20 @@ export function PageLink ({ showPicker = true, children, href, label, labelIcon,
   const triggerState = bindTrigger(popupState);
 
   return (
-    <div id={`page-navigation-${pageId}`}>
-      <Link passHref href={href}>
-        <PageAnchor onClick={stopPropagation}>
-          {labelIcon && (
-            <span onClick={preventDefault}>
-              <StyledPageIcon icon={labelIcon} {...triggerState} onClick={showPicker ? triggerState.onClick : undefined} />
-            </span>
-          )}
-          <PageTitle hasContent={isempty}>
-            {isempty ? 'Untitled' : label}
-          </PageTitle>
-          {children}
-          {showPicker && pageId && <EmojiMenu popupState={popupState} pageId={pageId} pageType={pageType} />}
-        </PageAnchor>
-      </Link>
-    </div>
+    <Link passHref href={href}>
+      <PageAnchor onClick={stopPropagation}>
+        {labelIcon && (
+          <span onClick={preventDefault}>
+            <StyledPageIcon icon={labelIcon} {...triggerState} onClick={showPicker ? triggerState.onClick : undefined} />
+          </span>
+        )}
+        <PageTitle hasContent={isempty}>
+          {isempty ? 'Untitled' : label}
+        </PageTitle>
+        {children}
+        {showPicker && pageId && <EmojiMenu popupState={popupState} pageId={pageId} pageType={pageType} />}
+      </PageAnchor>
+    </Link>
   );
 }
 
@@ -243,7 +241,7 @@ function EmojiMenu ({ popupState, pageId, pageType }: { popupState: any, pageId:
 
 const TreeItemComponent = React.forwardRef<React.Ref<HTMLDivElement>, TreeItemContentProps & { isAdjacent?: boolean }>(
   ({ isAdjacent, ...props }, ref) => (
-    <div style={{ position: 'relative' }}>
+    <div id={`page-navigation-${props.nodeId}`} style={{ position: 'relative' }}>
       <TreeItemContent {...props} ref={ref as React.Ref<HTMLDivElement>} />
       {isAdjacent && <AdjacentDropZone />}
     </div>

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -193,20 +193,22 @@ export function PageLink ({ showPicker = true, children, href, label, labelIcon,
   const triggerState = bindTrigger(popupState);
 
   return (
-    <Link passHref href={href}>
-      <PageAnchor onClick={stopPropagation}>
-        {labelIcon && (
-          <span onClick={preventDefault}>
-            <StyledPageIcon icon={labelIcon} {...triggerState} onClick={showPicker ? triggerState.onClick : undefined} />
-          </span>
-        )}
-        <PageTitle hasContent={isempty}>
-          {isempty ? 'Untitled' : label}
-        </PageTitle>
-        {children}
-        {showPicker && pageId && <EmojiMenu popupState={popupState} pageId={pageId} pageType={pageType} />}
-      </PageAnchor>
-    </Link>
+    <div id={`page-navigation-${pageId}`}>
+      <Link passHref href={href}>
+        <PageAnchor onClick={stopPropagation}>
+          {labelIcon && (
+            <span onClick={preventDefault}>
+              <StyledPageIcon icon={labelIcon} {...triggerState} onClick={showPicker ? triggerState.onClick : undefined} />
+            </span>
+          )}
+          <PageTitle hasContent={isempty}>
+            {isempty ? 'Untitled' : label}
+          </PageTitle>
+          {children}
+          {showPicker && pageId && <EmojiMenu popupState={popupState} pageId={pageId} pageType={pageType} />}
+        </PageAnchor>
+      </Link>
+    </div>
   );
 }
 

--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -205,7 +205,7 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
               target='_blank'
             />
           </Box>
-          <ScrollingContainer isScrolled={isScrolled} onScroll={onScroll}>
+          <ScrollingContainer isScrolled={isScrolled} onScroll={onScroll} className='page-navigation'>
             {favoritePageIds.length > 0 && (
             <Box mb={2}>
               <SectionName>


### PR DESCRIPTION
Scroll to the current page in the page navigation for a long list. Currently, we keep the scroll bar at the top which leads to a suboptimal UX. The user has to manually scroll to get to the page.