### PR TITLE
Include the number of charmverse spaces with deepdao communities 

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -31,7 +31,7 @@ export const jestConfig = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: [
-    path.join(__dirname, '/lib/deepdao/__tests__/getAggregatedData.spec.ts')
+    '**/lib/**/*.spec.ts'
   ],
 
   testTimeout: 30000,

--- a/lib/deepdao/__tests__/getAggregatedData.spec.ts
+++ b/lib/deepdao/__tests__/getAggregatedData.spec.ts
@@ -83,7 +83,7 @@ describe('GET /api/public/profile/[userPath]', () => {
     const aggregatedData = await getAggregatedData(user.id);
 
     expect(aggregatedData).toStrictEqual({
-      daos: 10,
+      daos: 11,
       proposals: 20,
       votes: 15,
       bounties: 1

--- a/lib/deepdao/getAggregatedData.ts
+++ b/lib/deepdao/getAggregatedData.ts
@@ -2,6 +2,7 @@ import { isUUID } from 'lib/utilities/strings';
 import { prisma } from 'db';
 import { DataNotFoundError } from 'lib/utilities/errors';
 import { getCompletedApplicationsOfUser } from 'lib/applications/getCompletedApplicationsOfUser';
+import { getSpacesCount } from 'lib/spaces/getSpacesCount';
 import { getParticipationScore } from './getParticipationScore';
 import { DeepDaoAggregateData } from './interfaces';
 
@@ -20,12 +21,13 @@ export async function getAggregatedData (userPath: string): Promise<DeepDaoAggre
 
   const participationScores = user.addresses.length !== 0 ? await Promise.all(user.addresses.map(address => getParticipationScore(address))) : [];
 
-  const completedBounties = await getCompletedApplicationsOfUser(user.id);
+  const completedBountiesCount = await getCompletedApplicationsOfUser(user.id);
+  const workspacesCount = await getSpacesCount(user.id);
 
   return {
-    daos: participationScores.reduce((acc, cur) => acc + cur.data.daos, 0),
+    daos: workspacesCount + participationScores.reduce((acc, cur) => acc + cur.data.daos, 0),
     proposals: participationScores.reduce((acc, cur) => acc + cur.data.proposals, 0),
     votes: participationScores.reduce((acc, cur) => acc + cur.data.votes, 0),
-    bounties: completedBounties
+    bounties: completedBountiesCount
   };
 }

--- a/lib/spaces/__tests__/getSpacesCount.spec.ts
+++ b/lib/spaces/__tests__/getSpacesCount.spec.ts
@@ -1,0 +1,30 @@
+import { User } from '@prisma/client';
+import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+import { prisma } from 'db';
+import { getSpacesCount } from '../getSpacesCount';
+
+let user: User;
+
+beforeAll(async () => {
+  const generated = await generateUserAndSpaceWithApiToken();
+  user = generated.user;
+
+  // External space the user didn't create but is a contributor of
+  const { space } = await generateUserAndSpaceWithApiToken();
+  // Inaccessible space by the user
+  await generateUserAndSpaceWithApiToken();
+
+  await prisma.spaceRole.create({
+    data: {
+      userId: user.id,
+      spaceId: space.id
+    }
+  });
+});
+
+describe('getSpacesCount', () => {
+  it('Should get count of spaces the user is part of', async () => {
+    const spacesCount = await getSpacesCount(user.id);
+    expect(spacesCount).toBe(2);
+  });
+});

--- a/lib/spaces/getSpacesCount.ts
+++ b/lib/spaces/getSpacesCount.ts
@@ -1,0 +1,14 @@
+import { prisma } from 'db';
+
+// Get a count of all the space an user is part of
+export function getSpacesCount (userId: string) {
+  return prisma.space.count({
+    where: {
+      spaceRoles: {
+        some: {
+          userId
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
Previously we only counted the number of daos you are part of in deepdao, but now we add the charmverse workspaces you are part of with that data 