### PR TITLE
fix styles for toggle input

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -254,7 +254,6 @@ const StyledReactBangleEditor = styled(ReactBangleEditor)`
   }
 
   .charm-paragraph {
-    display: flex;
     .bangle-nv-child-container {
       width: 100%;
     }

--- a/components/common/CharmEditor/components/Paragraph.tsx
+++ b/components/common/CharmEditor/components/Paragraph.tsx
@@ -5,8 +5,20 @@ import { Box, Typography } from '@mui/material';
 import { useEditorViewContext } from '@bangle.dev/react';
 import { useThreads } from 'hooks/useThreads';
 import { findTotalInlineComments } from 'lib/inline-comments/findTotalInlineComments';
+import styled from '@emotion/styled';
 import { renderSuggestionsTooltip } from './@bangle.dev/tooltip/suggest-tooltip';
 import { InlineCommentPluginState } from './inlineComment';
+
+const InlineCommentContainer = styled.div`
+  position: absolute;
+  right: -40px;
+  top: 5px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+`;
 
 export default function Paragraph (
   { node, children, calculateInlineComments = true, inlineCommentPluginKey }:
@@ -22,28 +34,21 @@ export default function Paragraph (
     <>
       {children}
       {totalInlineComments > 0 && (
-      <Box
-        alignItems='center'
-        display='flex'
-        gap={0.5}
-        sx={{
-          cursor: 'pointer',
-          userSelect: 'none'
-        }}
-        onClick={() => {
-          renderSuggestionsTooltip(inlineCommentPluginKey, { threadIds })(view.state, view.dispatch, view);
-        }}
-      >
-        <ModeCommentOutlinedIcon
-          color='secondary'
-          fontSize='small'
-        />
-        <Typography
-          component='span'
-          variant='subtitle1'
-        >{totalInlineComments}
-        </Typography>
-      </Box>
+        <InlineCommentContainer
+          onClick={() => {
+            renderSuggestionsTooltip(inlineCommentPluginKey, { threadIds })(view.state, view.dispatch, view);
+          }}
+        >
+          <ModeCommentOutlinedIcon
+            color='secondary'
+            fontSize='small'
+          />
+          <Typography
+            component='span'
+            variant='subtitle1'
+          >{totalInlineComments}
+          </Typography>
+        </InlineCommentContainer>
       )}
     </>
   );


### PR DESCRIPTION
The toggle layout broke when we made global style changes to the editor for inline comments. I am using position: absolute instead.. let me know if there's issues