### PR TITLE
Skip snoozed multisig tasks in notifications count 

### DIFF
--- a/components/common/PageLayout/components/Account/Account.tsx
+++ b/components/common/PageLayout/components/Account/Account.tsx
@@ -89,9 +89,16 @@ function Account (): JSX.Element {
     );
   }
 
+  const userNotificationState = user?.notificationState;
   const isConnectedWithWallet = (account && chainId);
   const chain = chainId ? getChainById(chainId) : null;
-  const totalTasks = tasks ? (tasks.mentioned.unmarked.length + tasks.gnosis.length) : 0;
+
+  // If the user has snoozed multisig tasks don't count them
+  const totalTasks = tasks
+    ? (tasks.mentioned.unmarked.length + (userNotificationState
+      ? (userNotificationState.snoozedUntil && new Date(userNotificationState.snoozedUntil) > new Date() ? 0
+        : tasks.gnosis.length) : tasks.gnosis.length))
+    : 0;
   const router = useRouter();
   return (
     <AccountCard>
@@ -115,7 +122,7 @@ function Account (): JSX.Element {
             <Badge
               color='error'
               sx={{
-                '&:hover .MuiBadge-badge': {
+                '& .MuiBadge-badge:hover': {
                   transform: 'scale(1.25) translate(50%, -50%)',
                   transition: '250ms ease-in-out transform'
                 }

--- a/components/nexus/components/SnoozeButton.tsx
+++ b/components/nexus/components/SnoozeButton.tsx
@@ -12,10 +12,12 @@ import Modal from 'components/common/Modal';
 import CancelIcon from '@mui/icons-material/Cancel';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { humanFriendlyDate } from 'lib/utilities/dates';
+import { useUser } from 'hooks/useUser';
+import { LoggedInUser } from 'models';
 import useTasksState from '../hooks/useTasksState';
 
 export default function SnoozeButton () {
-
+  const [, setUser] = useUser();
   const { isLoading, snoozedForDate, snoozedMessage, mutate: mutateTasks } = useTasksState();
 
   const isSnoozed = snoozedForDate !== null;
@@ -95,6 +97,11 @@ export default function SnoozeButton () {
       snoozeFor: newSnoozedForDate.toJSDate(),
       snoozeMessage: _snoozeMessage
     });
+    setUser((user: LoggedInUser) => ({ ...user,
+      notificationState: {
+        snoozedUntil: newSnoozedForDate.toString(),
+        snoozeMessage: _snoozeMessage
+      } }));
     await mutateTasks();
     setShowLoading(false);
   }

--- a/components/nexus/components/SnoozeButton.tsx
+++ b/components/nexus/components/SnoozeButton.tsx
@@ -64,6 +64,13 @@ export default function SnoozeButton () {
       snoozeFor: null,
       snoozeMessage: null
     });
+    setUser((user: LoggedInUser) => ({
+      ...user,
+      notificationState: {
+        snoozedUntil: null,
+        snoozeMessage: null
+      }
+    }));
     await mutateTasks();
     setShowLoading(false);
   }

--- a/models/User.ts
+++ b/models/User.ts
@@ -1,4 +1,4 @@
-import type { DiscordUser, FavoritePage, Poap, SpaceRole, User, Role as RoleMembership, SpaceRoleToRole, TelegramUser } from '@prisma/client';
+import type { DiscordUser, FavoritePage, Poap, SpaceRole, User, Role as RoleMembership, SpaceRoleToRole, TelegramUser, UserNotificationState } from '@prisma/client';
 
 export { FavoritePage, SpaceRole, User };
 
@@ -17,6 +17,7 @@ export interface LoggedInUser extends User {
   ensName?: string;
   discordUser?: DiscordUser | null
   telegramUser?: TelegramUser | null
+  notificationState?: UserNotificationState | null
 }
 
 export interface ExtendedPoap extends Poap {

--- a/pages/api/profile/index.ts
+++ b/pages/api/profile/index.ts
@@ -56,7 +56,8 @@ async function getUser (req: NextApiRequest, res: NextApiResponse<LoggedInUser |
         }
       },
       discordUser: true,
-      telegramUser: true
+      telegramUser: true,
+      notificationState: true
     }
   });
   if (!profile) {


### PR DESCRIPTION
1. Skip counting snoozed multisig tasks when counting your notifications
2. After adding a snooze/removing snooze for multisig tasks we update the users state to show a live update of the notifications count