### PR TITLE
pin the version of node in github ci for now

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -8,7 +8,7 @@ runs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: "16"
+        node-version: "16.14"
 
     - name: Cache Next.js build # copied from https://github.com/vercel/next.js/blob/canary/errors/no-cache.md
       uses: actions/cache@v2


### PR DESCRIPTION
The builds have started failing when doing npm ci if we don't have a cache of node_modules. Using v16.14 seems to work fine. 16.15 was released 7 days ago and includes a new version of npm, which I think may be the culprit.