### PR TITLE
Moved save button in description modal

### DIFF
--- a/components/profile/components/DescriptionModal.tsx
+++ b/components/profile/components/DescriptionModal.tsx
@@ -76,7 +76,7 @@ function DescriptionModal (props: DescriptionModalProps) {
             }}
           />
           <Box justifyContent='end' sx={{ display: 'flex' }}>{watchDescription.length}/500</Box>
-          <Box mt={4} sx={{ display: 'flex' }}>
+          <Box sx={{ display: 'flex' }}>
             <Button type='submit'>
               Save
             </Button>


### PR DESCRIPTION
Moved up the save button in description modal.

![image](https://user-images.githubusercontent.com/12700927/171881919-ce4b7bd8-975e-4609-8cf1-53becd2ac75f.png)
