### PR TITLE
Fix for incorrect page ordering

### DIFF
--- a/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
@@ -79,6 +79,8 @@ function DraggableTreeNode ({ item, onDropAdjacent, onDropChild, pathPrefix, add
     },
     collect: monitor => {
       let canDropItem: boolean = true;
+      // We use this to bypass the thrown error: Invariant Violation: Expected to find a valid target.
+      // If there is an error thrown, set canDrop to false.
       try {
         canDropItem = monitor.canDrop();
       }

--- a/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
@@ -11,7 +11,7 @@ import { useTreeItem } from '@mui/lab/TreeItem';
 import PageTreeItem from './PageTreeItem';
 import BoardViewTreeItem from './BoardViewTreeItem';
 
-export type MenuNode = Pick<Page, 'id' | 'title' | 'icon' | 'index' | 'parentId' | 'path' | 'type' | 'deletedAt'> & { isEmptyContent: boolean };
+export type MenuNode = Pick<Page, 'id' | 'title' | 'icon' | 'index' | 'parentId' | 'path' | 'type' | 'createdAt' | 'deletedAt'> & { isEmptyContent: boolean };
 
 export type ParentMenuNode = MenuNode & {
   children: ParentMenuNode[];
@@ -78,9 +78,16 @@ function DraggableTreeNode ({ item, onDropAdjacent, onDropChild, pathPrefix, add
       setIsAdjacent(_isAdjacent);
     },
     collect: monitor => {
+      let canDropItem: boolean = true;
+      try {
+        canDropItem = monitor.canDrop();
+      }
+      catch {
+        canDropItem = false;
+      }
       return {
         isOverCurrent: monitor.isOver({ shallow: true }),
-        canDrop: monitor.canDrop()
+        canDrop: canDropItem
       };
     }
   }));


### PR DESCRIPTION
Fixes for incorrect page ordering on drag and drop.

Some scenarios fixed by this PR that can be reproduced in production:

1. Dragging as child page
1.1 Make sure there are at least 2 pages in the workspace.
1.2 Drag one as the child page of the other.
1.3 Notice the console error:  _Uncaught Invariant Violation: Expected to find a valid target. targetId=_

2. Order shuffle for new pages
https://www.loom.com/share/d4f085548c9b42318d8705672ca00f8f
2.1 Create a new workspace.
2.2 Add 5 new pages.
2.3 Click randomly on the screen.
2.4 Notice the order changes.

3. Three is a problem
3.1 Create a new workspace.
3.2 Create two pages and a board.
3.3 Drag the second page above the first page.
3.4 Drag the board in between the two pages.
3.5 Notice the board is put first.