### PR TITLE
Bounty submissions rollup fix

### DIFF
--- a/lib/bounties/__tests__/rollupBountyStatus.spec.ts
+++ b/lib/bounties/__tests__/rollupBountyStatus.spec.ts
@@ -1,14 +1,10 @@
 
-import { Bounty, PageOperations, PagePermissionLevel, Space, User } from '@prisma/client';
-import { computeUserPagePermissions, permissionTemplates, upsertPermission } from 'lib/permissions/pages';
-import { createPage, generateUserAndSpaceWithApiToken, generateBountyWithSingleApplication } from 'testing/setupDatabase';
-import { v4 } from 'uuid';
+import { Space, User } from '@prisma/client';
+import { DataNotFoundError } from 'lib/utilities/errors';
 import { ExpectedAnError } from 'testing/errors';
-import { UserIsNotSpaceMemberError } from 'lib/users/errors';
-import { DataNotFoundError, InvalidInputError, UnauthorisedActionError } from 'lib/utilities/errors';
-import { createBounty } from '../createBounty';
+import { generateBountyWithSingleApplication, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+import { v4 } from 'uuid';
 import { rollupBountyStatus } from '../rollupBountyStatus';
-import { PositiveNumbersOnlyError } from '../../utilities/errors/numbers';
 
 let user: User;
 let space: Space;
@@ -102,6 +98,20 @@ describe('rollupBountyStatus', () => {
     const bountyAfterRollup = await rollupBountyStatus(bounty.id);
 
     expect(bountyAfterRollup.status).toBe('open');
+  });
+
+  it('should leave a bounty with suggestion status unchanged', async () => {
+    const bounty = await generateBountyWithSingleApplication({
+      userId: user.id,
+      spaceId: space.id,
+      bountyCap: 10,
+      applicationStatus: 'applied',
+      bountyStatus: 'suggestion'
+    });
+
+    const bountyAfterRollup = await rollupBountyStatus(bounty.id);
+
+    expect(bountyAfterRollup.status).toBe('suggestion');
   });
 
 });

--- a/lib/bounties/rollupBountyStatus.ts
+++ b/lib/bounties/rollupBountyStatus.ts
@@ -12,6 +12,11 @@ export async function rollupBountyStatus (bountyId: string): Promise<BountyWithD
     throw new DataNotFoundError(`Bounty with id ${bountyId} not found`);
   }
 
+  // No-op on bounty suggestions. They need to be approved first
+  if (bounty.status === 'suggestion') {
+    return bounty;
+  }
+
   function statusUpdate (newStatus: BountyStatus): Promise<BountyWithDetails> {
     return prisma.bounty.update({
       where: {

--- a/lib/bounties/updateBountySettings.ts
+++ b/lib/bounties/updateBountySettings.ts
@@ -49,7 +49,7 @@ export async function updateBountySettings ({
   }
 
   if (updateContent.permissions) {
-    const afterUpdate = await setBountyPermissions({
+    await setBountyPermissions({
       bountyId,
       permissionsToAssign: updateContent.permissions
     });

--- a/pages/api/bounties/[id]/index.ts
+++ b/pages/api/bounties/[id]/index.ts
@@ -72,7 +72,16 @@ async function updateBounty (req: NextApiRequest, res: NextApiResponse<BountyWit
     delete body.permissions;
   }
 
-  if (bounty.status === 'suggestion') {
+  const { error, isAdmin } = await hasAccessToSpace({
+    spaceId: bounty.spaceId,
+    userId,
+    adminOnly: true
+  });
+
+  // Only drop keys if user is not an admin
+  // Bounty suggestions only exist if creating bounties is disabled at workspace level.
+  // In this case, we wouldn't want non admin to configure any other fields than the title and description of the bounty until it is approved.
+  if (bounty.status === 'suggestion' && (error || !isAdmin)) {
     typedKeys(body).forEach(key => {
       if (key !== 'title' && key !== 'description' && key !== 'descriptionNodes') {
         delete body[key];


### PR DESCRIPTION
Fixes an issue whereby updating a bounty suggestion triggered rollup to open status

Ensures fields for suggestion are not dropped if update coming from an admin