### PR TITLE
replace deprecated use of mocked from ts-jest

### DIFF
--- a/components/common/BoardEditor/focalboard/src/cardFilter.test.ts
+++ b/components/common/BoardEditor/focalboard/src/cardFilter.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {mocked} from 'ts-jest/utils'
 
 import {createFilterClause} from './blocks/filterClause'
 
@@ -11,7 +10,7 @@ import {Utils} from './utils'
 import {IPropertyTemplate} from './blocks/board'
 
 jest.mock('./utils')
-const mockedUtils = mocked(Utils, true)
+const mockedUtils = jest.mocked(Utils, true)
 describe('src/cardFilter', () => {
     const board = TestBlockFactory.createBoard()
     board.id = '1'

--- a/components/common/BoardEditor/focalboard/src/components/blockIconSelector.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/blockIconSelector.test.tsx
@@ -8,7 +8,6 @@ import userEvent from '@testing-library/user-event'
 
 import '@testing-library/jest-dom'
 
-import {mocked} from 'ts-jest/utils'
 
 import mutator from '../mutator'
 
@@ -22,7 +21,7 @@ const board = TestBlockFactory.createBoard()
 const icon = '👍'
 
 jest.mock('../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 
 describe('components/blockIconSelector', () => {
     beforeEach(() => {

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.test.tsx
@@ -4,7 +4,6 @@
 import React from 'react'
 import {render, screen, act} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {mocked} from 'ts-jest/utils'
 import '@testing-library/jest-dom'
 import {createIntl} from 'react-intl'
 
@@ -17,7 +16,7 @@ import {propertyTypesList, typeDisplayName} from '../../widgets/propertyMenu'
 import CardDetailProperties from './cardDetailProperties'
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 
 describe('components/cardDetail/CardDetailProperties', () => {
     const board = TestBlockFactory.createBoard()

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/comment.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/comment.test.tsx
@@ -5,7 +5,6 @@ import userEvent from '@testing-library/user-event'
 import React from 'react'
 import {Provider as ReduxProvider} from 'react-redux'
 
-import {mocked} from 'ts-jest/utils'
 
 import {wrapIntl, mockStateStore} from '../../testUtils'
 
@@ -16,7 +15,7 @@ import mutator from '../../mutator'
 import Comment from './comment'
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 
 const board = TestBlockFactory.createBoard()
 const card = TestBlockFactory.createCard(board)

--- a/components/common/BoardEditor/focalboard/src/components/cardDialog.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDialog.test.tsx
@@ -7,7 +7,6 @@ import userEvent from '@testing-library/user-event'
 
 import React from 'react'
 import {Provider as ReduxProvider} from 'react-redux'
-import {mocked} from 'ts-jest/utils'
 
 import mutator from '../mutator'
 import {Utils} from '../utils'
@@ -20,8 +19,8 @@ jest.mock('../mutator')
 jest.mock('../utils')
 jest.mock('draft-js/lib/generateRandomKey', () => () => '123')
 
-const mockedUtils = mocked(Utils, true)
-const mockedMutator = mocked(mutator, true)
+const mockedUtils = jest.mocked(Utils, true)
+const mockedMutator = jest.mocked(mutator, true)
 mockedUtils.createGuid.mockReturnValue('test-id')
 
 beforeAll(() => {

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.test.tsx
@@ -3,7 +3,6 @@
 import {fireEvent, render, screen, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import {mocked} from 'ts-jest/utils'
 import {Provider as ReduxProvider} from 'react-redux'
 
 import {mockDOM, mockStateStore, wrapDNDIntl} from '../testUtils'
@@ -29,8 +28,8 @@ jest.mock('../utils')
 jest.mock('../mutator')
 jest.mock('../telemetry/telemetryClient')
 jest.mock('draft-js/lib/generateRandomKey', () => () => '123')
-const mockedUtils = mocked(Utils, true)
-const mockedMutator = mocked(Mutator, true)
+const mockedUtils = jest.mocked(Utils, true)
+const mockedMutator = jest.mocked(Mutator, true)
 mockedUtils.createGuid.mockReturnValue('test-id')
 describe('components/centerPanel', () => {
     const board = TestBlockFactory.createBoard()

--- a/components/common/BoardEditor/focalboard/src/components/gallery/gallery.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/gallery/gallery.test.tsx
@@ -8,7 +8,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 
 import userEvent from '@testing-library/user-event'
 
-import {mocked} from 'ts-jest/utils'
 
 import {wrapDNDIntl, mockStateStore, blocksById} from '../../testUtils'
 
@@ -21,7 +20,7 @@ import {RootState} from '../../store'
 import Gallery from './gallery'
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 
 describe('src/components/gallery/Gallery', () => {
     const board = TestBlockFactory.createBoard()

--- a/components/common/BoardEditor/focalboard/src/components/gallery/galleryCard.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/gallery/galleryCard.test.tsx
@@ -8,7 +8,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 
 import userEvent from '@testing-library/user-event'
 
-import {mocked} from 'ts-jest/utils'
 
 import {MockStoreEnhanced} from 'redux-mock-store'
 
@@ -29,9 +28,9 @@ jest.mock('../../utils')
 jest.mock('../../octoClient')
 
 describe('src/components/gallery/GalleryCard', () => {
-    const mockedMutator = mocked(mutator, true)
-    const mockedUtils = mocked(Utils, true)
-    const mockedOcto = mocked(octoClient, true)
+    const mockedMutator = jest.mocked(mutator, true)
+    const mockedUtils = jest.mocked(Utils, true)
+    const mockedOcto = jest.mocked(octoClient, true)
     mockedOcto.getFileAsDataUrl.mockResolvedValue('test.jpg')
 
     const board = TestBlockFactory.createBoard()

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanban.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanban.test.tsx
@@ -5,7 +5,6 @@ import {fireEvent, render, screen, waitFor} from '@testing-library/react'
 import '@testing-library/jest-dom'
 import React from 'react'
 import {Provider as ReduxProvider} from 'react-redux'
-import {mocked} from 'ts-jest/utils'
 import userEvent from '@testing-library/user-event'
 
 import {IPropertyOption, IPropertyTemplate} from '../../blocks/board'
@@ -18,7 +17,7 @@ import Kanban from './kanban'
 
 global.fetch = jest.fn()
 jest.mock('../../utils')
-const mockedUtils = mocked(Utils, true)
+const mockedUtils = jest.mocked(Utils, true)
 const mockedchangePropertyOptionValue = jest.spyOn(mutator, 'changePropertyOptionValue')
 const mockedChangeViewCardOrder = jest.spyOn(mutator, 'changeViewCardOrder')
 const mockedinsertPropertyOption = jest.spyOn(mutator, 'insertPropertyOption')

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.test.tsx
@@ -8,7 +8,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 
 import userEvent from '@testing-library/user-event'
 
-import {mocked} from 'ts-jest/utils'
 
 import Mutator from '../../mutator'
 import {Utils} from '../../utils'
@@ -22,8 +21,8 @@ import KanbanCard from './kanbanCard'
 jest.mock('../../mutator')
 jest.mock('../../utils')
 // jest.mock('../../telemetry/telemetryClient')
-const mockedUtils = mocked(Utils, true)
-const mockedMutator = mocked(Mutator, true)
+const mockedUtils = jest.mocked(Utils, true)
+const mockedMutator = jest.mocked(Mutator, true)
 
 describe('src/components/kanban/kanbanCard', () => {
     const board = TestBlockFactory.createBoard()

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanbanColumnHeader.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanbanColumnHeader.test.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import {fireEvent, render, screen, within} from '@testing-library/react'
 import {createIntl} from 'react-intl'
 import userEvent from '@testing-library/user-event'
-import {mocked} from 'ts-jest/utils'
 
 import Mutator from '../../mutator'
 import {wrapDNDIntl} from '../../testUtils'
@@ -13,7 +12,7 @@ import {IPropertyOption} from '../../blocks/board'
 
 import KanbanColumnHeader from './kanbanColumnHeader'
 jest.mock('../../mutator')
-const mockedMutator = mocked(Mutator, true)
+const mockedMutator = jest.mocked(Mutator, true)
 describe('src/components/kanban/kanbanColumnHeader', () => {
     const intl = createIntl({locale: 'en-us'})
     const board = TestBlockFactory.createBoard()

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanbanHiddenColumnItem.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanbanHiddenColumnItem.test.tsx
@@ -5,7 +5,6 @@ import {render, screen, within} from '@testing-library/react'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 import {createIntl} from 'react-intl'
-import {mocked} from 'ts-jest/utils'
 
 import {wrapDNDIntl} from '../../testUtils'
 import Mutator from '../../mutator'
@@ -15,7 +14,7 @@ import {IPropertyOption} from '../../blocks/board'
 import KanbanHiddenColumnItem from './kanbanHiddenColumnItem'
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(Mutator, true)
+const mockedMutator = jest.mocked(Mutator, true)
 
 describe('src/components/kanban/kanbanHiddenColumnItem', () => {
     const intl = createIntl({locale: 'en-us'})

--- a/components/common/BoardEditor/focalboard/src/components/topBar.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/topBar.test.tsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 import {render} from '@testing-library/react'
 import React from 'react'
-import {mocked} from 'ts-jest/utils'
 
 import {wrapDNDIntl} from '../testUtils'
 import {Constants} from '../constants'
@@ -12,7 +11,7 @@ import TopBar from './topBar'
 
 Object.defineProperty(Constants, 'versionString', {value: '1.0.0'})
 jest.mock('../utils')
-const mockedUtils = mocked(Utils, true)
+const mockedUtils = jest.mocked(Utils, true)
 
 describe('src/components/topBar', () => {
     beforeEach(jest.resetAllMocks)

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/emptyCardButton.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/emptyCardButton.test.tsx
@@ -7,7 +7,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
-import {mocked} from 'ts-jest/utils'
 
 import {wrapIntl, mockStateStore} from '../../testUtils'
 
@@ -21,7 +20,7 @@ const board = TestBlockFactory.createBoard()
 const activeView = TestBlockFactory.createBoardView(board)
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 describe('components/viewHeader/emptyCardButton', () => {
     const state = {
         users: {

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/filterComponent.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/filterComponent.test.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 import {render, screen} from '@testing-library/react'
 import {Provider as ReduxProvider} from 'react-redux'
 
-import {mocked} from 'ts-jest/utils'
 import '@testing-library/jest-dom'
 
 import userEvent from '@testing-library/user-event'
@@ -19,8 +18,7 @@ import {wrapIntl, mockStateStore} from '../../testUtils'
 
 import FilterComponenet from './filterComponent'
 
-jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 const filter: FilterClause = {
     propertyId: '1',
     condition: 'includes',

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/filterEntry.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/filterEntry.test.tsx
@@ -8,7 +8,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
-import {mocked} from 'ts-jest/utils'
 
 import {FilterClause} from '../../blocks/filterClause'
 
@@ -21,7 +20,7 @@ import mutator from '../../mutator'
 import FilterEntry from './filterEntry'
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 
 const board = TestBlockFactory.createBoard()
 const activeView = TestBlockFactory.createBoardView(board)

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/filterValue.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/filterValue.test.tsx
@@ -8,7 +8,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
-import {mocked} from 'ts-jest/utils'
 
 import {FilterClause} from '../../blocks/filterClause'
 
@@ -21,7 +20,7 @@ import mutator from '../../mutator'
 import FilterValue from './filterValue'
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 
 const board = TestBlockFactory.createBoard()
 const activeView = TestBlockFactory.createBoardView(board)

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/newCardButtonTemplateItem.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/newCardButtonTemplateItem.test.tsx
@@ -8,7 +8,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
-import {mocked} from 'ts-jest/utils'
 
 import {wrapIntl, mockStateStore} from '../../testUtils'
 
@@ -19,7 +18,7 @@ import mutator from '../../mutator'
 import NewCardButtonTemplateItem from './newCardButtonTemplateItem'
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 
 const board = TestBlockFactory.createBoard()
 const activeView = TestBlockFactory.createBoardView(board)

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderActionsMenu.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderActionsMenu.test.tsx
@@ -8,7 +8,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
-import {mocked} from 'ts-jest/utils'
 
 import {TestBlockFactory} from '../../test/testBlockFactory'
 
@@ -23,8 +22,8 @@ import ViewHeaderActionsMenu from './viewHeaderActionsMenu'
 jest.mock('../../archiver')
 jest.mock('../../csvExporter')
 jest.mock('../../mutator')
-const mockedArchiver = mocked(Archiver, true)
-const mockedCsvExporter = mocked(CsvExporter, true)
+const mockedArchiver = jest.mocked(Archiver, true)
+const mockedCsvExporter = jest.mocked(CsvExporter, true)
 
 const board = TestBlockFactory.createBoard()
 const activeView = TestBlockFactory.createBoardView(board)

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderGroupByMenu.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderGroupByMenu.test.tsx
@@ -6,7 +6,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
-import {mocked} from 'ts-jest/utils'
 
 import {TestBlockFactory} from '../../test/testBlockFactory'
 
@@ -17,7 +16,7 @@ import {wrapIntl, mockStateStore} from '../../testUtils'
 import ViewHeaderGroupByMenu from './viewHeaderGroupByMenu'
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 
 const board = TestBlockFactory.createBoard()
 const activeView = TestBlockFactory.createBoardView(board)

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderPropertiesMenu.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderPropertiesMenu.test.tsx
@@ -7,7 +7,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
-import {mocked} from 'ts-jest/utils'
 
 import {BoardView} from '../../blocks/boardView'
 
@@ -22,7 +21,7 @@ import {Constants} from '../../constants'
 import ViewHeaderPropertiesMenu from './viewHeaderPropertiesMenu'
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 
 const board = TestBlockFactory.createBoard()
 let activeView:BoardView

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderSortMenu.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderSortMenu.test.tsx
@@ -7,7 +7,6 @@ import {Provider as ReduxProvider} from 'react-redux'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
-import {mocked} from 'ts-jest/utils'
 
 import {wrapIntl, mockStateStore} from '../../testUtils'
 
@@ -18,7 +17,7 @@ import mutator from '../../mutator'
 import ViewHeaderSortMenu from './viewHeaderSortMenu'
 
 jest.mock('../../mutator')
-const mockedMutator = mocked(mutator, true)
+const mockedMutator = jest.mocked(mutator, true)
 
 const board = TestBlockFactory.createBoard()
 const activeView = TestBlockFactory.createBoardView(board)

--- a/components/common/BoardEditor/focalboard/src/components/viewTitle.test.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewTitle.test.tsx
@@ -7,7 +7,6 @@ import userEvent from '@testing-library/user-event'
 
 import React from 'react'
 import {Provider as ReduxProvider} from 'react-redux'
-import {mocked} from 'ts-jest/utils'
 
 import mutator from '../mutator'
 import {Utils} from '../utils'
@@ -20,8 +19,8 @@ jest.mock('../mutator')
 jest.mock('../utils')
 jest.mock('draft-js/lib/generateRandomKey', () => () => '123')
 
-const mockedMutator = mocked(mutator, true)
-const mockedUtils = mocked(Utils, true)
+const mockedMutator = jest.mocked(mutator, true)
+const mockedUtils = jest.mocked(Utils, true)
 mockedUtils.createGuid.mockReturnValue('test-id')
 
 beforeAll(() => {


### PR DESCRIPTION
removes annoying typescript errors, and i think is required if we actually want to run these tests :P