### PR TITLE
Better upload image ux with loading message and spinner

### DIFF
--- a/components/common/ImageSelector/ImageSelector.tsx
+++ b/components/common/ImageSelector/ImageSelector.tsx
@@ -4,6 +4,7 @@ import MultiTabs from 'components/common/MultiTabs';
 import PopperPopup from 'components/common/PopperPopup';
 import { uploadToS3 } from 'lib/aws/uploadToS3Browser';
 import { ReactNode, useState } from 'react';
+import { PimpedButton } from '../Button';
 import ImageSelectorGallery from './ImageSelectorGallery';
 
 interface ImageSelectorProps {
@@ -16,6 +17,7 @@ interface ImageSelectorProps {
 export default function ImageSelector ({ autoOpen = false, children, galleryImages, onImageSelect }: ImageSelectorProps) {
   const [embedLink, setEmbedLink] = useState('');
   const tabs: [string, ReactNode][] = [];
+  const [isUploading, setIsUploading] = useState(false);
 
   if (galleryImages) {
     tabs.push([
@@ -35,58 +37,62 @@ export default function ImageSelector ({ autoOpen = false, children, galleryImag
           width: 750
         }}
         >
-          <MultiTabs tabs={[
-            ...tabs,
-            [
-              'Upload',
-              <Box sx={{
-                display: 'flex',
-                justifyContent: 'center',
-                width: '100%'
-              }}
-              >
-                <Button component='label' variant='contained'>
-                  Choose an image
-                  <input
-                    type='file'
-                    hidden
-                    accept='image/*'
-                    onChange={async (e) => {
-                      const firstFile = e.target.files?.[0];
-                      if (firstFile) {
-                        const { url } = await uploadToS3(firstFile);
-                        onImageSelect(url);
-                      }
-                    }}
-                  />
-                </Button>
-              </Box>
-            ],
-            [
-              'Link',
-              <Box sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 2,
-                alignItems: 'center'
-              }}
-              >
-                <TextField autoFocus placeholder='Paste the image link...' value={embedLink} onChange={(e) => setEmbedLink(e.target.value)} />
-                <Button
-                  disabled={!embedLink}
-                  sx={{
-                    width: 250
-                  }}
-                  onClick={() => {
-                    onImageSelect(embedLink);
-                    setEmbedLink('');
-                  }}
+          <MultiTabs
+            disabled={isUploading}
+            tabs={[
+              ...tabs,
+              [
+                'Upload',
+                <Box sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  width: '100%'
+                }}
                 >
-                  Embed Image
-                </Button>
-              </Box>
-            ]
-          ]}
+                  <PimpedButton loading={isUploading} loadingMessage='Uploading image ...' disabled={isUploading} component='label' variant='contained'>
+                    Choose an image
+                    <input
+                      type='file'
+                      hidden
+                      accept='image/*'
+                      onChange={async (e) => {
+                        setIsUploading(true);
+                        const firstFile = e.target.files?.[0];
+                        if (firstFile) {
+                          const { url } = await uploadToS3(firstFile);
+                          onImageSelect(url);
+                        }
+                        setIsUploading(false);
+                      }}
+                    />
+                  </PimpedButton>
+                </Box>
+              ],
+              [
+                'Link',
+                <Box sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 2,
+                  alignItems: 'center'
+                }}
+                >
+                  <TextField autoFocus placeholder='Paste the image link...' value={embedLink} onChange={(e) => setEmbedLink(e.target.value)} />
+                  <Button
+                    disabled={!embedLink}
+                    sx={{
+                      width: 250
+                    }}
+                    onClick={() => {
+                      onImageSelect(embedLink);
+                      setEmbedLink('');
+                    }}
+                  >
+                    Embed Image
+                  </Button>
+                </Box>
+              ]
+            ]}
           />
         </Box>
   )}

--- a/components/common/ImageSelector/ImageSelector.tsx
+++ b/components/common/ImageSelector/ImageSelector.tsx
@@ -49,7 +49,7 @@ export default function ImageSelector ({ autoOpen = false, children, galleryImag
                   width: '100%'
                 }}
                 >
-                  <PimpedButton loading={isUploading} loadingMessage='Uploading image ...' disabled={isUploading} component='label' variant='contained'>
+                  <PimpedButton loading={isUploading} loadingMessage='Uploading image' disabled={isUploading} component='label' variant='contained'>
                     Choose an image
                     <input
                       type='file'

--- a/components/common/MultiTabs.tsx
+++ b/components/common/MultiTabs.tsx
@@ -32,11 +32,12 @@ function TabPanel (props: TabPanelProps) {
 
 interface MultiTabsProps {
   tabs: [string, React.ReactNode][]
+  disabled?: boolean
 }
 
 export default function MultiTabs (props: MultiTabsProps) {
   const [value, setValue] = React.useState(0);
-  const { tabs } = props;
+  const { tabs, disabled = false } = props;
   const handleChange = (_: React.SyntheticEvent<Element, Event>, newValue: number) => {
     setValue(newValue);
   };
@@ -44,14 +45,21 @@ export default function MultiTabs (props: MultiTabsProps) {
   return (
     <Box sx={{ width: '100%' }}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs value={value} onChange={handleChange} aria-label='multi tabs'>
+        <Tabs
+          indicatorColor={disabled ? 'secondary' : 'primary'}
+          value={value}
+          onChange={handleChange}
+          aria-label='multi tabs'
+        >
           {tabs.map(([tabLabel]) => (
             <Tab
+              disabled={disabled}
               sx={{
                 textTransform: 'initial'
               }}
               key={tabLabel}
               label={tabLabel}
+
             />
           ))}
         </Tabs>


### PR DESCRIPTION
Right now if after clicking on **Choose an image** and uploading an image, the UX is extremely confusing. The user has no idea whether its uploading or not. The button is not disabled so they can upload again, or switch tabs. This PR does the following things:-
1. Show an upload message for the upload button text while the image is being uploaded
2. DIsable the tabs so that one can't switch to pasting a link
3. DIsable the upload button while its uploading
4. Show a spinner beside the upload message

![image](https://user-images.githubusercontent.com/34683631/175821850-e81feff2-d28b-4680-b61c-b408d3eda025.png)
