### PR TITLE
Fix: keeping our page cache up-to-date

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -6,7 +6,6 @@ import { Page, PageContent } from 'models';
 import BountyIntegration from 'components/[pageId]/DocumentPage/components/BountyIntegration';
 import CardDetailProperties from 'components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties';
 import CommentsList from 'components/common/BoardEditor/focalboard/src/components/cardDetail/commentsList';
-import { title } from 'process';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import { getCardComments } from 'components/common/BoardEditor/focalboard/src/store/comments';
 import { usePages } from 'hooks/usePages';
@@ -120,7 +119,7 @@ function Editor ({ page, setPage, readOnly = false }: IEditorProps) {
                   pageUpdatedAt={page.updatedAt.toString()}
                   pageUpdatedBy={page.updatedBy}
                 />
-                <BountyIntegration linkedTaskId={card.id} title={title} readonly={readOnly} />
+                <BountyIntegration linkedTaskId={card.id} title={page.title} readonly={readOnly} />
               </Box>
 
               <hr />


### PR DESCRIPTION
There's a bug introduced recently where adding a page brings back stale data from pages. This update makes it so that the setter `setPages` updates the original cache from SWR, which in turn updates the object map returned from usePages()