### PR TITLE
Prevent deleting the last view of a board page

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
@@ -148,8 +148,6 @@ function ViewTabs({ board, activeView, intl, readonly, showView, views }: ViewTa
     defaultMessage: 'Delete view',
   })
 
-  
-
   return (<>
     <Tabs textColor='primary' indicatorColor='secondary' value={currentViewId} sx={{ minHeight: 40 }}>
       {shownViews.map(view => (
@@ -200,10 +198,10 @@ function ViewTabs({ board, activeView, intl, readonly, showView, views }: ViewTa
         <ListItemIcon><DuplicateIcon /></ListItemIcon>
         <ListItemText>{duplicateViewText}</ListItemText>
       </MenuItem>
-      <MenuItem dense onClick={handleDeleteView}>
+      {views.length !== 1 && <MenuItem dense onClick={handleDeleteView}>
         <ListItemIcon><DeleteIcon /></ListItemIcon>
         <ListItemText>{deleteViewText}</ListItemText>
-      </MenuItem>
+      </MenuItem>}
     </Menu>
 
     <Menu

--- a/pages/api/blocks/[id]/index.ts
+++ b/pages/api/blocks/[id]/index.ts
@@ -46,6 +46,21 @@ async function deleteBlock (req: NextApiRequest, res: NextApiResponse<{deletedCo
     const deletedChildPageIds = await modifyChildPages(blockId, userId, 'archive');
     deletedCount = deletedChildPageIds.length;
   }
+  else if (rootBlock.type === 'view') {
+    const viewsCount = await prisma.block.count({
+      where: {
+        type: 'view',
+        parentId: rootBlock.parentId
+      }
+    });
+
+    if (viewsCount === 1) {
+      throw new ApiError({
+        message: "Last view of a board page can't be deleted",
+        errorType: 'Undesirable operation'
+      });
+    }
+  }
   else {
     await prisma.block.delete({
       where: {


### PR DESCRIPTION
Client and server-side validation for not allowing the user to delete the last view of a page. A board page is completely unusable without at least a single view and a blank screen will be shown in that case. 