### PR TITLE
Add breadcrumbs for public page

### DIFF
--- a/charmClient.ts
+++ b/charmClient.ts
@@ -38,6 +38,7 @@ import { PublicSpaceInfo } from 'lib/spaces/interfaces';
 import { ApplicationWithTransactions } from 'lib/applications/actions';
 import { TransactionCreationData } from 'lib/transactions/interface';
 import { PublicUser } from 'pages/api/public/profile/[userPath]';
+import { PublicPageResponse } from 'pages/api/public/pages/[pageId]';
 import { SuggestionAction } from 'lib/bounties';
 
 type BlockUpdater = (blocks: FBBlock[]) => void;
@@ -192,8 +193,8 @@ class CharmClient {
     return http.DELETE(`/api/profile/gnosis-safes/${walletId}`);
   }
 
-  getPublicPage (pageId: string) {
-    return http.GET<{pages: Page[], blocks: Block[]}>(`/api/public/pages/${pageId}`);
+  getPublicPage (pageIdOrPath: string) {
+    return http.GET<PublicPageResponse>(`/api/public/pages/${pageIdOrPath}`);
   }
 
   createInviteLink (link: Partial<InviteLink>) {

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -377,7 +377,7 @@ function CharmEditor (
             // This fixes the placeholder and cursor not being aligned
             top: -34
           }}
-          show={isEmpty}
+          show={isEmpty && !readOnly}
         />
       )}
       state={state}
@@ -492,7 +492,7 @@ function CharmEditor (
       </Grow>
       )}
       {!disabledPageSpecificFeatures && <InlineCommentThread pluginKey={inlineCommentPluginKey} />}
-      <DevTools />
+      {!readOnly && <DevTools />}
     </StyledReactBangleEditor>
   );
 }

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -74,7 +74,7 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: prop => prop !== 'open' &&
     })
   }));
 
-const HeaderSpacer = styled.div`
+export const HeaderSpacer = styled.div`
   min-height: ${headerHeight}px;
 `;
 

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -9,8 +9,8 @@ import * as React from 'react';
 import { CommentThreadsListDisplayProvider } from 'hooks/useCommentThreadsListDisplay';
 import Header, { headerHeight } from './components/Header';
 import Sidebar from './components/Sidebar';
-import Favicon from './components/Favicon';
 import PageContainer from './components/PageContainer';
+import CurrentPageFavicon from './components/CurrentPageFavicon';
 
 const openedMixin = (theme: Theme, sidebarWidth: number) => ({
   width: '100%',
@@ -35,7 +35,7 @@ const closedMixin = (theme: Theme) => ({
   width: 0
 });
 
-const AppBar = styled(MuiAppBar, { shouldForwardProp: (prop: string) => prop !== 'sidebarWidth' && prop !== 'open' })
+export const AppBar = styled(MuiAppBar, { shouldForwardProp: (prop: string) => prop !== 'sidebarWidth' && prop !== 'open' })
   // eslint-disable-next-line no-unexpected-multiline
   <{ open: boolean, sidebarWidth: number }>(({ sidebarWidth, theme, open }) => ({
     background: 'transparent',
@@ -140,12 +140,6 @@ function PageLayout ({ hideSidebarOnSmallScreen = false, sidebarWidth = 300, chi
       </LayoutContainer>
     </>
   );
-}
-
-function CurrentPageFavicon () {
-  const { currentPageId, pages } = usePages();
-  const currentPage = pages[currentPageId];
-  return <Favicon pageIcon={currentPage?.icon} />;
 }
 
 export default PageLayout;

--- a/components/common/PageLayout/components/Account/Account.tsx
+++ b/components/common/PageLayout/components/Account/Account.tsx
@@ -65,7 +65,7 @@ function Account (): JSX.Element {
   if (isUserLoaded && !user) {
     return (
       <AccountCard>
-        <AccountButton sx={{ mt: 4 }} href='/'>Join CharmVerse</AccountButton>
+        <AccountButton href='/'>Join CharmVerse</AccountButton>
       </AccountCard>
     );
   }

--- a/components/common/PageLayout/components/CurrentPageFavicon.tsx
+++ b/components/common/PageLayout/components/CurrentPageFavicon.tsx
@@ -5,6 +5,5 @@ import Favicon from './Favicon';
 export default function CurrentPageFavicon () {
   const { currentPageId, pages } = usePages();
   const currentPage = pages[currentPageId];
-  console.log('current page', currentPage);
   return <Favicon pageIcon={currentPage?.icon} />;
 }

--- a/components/common/PageLayout/components/CurrentPageFavicon.tsx
+++ b/components/common/PageLayout/components/CurrentPageFavicon.tsx
@@ -5,5 +5,6 @@ import Favicon from './Favicon';
 export default function CurrentPageFavicon () {
   const { currentPageId, pages } = usePages();
   const currentPage = pages[currentPageId];
+  console.log('current page', currentPage);
   return <Favicon pageIcon={currentPage?.icon} />;
 }

--- a/components/common/PageLayout/components/CurrentPageFavicon.tsx
+++ b/components/common/PageLayout/components/CurrentPageFavicon.tsx
@@ -1,0 +1,9 @@
+
+import { usePages } from 'hooks/usePages';
+import Favicon from './Favicon';
+
+export default function CurrentPageFavicon () {
+  const { currentPageId, pages } = usePages();
+  const currentPage = pages[currentPageId];
+  return <Favicon pageIcon={currentPage?.icon} />;
+}

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -25,14 +25,14 @@ import { usePages } from 'hooks/usePages';
 import { useUser } from 'hooks/useUser';
 import { generateMarkdown } from 'lib/pages/generateMarkdown';
 import { useRouter } from 'next/router';
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import Account from '../Account';
 import ShareButton from '../ShareButton';
 import PageTitleWithBreadcrumbs from './PageTitleWithBreadcrumbs';
 
 export const headerHeight = 56;
 
-const StyledToolbar = styled(Toolbar)`
+export const StyledToolbar = styled(Toolbar)`
   background-color: ${({ theme }) => theme.palette.background.default};
   height: ${headerHeight}px;
   min-height: ${headerHeight}px;
@@ -57,11 +57,13 @@ function CommentThreadsListButton () {
   );
 }
 
-export default function Header (
-  { open, openSidebar, hideSidebarOnSmallScreen }:
-  {
-    open: boolean, openSidebar: () => void, hideSidebarOnSmallScreen?: boolean }
-) {
+interface HeaderProps {
+  open: boolean;
+  openSidebar: () => void;
+  hideSidebarOnSmallScreen?: boolean;
+}
+
+export default function Header ({ open, openSidebar, hideSidebarOnSmallScreen }: HeaderProps) {
   const router = useRouter();
   const colorMode = useColorMode();
   const { pages, currentPageId } = usePages();
@@ -124,6 +126,7 @@ export default function Header (
       >
         <MenuIcon />
       </IconButton>
+
       <Box sx={{
         display: 'flex',
         justifyContent: 'space-between',

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -115,8 +115,8 @@ export default function Header (
         edge='start'
         sx={{
           display: {
-            xs: hideSidebarOnSmallScreen ? 'none' : 'block',
-            md: 'block'
+            xs: hideSidebarOnSmallScreen ? 'none' : 'inline-flex',
+            md: 'inline-flex'
           },
           marginRight: '36px',
           ...(open && { display: 'none' })

--- a/components/common/PageLayout/components/Header/PageTitleWithBreadcrumbs.tsx
+++ b/components/common/PageLayout/components/Header/PageTitleWithBreadcrumbs.tsx
@@ -44,7 +44,7 @@ interface PageBreadCrumb {
   title: string;
 }
 
-function WorkspacePageTitle () {
+function WorkspacePageTitle ({ basePath }: { basePath: string }) {
   const router = useRouter();
   const { currentPageId, pages, isEditing } = usePages();
 
@@ -75,7 +75,7 @@ function WorkspacePageTitle () {
       {displayedCrumbs.map(crumb => (
         <BreadCrumb key={crumb.path}>
           {crumb.path ? (
-            <Link href={`/${router.query.domain}/${crumb.path}`}>
+            <Link href={`${basePath}/${crumb.path}`}>
               <PageTitleWrapper sx={{ maxWidth: 160 }}>
                 {crumb.icon && <PageIcon icon={crumb.icon} />}
                 {crumb.title || 'Untitled'}
@@ -138,11 +138,15 @@ function StandardPageTitle () {
 
 export default function PageTitleWithBreadcrumbs () {
   const router = useRouter();
+  console.log('router', router.route);
   if (router.route === '/[domain]/bounties/[bountyId]') {
     return <BountyPageTitle />;
   }
   else if (router.route === '/[domain]/[pageId]') {
-    return <WorkspacePageTitle />;
+    return <WorkspacePageTitle basePath={`/${router.query.domain}`} />;
+  }
+  else if (router.route === '/share/[pageId]') {
+    return <WorkspacePageTitle basePath='/share' />;
   }
   else if (router.route.startsWith('/nexus') || router.route.startsWith('/u/')) {
     return <div></div>;

--- a/components/common/PageLayout/components/Header/PageTitleWithBreadcrumbs.tsx
+++ b/components/common/PageLayout/components/Header/PageTitleWithBreadcrumbs.tsx
@@ -138,7 +138,6 @@ function StandardPageTitle () {
 
 export default function PageTitleWithBreadcrumbs () {
   const router = useRouter();
-  console.log('router', router.route);
   if (router.route === '/[domain]/bounties/[bountyId]') {
     return <BountyPageTitle />;
   }

--- a/components/share/PublicPage.tsx
+++ b/components/share/PublicPage.tsx
@@ -15,9 +15,8 @@ import ErrorPage from 'components/common/errors/ErrorPage';
 import { usePages, PagesMap } from 'hooks/usePages';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { Board } from 'lib/focalboard/board';
-import debouncePromise from 'lib/utilities/debouncePromise';
-import log from 'loglevel';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useSpaces } from 'hooks/useSpaces';
 import BoardPage from 'components/[pageId]/BoardPage';
 import DocumentPage from 'components/[pageId]/DocumentPage';
 
@@ -31,47 +30,35 @@ export default function PublicPage () {
   const router = useRouter();
   const pageIdOrPath = router.query.pageId as string;
   const dispatch = useAppDispatch();
-  const { pages, currentPageId, setCurrentPageId, setPages } = usePages();
+  const { pages, currentPageId, setCurrentPageId } = usePages();
+  const [, setSpaces] = useSpaces();
   const [, setTitleState] = usePageTitle();
   const [pageNotFound, setPageNotFound] = useState(false);
 
-  async function onLoad () {
-
-    try {
-      const { page: rootPage, pageBlock, boardBlock } = await charmClient.getPublicPage(pageIdOrPath);
-
-      setTitleState(rootPage.title);
-      setCurrentPageId(rootPage.id);
-
-      if (pageBlock) {
-        dispatch(setCurrent(pageBlock.id));
-        dispatch(addCard(pageBlock as unknown as Card));
-      }
-      if (boardBlock) {
-        dispatch(addBoard(boardBlock as unknown as Board));
-      }
-
-      if (rootPage.spaceId) {
-        const publicPagesInSpace = await charmClient.getPages(rootPage.spaceId);
-        const pageMap = publicPagesInSpace.reduce<PagesMap>((map, page) => {
-          map[page.id] = page;
-          return map;
-        }, {});
-
-        setPages(pageMap);
-      }
-      else {
-        throw new Error('Pages with no spaceId not supported');
-      }
-
-    }
-    catch (err) {
-      setPageNotFound(true);
-    }
-
-  }
-
   useEffect(() => {
+
+    async function onLoad () {
+
+      try {
+        const { page: rootPage, pageBlock, boardBlock, space } = await charmClient.getPublicPage(pageIdOrPath);
+
+        setTitleState(rootPage.title);
+        setCurrentPageId(rootPage.id);
+        setSpaces([space]);
+
+        if (pageBlock) {
+          dispatch(setCurrent(pageBlock.id));
+          dispatch(addCard(pageBlock as unknown as Card));
+        }
+        if (boardBlock) {
+          dispatch(addBoard(boardBlock as unknown as Board));
+        }
+      }
+      catch (err) {
+        setPageNotFound(true);
+      }
+    }
+
     onLoad();
   }, []);
 

--- a/components/share/PublicPage.tsx
+++ b/components/share/PublicPage.tsx
@@ -1,10 +1,16 @@
 import PageContainer from 'components/common/PageLayout/components/PageContainer';
+import { useTheme } from '@emotion/react';
 import { AppBar } from 'components/common/PageLayout/PageLayout';
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
+import { Box, Tooltip, IconButton } from '@mui/material';
+import SunIcon from '@mui/icons-material/WbSunny';
+import MoonIcon from '@mui/icons-material/DarkMode';
 import CurrentPageFavicon from 'components/common/PageLayout/components/CurrentPageFavicon';
-import Header from 'components/common/PageLayout/components/Header';
+import { StyledToolbar } from 'components/common/PageLayout/components/Header';
+import Account from 'components/common/PageLayout/components/Account';
+import PageTitleWithBreadcrumbs from 'components/common/PageLayout/components/Header/PageTitleWithBreadcrumbs';
 import charmClient from 'charmClient';
 import { Card } from 'components/common/BoardEditor/focalboard/src/blocks/card';
 import { addBoard } from 'components/common/BoardEditor/focalboard/src/store/boards';
@@ -12,13 +18,14 @@ import { addCard } from 'components/common/BoardEditor/focalboard/src/store/card
 import { useAppDispatch } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import { setCurrent } from 'components/common/BoardEditor/focalboard/src/store/views';
 import ErrorPage from 'components/common/errors/ErrorPage';
-import { usePages, PagesMap } from 'hooks/usePages';
+import { usePages } from 'hooks/usePages';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { Board } from 'lib/focalboard/board';
 import { useEffect, useState } from 'react';
 import { useSpaces } from 'hooks/useSpaces';
 import BoardPage from 'components/[pageId]/BoardPage';
 import DocumentPage from 'components/[pageId]/DocumentPage';
+import { useColorMode } from 'context/darkMode';
 
 const LayoutContainer = styled.div`
   display: flex;
@@ -27,6 +34,8 @@ const LayoutContainer = styled.div`
 
 export default function PublicPage () {
 
+  const theme = useTheme();
+  const colorMode = useColorMode();
   const router = useRouter();
   const pageIdOrPath = router.query.pageId as string;
   const dispatch = useAppDispatch();
@@ -76,10 +85,29 @@ export default function PublicPage () {
       <LayoutContainer>
 
         <AppBar sidebarWidth={0} position='fixed' open={false}>
-          <Header
-            open={false}
-            openSidebar={() => {}}
-          />
+
+          <StyledToolbar variant='dense'>
+            <Box sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              gap: 1,
+              width: '100%'
+            }}
+            >
+              <PageTitleWithBreadcrumbs />
+              <Box display='flex' alignItems='center'>
+                {/** dark mode toggle */}
+                <Tooltip title={theme.palette.mode === 'dark' ? 'Light mode' : 'Dark mode'} arrow placement='bottom'>
+                  <IconButton sx={{ mx: 1 }} onClick={colorMode.toggleColorMode} color='inherit'>
+                    {theme.palette.mode === 'dark' ? <SunIcon color='secondary' /> : <MoonIcon color='secondary' />}
+                  </IconButton>
+                </Tooltip>
+                {/** user account */}
+                <Account />
+              </Box>
+            </Box>
+          </StyledToolbar>
         </AppBar>
 
         <PageContainer>

--- a/components/share/PublicPage.tsx
+++ b/components/share/PublicPage.tsx
@@ -1,6 +1,6 @@
 import PageContainer from 'components/common/PageLayout/components/PageContainer';
 import { useTheme } from '@emotion/react';
-import { AppBar } from 'components/common/PageLayout/PageLayout';
+import { AppBar, HeaderSpacer } from 'components/common/PageLayout/PageLayout';
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
@@ -111,6 +111,7 @@ export default function PublicPage () {
         </AppBar>
 
         <PageContainer>
+          <HeaderSpacer />
           {currentPage?.type === 'board'
             ? (
               <BoardPage page={currentPage} setPage={() => {}} readonly={true} />

--- a/components/share/PublicPage.tsx
+++ b/components/share/PublicPage.tsx
@@ -1,0 +1,110 @@
+import PageContainer from 'components/common/PageLayout/components/PageContainer';
+import { AppBar } from 'components/common/PageLayout/PageLayout';
+import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+import CurrentPageFavicon from 'components/common/PageLayout/components/CurrentPageFavicon';
+import Header from 'components/common/PageLayout/components/Header';
+import charmClient from 'charmClient';
+import { Card } from 'components/common/BoardEditor/focalboard/src/blocks/card';
+import { addBoard } from 'components/common/BoardEditor/focalboard/src/store/boards';
+import { addCard } from 'components/common/BoardEditor/focalboard/src/store/cards';
+import { useAppDispatch } from 'components/common/BoardEditor/focalboard/src/store/hooks';
+import { setCurrent } from 'components/common/BoardEditor/focalboard/src/store/views';
+import ErrorPage from 'components/common/errors/ErrorPage';
+import { usePages, PagesMap } from 'hooks/usePages';
+import { usePageTitle } from 'hooks/usePageTitle';
+import { Board } from 'lib/focalboard/board';
+import debouncePromise from 'lib/utilities/debouncePromise';
+import log from 'loglevel';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import BoardPage from 'components/[pageId]/BoardPage';
+import DocumentPage from 'components/[pageId]/DocumentPage';
+
+const LayoutContainer = styled.div`
+  display: flex;
+  height: 100%;
+`;
+
+export default function PublicPage () {
+
+  const router = useRouter();
+  const pageIdOrPath = router.query.pageId as string;
+  const dispatch = useAppDispatch();
+  const { pages, currentPageId, setCurrentPageId, setPages } = usePages();
+  const [, setTitleState] = usePageTitle();
+  const [pageNotFound, setPageNotFound] = useState(false);
+
+  async function onLoad () {
+
+    try {
+      const { page: rootPage, pageBlock, boardBlock } = await charmClient.getPublicPage(pageIdOrPath);
+
+      setTitleState(rootPage.title);
+      setCurrentPageId(rootPage.id);
+
+      if (pageBlock) {
+        dispatch(setCurrent(pageBlock.id));
+        dispatch(addCard(pageBlock as unknown as Card));
+      }
+      if (boardBlock) {
+        dispatch(addBoard(boardBlock as unknown as Board));
+      }
+
+      if (rootPage.spaceId) {
+        const publicPagesInSpace = await charmClient.getPages(rootPage.spaceId);
+        const pageMap = publicPagesInSpace.reduce<PagesMap>((map, page) => {
+          map[page.id] = page;
+          return map;
+        }, {});
+
+        setPages(pageMap);
+      }
+      else {
+        throw new Error('Pages with no spaceId not supported');
+      }
+
+    }
+    catch (err) {
+      setPageNotFound(true);
+    }
+
+  }
+
+  useEffect(() => {
+    onLoad();
+  }, []);
+
+  const currentPage = pages[currentPageId];
+
+  if (pageNotFound) {
+    return <ErrorPage message={'Sorry, that page doesn\'t exist'} />;
+  }
+
+  return (
+    <>
+      <Head>
+        <CurrentPageFavicon />
+      </Head>
+      <LayoutContainer>
+
+        <AppBar sidebarWidth={0} position='fixed' open={false}>
+          <Header
+            open={false}
+            openSidebar={() => {}}
+          />
+        </AppBar>
+
+        <PageContainer>
+          {currentPage?.type === 'board'
+            ? (
+              <BoardPage page={currentPage} setPage={() => {}} readonly={true} />
+            ) : (
+              currentPage && <DocumentPage page={currentPage} setPage={() => {}} readOnly={true} />
+            )}
+        </PageContainer>
+
+      </LayoutContainer>
+    </>
+  );
+}

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -18,7 +18,7 @@ import useIsAdmin from './useIsAdmin';
 
 export type LinkedPage = (Page & {children: LinkedPage[], parent: null | LinkedPage});
 
-type PagesMap = Record<string, Page | undefined>;
+export type PagesMap = Record<string, Page | undefined>;
 
 type IContext = {
   currentPageId: string,

--- a/hooks/useSpaces.tsx
+++ b/hooks/useSpaces.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, createContext, useContext, useState, useEffect, useMemo } from 'react';
 import { Space } from '@prisma/client';
+import { useRouter } from 'next/router';
 import charmClient from 'charmClient';
 import { useUser } from './useUser';
 
@@ -12,9 +13,10 @@ export function SpacesProvider ({ children }: { children: ReactNode }) {
   const [user, _, isUserLoaded] = useUser();
   const [spaces, setSpaces] = useState<Space[]>([]);
   const [isLoaded, setIsLoaded] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
-    if (user) {
+    if (user && router.route !== '/share/[pageId]') {
       setIsLoaded(false);
       charmClient.getSpaces()
         .then(_spaces => {

--- a/lib/middleware/errors.ts
+++ b/lib/middleware/errors.ts
@@ -13,11 +13,11 @@ export class SpaceAccessDeniedError extends SystemError {
 
 export class NotFoundError extends SystemError {
 
-  constructor () {
+  constructor (message = 'Data not found') {
     super({
       severity: 'warning',
       errorType: 'Data not found',
-      message: 'Data not found'
+      message
     });
   }
 }

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -6,31 +6,20 @@ import { usePages } from 'hooks/usePages';
 import { useRouter } from 'next/router';
 import { ReactElement } from 'react';
 
-interface Props {
-  shouldLoadPublicPage: boolean
-}
+export default function BlocksEditorPage () {
 
-export default function BlocksEditorPage ({ shouldLoadPublicPage = false }: Props) {
-
-  const { currentPageId, setCurrentPageId, pages, refreshPage } = usePages();
+  const { pages } = usePages();
   const router = useRouter();
 
-  if (shouldLoadPublicPage) {
-    const pageId = router.query.pageId as string;
-    return <EditorPage shouldLoadPublicPage={true} onPageLoad={(_pageId) => setCurrentPageId(_pageId)} pageId={pageId} />;
-  }
-
-  // Handle non public page
   const pagePath = router.query.pageId as string;
   const pageIdList = Object.values(pages ?? {}) as Page[];
   const pageId = pageIdList.find(p => p.path === pagePath)?.id;
 
-  if (pageId) {
-
-    return <EditorPage shouldLoadPublicPage={false} onPageLoad={(_pageId) => setCurrentPageId(_pageId)} pageId={pageId} />;
+  if (!pageId) {
+    return null;
   }
 
-  return null;
+  return <EditorPage pageId={pageId} />;
 
 }
 

--- a/pages/api/public/pages/[pageId]/index.ts
+++ b/pages/api/public/pages/[pageId]/index.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 import { onError, onNoMatch } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
-import { Block, Page } from '@prisma/client';
+import { Block, Page, Space } from '@prisma/client';
 import { prisma } from 'db';
 import { isUUID } from 'lib/utilities/strings';
 import { NotFoundError } from 'lib/middleware/errors';
@@ -13,6 +13,7 @@ export interface PublicPageResponse {
   boardPage: Page | null;
   pageBlock: Block | null;
   boardBlock: Block | null;
+  space: Space;
 }
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
@@ -73,11 +74,22 @@ async function getPublicPage (req: NextApiRequest, res: NextApiResponse<PublicPa
     });
   }
 
+  const space = await prisma.space.findFirst({
+    where: {
+      id: page.spaceId!
+    }
+  });
+
+  if (!space) {
+    throw new NotFoundError('Space not found');
+  }
+
   return res.status(200).json({
     page,
     boardPage,
     pageBlock,
-    boardBlock
+    boardBlock,
+    space
   });
 }
 

--- a/pages/api/public/pages/[pageId]/index.ts
+++ b/pages/api/public/pages/[pageId]/index.ts
@@ -4,71 +4,80 @@ import { onError, onNoMatch } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
 import { Block, Page } from '@prisma/client';
 import { prisma } from 'db';
+import { isUUID } from 'lib/utilities/strings';
+import { NotFoundError } from 'lib/middleware/errors';
 import { computeUserPagePermissions } from 'lib/permissions/pages';
+
+export interface PublicPageResponse {
+  page: Page;
+  boardPage: Page | null;
+  pageBlock: Block | null;
+  boardBlock: Block | null;
+}
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler.get(getPublicPage);
 
-async function getPublicPage (req: NextApiRequest, res: NextApiResponse<{pages: Page[], blocks: Block[]}>) {
+async function getPublicPage (req: NextApiRequest, res: NextApiResponse<PublicPageResponse>) {
 
   const { pageId } = req.query;
 
-  if (pageId === undefined) {
+  if (typeof pageId !== 'string') {
     return res.status(400).json({ error: 'Please provide a valid page ID' } as any);
   }
 
-  const pages: Page[] = [];
-  const blocks: Block[] = [];
+  const query = isUUID(pageId)
+    ? { deletedAt: null, id: pageId }
+    : { deletedAt: null, path: pageId };
+
   const page = await prisma.page.findFirst({
-    where: {
-      deletedAt: null,
-      id: pageId as string
-    }
+    where: query
   });
 
-  const computed = await computeUserPagePermissions({
-    pageId: pageId as string
-  });
-
-  if (page === null || computed.read !== true) {
-    return res.status(404).json({ error: 'Page not found' } as any);
+  if (!page) {
+    throw new NotFoundError('Page not found');
   }
 
-  pages.push(page);
+  const computed = await computeUserPagePermissions({
+    pageId: page.id
+  });
+
+  if (computed.read !== true) {
+    throw new NotFoundError('Page not found');
+  }
+
+  let boardPage: Page | null = null;
+  let boardBlock: Block | null = null;
+  let pageBlock: Block | null = null;
 
   if (page.type === 'card' && page.parentId) {
-    const boardPage = await prisma.page.findFirst({
+    boardPage = await prisma.page.findFirst({
       where: {
         deletedAt: null,
         id: page.parentId
       }
     });
-    const cardBlock = await prisma.block.findFirst({
+    pageBlock = await prisma.block.findFirst({
       where: {
         deletedAt: null,
         id: page.id
       }
     });
 
-    const board = await prisma.block.findFirst({
+    boardBlock = await prisma.block.findFirst({
       where: {
         deletedAt: null,
         id: page.parentId
       }
     });
-
-    if (cardBlock && board) {
-      blocks.push(cardBlock, board);
-    }
-    if (boardPage) {
-      pages.push(boardPage);
-    }
   }
 
   return res.status(200).json({
-    pages,
-    blocks
+    page,
+    boardPage,
+    pageBlock,
+    boardBlock
   });
 }
 

--- a/pages/api/spaces/[id]/pages.ts
+++ b/pages/api/spaces/[id]/pages.ts
@@ -1,10 +1,9 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
-import { onError, onNoMatch, requireUser } from 'lib/middleware';
+import { onError, onNoMatch } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
 import { Page } from '@prisma/client';
-import { prisma } from 'db';
 import {} from 'lib/permissions/pages';
 import { getAccessiblePages } from 'lib/pages/server';
 

--- a/pages/api/spaces/[id]/pages.ts
+++ b/pages/api/spaces/[id]/pages.ts
@@ -20,6 +20,7 @@ async function getPages (req: NextApiRequest, res: NextApiResponse<Page[]>) {
     spaceId,
     userId
   });
+  console.log('accessiblePages', accessiblePages);
 
   return res.status(200).json(accessiblePages);
 }

--- a/pages/share/[pageId].tsx
+++ b/pages/share/[pageId].tsx
@@ -1,11 +1,7 @@
-import BlocksEditorPage from 'pages/[domain]/[pageId]';
-import PageContainer from 'components/common/PageLayout/components/PageContainer';
+
+import PublicPageComponent from 'components/share/PublicPage';
 
 export default function PublicPage () {
 
-  return (
-    <PageContainer>
-      <BlocksEditorPage shouldLoadPublicPage />
-    </PageContainer>
-  );
+  return <PublicPageComponent />;
 }

--- a/pages/share/view/[sharedViewId].tsx
+++ b/pages/share/view/[sharedViewId].tsx
@@ -1,6 +1,6 @@
-import PageView from 'pages/[domain]/[pageId]';
 import { useRouter } from 'next/router';
 import { generatePath } from 'lib/utilities/strings';
+import PageView from '../[pageId]';
 
 export default function PublicBoardView () {
   const router = useRouter();
@@ -18,5 +18,5 @@ export default function PublicBoardView () {
     return null;
   }
 
-  return <PageView shouldLoadPublicPage />;
+  return <PageView />;
 }


### PR DESCRIPTION
This was trickier than it looked because I had to make sure all the context loads properly, including with SWR refreshes. The flow now looks like this:
1) the PublicPage component determines what space and page we're looking at by calling getPublicPage(). This  api call now supports a path as well as a pageId.
2) usePages() is used to grab the rest of the pages. It depends on useSpace(), but that depends on the /domain URL. So I updated usePages() to check for the /share/[pageId] route and in that case, just assume it's the first workspace available (since we only load one for public pages).

![image](https://user-images.githubusercontent.com/305398/173016133-2708ef84-b050-4101-ad95-a551cdd22fd2.png)
