### PR TITLE
Bounty charmeditor

### DIFF
--- a/components/bounties/components/BountyEditorForm.tsx
+++ b/components/bounties/components/BountyEditorForm.tsx
@@ -66,7 +66,14 @@ function FormDescription ({ onContentChange, content, watch }:
   watch(['description', 'descriptionNodes']);
 
   return (
-    <Grid item>
+    <Grid
+      item
+      sx={{
+        '&.MuiGrid-item': {
+          maxWidth: '100%'
+        }
+      }}
+    >
       <InputLabel>
         Description
       </InputLabel>

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -346,7 +346,8 @@ function CharmEditor (
     specRegistry,
     plugins: charmEditorPlugins({
       onContentChange: _onContentChange,
-      readOnly
+      readOnly,
+      disabledPageSpecificFeatures
     }),
     initialValue: content ? Node.fromJSON(specRegistry.schema, content) : '',
     // hide the black bar when dragging items - we dont even support dragging most components
@@ -390,7 +391,7 @@ function CharmEditor (
             return (
               <Paragraph
                 inlineCommentPluginKey={inlineCommentPluginKey}
-                calculateInlineComments={!showingCommentThreadsList}
+                calculateInlineComments={!showingCommentThreadsList && !disabledPageSpecificFeatures}
                 {...props}
               >{_children}
               </Paragraph>
@@ -496,7 +497,7 @@ function CharmEditor (
         </PageThreadListBox>
       </Grow>
       )}
-      <InlineCommentThread pluginKey={inlineCommentPluginKey} />
+      {!disabledPageSpecificFeatures && <InlineCommentThread pluginKey={inlineCommentPluginKey} />}
       <DevTools />
     </StyledReactBangleEditor>
   );


### PR DESCRIPTION
1. Disabled inline comment for bounty charmeditor (for some reason we missed this)
2. Fixed the width of bounty charmeditor to take parents width