### PR TITLE
Immutable page title while focused

### DIFF
--- a/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
@@ -48,10 +48,6 @@ export default function PageTitle ({ value, onChange, readOnly }: PageTitleProps
   const view = useContext(EditorViewContext);
   const [title, setTitle] = useState(value);
 
-  useEffect(() => {
-    setTitle(value);
-  }, [value]);
-
   function _onChange (event: ChangeEvent<HTMLInputElement>) {
     setTitle(event.target.value);
     onChange(event);

--- a/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
@@ -2,7 +2,7 @@ import { EditorViewContext } from '@bangle.dev/react';
 import styled from '@emotion/styled';
 import { TextField, Typography } from '@mui/material';
 import { TextSelection } from 'prosemirror-state';
-import { ChangeEvent, useContext, useEffect, useState } from 'react';
+import { ChangeEvent, useContext, useEffect, useRef, useState } from 'react';
 
 const StyledPageTitle = styled(TextField)`
   &.MuiFormControl-root {
@@ -47,6 +47,14 @@ interface PageTitleProps {
 export default function PageTitle ({ value, onChange, readOnly }: PageTitleProps) {
   const view = useContext(EditorViewContext);
   const [title, setTitle] = useState(value);
+  const titleInput = useRef(null);
+
+  // sync value with updates if input is not focused
+  useEffect(() => {
+    if (document.activeElement !== titleInput.current) {
+      setTitle(value);
+    }
+  }, [value]);
 
   function _onChange (event: ChangeEvent<HTMLInputElement>) {
     setTitle(event.target.value);
@@ -58,6 +66,7 @@ export default function PageTitle ({ value, onChange, readOnly }: PageTitleProps
   }
   return (
     <StyledPageTitle
+      inputRef={titleInput}
       value={title}
       onChange={_onChange}
       placeholder='Untitled'


### PR DESCRIPTION
This solution is pretty simple for now: just don't sync backend changes with the title when the user has it in focus. Tested by using Firefox to throttle the network.

First I tried adding a trigger in Postgres to bump a document version on update, and then only updating the view when the version is more recent, but it didn't solve the issue: because we're waiting for Postgres to give us the new version, but the client has more recent changes. I would like to see how we will solve this for CharmEditor before coming up with a final solution.