### PR TITLE
autoOpen prop for PopperPopup component

### DIFF
--- a/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
+++ b/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
@@ -17,6 +17,7 @@ export default function IFrameSelector (props: IFrameSelectorProps) {
 
   return (
     <PopperPopup
+      autoOpen
       popupContent={(
         <Box sx={{
           width: 750

--- a/components/common/PopperPopup.tsx
+++ b/components/common/PopperPopup.tsx
@@ -1,31 +1,44 @@
-import { Popover } from '@mui/material';
+import { Popover, PopoverProps } from '@mui/material';
 import Paper from '@mui/material/Paper';
-import { bindPopover, bindToggle } from 'material-ui-popup-state';
+import PopupState, { bindPopover, bindToggle } from 'material-ui-popup-state';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useEffect, useRef } from 'react';
 
 interface PopperPopupProps {
   popupContent: React.ReactNode;
   children?: React.ReactNode | null;
+  autoOpen?: boolean
 }
 
 export default function PopperPopup (props: PopperPopupProps) {
 
-  const { popupContent, children } = props;
+  const { popupContent, children, autoOpen = false } = props;
 
   const popupState = usePopupState({ variant: 'popper', popupId: 'iframe-selector' });
   const toggleRef = useRef(null);
 
+  const popoverProps: PopoverProps = {
+    ...bindPopover(popupState),
+    anchorOrigin: {
+      vertical: 'bottom',
+      horizontal: 'center'
+    },
+    transformOrigin: {
+      vertical: 'top',
+      horizontal: 'center'
+    }
+  };
+
   useEffect(() => {
-    if (toggleRef.current) {
+    if (autoOpen && toggleRef.current) {
       popupState.setAnchorEl(toggleRef.current);
       setTimeout(() => {
         popupState.open();
       });
     }
-  }, [toggleRef]);
+  }, [toggleRef, autoOpen]);
 
-  return (
+  return autoOpen ? (
     <div ref={toggleRef}>
       {children && (
       <div {...bindToggle(popupState)}>
@@ -33,20 +46,24 @@ export default function PopperPopup (props: PopperPopupProps) {
       </div>
       )}
       <Popover
-        {...bindPopover(popupState)}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'center'
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'center'
-        }}
+        {...popoverProps}
       >
         <Paper>
           {popupContent}
         </Paper>
       </Popover>
     </div>
+  ) : (
+    <PopupState variant='popper'>
+      {(_popupState) => (
+        <div>
+          {children && (
+          <div {...bindToggle(_popupState)}>
+            {children}
+          </div>
+          )}
+        </div>
+      )}
+    </PopupState>
   );
 }


### PR DESCRIPTION
Opening the popper-popup for IframeSelect is fine but everytime I navigate to a page (that has a cover) it opens it up, I reckon it does the same in all the places we are using `PopperPopup` component, added an `autoOpen` prop to disable this by default