### PR TITLE
add test and fix: properly update the URL when closing cards

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm run start:test:ci &
 
       - name: Run tests
-        run: npm run test:server
+        run: npm run test:server:ci
 
   deploy:
     name: Deploy to production

--- a/lib/utilities/__tests__/strings.spec.ts
+++ b/lib/utilities/__tests__/strings.spec.ts
@@ -1,0 +1,19 @@
+import { getUriWithParam } from '../strings';
+
+describe('getUriWithParam()', () => {
+
+  const baseUrl = 'https://google.com/search?q=3531422';
+
+  it('should add a property to the query string', () => {
+    const result = getUriWithParam(baseUrl, { cardId: 'baz' });
+
+    expect(result).toBe(`${baseUrl}&cardId=baz`);
+  });
+
+  it('should remove a property from the query string', () => {
+    const result = getUriWithParam(`${baseUrl}&cardId=foo`, { cardId: undefined });
+
+    expect(result).toEqual(baseUrl);
+  });
+
+});

--- a/lib/utilities/__tests__/strings.spec.ts
+++ b/lib/utilities/__tests__/strings.spec.ts
@@ -10,6 +10,12 @@ describe('getUriWithParam()', () => {
     expect(result).toBe(`${baseUrl}&cardId=baz`);
   });
 
+  it('should replace a property from the query string', () => {
+    const result = getUriWithParam(`${baseUrl}&cardId=foo`, { cardId: 'baz' });
+
+    expect(result).toEqual(`${baseUrl}&cardId=baz`);
+  });
+
   it('should remove a property from the query string', () => {
     const result = getUriWithParam(`${baseUrl}&cardId=foo`, { cardId: undefined });
 

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -56,8 +56,13 @@ export function getUriWithParam (
   const Url = new URL(baseUrl);
   const urlParams: URLSearchParams = new URLSearchParams(Url.search);
   for (const key in params) {
-    if (params[key] !== undefined) {
-      urlParams.set(key, params[key]);
+    if (params.hasOwnProperty(key)) {
+      if (typeof params[key] === 'string') {
+        urlParams.set(key, params[key]);
+      }
+      else {
+        urlParams.delete(key);
+      }
     }
   }
   Url.search = urlParams.toString();

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "npm run server:dev",
     "start:dev:cron": "concurrently --names \"cron,next\" -c \"yellow,green\" \"npm run cron:dev\" \"npm run server:dev\"",
     "postinstall": "patch-package",
-    "start:test": "NODE_OPTIONS=\"--max_old_space_size=4096\" dotenv -e .env.test.local -- npm start",
+    "start:test": "NODE_OPTIONS=\"--max_old_space_size=4096\" dotenv -e .env.test.local -- prisma migrate deploy && dotenv -e .env.test.local -- npm start",
     "start:test:ci": "NODE_OPTIONS=\"--max_old_space_size=4096\" npx react-env --path .env.test.local -- npx next start",
     "start:prod": "npm run migrate:prod && concurrently --names \"cron,next\" -c \"yellow,green\" \"npm run cron:prod\" \"npm run server:prod\"",
     "start:staging": "npm run migrate:staging && concurrently --names \"cron,next\" -c \"yellow,green\" \"npm run cron:staging\" \"npm run server:staging\"",
@@ -33,7 +33,8 @@
     "test:setup-db": "./testing/configure-db.sh",
     "test:client": "npm run test-setup && jest --config='./jest.config-client.ts'",
     "test:migrate": "dotenv -e .env.local -- npx prisma migrate dev",
-    "test:server": "dotenv -e .env.test.local --override -- npx jest --config='./jest.config-server.ts' --verbose",
+    "test:server": "dotenv -e .env.test.local --override -- npx jest --config='./jest.config-server.ts' --verbose --watch",
+    "test:server:ci": "dotenv -e .env.test.local --override -- npx jest --config='./jest.config-server.ts'",
     "test:server:debug": "dotenv -e .env.test.local --override -- node --inspect-brk --expose-gc ./node_modules/.bin/jest --runInBand --logHeapUsage --config='./jest.config-server.ts' --verbose",
     "test:server-integration": "dotenv -e .env.test.local --override -- npx jest --config='./jest.config-server-integration.ts' --verbose"
   },


### PR DESCRIPTION
my update to the URL stuff doesn't remove cardId when closing a card in focalboard. Added some tests :)

Also, by adding `--watch`, running `npm run test:server` now only runs against tests/files that changed. It somehow can tell when I change a file what tests are running against it...