### PR TITLE
improve UI for permissions border

### DIFF
--- a/components/common/PageLayout/components/ShareButton/ShareButton.tsx
+++ b/components/common/PageLayout/components/ShareButton/ShareButton.tsx
@@ -6,23 +6,19 @@ import Divider from '@mui/material/Divider';
 import Loader from 'components/common/Loader';
 import charmClient from 'charmClient';
 import { usePages } from 'hooks/usePages';
-import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
 import { useState } from 'react';
-import { IPagePermissionFlags, IPagePermissionWithAssignee, PagePermissionLevelType } from 'lib/permissions/pages/page-permission-interfaces';
+import { IPagePermissionFlags, IPagePermissionWithAssignee } from 'lib/permissions/pages/page-permission-interfaces';
 import { useUser } from 'hooks/useUser';
 import PagePermissions from './components/PagePermissions';
 import ShareToWeb from './components/ShareToWeb';
 
 export default function ShareButton ({ headerHeight }: { headerHeight: number }) {
 
-  const { currentPageId, getPagePermissions } = usePages();
-  const [space] = useCurrentSpace();
+  const { currentPageId } = usePages();
   const popupState = usePopupState({ variant: 'popover', popupId: 'share-menu' });
   const [pagePermissions, setPagePermissions] = useState<null | IPagePermissionFlags>(null);
-  const [pagePermissions2, setPagePermissions2] = useState<IPagePermissionWithAssignee []>([]);
-  const [userPagePermissions, setUserPagePermissions] = useState<null | IPagePermissionFlags>(null);
-  const [spaceLevelPermission, setSpaceLevelPermission] = useState<IPagePermissionWithAssignee | null>(null);
+  const [pagePermissions2, setPagePermissions2] = useState<IPagePermissionWithAssignee[] | null>(null);
   const [user] = useUser();
 
   async function retrievePermissions () {
@@ -43,16 +39,9 @@ export default function ShareButton ({ headerHeight }: { headerHeight: number })
 
   function refreshPermissions () {
 
-    const userPermissions = getPagePermissions(currentPageId);
-    setUserPagePermissions(userPermissions);
-
     charmClient.listPagePermissions(currentPageId)
-      .then(permissionSet => {
-
-        const _spaceLevelPermission = permissionSet.find(permission => space && permission.spaceId === space?.id);
-
-        setSpaceLevelPermission(_spaceLevelPermission ?? null);
-        setPagePermissions2(permissionSet);
+      .then(permissions => {
+        setPagePermissions2(permissions);
       });
   }
 
@@ -89,7 +78,7 @@ export default function ShareButton ({ headerHeight }: { headerHeight: number })
         }}
       >
         {
-          !(pagePermissions && spaceLevelPermission)
+          !(pagePermissions && pagePermissions2)
             ? (<Box sx={{ height: 100 }}><Loader size={20} sx={{ height: 600 }} /></Box>)
             : (
               <>
@@ -97,10 +86,8 @@ export default function ShareButton ({ headerHeight }: { headerHeight: number })
                 <Divider />
                 <PagePermissions
                   pageId={currentPageId}
-                  userPagePermissions={userPagePermissions}
                   refreshPermissions={refreshPermissions}
                   pagePermissions={pagePermissions2}
-                  spaceLevelPermission={spaceLevelPermission}
                 />
               </>
             )

--- a/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -87,16 +87,17 @@ interface Props {
   pageId: string;
   refreshPermissions: () => void;
   pagePermissions: IPagePermissionWithAssignee[];
-  spaceLevelPermission: IPagePermissionWithAssignee | null;
-  userPagePermissions: IPagePermissionFlags | null;
 }
 
-export default function PagePermissions ({ pageId, pagePermissions, refreshPermissions, spaceLevelPermission, userPagePermissions }: Props) {
+export default function PagePermissions ({ pageId, pagePermissions, refreshPermissions }: Props) {
 
   const theme = useTheme();
-  const { pages } = usePages();
+  const { pages, getPagePermissions } = usePages();
   const [space] = useCurrentSpace();
   const popupState = usePopupState({ variant: 'popover', popupId: 'add-a-permission' });
+
+  const spaceLevelPermission = pagePermissions.find(permission => space && permission.spaceId === space?.id);
+  const userPagePermissions = getPagePermissions(pageId);
 
   useEffect(() => {
     refreshPermissions();

--- a/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -171,7 +171,7 @@ export default function PagePermissions ({ pageId, pagePermissions, refreshPermi
                 renderValue={value => permissionsWithoutCustom[value as string] || 'No access'}
                 onChange={level => updateSpacePagePermissionLevel(level as PagePermissionLevelType)}
                 keyAndLabel={permissionsWithRemove}
-                defaultValue={spaceLevelPermission?.permissionLevel}
+                defaultValue={spaceLevelPermission?.permissionLevel ?? 'No access'}
               />
             ) : (
               <Typography

--- a/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -191,6 +191,7 @@ export default function PagePermissions ({ pageId }: Props) {
             {
             userPagePermissions?.grant_permissions === true ? (
               <SmallSelect
+                renderValue={value => permissionsWithoutCustom[value as string] || 'No access'}
                 onChange={level => updateSpacePagePermissionLevel(level as PagePermissionLevelType)}
                 keyAndLabel={permissionsWithRemove}
                 defaultValue={spaceLevelPermission?.permissionLevel}
@@ -235,6 +236,7 @@ export default function PagePermissions ({ pageId }: Props) {
                   {
                   userPagePermissions?.grant_permissions === true ? (
                     <SmallSelect
+                      renderValue={value => permissionsWithoutCustom[value as string] || 'No access'}
                       onChange={level => updatePagePermissionLevel(permission, level as PagePermissionLevelType)}
                       keyAndLabel={permissionsWithRemove}
                       defaultValue={permission.permissionLevel}

--- a/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -7,7 +7,7 @@ import Input from '@mui/material/OutlinedInput';
 import Typography from '@mui/material/Typography';
 import { Space } from '@prisma/client';
 import charmClient from 'charmClient';
-import InputEnumToOptions from 'components/common/form/InputEnumToOptions';
+import { SmallSelect } from 'components/common/form/InputEnumToOptions';
 import Link from 'components/common/Link';
 import Modal from 'components/common/Modal';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
@@ -164,7 +164,6 @@ export default function PagePermissions ({ pageId }: Props) {
   const { custom, ...permissionsWithoutCustom } = permissionLevels as Record<string, string>;
   const permissionsWithRemove = { ...permissionsWithoutCustom, delete: 'Remove' };
 
-  console.log({ pagePermissions, pageId });
   return (
     <Box padding={1}>
 
@@ -188,30 +187,22 @@ export default function PagePermissions ({ pageId }: Props) {
           <Typography variant='body2'>
             Everyone at {space?.name}
           </Typography>
-          <div style={{ width: '120px', textAlign: 'center' }}>
+          <div style={{ width: '160px', textAlign: 'right' }}>
             {
-            selectedPermissionId === 'space' ? (
-              <InputEnumToOptions
+            userPagePermissions?.grant_permissions === true ? (
+              <SmallSelect
                 onChange={level => updateSpacePagePermissionLevel(level as PagePermissionLevelType)}
                 keyAndLabel={permissionsWithRemove}
                 defaultValue={spaceLevelPermission?.permissionLevel}
-                autoExpand
               />
             ) : (
-              <div onClick={() => {
-                if (userPagePermissions?.grant_permissions === true) {
-                  setSelectedPermissionId('space');
-                }
-              }}
+              <Typography
+                color='secondary'
+                variant='caption'
+                sx={{ ':hover': { borderWidth: 2, borderColor: theme.palette.gray, borderRadius: 1, borderStyle: 'solid', px: 3, py: 1 } }}
               >
-                <Typography
-                  color='secondary'
-                  variant='caption'
-                  sx={{ ':hover': { borderWidth: 2, borderColor: theme.palette.gray, borderRadius: 1, borderStyle: 'solid', px: 3, py: 1 } }}
-                >
-                  {spaceLevelPermission ? permissionsWithoutCustom[spaceLevelPermission.permissionLevel] : (permissionsLoaded ? 'No access' : '')}
-                </Typography>
-              </div>
+                {spaceLevelPermission ? permissionsWithoutCustom[spaceLevelPermission.permissionLevel] : (permissionsLoaded ? 'No access' : '')}
+              </Typography>
             )
           }
           </div>
@@ -240,26 +231,18 @@ export default function PagePermissions ({ pageId }: Props) {
                 <Typography variant='body2'>
                   {permission.displayName}
                 </Typography>
-                <div style={{ width: '120px', textAlign: 'center' }}>
+                <div style={{ width: '160px', textAlign: 'right' }}>
                   {
-                  selectedPermissionId === permission.id ? (
-                    <InputEnumToOptions
+                  userPagePermissions?.grant_permissions === true ? (
+                    <SmallSelect
                       onChange={level => updatePagePermissionLevel(permission, level as PagePermissionLevelType)}
                       keyAndLabel={permissionsWithRemove}
                       defaultValue={permission.permissionLevel}
-                      autoExpand
                     />
                   ) : (
-                    <div onClick={() => {
-                      if (userPagePermissions?.grant_permissions === true) {
-                        setSelectedPermissionId(permission.id);
-                      }
-                    }}
-                    >
-                      <Typography color='secondary' variant='caption' sx={{ ':hover': { borderWidth: 2, borderColor: theme.palette.gray, borderRadius: 1, borderStyle: 'solid', px: 3, py: 1 } }}>
-                        {permissionLevels[permission.permissionLevel]}
-                      </Typography>
-                    </div>
+                    <Typography color='secondary' variant='caption' sx={{ ':hover': { borderWidth: 2, borderColor: theme.palette.gray, borderRadius: 1, borderStyle: 'solid', px: 3, py: 1 } }}>
+                      {permissionLevels[permission.permissionLevel]}
+                    </Typography>
                   )
                 }
                 </div>

--- a/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -84,43 +84,23 @@ function sortPagePermissions (pagePermissions: IPagePermissionWithAssignee[], sp
 }
 
 interface Props {
-  pageId: string
+  pageId: string;
+  refreshPermissions: () => void;
+  pagePermissions: IPagePermissionWithAssignee[];
+  spaceLevelPermission: IPagePermissionWithAssignee | null;
+  userPagePermissions: IPagePermissionFlags | null;
 }
 
-export default function PagePermissions ({ pageId }: Props) {
+export default function PagePermissions ({ pageId, pagePermissions, refreshPermissions, spaceLevelPermission, userPagePermissions }: Props) {
 
-  const [pagePermissions, setPagePermissions] = useState<IPagePermissionWithAssignee []>([]);
   const theme = useTheme();
   const { pages } = usePages();
   const [space] = useCurrentSpace();
-  const { getPagePermissions } = usePages();
-  const [userPagePermissions, setUserPagePermissions] = useState<null | IPagePermissionFlags>(null);
   const popupState = usePopupState({ variant: 'popover', popupId: 'add-a-permission' });
-
-  const [spaceLevelPermission, setSpaceLevelPermission] = useState<IPagePermissionWithAssignee | null>(null);
-
-  // Only used on first run
-  const [permissionsLoaded, setPermissionsLoaded] = useState(false);
 
   useEffect(() => {
     refreshPermissions();
   }, [pageId]);
-
-  function refreshPermissions () {
-
-    const userPermissions = getPagePermissions(pageId);
-    setUserPagePermissions(userPermissions);
-
-    charmClient.listPagePermissions(pageId)
-      .then(permissionSet => {
-
-        const _spaceLevelPermission = permissionSet.find(permission => space && permission.spaceId === space?.id);
-
-        setSpaceLevelPermission(_spaceLevelPermission ?? null);
-        setPagePermissions(permissionSet);
-        setPermissionsLoaded(true);
-      });
-  }
 
   async function updateSpacePagePermissionLevel (permissionLevel: PagePermissionLevelType | 'delete') {
     if (permissionLevel === 'delete') {
@@ -162,8 +142,7 @@ export default function PagePermissions ({ pageId }: Props) {
   const permissionsWithRemove = { ...permissionsWithoutCustom, delete: 'Remove' };
 
   return (
-    <Box padding={1}>
-
+    <Box p={1}>
       {userPagePermissions?.grant_permissions === true && (
         <Box mb={1} onClick={() => popupState.open()}>
           <StyledInput
@@ -199,7 +178,7 @@ export default function PagePermissions ({ pageId }: Props) {
                 variant='caption'
                 sx={{ ':hover': { borderWidth: 2, borderColor: theme.palette.gray, borderRadius: 1, borderStyle: 'solid', px: 3, py: 1 } }}
               >
-                {spaceLevelPermission ? permissionsWithoutCustom[spaceLevelPermission.permissionLevel] : (permissionsLoaded ? 'No access' : '')}
+                {spaceLevelPermission ? permissionsWithoutCustom[spaceLevelPermission.permissionLevel] : 'No access'}
               </Typography>
             )
           }
@@ -274,7 +253,6 @@ export default function PagePermissions ({ pageId }: Props) {
           }}
         />
       </Modal>
-
     </Box>
   );
 }

--- a/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -160,7 +160,12 @@ export default function PagePermissions ({ pageId, pagePermissions, refreshPermi
       )}
 
       <Box display='block' py={0.5}>
-        <Box display='flex' justifyContent='space-between' alignItems='center'>
+        <Box
+          display='flex'
+          justifyContent='space-between'
+          alignItems='center'
+
+        >
           <Typography variant='body2'>
             Everyone at {space?.name}
           </Typography>
@@ -177,7 +182,6 @@ export default function PagePermissions ({ pageId, pagePermissions, refreshPermi
               <Typography
                 color='secondary'
                 variant='caption'
-                sx={{ ':hover': { borderWidth: 2, borderColor: theme.palette.gray, borderRadius: 1, borderStyle: 'solid', px: 3, py: 1 } }}
               >
                 {spaceLevelPermission ? permissionsWithoutCustom[spaceLevelPermission.permissionLevel] : 'No access'}
               </Typography>
@@ -213,13 +217,13 @@ export default function PagePermissions ({ pageId, pagePermissions, refreshPermi
                   {
                   userPagePermissions?.grant_permissions === true ? (
                     <SmallSelect
-                      renderValue={value => permissionsWithoutCustom[value as string] || 'No access'}
+                      renderValue={value => permissionsWithoutCustom[value as string]}
                       onChange={level => updatePagePermissionLevel(permission, level as PagePermissionLevelType)}
                       keyAndLabel={permissionsWithRemove}
                       defaultValue={permission.permissionLevel}
                     />
                   ) : (
-                    <Typography color='secondary' variant='caption' sx={{ ':hover': { borderWidth: 2, borderColor: theme.palette.gray, borderRadius: 1, borderStyle: 'solid', px: 3, py: 1 } }}>
+                    <Typography color='secondary' variant='caption'>
                       {permissionLevels[permission.permissionLevel]}
                     </Typography>
                   )

--- a/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -95,7 +95,6 @@ export default function PagePermissions ({ pageId }: Props) {
   const [space] = useCurrentSpace();
   const { getPagePermissions } = usePages();
   const [userPagePermissions, setUserPagePermissions] = useState<null | IPagePermissionFlags>(null);
-  const [selectedPermissionId, setSelectedPermissionId] = useState<string | null>(null);
   const popupState = usePopupState({ variant: 'popover', popupId: 'add-a-permission' });
 
   const [spaceLevelPermission, setSpaceLevelPermission] = useState<IPagePermissionWithAssignee | null>(null);
@@ -138,7 +137,6 @@ export default function PagePermissions ({ pageId }: Props) {
       });
     }
     await refreshPermissions();
-    setSelectedPermissionId(null);
   }
 
   async function updatePagePermissionLevel (permission: IPagePermissionWithAssignee, permissionLevel: PagePermissionLevelType | 'delete') {
@@ -156,7 +154,6 @@ export default function PagePermissions ({ pageId }: Props) {
       });
     }
     await refreshPermissions();
-    setSelectedPermissionId(null);
   }
 
   const sortedPermissions = sortPagePermissions(pagePermissions);
@@ -227,7 +224,7 @@ export default function PagePermissions ({ pageId }: Props) {
       {
         sortedPermissions.map(permission => {
           return (
-            <Box display='block' py={0.5} onMouseLeave={() => setSelectedPermissionId(null)}>
+            <Box display='block' py={0.5}>
               <Box display='flex' justifyContent='space-between' alignItems='center' key={permission.displayName}>
                 <Typography variant='body2'>
                   {permission.displayName}

--- a/components/common/form/InputEnumToOptions.tsx
+++ b/components/common/form/InputEnumToOptions.tsx
@@ -4,12 +4,11 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import { useEffect, useState } from 'react';
 
-export interface Props extends SelectProps {
+export interface Props extends Omit<SelectProps, 'onChange'> {
   onChange?: (option: string) => void;
   defaultValue?: string;
   title?: string;
   keyAndLabel: Record<string | any, string | number>;
-  sx?: any;
 }
 
 export default function InputEnumToOptions ({ onChange = () => {}, defaultValue, title, keyAndLabel, sx, ...props }: Props) {

--- a/components/common/form/InputEnumToOptions.tsx
+++ b/components/common/form/InputEnumToOptions.tsx
@@ -1,10 +1,10 @@
 import FormControl from '@mui/material/FormControl';
-import Select from '@mui/material/Select';
+import Select, { SelectProps } from '@mui/material/Select';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import { useEffect, useState } from 'react';
 
-export interface Props {
+export interface Props extends SelectProps {
   onChange?: (option: string) => void;
   defaultValue?: string;
   title?: string;
@@ -12,7 +12,7 @@ export interface Props {
   sx?: any;
 }
 
-export default function InputEnumToOptions ({ onChange = () => {}, defaultValue, title, keyAndLabel, sx }: Props) {
+export default function InputEnumToOptions ({ onChange = () => {}, defaultValue, title, keyAndLabel, sx, ...props }: Props) {
 
   const options = Object.entries(keyAndLabel);
 
@@ -39,6 +39,7 @@ export default function InputEnumToOptions ({ onChange = () => {}, defaultValue,
             onChange(ev.target.value as string);
           }
         }}
+        {...props}
       >
         {
           options.map(option => {

--- a/components/common/form/InputEnumToOptions.tsx
+++ b/components/common/form/InputEnumToOptions.tsx
@@ -5,14 +5,14 @@ import MenuItem from '@mui/material/MenuItem';
 import { useEffect, useState } from 'react';
 
 export interface Props {
-  onChange?: (option: string) => void
-  defaultValue?: string,
-  title?: string
-  keyAndLabel: Record<string | any, string | number>
-  autoExpand?: boolean
+  onChange?: (option: string) => void;
+  defaultValue?: string;
+  title?: string;
+  keyAndLabel: Record<string | any, string | number>;
+  sx?: any;
 }
 
-export default function InputEnumToOptions ({ onChange = () => {}, defaultValue, title, keyAndLabel, autoExpand = false }: Props) {
+export default function InputEnumToOptions ({ onChange = () => {}, defaultValue, title, keyAndLabel, sx }: Props) {
 
   const options = Object.entries(keyAndLabel);
 
@@ -31,8 +31,8 @@ export default function InputEnumToOptions ({ onChange = () => {}, defaultValue,
       }
 
       <Select
+        sx={sx}
         value={value}
-        defaultOpen={autoExpand}
         onChange={(ev) => {
           setValue(ev.target.value as string);
           if (ev.target.value) {
@@ -47,5 +47,20 @@ export default function InputEnumToOptions ({ onChange = () => {}, defaultValue,
         }
       </Select>
     </FormControl>
+  );
+}
+
+export function SmallSelect ({ sx = {}, ...props }: Props) {
+  return (
+    <InputEnumToOptions
+      {...props}
+      sx={{
+        ...sx,
+        background: 'transparent',
+        fontSize: '.8em',
+        borderColor: 'transparent',
+        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'transparent' }
+      }}
+    />
   );
 }


### PR DESCRIPTION
Related card: https://app.charmverse.io/charmverse/page-49366552253645923?viewId=d15c9b90-8918-44da-bbd8-db8712faa723&cardId=ae01f13c-f888-405b-aa18-eb94ba4e800e

The layout for permissions breaks when the option is logn (see loom). I replaced the custom ui with standard MUI select and some CSS:

https://www.loom.com/share/d085c99689424177988848bbbd814df0

new UI:
![image](https://user-images.githubusercontent.com/305398/169876307-ab156a8c-36e4-4afc-9e5b-eb9755aa8609.png)
