### PR TITLE
Show notifications badge beside avatar on top right

### DIFF
--- a/components/common/PageLayout/components/Account/Account.tsx
+++ b/components/common/PageLayout/components/Account/Account.tsx
@@ -13,6 +13,9 @@ import { getChainById } from 'connectors';
 import { useContext } from 'react';
 import NetworkModal from 'components/common/PageLayout/components/Account/components/NetworkModal';
 import styled from '@emotion/styled';
+import useTasks from 'components/nexus/hooks/useTasks';
+import { Badge } from '@mui/material';
+import { useRouter } from 'next/router';
 
 const AccountCard = styled.div`
   display: inline-flex;
@@ -54,6 +57,7 @@ function Account (): JSX.Element {
 
   const networkModalState = usePopupState({ variant: 'popover', popupId: 'network-modal' });
   const [user, , isUserLoaded] = useUser();
+  const { tasks } = useTasks();
 
   if (typeof window === 'undefined') {
     return (
@@ -87,7 +91,8 @@ function Account (): JSX.Element {
 
   const isConnectedWithWallet = (account && chainId);
   const chain = chainId ? getChainById(chainId) : null;
-
+  const totalTasks = tasks ? (tasks.mentioned.unmarked.length + tasks.gnosis.length) : 0;
+  const router = useRouter();
   return (
     <AccountCard>
       <StyledButtonGroup variant='contained' disableElevation>
@@ -106,7 +111,26 @@ function Account (): JSX.Element {
             borderTopLeftRadius: '0 !important',
             borderBottomLeftRadius: '0 !important'
           }) : {}}
-          endIcon={<Avatar avatar={user?.avatar} name={user?.username || ''} size='small' />}
+          endIcon={(
+            <Badge
+              color='error'
+              sx={{
+                '&:hover .MuiBadge-badge': {
+                  transform: 'scale(1.25) translate(50%, -50%)',
+                  transition: '250ms ease-in-out transform'
+                }
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                router.push('/nexus');
+              }}
+              badgeContent={totalTasks}
+              max={10}
+            >
+              <Avatar avatar={user?.avatar} name={user?.username || ''} size='small' />
+            </Badge>
+            )}
         >
           {user?.username}
         </AccountButton>

--- a/components/nexus/TasksPage.tsx
+++ b/components/nexus/TasksPage.tsx
@@ -103,7 +103,7 @@ export default function TasksPage () {
           />
         ))}
       </Tabs>
-      {currentTask === 'multisig' ? <GnosisTasksList error={error} mutateTasks={mutateTasks} tasks={tasks} /> : currentTask === 'discussion' ? <MentionedTasksList error={error} tasks={tasks} /> : null}
+      {currentTask === 'multisig' ? <GnosisTasksList error={error} mutateTasks={mutateTasks} tasks={tasks} /> : currentTask === 'discussion' ? <MentionedTasksList mutateTasks={mutateTasks} error={error} tasks={tasks} /> : null}
     </>
   );
 }

--- a/components/nexus/hooks/useTasks.ts
+++ b/components/nexus/hooks/useTasks.ts
@@ -1,9 +1,13 @@
-import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 import charmClient from 'charmClient';
+import { useUser } from 'hooks/useUser';
 
 export default function useTasks () {
-
-  const { data: tasks, error: serverError, mutate } = useSWR('/tasks/list', () => charmClient.getTasks());
+  const [user] = useUser();
+  const { data: tasks, error: serverError, mutate } = useSWRImmutable(user ? '/tasks/list' : null, () => charmClient.getTasks(), {
+    // 10 minutes
+    refreshInterval: 1000 * 10 * 60
+  });
   const error = serverError?.message || serverError;
   const isLoading = !tasks;
 


### PR DESCRIPTION
1. Show the total number of unattended tasks you have beside your avatar on the top right
2. Used `useSWRImmutable` to fetch tasks as fetching gnosis tasks can take a long time
3. Update the tasks state right after viewing the mentioned tasks (when you navigate to the mentioned tasks tab in your nexus we mark all the mentions as "seen", now since it will impact how many tasks is shown, I had to update the tasks state)

![image](https://user-images.githubusercontent.com/34683631/175078807-031971d6-a627-4128-b430-7889a576a246.png)

