### PR TITLE
fix access to bounties state

### DIFF
--- a/charmClient.ts
+++ b/charmClient.ts
@@ -418,15 +418,6 @@ class CharmClient {
     return data;
   }
 
-  async changeBountyStatus (bountyId: string, newStatus: BountyStatus): Promise<BountyWithDetails> {
-
-    const data = await http.PUT<BountyWithDetails>(`/api/bounties/${bountyId}`, {
-      status: newStatus
-    });
-
-    return data;
-  }
-
   async closeBountySubmissions (bountyId: string): Promise<BountyWithDetails> {
     return http.POST<BountyWithDetails>(`/api/bounties/${bountyId}/close-submissions`);
   }

--- a/components/bounties/BountyList.tsx
+++ b/components/bounties/BountyList.tsx
@@ -41,7 +41,7 @@ export default function BountyList () {
 
   const [space] = useCurrentSpace();
 
-  const [savedBountyFilters, setSavedBountyFilters] = useLocalStorage<BountyStatus []>(`${space?.id}-bounty-filters`, ['open', 'inProgress']);
+  const [savedBountyFilters, setSavedBountyFilters] = useLocalStorage<BountyStatus[]>(`${space?.id}-bounty-filters`, ['open', 'inProgress']);
 
   // Filter out the old bounty filters
   useEffect(() => {

--- a/components/bounties/[bountyId]/components_v3/BountySubmissions.tsx
+++ b/components/bounties/[bountyId]/components_v3/BountySubmissions.tsx
@@ -46,8 +46,8 @@ export const SubmissionStatusColors: Record<ApplicationStatus, BrandColor> = {
 export const SubmissionStatusLabels: Record<ApplicationStatus, string> = {
   applied: 'Applied',
   rejected: 'Rejected',
-  inProgress: 'In progress',
-  review: 'Review',
+  inProgress: 'In Progress',
+  review: 'In Review',
   complete: 'Complete',
   paid: 'Paid'
 };

--- a/components/common/BoardEditor/focalboard/src/store/cards.ts
+++ b/components/common/BoardEditor/focalboard/src/store/cards.ts
@@ -78,7 +78,6 @@ const cardsSlice = createSlice({
               }
             });
             for (const block of action.payload.blocks) {
-                console.log(action.payload.blocks)
               const boardPage = boardsRecord[block.parentId];
               // check boardPage exists, its possible a deleted card still exists. TODO: delete cards when a board is deleted!
               if (boardPage) {

--- a/hooks/useBounties.tsx
+++ b/hooks/useBounties.tsx
@@ -47,18 +47,19 @@ export function BountiesProvider ({ children }: { children: ReactNode }) {
 
   // Updates the value of a bounty in the bounty list
   function refreshBountyList (bounty: BountyWithDetails) {
-    const bountyIndex = bounties.findIndex(bountyInList => bountyInList.id === bounty.id);
+    setBounties(_bounties => {
+      const bountyIndex = _bounties.findIndex(bountyInList => bountyInList.id === bounty.id);
 
-    const updatedList = bounties.slice();
+      const updatedList = _bounties.slice();
 
-    if (bountyIndex > -1) {
-      updatedList[bountyIndex] = bounty;
-    }
-    else {
-      updatedList.push(bounty);
-    }
-
-    setBounties(updatedList);
+      if (bountyIndex > -1) {
+        updatedList[bountyIndex] = bounty;
+      }
+      else {
+        updatedList.push(bounty);
+      }
+      return updatedList;
+    });
   }
 
   async function updateBounty (bountyId: string, bountyUpdate: Partial<Bounty>) {
@@ -89,7 +90,7 @@ export function BountiesProvider ({ children }: { children: ReactNode }) {
 
   async function deleteBounty (bountyId: string): Promise<true> {
     await charmClient.deleteBounty(bountyId);
-    setBounties(bounties.filter(bounty => bounty.id !== bountyId));
+    setBounties(_bounties => _bounties.filter(bounty => bounty.id !== bountyId));
     if (currentBounty?.id === bountyId) {
       setCurrentBounty(null);
     }
@@ -110,7 +111,7 @@ export function BountiesProvider ({ children }: { children: ReactNode }) {
 
     if (bountyToSet) {
       // Replace current bounty in list of bounties
-      setBounties(bounties.map(b => b.id === bountyToSet.id ? bountyToSet : b));
+      setBounties(_bounties => _bounties.map(b => b.id === bountyToSet.id ? bountyToSet : b));
     }
 
   }


### PR DESCRIPTION
This fixes some bugs due to stale bounty state. To reproduce one example:

1. Create a few bounties
2. Edit one bounty's status by creating a submission
3. Go back to bounties page: there is only one bounty (the bounty we edited).

We had a similar issue with usePages where we were reading the context value directly, but it turns out to be the initial state, so when the method gets calle,d 'bounties' is still an empty array.