### PR TITLE
Multi role user permission inheritance

### DIFF
--- a/components/common/Loader.tsx
+++ b/components/common/Loader.tsx
@@ -13,14 +13,24 @@ export interface ILoaderInput {
   message?: string;
   size?: number;
   sx?: any;
+  position?: 'left' | 'right'
 }
 
-export default function Loader ({ message, size, sx }: ILoaderInput) {
+export default function Loader ({ message, size, sx, position = 'left' }: ILoaderInput) {
   return (
     <Container sx={sx}>
       <div>
-        <CircularProgress size={size} />
+        {
+          position === 'left' && (
+            <CircularProgress size={size} />
+          )
+        }
         { message !== undefined && <Typography sx={{ textAlign: 'center' }}>{message}</Typography>}
+        {
+          position === 'right' && (
+            <CircularProgress size={size} />
+          )
+        }
       </div>
     </Container>
   );


### PR DESCRIPTION
Fixes an issue where multiple permissions were added at once but not inherited

We now send new permissions from a client-side orchestrated queue to ensure deterministic behaviour.