### PR TITLE
install dev tools from zip file

### DIFF
--- a/lib/users/getDisplayName.ts
+++ b/lib/users/getDisplayName.ts
@@ -4,7 +4,7 @@ import { PublicUser } from 'pages/api/public/profile/[userPath]/index';
 
 export function getDisplayName (user?: User | LoggedInUser | PublicUser) {
   if (!user) return '';
-  console.log('user', user);
+
   return (user as LoggedInUser).ensName
     || user.username
     || ((user as User).addresses && shortenHex((user as User).addresses[0]));

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "node-fetch": "2.6",
         "patch-package": "^6.4.7",
         "promise-retry": "^2.0.1",
-        "prosemirror-dev-tools": "github:charmverse/prosemirror-dev-tools#module-updates",
+        "prosemirror-dev-tools": "https://s3.amazonaws.com/charm.public/npm/prosemirror-dev-tools-3.3.4.tgz",
         "prosemirror-menu": "^1.1.4",
         "prosemirror-state": "^1.3.4",
         "prosemirror-trailing-node": "^1.0.8",
@@ -20204,7 +20204,8 @@
     },
     "node_modules/prosemirror-dev-tools": {
       "version": "3.3.4",
-      "resolved": "git+ssh://git@github.com/charmverse/prosemirror-dev-tools.git#5f297d2d09d12e3e4ecbc9f4f9440fc2317a106c",
+      "resolved": "https://s3.amazonaws.com/charm.public/npm/prosemirror-dev-tools-3.3.4.tgz",
+      "integrity": "sha512-qelmnZprJ+RVXvr6AFA4CZNxXM0RhvNH4HCzmEDVvhOuiCfHFMLw3/V51rZ0cW+ut/Uf3ZywVnytetNuLQsqag==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -39897,8 +39898,8 @@
       }
     },
     "prosemirror-dev-tools": {
-      "version": "git+ssh://git@github.com/charmverse/prosemirror-dev-tools.git#5f297d2d09d12e3e4ecbc9f4f9440fc2317a106c",
-      "from": "prosemirror-dev-tools@github:charmverse/prosemirror-dev-tools#module-updates",
+      "version": "https://s3.amazonaws.com/charm.public/npm/prosemirror-dev-tools-3.3.4.tgz",
+      "integrity": "sha512-qelmnZprJ+RVXvr6AFA4CZNxXM0RhvNH4HCzmEDVvhOuiCfHFMLw3/V51rZ0cW+ut/Uf3ZywVnytetNuLQsqag==",
       "requires": {}
     },
     "prosemirror-dropcursor": {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "node-fetch": "2.6",
     "patch-package": "^6.4.7",
     "promise-retry": "^2.0.1",
-    "prosemirror-dev-tools": "github:charmverse/prosemirror-dev-tools#module-updates",
+    "prosemirror-dev-tools": "https://s3.amazonaws.com/charm.public/npm/prosemirror-dev-tools-3.3.4.tgz",
     "prosemirror-menu": "^1.1.4",
     "prosemirror-state": "^1.3.4",
     "prosemirror-trailing-node": "^1.0.8",


### PR DESCRIPTION
Problem:
Currently, our fork of prosemirror-dev-tools includes another fork of a library called "unstated". I'm using the because the npm version has an old version of React, causing errors during install. Because of this, npm needs to run a build command on unstated because the compiled code is not included on github.

Fix:
With this PR, I have packaged our fork of PMT using `npm pack` and linked to it on S3 instead of using a github URL. Our fork comes with its dependencies already compiled, and this seems to work fine without yarn installed on my dev environment.