### PR TITLE
Small tweaks to Personal Nexus and integrations

### DIFF
--- a/components/profile/components/ProfileLayout.tsx
+++ b/components/profile/components/ProfileLayout.tsx
@@ -18,14 +18,13 @@ import ProfileSidebar from './ProfileSidebar';
 const Container = styled(Box)`
   width: 1200px;
   max-width: 100%;
-  margin: 0 auto;
 `;
 
 export default function ProfileLayout (props: { children: React.ReactNode }) {
   return (
     <PageLayout hideSidebarOnSmallScreen sidebarWidth={55} sidebar={ProfileSidebar}>
       <ScrollableWindow>
-        <Container py={3} sx={{ px: { xs: '20px', sm: '80px' } }}>
+        <Container py={3} sx={{ px: { xs: '20px', sm: '80px' } }} mx='auto' mb={10}>
           {props.children}
         </Container>
       </ScrollableWindow>

--- a/components/profile/integrations/IntegrationsPage.tsx
+++ b/components/profile/integrations/IntegrationsPage.tsx
@@ -1,4 +1,4 @@
-import { Divider, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import MultiSigList from './components/GnosisSafes';
 import IdentityProviders from './components/IdentityProviders';
 
@@ -8,7 +8,6 @@ export default function MyIntegrations () {
     <>
       <Typography variant='h1' gutterBottom>Integrations</Typography>
       <IdentityProviders />
-      <Divider sx={{ mt: 2, mb: 3 }} />
       <MultiSigList />
     </>
   );

--- a/components/profile/integrations/components/DiscordProvider.tsx
+++ b/components/profile/integrations/components/DiscordProvider.tsx
@@ -1,0 +1,98 @@
+import charmClient from 'charmClient';
+import { useEffect, useState } from 'react';
+import { useSnackbar } from 'hooks/useSnackbar';
+import { useUser } from 'hooks/useUser';
+import log from 'lib/log';
+import { getCookie, deleteCookie } from 'lib/browser';
+import { AUTH_CODE_COOKIE, AUTH_ERROR_COOKIE } from 'lib/discord/constants';
+
+interface State {
+  isConnected: boolean;
+  isLoading: boolean;
+  connect: () => void;
+  error?: string;
+}
+
+interface Props {
+  children: (state: State) => JSX.Element;
+}
+
+export default function DiscordProvider ({ children }: Props) {
+
+  const [user, setUser] = useUser();
+  const { showMessage } = useSnackbar();
+  const authCode = getCookie(AUTH_CODE_COOKIE);
+  const authError = getCookie(AUTH_ERROR_COOKIE);
+
+  const [discordError, setDiscordError] = useState('');
+  const [isDisconnectingDiscord, setIsDisconnectingDiscord] = useState(false);
+  const [isConnectDiscordLoading, setIsConnectDiscordLoading] = useState(false);
+
+  const connectedWithDiscord = Boolean(user?.discordUser);
+
+  async function connect () {
+    if (!isConnectDiscordLoading) {
+      if (connectedWithDiscord) {
+        await disconnect();
+      }
+      else {
+        window.location.replace(`/api/discord/oauth?redirect=${encodeURIComponent(window.location.href.split('?')[0])}&type=connect`);
+      }
+    }
+    setIsDisconnectingDiscord(false);
+  }
+
+  function disconnect () {
+
+    setIsDisconnectingDiscord(true);
+
+    return charmClient.disconnectDiscord()
+      .then(() => {
+        setUser({ ...user, discordUser: null });
+      })
+      .catch(error => {
+        log.warn('Error disconnecting from discord', error);
+      })
+      .finally(() => {
+        setIsDisconnectingDiscord(false);
+      });
+  }
+
+  useEffect(() => {
+    if (authError) {
+      deleteCookie(AUTH_ERROR_COOKIE);
+      showMessage('Failed to connect to discord');
+    }
+  }, [authError]);
+
+  // We might get redirected after connection with discord, so check the query param if it has a discord field
+  // It can either be fail or success
+  useEffect(() => {
+    // Connection with discord
+    if (authCode && user) {
+
+      deleteCookie(AUTH_CODE_COOKIE);
+      setIsConnectDiscordLoading(true);
+
+      charmClient.connectDiscord({
+        code: authCode
+      })
+        .then(updatedUserFields => {
+          setUser({ ...user, ...updatedUserFields });
+        })
+        .catch((err) => {
+          setDiscordError(err.message || err.error || 'Something went wrong. Please try again');
+        })
+        .finally(() => {
+          setIsConnectDiscordLoading(false);
+        });
+    }
+  }, [user]);
+
+  return children({
+    isConnected: connectedWithDiscord,
+    isLoading: !discordError && (!!authCode || isDisconnectingDiscord || isConnectDiscordLoading),
+    connect,
+    error: discordError
+  });
+}

--- a/components/profile/integrations/components/IdentityProviders.tsx
+++ b/components/profile/integrations/components/IdentityProviders.tsx
@@ -1,26 +1,22 @@
 
 import styled from '@emotion/styled';
-import { Alert, CircularProgress, Divider, Stack, SvgIcon, Tooltip, Typography } from '@mui/material';
+import { Alert, Box, Card, Divider, Grid, Stack, SvgIcon, Tooltip, Typography } from '@mui/material';
 import { useWeb3React } from '@web3-react/core';
 import charmClient from 'charmClient';
 import Button from 'components/common/Button';
 import { injected, walletConnect, walletLink } from 'connectors';
-import { ReactNode, useContext, useEffect, useState } from 'react';
+import { ReactNode, useContext, useState } from 'react';
 import { Web3Connection } from 'components/_app/Web3ConnectionManager';
-import useENSName from 'hooks/useENSName';
-import { useSnackbar } from 'hooks/useSnackbar';
 import { useUser } from 'hooks/useUser';
-import log from 'lib/log';
-import { getDisplayName } from 'lib/users';
 import { LoggedInUser } from 'models';
-import { useRouter } from 'next/router';
 import { TelegramAccount } from 'pages/api/telegram/connect';
 import DiscordIcon from 'public/images/discord_logo.svg';
 import TelegramIcon from 'public/images/telegram_logo.svg';
 import TelegramLoginIframe, { loginWithTelegram } from './TelegramLoginIframe';
+import DiscordProvider from './DiscordProvider';
 
 const StyledButton = styled(Button)`
-  width: 100px;
+  width: 140px;
 `;
 
 const ImageIcon = styled.img`
@@ -28,69 +24,37 @@ const ImageIcon = styled.img`
   width: auto;
 `;
 
+const GridContainer = styled.div`
+  gap: 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+`;
+
 function ProviderRow ({ children }: { children: ReactNode }) {
   return (
-    <Stack
-      direction='row'
-      alignItems='center'
-      justifyContent='space-between'
-      my={3}
-      sx={{
-        width: {
-          lg: '500px'
-        }
-      }}
-    >
-      {children}
-    </Stack>
+    <Card sx={{ height: '100%' }}>
+      <Stack
+        direction='column'
+        alignItems='center'
+        justifyContent='space-between'
+        spacing={3}
+        my={3}
+      >
+        {children}
+      </Stack>
+    </Card>
   );
 }
 
 export default function IdentityProviders () {
   const { account, connector } = useWeb3React();
   const { openWalletSelectorModal } = useContext(Web3Connection);
-  const ENSName = useENSName(account);
   const [user, setUser] = useUser();
-  const [isDisconnectingDiscord, setIsDisconnectingDiscord] = useState(false);
   const [isConnectingTelegram, setIsConnectingTelegram] = useState(false);
   const [isLoggingOut] = useState(false);
-  const [discordError, setDiscordError] = useState('');
   const [telegramError, setTelegramError] = useState('');
-  const router = useRouter();
-  const isConnectingToDiscord = typeof router.query.code === 'string' && router.query.discord === '1' && router.query.type === 'connect';
-  const discordConnectFailed = router.query.discord === '2' && router.query.type === 'connect';
-  const [isConnectDiscordLoading, setIsConnectDiscordLoading] = useState(false);
-  const { showMessage } = useSnackbar();
 
-  const connectedWithDiscord = Boolean(user?.discordUser);
   const connectedWithTelegram = Boolean(user?.telegramUser);
-
-  useEffect(() => {
-    if (discordConnectFailed === true) {
-      showMessage('Failed to connect to discord');
-    }
-  }, [discordConnectFailed]);
-  console.log('isConnectingToDiscord', isConnectingToDiscord, router.query);
-  // We might get redirected after connection with discord, so check the query param if it has a discord field
-  // It can either be fail or success
-  useEffect(() => {
-    // Connection with discord
-    if (isConnectingToDiscord && user) {
-      setIsConnectDiscordLoading(true);
-      charmClient.connectDiscord({
-        code: router.query.code as string
-      })
-        .then(updatedUserFields => {
-          setUser({ ...user, ...updatedUserFields });
-        })
-        .catch((err) => {
-          setDiscordError(err.message || err.error || 'Something went wrong. Please try again');
-        })
-        .finally(() => {
-          setIsConnectDiscordLoading(false);
-        });
-    }
-  }, []);
 
   const handleWalletProviderSwitch = () => {
     openWalletSelectorModal();
@@ -107,26 +71,6 @@ export default function IdentityProviders () {
       default:
         return '';
     }
-  }
-
-  async function connectWithDiscord () {
-    if (!isConnectDiscordLoading) {
-      if (connectedWithDiscord) {
-        setIsDisconnectingDiscord(true);
-        try {
-          await charmClient.disconnectDiscord();
-          setUser({ ...user, discordUser: null });
-        }
-        catch (err) {
-          log.warn('Error disconnecting from discord', err);
-        }
-        setIsDisconnectingDiscord(false);
-      }
-      else {
-        window.location.replace(`/api/discord/oauth?redirect=${encodeURIComponent(window.location.href.split('?')[0])}&type=connect`);
-      }
-    }
-    setIsDisconnectingDiscord(false);
   }
 
   async function disconnectFromTelegram () {
@@ -163,67 +107,59 @@ export default function IdentityProviders () {
 
   }
 
-  const userName = ENSName || (user ? getDisplayName(user) : '');
-
   return (
-    <>
-      <Divider />
-
+    <GridContainer>
       <ProviderRow>
         <ImageIcon src='/walletLogos/metamask.png' />
-        <Typography color='secondary'>
+        <Typography color='secondary' variant='button'>
           {account ? `Connected with ${connectorName(connector)}` : 'Connect your wallet'}
         </Typography>
-        <StyledButton size='small' variant='outlined' onClick={handleWalletProviderSwitch}>
+        <StyledButton variant='outlined' onClick={handleWalletProviderSwitch}>
           {account ? 'Switch' : 'Connect'}
         </StyledButton>
       </ProviderRow>
 
-      <Divider />
+      <DiscordProvider>
+        {({ isConnected, isLoading, connect, error }) => (
+          <ProviderRow>
+            <SvgIcon sx={{ color: '#5765f2', height: 48, width: 'auto' }}>
+              <DiscordIcon />
+            </SvgIcon>
+            <Typography color='secondary' variant='button'>
+              {isConnected ? 'Connected with Discord' : 'Connect with Discord'}
+            </Typography>
+            <Tooltip arrow placement='bottom' title={user?.addresses.length === 0 ? 'You must have at least one wallet address to disconnect from discord' : ''}>
+              {/** div is used to make sure the tooltip is rendered as disabled button doesn't allow tooltip */}
+              <div>
+                <StyledButton
+                  variant='outlined'
+                  color={isConnected ? 'error' : 'primary'}
+                  disabled={isLoggingOut || isLoading || user?.addresses.length === 0}
+                  onClick={connect}
+                  loading={isLoading}
+                >
+                  {isConnected ? 'Disconnect' : 'Connect'}
+                </StyledButton>
+              </div>
+            </Tooltip>
 
-      <ProviderRow>
-        <SvgIcon sx={{ height: 48, width: 'auto' }}>
-          <DiscordIcon />
-        </SvgIcon>
-        <Typography color='secondary'>
-          {connectedWithDiscord ? 'Connected with Discord' : 'Connect with Discord'}
-        </Typography>
-        <Tooltip arrow placement='bottom' title={user?.addresses.length === 0 ? 'You must have at least one wallet address to disconnect from discord' : ''}>
-          {/** div is used to make sure the tooltip is rendered as disabled button doesn't allow tooltip */}
-          <div>
-            <StyledButton
-              size='small'
-              variant='outlined'
-              color={connectedWithDiscord ? 'error' : 'primary'}
-              disabled={isLoggingOut || isDisconnectingDiscord || isConnectDiscordLoading || user?.addresses.length === 0}
-              onClick={connectWithDiscord}
-              endIcon={(
-                isConnectDiscordLoading && <CircularProgress size={20} />
-              )}
-            >
-              {connectedWithDiscord ? 'Disconnect' : 'Connect'}
-            </StyledButton>
-          </div>
-        </Tooltip>
-      </ProviderRow>
-
-      {discordError && (
-        <Alert severity='error'>
-          {discordError}
-        </Alert>
-      )}
-
-      <Divider />
+            {error && (
+              <Alert severity='error'>
+                {error}
+              </Alert>
+            )}
+          </ProviderRow>
+        )}
+      </DiscordProvider>
 
       <ProviderRow>
         <SvgIcon sx={{ height: 48, width: 'auto' }}>
           <TelegramIcon />
         </SvgIcon>
-        <Typography color='secondary'>
+        <Typography color='secondary' variant='button'>
           {connectedWithTelegram ? 'Connected with Telegram' : 'Connect with Telegram'}
         </Typography>
         <StyledButton
-          size='small'
           variant='outlined'
           sx={{ overflow: 'hidden' }}
           color={connectedWithTelegram ? 'error' : 'primary'}
@@ -234,14 +170,14 @@ export default function IdentityProviders () {
           {connectedWithTelegram ? 'Disconnect' : 'Connect'}
         </StyledButton>
         <TelegramLoginIframe />
-      </ProviderRow>
 
-      {telegramError && (
-        <Alert severity='error'>
-          {telegramError}
-        </Alert>
-      )}
-    </>
+        {telegramError && (
+          <Alert severity='error'>
+            {telegramError}
+          </Alert>
+        )}
+      </ProviderRow>
+    </GridContainer>
 
   );
 }

--- a/components/profile/tasks/GnosisTasksList.tsx
+++ b/components/profile/tasks/GnosisTasksList.tsx
@@ -571,24 +571,33 @@ export default function GnosisTasksSection () {
 
   const safesWithTasks = tasks?.gnosis;
 
+  if (!safesWithTasks) {
+    if (error) {
+      return (
+        <Box>
+          <Alert severity='error'>
+            There was an error. Please try again later!
+          </Alert>
+        </Box>
+      );
+    }
+    else {
+      return <LoadingComponent height='200px' isLoading={true} />;
+    }
+  }
+
   return (
     <>
-      <Box mb={2} display='flex' justifyContent='flex-end'>
-        {safesWithTasks && safeData?.length ? (
+      {safeData?.length ? (
+        <Box mb={2} display='flex' justifyContent='flex-end'>
           <SnoozeTransactions
             message={taskUser?.gnosisSafeState?.transactionsSnoozeMessage ?? null}
             snoozedForDate={snoozedForDate}
             setSnoozedForDate={setSnoozedForDate}
           />
-        ) : null}
-      </Box>
-      {!safesWithTasks && !error && <LoadingComponent height='200px' isLoading={true} />}
-      {error && !safesWithTasks && (
-        <Alert severity='error'>
-          There was an error. Please try again later!
-        </Alert>
-      )}
-      {safesWithTasks && safesWithTasks.map(safe => (
+        </Box>
+      ) : null}
+      {safesWithTasks.map(safe => (
         <SafeTasks
           isSnoozed={isSnoozed}
           key={safe.safeAddress}

--- a/components/profile/tasks/IntegrationCard.tsx
+++ b/components/profile/tasks/IntegrationCard.tsx
@@ -38,7 +38,7 @@ export default function IntegrationCard () {
 
   return currentUser && (
     <IntegrationCardContainer>
-      <Grid container spacing={3}>
+      <Grid container spacing={2}>
         <Grid item xs>
           <Link href='/profile/integrations'>
             <Paper

--- a/components/profile/tasks/IntegrationCard.tsx
+++ b/components/profile/tasks/IntegrationCard.tsx
@@ -40,7 +40,7 @@ export default function IntegrationCard () {
     <IntegrationCardContainer>
       <Grid container spacing={3}>
         <Grid item xs>
-          <Link href='profile/integrations'>
+          <Link href='/profile/integrations'>
             <Paper
               elevation={1}
               sx={{

--- a/components/profile/tasks/TasksPage.tsx
+++ b/components/profile/tasks/TasksPage.tsx
@@ -12,6 +12,7 @@ import IntegrationCard from './IntegrationCard';
 type TaskType = 'multisig' | 'bounty' | 'proposal' | 'discussion'
 
 const tabStyles = {
+  mb: 2,
   minHeight: {
     xs: '34px',
     sm: '48px'

--- a/lib/discord/constants.ts
+++ b/lib/discord/constants.ts
@@ -1,0 +1,3 @@
+
+export const AUTH_CODE_COOKIE = 'discord-auth-code';
+export const AUTH_ERROR_COOKIE = 'discord-auth-error';

--- a/lib/gnosis/gnosis.importSafes.ts
+++ b/lib/gnosis/gnosis.importSafes.ts
@@ -12,7 +12,7 @@ interface ImportSafeProps {
 export async function importSafesFromWallet ({ signer, addresses, getWalletName }: ImportSafeProps) {
 
   const safes = await getSafesForAddresses(signer, addresses);
-  console.log(safes);
+
   const safesData = safes.map(safe => ({
     address: safe.address,
     owners: safe.owners,

--- a/lib/gnosis/gnosis.ts
+++ b/lib/gnosis/gnosis.ts
@@ -1,4 +1,4 @@
-
+import uniqBy from 'lodash/uniqBy';
 import { Signer, ethers } from 'ethers';
 import { RPC } from 'connectors';
 import { UserGnosisSafe } from '@prisma/client';
@@ -65,7 +65,8 @@ export async function getSafesForAddresses (signer: ethers.Signer, addresses: st
     return Promise.all(addresses.map(address => getSafesForAddress({ signer, chainId: network.chainId, address })));
   })).then(list => list.flat().flat());
 
-  return safes;
+  // de-dupe safes in case user has multiple addresses and they own the same safe
+  return uniqBy(safes, safe => safe.address);
 }
 
 async function getTransactionsforSafe (signer: Signer, wallet: UserGnosisSafe): Promise<GnosisTransaction[]> {


### PR DESCRIPTION
- de-dupe gnosis safes for users that have more than one wallet in control of a safe
- use purple color for discord icon on Integrations page
- better layout for Integrations
- most of this PR turned into a refactor of Discord connect. I split it up from the main page and we're now using cookies instead of the URL - I left the URL alone because some components are still using it. Please check it works on your end!

New layout:
![image](https://user-images.githubusercontent.com/305398/170644844-1699df36-f4b8-41fc-a2b4-815d1d99ad1c.png)
