### PR TITLE
Fix toggling for Firefox

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -255,12 +255,6 @@ const StyledReactBangleEditor = styled(ReactBangleEditor)`
     }
     cursor: pointer;
   }
-
-  .charm-paragraph {
-    .bangle-nv-child-container {
-      width: 100%;
-    }
-  }
 `;
 
 const PageThreadListBox = styled.div`

--- a/components/common/CharmEditor/components/disclosure/commands.ts
+++ b/components/common/CharmEditor/components/disclosure/commands.ts
@@ -40,3 +40,20 @@ export const backspaceCmd: Command = (state, dispatch) => {
   }
   return false;
 };
+
+// export const moveDownCmd: Command = (state, dispatch) => {
+//   const { tr } = state;
+//   // @ts-ignore types package is missing $cursor property as of 1.2.8
+//   const { $cursor } = state.selection;
+//   const summaryNode = findParentNodeOfTypeClosestToPos($cursor, state.schema.nodes.disclosureSummary);
+//   console.log('hit enter', !!summaryNode);
+//   if (summaryNode) {
+//     console.log('move cursor down', tr.doc.resolve(summaryNode.pos + summaryNode.node.nodeSize + 1));
+//     tr.setSelection(new TextSelection(tr.doc.resolve(summaryNode.pos + summaryNode.node.nodeSize + 1)));
+//     if (dispatch) {
+//       dispatch(tr);
+//     }
+//     return true;
+//   }
+//   return false;
+// };

--- a/components/common/CharmEditor/components/disclosure/commands.ts
+++ b/components/common/CharmEditor/components/disclosure/commands.ts
@@ -41,6 +41,8 @@ export const backspaceCmd: Command = (state, dispatch) => {
   return false;
 };
 
+// TODO: we should move cursor to the content section when hitting Enter
+
 // export const moveDownCmd: Command = (state, dispatch) => {
 //   const { tr } = state;
 //   // @ts-ignore types package is missing $cursor property as of 1.2.8

--- a/components/common/CharmEditor/components/disclosure/commands.ts
+++ b/components/common/CharmEditor/components/disclosure/commands.ts
@@ -1,0 +1,42 @@
+
+import { Command, Fragment, Node, TextSelection } from '@bangle.dev/pm';
+import { findParentNodeOfTypeClosestToPos } from '@bangle.dev/utils';
+
+export const backspaceCmd: Command = (state, dispatch) => {
+  const { tr } = state;
+  // @ts-ignore types package is missing $cursor property as of 1.2.8
+  const { $cursor } = state.selection;
+
+  const summaryNode = findParentNodeOfTypeClosestToPos($cursor, state.schema.nodes.disclosureSummary);
+  const disclosureNode = findParentNodeOfTypeClosestToPos($cursor, state.schema.nodes.disclosureDetails);
+
+  // if we are inside a summary node and at the beginning, delete the disclosure
+  if ($cursor.parentOffset === 0 && disclosureNode && summaryNode) {
+    const nodes: Node[] = [];
+
+    summaryNode.node.descendants(node => {
+      nodes.push(node);
+      return false;
+    });
+
+    disclosureNode.node.descendants(node => {
+      if (node.type.name !== 'disclosureSummary') {
+        nodes.push(node);
+      }
+      return false;
+    });
+
+    const disclosureStart = disclosureNode.pos;
+    const disclosureEnd = disclosureStart + disclosureNode.node.nodeSize;
+    const nakedNodes = tr.doc.copy(Fragment.from(nodes));
+    tr.replaceWith(disclosureStart, disclosureEnd, nakedNodes);
+    // try to set cursor to first node, doesnt seem to work in FF
+    tr.setSelection(new TextSelection(tr.doc.resolve(disclosureNode.pos)));
+    if (dispatch) {
+      dispatch(tr);
+    }
+
+    return true;
+  }
+  return false;
+};

--- a/components/common/CharmEditor/components/disclosure/disclosure.ts
+++ b/components/common/CharmEditor/components/disclosure/disclosure.ts
@@ -1,5 +1,6 @@
 import { RawPlugins, RawSpecs, createElement } from '@bangle.dev/core';
-import { DOMOutputSpec, Plugin, PluginKey } from '@bangle.dev/pm';
+import { DOMOutputSpec, Plugin, PluginKey, keymap } from '@bangle.dev/pm';
+import { backspaceCmd } from './commands';
 
 export function spec () {
   return [
@@ -48,6 +49,10 @@ function detailsSpec (): RawSpecs {
 export function plugins (): RawPlugins {
   return () => {
     return [
+
+      keymap({
+        Backspace: backspaceCmd
+      }),
       ContainerPlugin({ type: 'disclosureSummary', contentDOM: ['summary'] }),
       ContainerPlugin({ type: 'disclosureDetails', contentDOM: ['details'] })
     ];

--- a/components/common/CharmEditor/components/disclosure/disclosure.ts
+++ b/components/common/CharmEditor/components/disclosure/disclosure.ts
@@ -1,6 +1,7 @@
 import { RawPlugins, RawSpecs, createElement } from '@bangle.dev/core';
-import { DOMOutputSpec, Plugin, PluginKey, keymap } from '@bangle.dev/pm';
-import { backspaceCmd } from './commands';
+import { DOMOutputSpec, Plugin, PluginKey, keymap, TextSelection } from '@bangle.dev/pm';
+import { hasParentNodeOfType } from '@bangle.dev/utils';
+import { backspaceCmd, moveDownCmd } from './commands';
 
 export function spec () {
   return [
@@ -49,9 +50,9 @@ function detailsSpec (): RawSpecs {
 export function plugins (): RawPlugins {
   return () => {
     return [
-
       keymap({
         Backspace: backspaceCmd
+        // Enter: moveDownCmd
       }),
       ContainerPlugin({ type: 'disclosureSummary', contentDOM: ['summary'] }),
       ContainerPlugin({ type: 'disclosureDetails', contentDOM: ['details'] })
@@ -63,6 +64,37 @@ function ContainerPlugin ({ type, contentDOM }: { type: string, contentDOM: DOMO
   return new Plugin({
     key: new PluginKey(`${type}-NodeView`),
     props: {
+      handleDOMEvents: {
+        // listen to 'space bar' and disable action or else Firefox will toggle the details
+        keyup: (view, event) => {
+          if (event.key === ' ') {
+            event.preventDefault();
+            return true;
+          }
+          return false;
+        },
+        // disable toggle effect unelss user is clicking the toggle element
+        click: (view, event) => {
+          const coordinates = view.posAtCoords({
+            left: event.clientX,
+            top: event.clientY
+          });
+          if (!coordinates || !(event.target instanceof Element)) {
+            return false;
+          }
+          const selection = new TextSelection(view.state.doc.resolve(coordinates.pos));
+          const isInsideSummary = hasParentNodeOfType(view.state.schema.nodes.disclosureSummary)(selection);
+          const targetEdge = event.target.getBoundingClientRect().left;
+          const distanceFromEdge = event.clientX - targetEdge;
+          if (isInsideSummary && distanceFromEdge > 20) {
+            event.stopPropagation();
+            event.preventDefault();
+            return true;
+          }
+
+          return false;
+        }
+      },
       nodeViews: {
         [type]: function nodeView (node, view, getPos, decorations) {
           // @ts-ignore

--- a/components/common/CharmEditor/components/disclosure/disclosure.ts
+++ b/components/common/CharmEditor/components/disclosure/disclosure.ts
@@ -1,7 +1,7 @@
 import { RawPlugins, RawSpecs, createElement } from '@bangle.dev/core';
 import { DOMOutputSpec, Plugin, PluginKey, keymap, TextSelection } from '@bangle.dev/pm';
 import { hasParentNodeOfType } from '@bangle.dev/utils';
-import { backspaceCmd, moveDownCmd } from './commands';
+import { backspaceCmd } from './commands';
 
 export function spec () {
   return [

--- a/components/common/CharmEditor/components/quote/components/Quote.tsx
+++ b/components/common/CharmEditor/components/quote/components/Quote.tsx
@@ -2,11 +2,7 @@ import styled from '@emotion/styled';
 
 const StyledBlockQuote = styled.div`
   border-left: 4px solid ${({ theme }) => theme.palette.text.primary};
-  font-size: 20px;
   padding-left: ${({ theme }) => theme.spacing(2)};
-  padding-top: ${({ theme }) => theme.spacing(1.2)};
-  padding-bottom: ${({ theme }) => theme.spacing(1.2)};
-  margin-top: ${({ theme }) => theme.spacing(1)};
   display: flex;
   gap: ${({ theme }) => theme.spacing(1)};
 `;

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -408,10 +408,6 @@ details {
     margin-left: -14px;
     outline: 0 none;
 
-    p:empty::before {
-      content: "Toggle";
-    }
-
     &::marker {
       color: var(--prop-gray);
     }

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -406,6 +406,8 @@ details {
 
   &[open] > summary::before {
     content: "▼";
+    transform: rotate(0);
+    top: 1px;
   }
 
   summary {
@@ -415,8 +417,11 @@ details {
     margin-left: -20px;
 
     &::before {
-      content: "►";
+      content: "▼";
+      cursor: pointer;
+      transform: rotate(-90deg);
       position: relative;
+      top: -3px;
       min-width: 20px;
       display: inline-block;
     }

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -402,14 +402,29 @@ ol li {
 
 /** Disclosure component **/
 details {
-  padding-left: 14px;
+  padding-left: 20px;
+
+  &[open] summary::before {
+    content: "▼";
+  }
 
   summary {
-    margin-left: -14px;
     outline: 0 none;
+    list-style: none;
+    display: flex;
+    margin-left: -20px;
 
+    &::before {
+      content: "►";
+      position: relative;
+      min-width: 20px;
+      display: inline-block;
+    }
+
+    &::-webkit-details-marker,
     &::marker {
       color: var(--prop-gray);
+      display: none;
     }
 
     & > * {

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -404,7 +404,7 @@ ol li {
 details {
   padding-left: 20px;
 
-  &[open] summary::before {
+  &[open] > summary::before {
     content: "▼";
   }
 

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -408,6 +408,10 @@ details {
     margin-left: -14px;
     outline: 0 none;
 
+    p:empty::before {
+      content: "Toggle";
+    }
+
     &::marker {
       color: var(--prop-gray);
     }


### PR DESCRIPTION
- fixes an issue that space bar would toggle the summary open and close
- fixes a layout issue when header is more than one line, so the indent carries down