### PR TITLE
Moved discord roles import logic inside a hook

### DIFF
--- a/components/settings/roles/RoleSettings.tsx
+++ b/components/settings/roles/RoleSettings.tsx
@@ -1,24 +1,20 @@
 
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { CircularProgress, Menu, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import Button from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import Legend from 'components/settings/Legend';
 import ImportGuildRolesMenuItem from 'components/settings/roles/components/ImportGuildRolesMenuItem';
 import useRoles from 'components/settings/roles/hooks/useRoles';
-import { bindPopover, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
-import useIsAdmin from 'hooks/useIsAdmin';
-import { useEffect, useRef, useState } from 'react';
-import { CircularProgress, Menu, Typography } from '@mui/material';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import { useRouter } from 'next/router';
-import { useSnackbar } from 'hooks/useSnackbar';
-import charmClient from 'charmClient';
-import useSWRImmutable from 'swr/immutable';
-import { Space } from '@prisma/client';
-import RoleRow from './components/RoleRow';
-import RoleForm from './components/RoleForm';
+import useIsAdmin from 'hooks/useIsAdmin';
+import { bindPopover, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
+import { useRef, useState } from 'react';
 import ImportDiscordRolesMenuItem from './components/ImportDiscordRolesMenuItem';
+import RoleForm from './components/RoleForm';
+import RoleRow from './components/RoleRow';
+import { useImportDiscordRoles } from './hooks/useImportDiscordRoles';
 import SpacePermissions from './spacePermissions/SpacePermissions';
 
 export default function RoleSettings () {
@@ -36,36 +32,10 @@ export default function RoleSettings () {
   const handleClose = () => {
     setAnchorEl(null);
   };
-  const router = useRouter();
-  const { showMessage } = useSnackbar();
-
   const [space] = useCurrentSpace();
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  const shouldRequestServers = isAdmin && space && typeof router.query.guild_id === 'string' && router.query.discord === '1' && router.query.type === 'server';
-  const serverConnectFailed = router.query.discord === '2' && router.query.type === 'server';
-  const guildId = router.query.guild_id as string;
-  // Using immutable version as otherwise the endpoint is hit twice
-  const { data, isValidating, error } = useSWRImmutable(shouldRequestServers && space ? 'discord-roles-import' : null, async () => {
-    return charmClient.importRolesFromDiscordServer({
-      guildId,
-      spaceId: (space as Space).id
-    });
-  });
-
-  useEffect(() => {
-    if (data && !isValidating) {
-      showMessage(`Successfully imported ${data.importedRoleCount} discord roles`, 'success');
-      router.replace(window.location.href.split('?')[0], undefined, { shallow: true });
-    }
-    else if (error) {
-      // Major failure while trying to import discord server role
-      showMessage(error.message || error.error || 'Something went wrong. Please try again', 'error');
-    }
-    else if (serverConnectFailed) {
-      showMessage('Failed to connect to Discord', 'warning');
-    }
-  }, [data, isValidating, serverConnectFailed]);
+  const { isValidating } = useImportDiscordRoles();
 
   return (
     <>
@@ -97,20 +67,6 @@ export default function RoleSettings () {
           </Box>
         )}
       </Legend>
-      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
-        <ImportDiscordRolesMenuItem />
-        <ImportGuildRolesMenuItem onClose={handleClose} />
-      </Menu>
-      <Modal {...bindPopover(popupState)} title='Add a role'>
-        <RoleForm
-          mode='create'
-          submitted={() => {
-            popupState.close();
-            refreshRoles();
-          }}
-        />
-      </Modal>
-
       {isValidating ? (
         <Box display='flex' alignItems='center' gap={1}>
           <CircularProgress size={24} />
@@ -127,6 +83,20 @@ export default function RoleSettings () {
           key={role.id}
         />
       ))}
+
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        <ImportDiscordRolesMenuItem />
+        <ImportGuildRolesMenuItem onClose={handleClose} />
+      </Menu>
+      <Modal {...bindPopover(popupState)} title='Add a role'>
+        <RoleForm
+          mode='create'
+          submitted={() => {
+            popupState.close();
+            refreshRoles();
+          }}
+        />
+      </Modal>
     </>
   );
 }

--- a/components/settings/roles/hooks/useImportDiscordRoles.ts
+++ b/components/settings/roles/hooks/useImportDiscordRoles.ts
@@ -1,0 +1,50 @@
+import { Space } from '@prisma/client';
+import charmClient from 'charmClient';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import useIsAdmin from 'hooks/useIsAdmin';
+import { useSnackbar } from 'hooks/useSnackbar';
+import { silentlyUpdateURL } from 'lib/browser';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import useSWRImmutable from 'swr/immutable';
+import useRoles from './useRoles';
+
+export function useImportDiscordRoles () {
+  const { showMessage } = useSnackbar();
+  const isAdmin = useIsAdmin();
+  const router = useRouter();
+  const [space] = useCurrentSpace();
+  const {
+    refreshRoles
+  } = useRoles();
+
+  const shouldRequestServers = isAdmin && space && typeof router.query.guild_id === 'string' && router.query.discord === '1' && router.query.type === 'server';
+  const serverConnectFailed = router.query.discord === '2' && router.query.type === 'server';
+  const guildId = router.query.guild_id as string;
+  // Using immutable version as otherwise its called twice
+  const { data, isValidating, error } = useSWRImmutable(shouldRequestServers && space ? 'discord-roles-import' : null, async () => {
+    return charmClient.importRolesFromDiscordServer({
+      guildId,
+      spaceId: (space as Space).id
+    });
+  });
+
+  useEffect(() => {
+    if (data && !isValidating) {
+      showMessage(`Successfully imported ${data.importedRoleCount} discord roles`, 'success');
+      refreshRoles();
+    }
+    else if (error) {
+      // Major failure while trying to import discord server role
+      showMessage(error.message || error.error || 'Something went wrong. Please try again', 'error');
+    }
+    else if (serverConnectFailed) {
+      showMessage('Failed to connect to Discord', 'warning');
+    }
+    silentlyUpdateURL(window.location.href.split('?')[0]);
+  }, [data, isValidating, serverConnectFailed]);
+
+  return {
+    isValidating
+  };
+}


### PR DESCRIPTION
Discord roles import logic was previously written inside `RoleSettings`, while it doesn't introduce any bug it's not a good practice. Now the whole logic is located inside a local hook, making it much easier to reuse and reason about.