### PR TITLE
Simplify loading of permissions and fix for loading context for public pages

### DIFF
--- a/charmClient.ts
+++ b/charmClient.ts
@@ -153,7 +153,7 @@ class CharmClient {
   }
 
   createPage (pageOpts: Prisma.PageCreateInput) {
-    return http.POST<Page>('/api/pages', pageOpts);
+    return http.POST<IPageWithPermissions>('/api/pages', pageOpts);
   }
 
   getPage (pageId: string, spaceId?:string) {

--- a/charmClient.ts
+++ b/charmClient.ts
@@ -141,7 +141,7 @@ class CharmClient {
   }
 
   getPages (spaceId: string) {
-    return http.GET<Page[]>(`/api/spaces/${spaceId}/pages`);
+    return http.GET<IPageWithPermissions[]>(`/api/spaces/${spaceId}/pages`);
   }
 
   getArchivedPages (spaceId: string) {
@@ -590,7 +590,7 @@ class CharmClient {
     return http.GET('/api/permissions/query', request);
   }
 
-  listPagePermissions (pageId: string): Promise<IPagePermissionWithAssignee []> {
+  listPagePermissions (pageId: string): Promise<IPagePermissionWithAssignee[]> {
     return http.GET('/api/permissions', { pageId });
   }
 

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -14,7 +14,7 @@ import { Page, PageContent } from 'models';
 import { ComponentProps, Dispatch, ReactNode, SetStateAction, SyntheticEvent, useCallback, useEffect, useMemo, memo } from 'react';
 import { useDrop } from 'react-dnd';
 import { checkForEmpty } from 'components/common/CharmEditor/utils';
-import { addPageAndRedirect, NewPageInput } from 'lib/pages';
+import { addPageAndRedirect, NewPageInput, IPageWithPermissions } from 'lib/pages';
 import sortBy from 'lodash/sortBy';
 import TreeNode, { MenuNode, ParentMenuNode } from './components/TreeNode';
 
@@ -73,7 +73,7 @@ function mapTree (items: MenuNode[], key: 'parentId', rootPageIds?: string[]): P
 type TreeRootProps = {
   children: ReactNode,
   isFavorites?: boolean,
-  setPages: Dispatch<SetStateAction<Record<string, Page | undefined>>>
+  setPages: Dispatch<SetStateAction<Record<string, IPageWithPermissions | undefined>>>
 } & ComponentProps<typeof TreeView>;
 
 function TreeRoot ({ children, setPages, isFavorites, ...rest }: TreeRootProps) {
@@ -131,7 +131,7 @@ function PageNavigation ({
   const [expanded, setExpanded] = useLocalStorage<string[]>(`${space!.id}.expanded-pages`, []);
 
   const pagesArray: MenuNode[] = Object.values(pages)
-    .filter((page): page is Page => Boolean(isTruthy(page) && (page.type === 'board' || page.type === 'page' || rootPageIds?.includes(page.id))))
+    .filter((page): page is IPageWithPermissions => isTruthy(page && (page.type === 'board' || page.type === 'page' || rootPageIds?.includes(page.id))))
     .map((page): MenuNode => ({
       id: page.id,
       title: page.title,

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -2,9 +2,7 @@ import React, { forwardRef, ReactNode, SyntheticEvent, useCallback, useMemo, mem
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useIntl } from 'react-intl';
-import { mutate } from 'swr';
 import { Page } from '@prisma/client';
-import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import DeleteIcon from '@mui/icons-material/DeleteOutlined';
@@ -20,6 +18,7 @@ import Tooltip from '@mui/material/Tooltip';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
 import { bindMenu, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
+import { IPageWithPermissions } from 'lib/pages';
 import charmClient from 'charmClient';
 import TreeItemContent from 'components/common/TreeItemContent';
 import mutator from 'components/common/BoardEditor/focalboard/src/mutator';
@@ -221,7 +220,7 @@ function EmojiMenu ({ popupState, pageId, pageType }: { popupState: any, pageId:
       setPages(_pages => ({
         ..._pages,
         [pageId]: {
-          ..._pages[pageId] as Page,
+          ..._pages[pageId] as IPageWithPermissions,
           icon: emoji
         }
       }));
@@ -391,7 +390,7 @@ function PageActionsMenu ({ closeMenu, pageId, pagePath }: { closeMenu: () => vo
 
     if (page && user && space) {
       const { pageIds } = await charmClient.archivePage(page.id);
-      let newPage: null | Page = null;
+      let newPage: null | IPageWithPermissions = null;
       if (totalNonArchivedPages - pageIds.length === 0 && pageIds.length !== 0) {
         newPage = await charmClient.createPage(untitledPage({
           userId: user.id,
@@ -419,7 +418,7 @@ function PageActionsMenu ({ closeMenu, pageId, pagePath }: { closeMenu: () => vo
           _pages[_pageId] = {
             ..._pages[_pageId],
             deletedAt: new Date()
-          } as Page;
+          } as IPageWithPermissions;
         });
         // If a new page was created add that to state
         if (newPage) {

--- a/components/common/PageLayout/components/ShareButton/ShareButton.tsx
+++ b/components/common/PageLayout/components/ShareButton/ShareButton.tsx
@@ -27,8 +27,10 @@ export default function ShareButton ({ headerHeight }: { headerHeight: number })
 
   // watch changes to the page in case permissions get updated
   useEffect(() => {
-    refreshPermissions();
-  }, [pages[currentPageId]]);
+    if (popupState.isOpen) {
+      refreshPermissions();
+    }
+  }, [pages[currentPageId], popupState.isOpen]);
 
   return (
     <>

--- a/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -1,22 +1,20 @@
 import styled from '@emotion/styled';
 import Box from '@mui/material/Box';
-import { useTheme } from '@emotion/react';
 import Button from '@mui/material/Button';
 import InputAdornment from '@mui/material/InputAdornment';
 import Input from '@mui/material/OutlinedInput';
 import Typography from '@mui/material/Typography';
-import { Space } from '@prisma/client';
 import charmClient from 'charmClient';
 import { SmallSelect } from 'components/common/form/InputEnumToOptions';
 import Link from 'components/common/Link';
 import Modal from 'components/common/Modal';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
-import { IPagePermissionFlags, IPagePermissionWithAssignee, PagePermissionLevelType } from 'lib/permissions/pages/page-permission-interfaces';
+import { IPagePermissionWithAssignee, PagePermissionLevelType } from 'lib/permissions/pages/page-permission-interfaces';
 import { permissionLevels } from 'lib/permissions/pages/page-permission-mapping';
 import { getDisplayName } from 'lib/users/getDisplayName';
 import { bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import AddPagePermissionsForm from './AddPagePermissionsForm';
 
 const permissionDisplayOrder = ['space', 'role', 'user'];
@@ -47,7 +45,7 @@ const StyledInput = styled(Input)`
  * @sideEffect Removes the permission from currrent space from the list so it can be handled in its own row
  * @param pagePermissions
  */
-function sortPagePermissions (pagePermissions: IPagePermissionWithAssignee[], space?: Space):
+function sortPagePermissions (pagePermissions: IPagePermissionWithAssignee[]):
   (IPagePermissionWithAssignee & {displayName: string})[] {
   const sortedPermissions = pagePermissions
     .filter(permission => {
@@ -91,7 +89,6 @@ interface Props {
 
 export default function PagePermissions ({ pageId, pagePermissions, refreshPermissions }: Props) {
 
-  const theme = useTheme();
   const { pages, getPagePermissions } = usePages();
   const [space] = useCurrentSpace();
   const popupState = usePopupState({ variant: 'popover', popupId: 'add-a-permission' });

--- a/components/common/PageLayout/components/ShareButton/components/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/ShareToWeb.tsx
@@ -11,7 +11,7 @@ import Link from 'components/common/Link';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
 import { IPageWithPermissions } from 'lib/pages';
-import { IPagePermissionWithSource } from 'lib/permissions/pages/page-permission-interfaces';
+import { IPagePermissionWithSource, IPagePermissionWithAssignee } from 'lib/permissions/pages/page-permission-interfaces';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
@@ -41,50 +41,35 @@ const CopyButton = styled((props: any) => <Button color='secondary' variant='out
 `;
 
 interface Props {
-  pageId: string
+  pageId: string;
+  pagePermissions: IPagePermissionWithAssignee[];
 }
 
-export default function ShareToWeb ({ pageId }: Props) {
+export default function ShareToWeb ({ pageId, pagePermissions }: Props) {
 
   const router = useRouter();
-  // What user can do
-  const { pages, setPages, getPagePermissions, refreshPage } = usePages();
+  const { pages, getPagePermissions, refreshPage } = usePages();
   const [copied, setCopied] = useState<boolean>(false);
   const [space] = useCurrentSpace();
+  const publicPermission = pagePermissions.find(publicPerm => publicPerm.public === true) ?? null;
 
   const currentPagePermissions = getPagePermissions(pageId);
 
   // Current values of the public permission
-  const [publicPermission, setPublicPermission] = useState<IPagePermissionWithSource | null>(null);
   const [shareLink, setShareLink] = useState<null | string>(null);
-
-  useEffect(() => {
-    if (pageId) {
-      // Access the raw permissions
-      const permissionList = (pages[pageId] as IPageWithPermissions)?.permissions;
-
-      const foundPublic = permissionList.find(publicPerm => publicPerm.public === true) ?? null;
-      // Add ref to new model here
-      setPublicPermission(foundPublic);
-    }
-    else {
-      setPublicPermission(null);
-    }
-
-  }, [pageId, pages]);
 
   async function togglePublic () {
     if (publicPermission) {
       await charmClient.deletePermission(publicPermission.id);
-      setPublicPermission(null);
+      refreshPage(pageId);
     }
     else {
-      const newPermission = await charmClient.createPermission({
+      await charmClient.createPermission({
         pageId,
         permissionLevel: 'view',
         public: true
       });
-      setPublicPermission(newPermission);
+      refreshPage(pageId);
     }
   }
 
@@ -163,18 +148,17 @@ export default function ShareToWeb ({ pageId }: Props) {
         }
       </Collapse>
       {
-
-publicPermission?.sourcePermission && (
-  <Box display='block'>
-    <Typography variant='caption' sx={{ ml: 1 }}>
-      Inherited from
-      <Link sx={{ ml: 0.5 }} href={`/${space?.domain}/${pages[publicPermission?.sourcePermission.pageId]?.path}`}>
-        {pages[publicPermission?.sourcePermission.pageId]?.title || 'Untitled'}
-      </Link>
-    </Typography>
-  </Box>
-)
-}
+        publicPermission?.sourcePermission && (
+          <Box display='block'>
+            <Typography variant='caption' sx={{ ml: 1 }}>
+              Inherited from
+              <Link sx={{ ml: 0.5 }} href={`/${space?.domain}/${pages[publicPermission?.sourcePermission.pageId]?.path}`}>
+                {pages[publicPermission?.sourcePermission.pageId]?.title || 'Untitled'}
+              </Link>
+            </Typography>
+          </Box>
+        )
+      }
     </>
   );
 }

--- a/components/common/PageLayout/components/ShareButton/components/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/ShareButton/components/ShareToWeb.tsx
@@ -89,13 +89,13 @@ export default function ShareToWeb ({ pageId, pagePermissions }: Props) {
     }
     else if (currentPage?.type === 'page' || currentPage?.type === 'card') {
       const shareLinkToSet = (typeof window !== 'undefined')
-        ? `${window.location.origin}/share/${pageId}` : '';
+        ? `${window.location.origin}/share/${currentPage.path}` : '';
       setShareLink(shareLinkToSet);
     }
     else if (currentPage?.type === 'board') {
       const viewIdToProvide = router.query.viewId;
       const shareLinkToSet = (typeof window !== 'undefined')
-        ? `${window.location.origin}/share/${pageId}?viewId=${viewIdToProvide}` : '';
+        ? `${window.location.origin}/share/${currentPage.path}?viewId=${viewIdToProvide}` : '';
       setShareLink(shareLinkToSet);
     }
   }

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -17,7 +17,7 @@ import useIsAdmin from './useIsAdmin';
 
 export type LinkedPage = (Page & {children: LinkedPage[], parent: null | LinkedPage});
 
-export type PagesMap = Record<string, Page | undefined>;
+export type PagesMap = Record<string, IPageWithPermissions | undefined>;
 
 type IContext = {
   currentPageId: string,
@@ -114,6 +114,7 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
 
   async function refreshPage (pageId: string): Promise<IPageWithPermissions> {
     const freshPageVersion = await charmClient.getPage(pageId);
+    console.log('perms', freshPageVersion.permissions);
     _setPages(_pages => ({
       ..._pages,
       [freshPageVersion.id]: freshPageVersion
@@ -138,13 +139,6 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
       setPages(data.reduce((acc, page) => ({ ...acc, [page.id]: page }), {}) || {});
     }
   }, [data]);
-
-  useEffect(() => {
-    if (currentPageId) {
-      refreshPage(currentPageId);
-    }
-
-  }, [currentPageId]);
 
   return (
     <PagesContext.Provider value={value}>

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -114,7 +114,6 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
 
   async function refreshPage (pageId: string): Promise<IPageWithPermissions> {
     const freshPageVersion = await charmClient.getPage(pageId);
-    console.log('perms', freshPageVersion.permissions);
     _setPages(_pages => ({
       ..._pages,
       [freshPageVersion.id]: freshPageVersion

--- a/pages/api/permissions/index.ts
+++ b/pages/api/permissions/index.ts
@@ -7,7 +7,6 @@ import { withSessionRoute } from 'lib/session/withSession';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 import nc from 'next-connect';
-import { getPage } from '../../../lib/pages/server';
 import { PermissionNotFoundError } from '../../../lib/permissions/pages/errors';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
@@ -19,7 +18,7 @@ handler.use(requireUser)
   .use(requireKeys<PagePermission>(['pageId'], 'body'))
   .post(addPagePermission);
 
-async function findPagePermissions (req: NextApiRequest, res: NextApiResponse<IPagePermissionWithAssignee []>) {
+async function findPagePermissions (req: NextApiRequest, res: NextApiResponse<IPagePermissionWithAssignee[]>) {
 
   const { pageId } = req.query as any as IPagePermissionRequest;
 

--- a/pages/api/spaces/[id]/pages.ts
+++ b/pages/api/spaces/[id]/pages.ts
@@ -1,18 +1,16 @@
 
+import { onError, onNoMatch } from 'lib/middleware';
+import { getAccessiblePages, IPageWithPermissions } from 'lib/pages/server';
+import { withSessionRoute } from 'lib/session/withSession';
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
-import { onError, onNoMatch } from 'lib/middleware';
-import { withSessionRoute } from 'lib/session/withSession';
-import { Page } from '@prisma/client';
-import {} from 'lib/permissions/pages';
-import { getAccessiblePages } from 'lib/pages/server';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler
   .get(getPages);
 
-async function getPages (req: NextApiRequest, res: NextApiResponse<Page[]>) {
+async function getPages (req: NextApiRequest, res: NextApiResponse<IPageWithPermissions[]>) {
   const spaceId = req.query.id as string;
   const archived = req.query.archived as string === 'true';
   const userId = req.session?.user?.id;


### PR DESCRIPTION
The fix was to remove teh call to 'refreshPage' inside of usePAges but it required a number of other changes which led to some nice cleanup.. thanks @motechFR 