### PR TITLE
update next to 12.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "millify": "^4.0.0",
         "mjml-react": "^2.0.8",
         "nanoevents": "^6.0.2",
-        "next": "^12.1.5",
+        "next": "^12.1.6",
         "next-connect": "^0.12.2",
         "next-swagger-doc": "^0.2.1",
         "next-transpile-modules": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "millify": "^4.0.0",
     "mjml-react": "^2.0.8",
     "nanoevents": "^6.0.2",
-    "next": "^12.1.5",
+    "next": "^12.1.6",
     "next-connect": "^0.12.2",
     "next-swagger-doc": "^0.2.1",
     "next-transpile-modules": "^9.0.0",


### PR DESCRIPTION
Just want to keep updating next.js. They've been working on 12.1.7 for a while so I assume this should be pretty stable.
changelog: https://github.com/vercel/next.js/releases/tag/v12.1.6