### PR TITLE
Fix: too many requests to gnosis safe and handle more types of transactions

### DIFF
--- a/lib/gnosis/gnosis.tasks.ts
+++ b/lib/gnosis/gnosis.tasks.ts
@@ -98,8 +98,8 @@ type TransactionParameter = PaymentAction | DeadlineAction | DataAction;
 function getTaskActions (transaction: GnosisTransaction, getRecipient: (address: string) => ActionUser): SendAction[] {
   const data = transaction.dataDecoded as any | undefined;
   const parameters: TransactionParameter[] = data?.parameters ?? [];
-  console.log('response', transaction);
-  console.log('data', data?.parameters);
+  // console.log('response', transaction);
+  // console.log('data', data?.parameters);
   const paymentActions = parameters
     .filter((action): action is PaymentAction => !!(action as PaymentAction).decodedValue?.[0].to)
     .map(action => action.decodedValue).flat()

--- a/lib/gnosis/gnosis.tasks.ts
+++ b/lib/gnosis/gnosis.tasks.ts
@@ -15,6 +15,7 @@ interface ActionUser {
 }
 
 interface SendAction {
+  deadline?: string;
   to: ActionUser;
   value: string;
   friendlyValue: string;
@@ -89,14 +90,30 @@ function getTaskDescription (transaction: GnosisTransaction): string {
   return 'N/A';
 }
 
+type PaymentAction = { decodedValue: { to: string, value: string }[] }; // TODO: find out the type and name of this action (it is used when there are multiple recipients)
+type DeadlineAction = { name: 'deadline', type: 'uint256', value: number };
+type DataAction = { name: 'data', type: 'bytes[]', value: string[] };
+type TransactionParameter = PaymentAction | DeadlineAction | DataAction;
+
 function getTaskActions (transaction: GnosisTransaction, getRecipient: (address: string) => ActionUser): SendAction[] {
   const data = transaction.dataDecoded as any | undefined;
-  const actions = data
-    ? data?.parameters[0].valueDecoded as { to: string, value: string }[]
-    : [{ to: transaction.to, value: transaction.value }];
+  const parameters: TransactionParameter[] = data?.parameters ?? [];
+  console.log('response', transaction);
+  console.log('data', data?.parameters);
+  const paymentActions = parameters
+    .filter((action): action is PaymentAction => !!(action as PaymentAction).decodedValue?.[0].to)
+    .map(action => action.decodedValue).flat()
+    || [];
+  // its possible for there to be data in 'valueDecoded' that is not a payment action. TODO: find out what other cases exist
+  if (paymentActions.length > 0) {
+    paymentActions.push({ to: transaction.to, value: transaction.value });
+  }
+  const deadline = parameters.find(action => (action as DeadlineAction).name === 'deadline') as DeadlineAction;
+  const deadlineValue = deadline?.value ? new Date(deadline.value * 1000).toISOString() : undefined;
 
-  return actions.map(action => ({
+  return paymentActions.map(action => ({
     value: action.value,
+    deadline: deadlineValue,
     friendlyValue: getFriendlyEthValue(action.value),
     to: getRecipient(action.to)
   }));

--- a/scripts/sendNotifications.ts
+++ b/scripts/sendNotifications.ts
@@ -1,0 +1,7 @@
+
+import { getNotifications, sendUserNotifications } from 'background/tasks/sendNotifications/sendNotifications';
+
+(async () => {
+  const r = await getNotifications();
+  console.log('result', r);
+})();


### PR DESCRIPTION
I can't find any documentation about rate limits for Gnosis, the error goes between "Service Unavailable" and "Service Temporarily Unavailable". This could be Alchemy but I feel like it's Gnosis... anyway i added a try/catch so a single exception won't fail everything else.

There's also no documentation about the different types of responses I can get, AFAIK. They have some types on their swagger ui but it doesn't go into enough detail.

I want to keep looking for rate limit docs, may need to find their Discord channel or whatever :/