### PR TITLE
fix widths of modals

### DIFF
--- a/components/common/Modal/Modal.tsx
+++ b/components/common/Modal/Modal.tsx
@@ -15,8 +15,7 @@ const ModalContainer = styled.div<{ size: ModalSize }>`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  max-width: ${({ size }) => size === 'large' ? '670px' : size === 'fluid' ? 'auto' : size === 'small' ? defaultSize : size};
-  width: 100%;
+  width: ${({ size }) => size === 'large' ? '670px' : size === 'fluid' ? 'auto' : size === 'small' ? defaultSize : size};
   background-color: ${({ theme }) => theme.palette.background.paper};
   border-radius: ${({ theme }) => theme.spacing(1)};
   box-shadow: ${({ theme }) => theme.shadows[15]};

--- a/components/common/Modal/SuccessModal.tsx
+++ b/components/common/Modal/SuccessModal.tsx
@@ -9,7 +9,7 @@ export default function SuccessModal ({ title, ...props }: { title?: string } & 
       <DialogTitle onClose={props.onClose} sx={{ padding: 0 }}>
         <Box display='flex' gap={1} width={300} alignItems='center'>
           <CheckCircleOutlineIcon color='success' fontSize='large' />
-          {typeof title === 'undefined' ? 'Success' : title}
+          {typeof title === 'undefined' ? 'Success' : 'title'}
         </Box>
       </DialogTitle>
     </Modal>

--- a/components/common/Modal/SuccessModal.tsx
+++ b/components/common/Modal/SuccessModal.tsx
@@ -9,7 +9,7 @@ export default function SuccessModal ({ title, ...props }: { title?: string } & 
       <DialogTitle onClose={props.onClose} sx={{ padding: 0 }}>
         <Box display='flex' gap={1} width={300} alignItems='center'>
           <CheckCircleOutlineIcon color='success' fontSize='large' />
-          {typeof title === 'undefined' ? 'Success' : 'title'}
+          {typeof title === 'undefined' ? 'Success' : title}
         </Box>
       </DialogTitle>
     </Modal>


### PR DESCRIPTION
This reverts a change to the Modal component from the profile section. It causes the success modal used on token gates to stretch full width:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/305398/170805932-ae7d3e0b-d3d3-46da-92df-1edfb9947a49.png">

@AndreiMitrea can you let me know which modal relied on this update? 