### PR TITLE
Only show show actions if the editor content isn't empty

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -366,7 +366,7 @@ function CharmEditor (
         width: '100%',
         height: '100%'
       }}
-      className='czi-editor-frame-body'
+      className={`czi-editor-frame-body ${isEmpty ? 'empty-editor' : ''}`}
       pmViewOpts={{
         editable: () => !readOnly,
         plugins: []

--- a/components/common/CharmEditor/components/rowActions/rowActions.ts
+++ b/components/common/CharmEditor/components/rowActions/rowActions.ts
@@ -43,7 +43,16 @@ export function plugins ({ key }: { key: PluginKey }) {
         view.dom.parentNode?.appendChild(tooltipDOM);
 
         function onMouseOver (e: MouseEventInit) {
-
+          const isEditorEmpty = Boolean(document.querySelector('.empty-editor'));
+          const rowHandleElement = document.querySelector('.row-handle') as HTMLDivElement;
+          if (rowHandleElement) {
+            if (!isEditorEmpty) {
+              rowHandleElement.style.display = 'initial';
+            }
+            else {
+              rowHandleElement.style.display = 'none';
+            }
+          }
           // @ts-ignore
           const containerXOffset = e.target.getBoundingClientRect().left;
           const clientX = e.clientX!;


### PR DESCRIPTION
We are showing the row action component even when the editor is empty. This PR hide the row-action component unless the editor has content
Now
![image](https://user-images.githubusercontent.com/34683631/172057034-0c46790d-a9ba-4ef5-960a-96e4f3042698.png)
Previously
![image](https://user-images.githubusercontent.com/34683631/172057094-392b50c1-2603-4850-9562-fca3ac0ede82.png)
