### PR TITLE
reorganize iframe component for charm editor

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -39,7 +39,7 @@ import EmojiSuggest, * as emoji from './components/emojiSuggest';
 import NestedPage, { nestedPagePluginKeyName, nestedPagePlugins, NestedPagesList, nestedPageSpec } from './components/nestedPage';
 import Placeholder from './components/Placeholder';
 import Quote, * as quote from './components/quote';
-import ResizableIframe, { iframeSpec } from './components/ResizableIframe';
+import * as iframe from './components/iframe';
 import ResizableImage, { imageSpec } from './components/ResizableImage';
 import * as trailingNode from './components/trailingNode';
 import * as tabIndent from './components/tabIndent';
@@ -87,7 +87,7 @@ export const specRegistry = new SpecRegistry([
   mentionSpecs(), // NO
   code.spec(), // OK
   codeBlock.spec(), // OK
-  iframeSpec(), // OK
+  iframe.spec(), // OK
   heading.spec(), // OK
   inlinePaletteSpecs(), // Not required
   callout.spec(), // OK
@@ -440,7 +440,7 @@ function CharmEditor (
           }
           case 'iframe': {
             return (
-              <ResizableIframe
+              <iframe.Component
                 readOnly={readOnly}
                 onResizeStop={onResizeStop}
                 {...props}

--- a/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
+++ b/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
@@ -1,8 +1,9 @@
 import { Button, TextField } from '@mui/material';
 import { Box } from '@mui/system';
+import { usePopupState } from 'material-ui-popup-state/hooks';
 import MultiTabs from 'components/common/MultiTabs';
 import PopperPopup from 'components/common/PopperPopup';
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
 interface IFrameSelectorProps {
   onIFrameSelect: (videoSrc: string) => void
@@ -14,47 +15,53 @@ interface IFrameSelectorProps {
 export default function IFrameSelector (props: IFrameSelectorProps) {
   const [embedLink, setEmbedLink] = useState('');
   const { type, tabs = [], children, onIFrameSelect } = props;
+  const popupState = usePopupState({ variant: 'popper', popupId: 'iframe-selector' });
+  useEffect(() => {
+    popupState.open();
+  }, []);
 
   return (
-    <PopperPopup popupContent={(
-      <Box sx={{
-        width: 750
-      }}
-      >
-        <MultiTabs tabs={[
-          ...tabs,
-          [
-            'Link',
-            <Box sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
-              alignItems: 'center'
-            }}
-            >
-              <TextField
-                autoFocus
-                placeholder={`Paste the ${type} link...`}
-                value={embedLink}
-                onChange={(e) => setEmbedLink(e.target.value)}
-              />
-              <Button
-                disabled={!embedLink}
-                sx={{
-                  width: 250
-                }}
-                onClick={() => {
-                  onIFrameSelect(embedLink);
-                  setEmbedLink('');
-                }}
+    <PopperPopup
+      popupState={popupState}
+      popupContent={(
+        <Box sx={{
+          width: 750
+        }}
+        >
+          <MultiTabs tabs={[
+            ...tabs,
+            [
+              'Link',
+              <Box sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                alignItems: 'center'
+              }}
               >
-                {type === 'embed' ? 'Embed link' : 'Insert Video'}
-              </Button>
-            </Box>
-          ]
-        ]}
-        />
-      </Box>
+                <TextField
+                  autoFocus
+                  placeholder={`Paste the ${type} link...`}
+                  value={embedLink}
+                  onChange={(e) => setEmbedLink(e.target.value)}
+                />
+                <Button
+                  disabled={!embedLink}
+                  sx={{
+                    width: 250
+                  }}
+                  onClick={() => {
+                    onIFrameSelect(embedLink);
+                    setEmbedLink('');
+                  }}
+                >
+                  {type === 'embed' ? 'Embed link' : 'Insert Video'}
+                </Button>
+              </Box>
+            ]
+          ]}
+          />
+        </Box>
   )}
     >
       {children}

--- a/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
+++ b/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
@@ -2,7 +2,6 @@ import { Button, TextField } from '@mui/material';
 import { Box } from '@mui/system';
 import MultiTabs from 'components/common/MultiTabs';
 import PopperPopup from 'components/common/PopperPopup';
-import Snackbar from 'components/common/Snackbar';
 import { ReactNode, useState } from 'react';
 
 interface IFrameSelectorProps {
@@ -33,7 +32,12 @@ export default function IFrameSelector (props: IFrameSelectorProps) {
               alignItems: 'center'
             }}
             >
-              <TextField autoFocus placeholder={`Paste the ${type} link...`} value={embedLink} onChange={(e) => setEmbedLink(e.target.value)} />
+              <TextField
+                autoFocus
+                placeholder={`Paste the ${type} link...`}
+                value={embedLink}
+                onChange={(e) => setEmbedLink(e.target.value)}
+              />
               <Button
                 disabled={!embedLink}
                 sx={{

--- a/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
+++ b/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
@@ -1,9 +1,8 @@
 import { Button, TextField } from '@mui/material';
 import { Box } from '@mui/system';
-import { usePopupState } from 'material-ui-popup-state/hooks';
 import MultiTabs from 'components/common/MultiTabs';
 import PopperPopup from 'components/common/PopperPopup';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 interface IFrameSelectorProps {
   onIFrameSelect: (videoSrc: string) => void
@@ -15,14 +14,9 @@ interface IFrameSelectorProps {
 export default function IFrameSelector (props: IFrameSelectorProps) {
   const [embedLink, setEmbedLink] = useState('');
   const { type, tabs = [], children, onIFrameSelect } = props;
-  const popupState = usePopupState({ variant: 'popper', popupId: 'iframe-selector' });
-  useEffect(() => {
-    popupState.open();
-  }, []);
 
   return (
     <PopperPopup
-      popupState={popupState}
       popupContent={(
         <Box sx={{
           width: 750

--- a/components/common/CharmEditor/components/iframe/IframeComponent.tsx
+++ b/components/common/CharmEditor/components/iframe/IframeComponent.tsx
@@ -10,10 +10,10 @@ import { Box } from '@mui/system';
 import { MAX_EMBED_WIDTH, MIN_EMBED_HEIGHT, MAX_EMBED_HEIGHT, VIDEO_ASPECT_RATIO, MIN_EMBED_WIDTH } from 'lib/embed/constants';
 import { extractEmbedLink } from 'lib/embed/extractEmbedLink';
 import { HTMLAttributes, useState, memo } from 'react';
-import BlockAligner from './BlockAligner';
+import BlockAligner from '../BlockAligner';
 import IFrameSelector from './IFrameSelector';
-import Resizable from './Resizable';
-import VerticalResizer from './Resizable/VerticalResizer';
+import Resizable from '../Resizable';
+import VerticalResizer from '../Resizable/VerticalResizer';
 
 const name = 'iframe';
 

--- a/components/common/CharmEditor/components/iframe/IframeComponent.tsx
+++ b/components/common/CharmEditor/components/iframe/IframeComponent.tsx
@@ -164,8 +164,6 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
   const [height, setHeight] = useState(node.attrs.height);
   const view = useEditorViewContext();
 
-  console.log('node attrs', node.attrs);
-
   // If there are no source for the node, return the image select component
   if (!node.attrs.src) {
     return readOnly ? <EmptyIframeContainer type={node.attrs.type} readOnly={readOnly} /> : (
@@ -224,7 +222,6 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
     );
   }
   else {
-    console.log('node attrs', node.attrs);
     return (
       <Resizable
         aspectRatio={VIDEO_ASPECT_RATIO}

--- a/components/common/CharmEditor/components/iframe/IframeComponent.tsx
+++ b/components/common/CharmEditor/components/iframe/IframeComponent.tsx
@@ -164,6 +164,8 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
   const [height, setHeight] = useState(node.attrs.height);
   const view = useEditorViewContext();
 
+  console.log('node attrs', node.attrs);
+
   // If there are no source for the node, return the image select component
   if (!node.attrs.src) {
     return readOnly ? <EmptyIframeContainer type={node.attrs.type} readOnly={readOnly} /> : (
@@ -222,6 +224,7 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
     );
   }
   else {
+    console.log('node attrs', node.attrs);
     return (
       <Resizable
         aspectRatio={VIDEO_ASPECT_RATIO}

--- a/components/common/CharmEditor/components/iframe/iframe.ts
+++ b/components/common/CharmEditor/components/iframe/iframe.ts
@@ -1,0 +1,103 @@
+import { Plugin, RawSpecs } from '@bangle.dev/core';
+import { EditorState, EditorView, Node, Schema, Slice, Transaction } from '@bangle.dev/pm';
+
+import { MAX_EMBED_WIDTH, MIN_EMBED_HEIGHT } from 'lib/embed/constants';
+import { extractEmbedLink } from 'lib/embed/extractEmbedLink';
+
+const name = 'iframe';
+
+interface DispatchFn {
+  (tr: Transaction): void;
+}
+
+// inject a real iframe node when pasting embed codes
+
+export const iframePlugin = new Plugin({
+  props: {
+    handlePaste: (view: EditorView, rawEvent: ClipboardEvent, slice: Slice) => {
+      // @ts-ignore
+      const contentRow = slice.content.content?.[0].content.content;
+      const embedUrl = extractEmbedLink(contentRow?.[0]?.text);
+      if (embedUrl) {
+        insertIframeNode(view.state, view.dispatch, view, { src: embedUrl });
+        return true;
+      }
+      return false;
+    }
+  }
+});
+
+const getTypeFromSchema = (schema: Schema) => schema.nodes[name];
+
+function insertIframeNode (state: EditorState, dispatch: DispatchFn, view: EditorView, attrs?: { [key: string]: any }) {
+  const type = getTypeFromSchema(state.schema);
+  const newTr = type.create(attrs);
+  const { tr } = view.state;
+  const cursorPosition = state.selection.$head.pos;
+  tr.insert(cursorPosition, newTr);
+  if (dispatch) {
+    dispatch(state.tr.replaceSelectionWith(newTr));
+  }
+}
+
+export function spec (): RawSpecs {
+  return {
+    type: 'node',
+    name,
+    markdown: {
+      toMarkdown: (state, node, parent, index) => {
+
+        // eslint-disable-next-line prefer-const
+        let { height, width, src } = node.attrs;
+
+        if (height && width && src) {
+          height = parseInt(height);
+          width = parseInt(width);
+
+          const attributesToWrite = ` width=${width}px height=${height}px src=${src} `;
+
+          const toRender = `\r\n<iframe ${attributesToWrite}></iframe>\r\n\r\n\r\n`;
+
+          // Ensure markdown html will be separated by newlines
+          state.ensureNewLine();
+          state.text(toRender);
+          state.ensureNewLine();
+        }
+      }
+    },
+    schema: {
+      attrs: {
+        src: {
+          default: ''
+        },
+        width: {
+          default: MAX_EMBED_WIDTH
+        },
+        height: {
+          default: MIN_EMBED_HEIGHT
+        },
+        // Type of iframe, it could either be video or embed
+        type: {
+          default: 'embed'
+        }
+      },
+      group: 'block',
+      inline: false,
+      draggable: false,
+      isolating: true, // dont allow backspace to delete
+      parseDOM: [
+        {
+          tag: 'iframe',
+          getAttrs: (dom: any) => {
+            return {
+              src: dom.getAttribute('src')
+            };
+          }
+        }
+      ],
+      toDOM: (node: Node) => {
+        return ['iframe', { class: 'ns-embed', style: `height: ${node.attrs.height};`, ...node.attrs }];
+      }
+    }
+  };
+}

--- a/components/common/CharmEditor/components/iframe/index.ts
+++ b/components/common/CharmEditor/components/iframe/index.ts
@@ -1,0 +1,2 @@
+export * from './iframe';
+export { default as Component } from './IframeComponent';

--- a/components/common/CharmEditor/components/inlinePalette/useEditorItems.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/useEditorItems.tsx
@@ -212,27 +212,31 @@ const paletteGroupItemsRecord: Record<string, Omit<PaletteItemType, 'group'>[]> 
       description: 'Insert a video block in the line below',
       editorExecuteCommand: () => {
         return (state, dispatch, view) => {
-          rafCommandExec(view!, (_state, _dispatch) => {
+          if (view) {
+            rafCommandExec(view, (_state, _dispatch) => {
 
-            const node = _state.schema.nodes.iframe.create({
-              src: null,
-              type: 'video',
-              width: (MIN_EMBED_WIDTH + MAX_EMBED_WIDTH) / 2,
-              height: ((MIN_EMBED_WIDTH + MAX_EMBED_WIDTH) / 2) / VIDEO_ASPECT_RATIO
+              const node = _state.schema.nodes.iframe.create({
+                src: null,
+                type: 'video',
+                width: MAX_EMBED_WIDTH,
+                height: MAX_EMBED_WIDTH / VIDEO_ASPECT_RATIO
+              });
+
+              if (_dispatch && isAtBeginningOfLine(_state)) {
+                _dispatch(_state.tr.replaceSelectionWith(node));
+                return true;
+              }
+
+              return insertNode(_state, _dispatch, node);
             });
 
-            if (_dispatch && isAtBeginningOfLine(_state)) {
-              _dispatch(_state.tr.replaceSelectionWith(node));
-              return true;
-            }
-
-            return insertNode(_state, _dispatch, node);
-          });
-          return replaceSuggestionMarkWith(palettePluginKey, '')(
-            state,
-            dispatch,
-            view
-          );
+            return replaceSuggestionMarkWith(palettePluginKey, '')(
+              state,
+              dispatch,
+              view
+            );
+          }
+          return false;
         };
       }
     },
@@ -244,32 +248,30 @@ const paletteGroupItemsRecord: Record<string, Omit<PaletteItemType, 'group'>[]> 
       description: 'Insert an embed block in the line below',
       editorExecuteCommand: () => {
         return (state, dispatch, view) => {
-          rafCommandExec(view!, (_state, _dispatch) => {
+          if (view) {
+            rafCommandExec(view, (_state, _dispatch) => {
 
-            const node = _state.schema.nodes.paragraph.create(
-              undefined,
-              Fragment.fromArray([
-                _state.schema.nodes.iframe.create({
-                  src: null,
-                  type: 'embed',
-                  width: MAX_EMBED_WIDTH,
-                  height: MIN_EMBED_HEIGHT
-                })
-              ])
+              const node = _state.schema.nodes.iframe.create({
+                src: null,
+                type: 'embed',
+                width: MAX_EMBED_WIDTH,
+                height: MIN_EMBED_HEIGHT
+              });
+
+              if (_dispatch && isAtBeginningOfLine(_state)) {
+                _dispatch(_state.tr.replaceSelectionWith(node));
+                return true;
+              }
+              return insertNode(_state, _dispatch, node);
+            });
+            return replaceSuggestionMarkWith(palettePluginKey, '')(
+              state,
+              dispatch,
+              view
             );
-
-            if (_dispatch && isAtBeginningOfLine(_state)) {
-              _dispatch(_state.tr.replaceSelectionWith(node));
-              return true;
-            }
-            return insertNode(_state, _dispatch, node);
-          });
-          return replaceSuggestionMarkWith(palettePluginKey, '')(
-            state,
-            dispatch,
-            view
-          );
+          }
         };
+        return false;
       }
     },
     {

--- a/components/common/CharmEditor/components/inlinePalette/useEditorItems.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/useEditorItems.tsx
@@ -214,17 +214,12 @@ const paletteGroupItemsRecord: Record<string, Omit<PaletteItemType, 'group'>[]> 
         return (state, dispatch, view) => {
           rafCommandExec(view!, (_state, _dispatch) => {
 
-            const node = _state.schema.nodes.paragraph.create(
-              undefined,
-              Fragment.fromArray([
-                _state.schema.nodes.iframe.create({
-                  src: null,
-                  type: 'video',
-                  width: (MIN_EMBED_WIDTH + MAX_EMBED_WIDTH) / 2,
-                  height: ((MIN_EMBED_WIDTH + MAX_EMBED_WIDTH) / 2) / VIDEO_ASPECT_RATIO
-                })
-              ])
-            );
+            const node = _state.schema.nodes.iframe.create({
+              src: null,
+              type: 'video',
+              width: (MIN_EMBED_WIDTH + MAX_EMBED_WIDTH) / 2,
+              height: ((MIN_EMBED_WIDTH + MAX_EMBED_WIDTH) / 2) / VIDEO_ASPECT_RATIO
+            });
 
             if (_dispatch && isAtBeginningOfLine(_state)) {
               _dispatch(_state.tr.replaceSelectionWith(node));

--- a/components/common/CharmEditor/components/inlinePalette/useEditorItems.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/useEditorItems.tsx
@@ -270,8 +270,8 @@ const paletteGroupItemsRecord: Record<string, Omit<PaletteItemType, 'group'>[]> 
               view
             );
           }
+          return false;
         };
-        return false;
       }
     },
     {

--- a/components/common/PopperPopup.tsx
+++ b/components/common/PopperPopup.tsx
@@ -1,41 +1,47 @@
 import { Popover } from '@mui/material';
 import Paper from '@mui/material/Paper';
-import PopupState, { bindPopover, bindToggle } from 'material-ui-popup-state';
+import { bindPopover, bindToggle } from 'material-ui-popup-state';
+import { PopupState } from 'material-ui-popup-state/hooks';
 import * as React from 'react';
 
 interface PopperPopupProps {
-  popupContent: React.ReactNode
-  children?: React.ReactNode | null
+  popupContent: React.ReactNode;
+  popupState: PopupState;
+  children?: React.ReactNode | null;
 }
 
 export default function PopperPopup (props: PopperPopupProps) {
-  const { popupContent, children } = props;
+  const { popupContent, popupState, children } = props;
+  console.log('popupState', popupState);
+  const toggleRef = React.useRef(null);
+  React.useEffect(() => {
+    if (toggleRef.current) {
+      console.log('set anchor', toggleRef.current);
+      popupState.setAnchorEl(toggleRef.current);
+    }
+  }, [toggleRef]);
   return (
-    <PopupState variant='popper'>
-      {(popupState) => (
-        <div>
-          {children && (
-          <div {...bindToggle(popupState)}>
-            {children}
-          </div>
-          )}
-          <Popover
-            {...bindPopover(popupState)}
-            anchorOrigin={{
-              vertical: 'bottom',
-              horizontal: 'center'
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'center'
-            }}
-          >
-            <Paper>
-              {popupContent}
-            </Paper>
-          </Popover>
-        </div>
+    <div ref={toggleRef}>
+      {children && (
+      <div {...bindToggle(popupState)}>
+        {children}
+      </div>
       )}
-    </PopupState>
+      <Popover
+        {...bindPopover(popupState)}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center'
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center'
+        }}
+      >
+        <Paper>
+          {popupContent}
+        </Paper>
+      </Popover>
+    </div>
   );
 }

--- a/components/common/PopperPopup.tsx
+++ b/components/common/PopperPopup.tsx
@@ -1,25 +1,28 @@
 import { Popover } from '@mui/material';
 import Paper from '@mui/material/Paper';
 import { bindPopover, bindToggle } from 'material-ui-popup-state';
-import { PopupState } from 'material-ui-popup-state/hooks';
-import * as React from 'react';
+import { usePopupState } from 'material-ui-popup-state/hooks';
+import { useEffect, useRef } from 'react';
 
 interface PopperPopupProps {
   popupContent: React.ReactNode;
-  popupState: PopupState;
   children?: React.ReactNode | null;
 }
 
 export default function PopperPopup (props: PopperPopupProps) {
-  const { popupContent, popupState, children } = props;
-  console.log('popupState', popupState);
-  const toggleRef = React.useRef(null);
-  React.useEffect(() => {
+
+  const { popupContent, children } = props;
+
+  const popupState = usePopupState({ variant: 'popper', popupId: 'iframe-selector' });
+  const toggleRef = useRef(null);
+
+  useEffect(() => {
     if (toggleRef.current) {
-      console.log('set anchor', toggleRef.current);
       popupState.setAnchorEl(toggleRef.current);
+      popupState.open();
     }
   }, [toggleRef]);
+
   return (
     <div ref={toggleRef}>
       {children && (

--- a/components/common/PopperPopup.tsx
+++ b/components/common/PopperPopup.tsx
@@ -19,7 +19,9 @@ export default function PopperPopup (props: PopperPopupProps) {
   useEffect(() => {
     if (toggleRef.current) {
       popupState.setAnchorEl(toggleRef.current);
-      popupState.open();
+      setTimeout(() => {
+        popupState.open();
+      });
     }
   }, [toggleRef]);
 

--- a/lib/embed/extractEmbedLink.ts
+++ b/lib/embed/extractEmbedLink.ts
@@ -17,7 +17,6 @@ export function extractEmbedLink (url: string) {
       embedUrl += `?start=${urlSearchParams.get('t')}`;
     }
   }
-
   else if (isIframeEmbed) {
     const indexOfSrc = url.indexOf('src');
     const indexOfFirstQuote = url.indexOf('"', indexOfSrc);


### PR DESCRIPTION
- group iframe embed code for CharmEditor into one folder
- fix default video width of 400px to be full-width (this feels more intuitive to me, but also mirrors notion)
- have video/iframe input appear by default
- removed the paragraph component wrapper around iframe and video embeds when inserting into the doc...  @Devorein is there any reason to keep them wrapped by p tags?