### PR TITLE
Fix for not displayed poaps

### DIFF
--- a/components/profile/components/PoapSection.tsx
+++ b/components/profile/components/PoapSection.tsx
@@ -34,13 +34,17 @@ function PoapSection (props: PoapSectionProps) {
   const managePoapModalState = usePopupState({ variant: 'popover', popupId: 'poap-modal' });
   const { openWalletSelectorModal } = useContext(Web3Connection);
   const isPublic = isPublicUser(user);
-  const { data: poapData, mutate: mutatePoaps } = useSWRImmutable(`/poaps/${user.id}`, () => {
-    return isPublic ? Promise.resolve({ visiblePoaps: user.visiblePoaps || [], hiddenPoaps: [] }) : charmClient.getUserPoaps();
+  const { data: poapData, mutate: mutatePoaps } = useSWRImmutable(`/poaps/${user.id}/${isPublic}`, () => {
+    return isPublicUser(user) ? Promise.resolve({ visiblePoaps: [], hiddenPoaps: [] }) : charmClient.getUserPoaps();
   });
 
   const hasConnectedWallet: boolean = !isPublic && user.addresses.length !== 0;
 
-  const poaps = poapData?.visiblePoaps || [];
+  let poaps = poapData?.visiblePoaps || [];
+
+  if (isPublic) {
+    poaps = user.visiblePoaps;
+  }
 
   return (
     <StyledBox p={2}>

--- a/components/profile/components/PoapSection.tsx
+++ b/components/profile/components/PoapSection.tsx
@@ -35,7 +35,7 @@ function PoapSection (props: PoapSectionProps) {
   const { openWalletSelectorModal } = useContext(Web3Connection);
   const isPublic = isPublicUser(user);
   const { data: poapData, mutate: mutatePoaps } = useSWRImmutable(`/poaps/${user.id}`, () => {
-    return isPublicUser(user) ? Promise.resolve({ visiblePoaps: user.visiblePoaps || [], hiddenPoaps: [] }) : charmClient.getUserPoaps();
+    return isPublic ? Promise.resolve({ visiblePoaps: user.visiblePoaps || [], hiddenPoaps: [] }) : charmClient.getUserPoaps();
   });
 
   const hasConnectedWallet: boolean = !isPublic && user.addresses.length !== 0;

--- a/components/profile/components/PoapSection.tsx
+++ b/components/profile/components/PoapSection.tsx
@@ -35,16 +35,12 @@ function PoapSection (props: PoapSectionProps) {
   const { openWalletSelectorModal } = useContext(Web3Connection);
   const isPublic = isPublicUser(user);
   const { data: poapData, mutate: mutatePoaps } = useSWRImmutable(`/poaps/${user.id}`, () => {
-    return isPublicUser(user) ? Promise.resolve({ visiblePoaps: [], hiddenPoaps: [] }) : charmClient.getUserPoaps();
+    return isPublicUser(user) ? Promise.resolve({ visiblePoaps: user.visiblePoaps || [], hiddenPoaps: [] }) : charmClient.getUserPoaps();
   });
 
   const hasConnectedWallet: boolean = !isPublic && user.addresses.length !== 0;
 
-  let poaps = poapData?.visiblePoaps || [];
-
-  if (isPublic) {
-    poaps = user.visiblePoaps;
-  }
+  const poaps = poapData?.visiblePoaps || [];
 
   return (
     <StyledBox p={2}>


### PR DESCRIPTION
This PR contains a fix for a scenario in which the POAPs are not displayed.

STR
1. Go to the nexus profile.
2. Notice existing poap(s).
3. Copy the public profile URL.
4. Go to that page in the same tab.
5. Notice the poap(s).
6. Click on the name in the top right corner.
7. Click on the My public Profile link.
8. Notice the missing poap(s).