### PR TITLE
Used twemoji for callout emoji

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -494,7 +494,7 @@ function CharmEditor (
       </Grow>
       )}
       {!disabledPageSpecificFeatures && <InlineCommentThread pluginKey={inlineCommentPluginKey} />}
-      <DevTools />
+      {/* <DevTools /> */}
     </StyledReactBangleEditor>
   );
 }

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -494,7 +494,7 @@ function CharmEditor (
       </Grow>
       )}
       {!disabledPageSpecificFeatures && <InlineCommentThread pluginKey={inlineCommentPluginKey} />}
-      {/* <DevTools /> */}
+      <DevTools />
     </StyledReactBangleEditor>
   );
 }

--- a/components/common/CharmEditor/components/callout/components/Callout.tsx
+++ b/components/common/CharmEditor/components/callout/components/Callout.tsx
@@ -2,10 +2,11 @@
 import { NodeViewProps } from '@bangle.dev/core';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { Box, IconButton, Menu } from '@mui/material';
+import { Box, Menu } from '@mui/material';
 import { getTwitterEmoji } from 'components/common/Emoji';
 import { BaseEmoji, Picker } from 'emoji-mart';
 import { MouseEvent, ReactNode, useState } from 'react';
+import { alpha } from '@mui/system';
 
 const StyledCallout = styled.div`
   background-color: ${({ theme }) => theme.palette.background.light};
@@ -48,23 +49,48 @@ export default function Callout ({ children, node, updateAttrs }: NodeViewProps 
   const handleClose = () => {
     setAnchorEl(null);
   };
-
   const theme = useTheme();
   const twemojiImage = getTwitterEmoji(node.attrs.emoji);
 
   return (
     <StyledCallout>
       <CalloutEmoji>
-        <IconButton
+        <Box
           sx={{
             width: 35,
             height: 35,
-            fontSize: 20
+            fontSize: 20,
+            padding: 0.75,
+            borderRadius: '50%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            '&:hover': {
+              // Copied from IconButton.js in @mui/system
+              background: alpha(theme.palette.action.active, theme.palette.action.hoverOpacity),
+              transition: 'background 100ms ease-in-out'
+            }
           }}
           onClick={handleClick}
         >
-          {twemojiImage ? <img src={twemojiImage} /> : node.attrs.emoji}
-        </IconButton>
+          {twemojiImage ? (
+            <img
+              style={{
+                cursor: 'pointer',
+                transition: 'background 100ms ease-in-out'
+              }}
+              src={twemojiImage}
+            />
+          ) : (
+            <div style={{
+              cursor: 'pointer',
+              transition: 'background 100ms ease-in-out'
+            }}
+            >
+              {node.attrs.emoji}
+            </div>
+          )}
+        </Box>
         <Menu
           anchorEl={anchorEl}
           open={open}

--- a/components/common/CharmEditor/components/callout/components/Callout.tsx
+++ b/components/common/CharmEditor/components/callout/components/Callout.tsx
@@ -2,7 +2,8 @@
 import { NodeViewProps } from '@bangle.dev/core';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { Box, Menu } from '@mui/material';
+import { Box, IconButton, Menu } from '@mui/material';
+import { getTwitterEmoji } from 'components/common/Emoji';
 import { BaseEmoji, Picker } from 'emoji-mart';
 import { MouseEvent, ReactNode, useState } from 'react';
 
@@ -40,7 +41,7 @@ const CalloutEmoji = styled.div`
 export default function Callout ({ children, node, updateAttrs }: NodeViewProps & { children: ReactNode }) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
-  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+  const handleClick = (event: MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
     event.preventDefault();
   };
@@ -49,13 +50,21 @@ export default function Callout ({ children, node, updateAttrs }: NodeViewProps 
   };
 
   const theme = useTheme();
+  const twemojiImage = getTwitterEmoji(node.attrs.emoji);
 
   return (
     <StyledCallout>
       <CalloutEmoji>
-        <Box onClick={handleClick}>
-          {node.attrs.emoji}
-        </Box>
+        <IconButton
+          sx={{
+            width: 35,
+            height: 35,
+            fontSize: 20
+          }}
+          onClick={handleClick}
+        >
+          {twemojiImage ? <img src={twemojiImage} /> : node.attrs.emoji}
+        </IconButton>
         <Menu
           anchorEl={anchorEl}
           open={open}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34683631/171031765-a68ce576-3ad1-4ad7-b016-6d002f94fabe.png)
Better UX for callout emoji (using twemoji and IconButton for hover styling). Fallback to regular emoji for Mac