### PR TITLE
fix bug deleting a node

### DIFF
--- a/components/common/CharmEditor/components/@bangle.dev/react/NodeViewWrapper.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/NodeViewWrapper.tsx
@@ -72,7 +72,7 @@ export class NodeViewWrapper extends React.Component<PropsType, StateType> {
     // }
 
     return (
-      <span
+      <div
         className="bangle-nv-child-container"
         ref={this.attachToContentDOM}
       />


### PR DESCRIPTION
Not 100% sure why, but when deleting a paragraph content inside a list item, it crashes the editor. This is serious because the user can't undo. Another fix would be to not use "span" as the contentDOM for Paragraph tags, but this seems less intrusive.