### PR TITLE
Get the card id from url

### DIFF
--- a/components/common/CharmEditor/components/nestedPage/hooks/useNestedPage.ts
+++ b/components/common/CharmEditor/components/nestedPage/hooks/useNestedPage.ts
@@ -14,13 +14,15 @@ export default function useNestedPage () {
   const { currentPageId } = usePages();
   const view = useEditorViewContext();
   const router = useRouter();
+  const cardId = (new URLSearchParams(window.location.search)).get('cardId');
+  const isInsideCard = (cardId && cardId?.length !== 0);
   const addNestedPage = useCallback(async () => {
     if (user && space) {
       const pageId = v4();
       const newPage = await addPage({
         id: pageId,
         createdBy: user.id,
-        parentId: currentPageId,
+        parentId: isInsideCard ? cardId : currentPageId,
         spaceId: space.id
       });
       rafCommandExec(view, (state, dispatch) => {
@@ -29,7 +31,15 @@ export default function useNestedPage () {
         });
         if (dispatch) {
           dispatch(state.tr.replaceSelectionWith(nestedPageNode));
-          router.push(`/${router.query.domain}/${newPage.path}`);
+          if (isInsideCard) {
+            // A small delay to let the inserted page be saved in the editor
+            setTimeout(() => {
+              router.push(`/${router.query.domain}/${newPage.path}`);
+            }, 150);
+          }
+          else {
+            router.push(`/${router.query.domain}/${newPage.path}`);
+          }
         }
         return true;
       });

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -43,6 +43,7 @@ function mapTree (items: MenuNode[], key: 'parentId', rootPageIds?: string[]): P
     node = tempItems[i];
     const nodeIndex = node[key];
     const index = nodeIndex ? map[nodeIndex] : -1;
+
     if (node[key] && tempItems[index] && node.deletedAt === null) {
       // Make sure its not a database page or a focalboard card
       if (tempItems[index].type === 'page') {
@@ -50,7 +51,8 @@ function mapTree (items: MenuNode[], key: 'parentId', rootPageIds?: string[]): P
         sortArrayByObjectProperty(tempItems[index].children, 'index');
       }
     }
-    else if (!rootPageIds && node.deletedAt === null) {
+    // If its a root page always show it
+    else if ((node.parentId === null) && !rootPageIds && node.deletedAt === null) {
       roots.push(node);
     }
     if (rootPageIds?.includes(node.id)) {


### PR DESCRIPTION
1. When inserting a child page using `/insert page` inside a card (inside the dialog, not as a standalone page) we made the board page the parent of the created child page. This happened because we used `currentPageId` from the `usePages` hook which didn't change if a card dialog is being shown (as it only updates the URL). Now we detect if we are inside a card dialog and provide the correct `parentId`. However if the child page is created (via `/insert page`) for a standalone card (a card viewed as a page), it assigns the correct `parentId`
2. Child pages of a card page were not hidden in the page navigation (We didn't face this issue previously because of the first point)