### PR TITLE
Payment icons

### DIFF
--- a/components/bounties/components/BountyStatusBadge.tsx
+++ b/components/bounties/components/BountyStatusBadge.tsx
@@ -153,7 +153,7 @@ export function BountyAmount ({ bounty, truncate = false }: { bounty: Pick<Bount
             ) : (
               <>
                 <Box
-                  mr={0.75}
+                  mr={0.5}
                   component='span'
                   sx={{
                     width: 25,

--- a/components/bounties/components/BountyStatusBadge.tsx
+++ b/components/bounties/components/BountyStatusBadge.tsx
@@ -11,7 +11,7 @@ import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
 import Tooltip from '@mui/material/Tooltip';
 import { Bounty, BountyStatus } from '@prisma/client';
-import { getChainById } from 'connectors';
+import TokenLogo from 'components/common/TokenLogo';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePaymentMethods } from 'hooks/usePaymentMethods';
 import { getTokenAndChainInfoFromPayments } from 'lib/tokens/tokenData';
@@ -129,7 +129,7 @@ export function BountyAmount ({ bounty, truncate = false }: { bounty: Pick<Bount
     symbolOrAddress: bounty.rewardToken
   });
 
-  const tooltip = `${tokenInfo.chain.chainName} (${tokenInfo.tokenSymbol})`;
+  const tooltip = `${tokenInfo.tokenName} (${tokenInfo.tokenSymbol})`;
 
   return (
     <Tooltip arrow placement='top' title={bounty.rewardAmount === 0 ? '' : tooltip}>
@@ -161,12 +161,7 @@ export function BountyAmount ({ bounty, truncate = false }: { bounty: Pick<Bount
                     alignItems: 'center'
                   }}
                 >
-                  <Box component='span' sx={{ width: '25px', height: '25px' }}>
-                    <img
-                      height='100%'
-                      src={tokenInfo.canonicalLogo}
-                    />
-                  </Box>
+                  <TokenLogo src={tokenInfo.canonicalLogo} />
                 </Box>
                 <Typography
                   component='span'

--- a/components/common/TokenLogo.tsx
+++ b/components/common/TokenLogo.tsx
@@ -1,0 +1,9 @@
+import { Box, SxProps } from '@mui/material';
+
+export default function TokenLogo ({ src, height = 25, sx }: { src: string, height?: number | string, sx?: SxProps }) {
+  return (
+    <Box display='flex' justifyContent='center' sx={sx}>
+      <img style={{ height, width: 'auto' }} src={src} />
+    </Box>
+  );
+}

--- a/components/common/form/InputSearchCrypto.tsx
+++ b/components/common/form/InputSearchCrypto.tsx
@@ -42,19 +42,17 @@ export function InputSearchCrypto ({
   const ERC20PopupState = usePopupState({ variant: 'popover', popupId: 'ERC20-popup' });
 
   useEffect(() => {
-    setInputValue(defaultValue);
     setValue(defaultValue);
   }, [cryptoList]);
 
   useEffect(() => {
     if (parentValue) {
-      setInputValue(parentValue);
       setValue(parentValue);
     }
   }, [cryptoList, parentValue]);
 
   function emitValue (received: string) {
-    if (received !== null && cryptoList.indexOf(received as CryptoCurrency) >= 0) {
+    if (received && cryptoList.includes(received as CryptoCurrency)) {
       setValue(received);
       onChange(received as CryptoCurrency);
     }
@@ -95,8 +93,7 @@ export function InputSearchCrypto ({
         autoHighlight
         size='small'
         getOptionLabel={(option) => {
-          const tokenInfo = getTokenInfo(paymentMethods, option);
-          return tokenInfo.tokenSymbol;
+          return getTokenInfo(paymentMethods, option).tokenSymbol;
         }}
         renderOption={(props, option) => {
           if (option === ADD_NEW_CUSTOM) {

--- a/components/common/form/InputSearchCrypto.tsx
+++ b/components/common/form/InputSearchCrypto.tsx
@@ -7,7 +7,8 @@ import { usePopupState } from 'material-ui-popup-state/hooks';
 import { PaymentMethod } from '@prisma/client';
 import { usePaymentMethods } from 'hooks/usePaymentMethods';
 import AddIcon from '@mui/icons-material/Add';
-import { getTokenInfo } from 'lib/tokens/tokenData';
+import TokenLogo from 'components/common/TokenLogo';
+import { getTokenInfo, getTokenAndChainInfoFromPayments } from 'lib/tokens/tokenData';
 import CustomERCTokenForm from 'components/settings/payment-methods/components/CustomERCTokenForm';
 
 export interface IInputSearchCryptoProps {
@@ -106,19 +107,13 @@ export function InputSearchCrypto ({
               </Box>
             );
           }
-          const tokenInfo = getTokenInfo(paymentMethods, option);
+          const tokenInfo = getTokenAndChainInfoFromPayments({ methods: paymentMethods, chainId: 1, symbolOrAddress: option });
 
           return (
             <Box component='li' sx={{ '& > img': { flexShrink: 0 }, display: 'flex', gap: 1, alignItems: 'center' }} {...props}>
-              {
-                tokenInfo.tokenLogo && (
-                  <img
-                    width='20px'
-                    height='20px'
-                    src={tokenInfo.tokenLogo}
-                  />
-                )
-              }
+              <Box display='inline-block' width={20}>
+                <TokenLogo height={20} src={tokenInfo.canonicalLogo} />
+              </Box>
               <Box component='span'>
                 {tokenInfo.tokenSymbol}
               </Box>

--- a/components/settings/payment-methods/PaymentMethods.tsx
+++ b/components/settings/payment-methods/PaymentMethods.tsx
@@ -35,13 +35,6 @@ export default function PaymentMethods () {
 
         <Stack component='span' spacing={1} direction='row'>
           <Button
-            onClick={gnosisPopupState.open}
-            variant='outlined'
-            sx={{ float: 'right' }}
-          >
-            Add Gnosis Safe wallet
-          </Button>
-          <Button
             onClick={ERC20PopupState.open}
             variant='outlined'
             sx={{ float: 'right' }}

--- a/connectors.ts
+++ b/connectors.ts
@@ -332,7 +332,7 @@ export function getCryptos (chainId: number): Array<string | CryptoCurrency> {
 
 }
 
-export function getChainExplorerLink (chainId: string | number, transactionOrContractId: string, endpoint: 'transaction' | 'token' = 'transaction'): string {
+export function getChainExplorerLink (chainId: string | number, transactionOrContractId: string, endpoint: 'transaction' | 'address' = 'transaction'): string {
 
   chainId = chainId.toString();
 

--- a/lib/tokens/tokenData.ts
+++ b/lib/tokens/tokenData.ts
@@ -1,6 +1,6 @@
 import * as http from 'adapters/http';
 import { PaymentMethod } from '@prisma/client';
-import { TokenLogoPaths, CryptoCurrency, CryptoCurrencyList } from 'connectors';
+import { TokenLogoPaths, CryptoCurrency, CryptoCurrencyList, getChainById, IChainDetails } from 'connectors';
 
 export interface ITokenMetadataRequest {
   chainId: number,
@@ -90,4 +90,70 @@ export function getTokenInfo (paymentMethods: PaymentMethod[], symbolOrAddress: 
   };
 
   return tokenInfo;
+}
+
+// /**
+//  * Returns a standardised shape for either a contract address, or a native currency
+//  * @param paymentMethods Call this function from a component that can access the usePaymentMethods hook which provides available methods to search through
+//  */
+//  export function getTokenInfoFromPayments (paymentMethods: PaymentMethod[], symbolOrAddress: string): TokenInfo {
+
+//   const paymentMethod = paymentMethods.find(method => (
+//     method.contractAddress === symbolOrAddress || method.tokenSymbol === symbolOrAddress
+//   ));
+
+//   if (paymentMethod) {
+//     return getTokenInfo(paymentMethod);
+//   }
+//   else {
+//     return {
+//       tokenName: TokenLogoPaths[symbolOrAddress as CryptoCurrency],
+//       tokenSymbol: symbolOrAddress,
+//       tokenLogo: CryptoCurrencyList[symbolOrAddress as CryptoCurrency],
+//       isContract: false
+//     };
+//   }
+// }
+
+type TokenAndChain = TokenInfo & { chain: IChainDetails, canonicalLogo: string };
+type getTokenAndChainInfoFromPaymentsProps = { chainId: number, methods: PaymentMethod[], symbolOrAddress: string }
+
+export function getTokenAndChainInfoFromPayments ({ chainId, methods, symbolOrAddress }: getTokenAndChainInfoFromPaymentsProps): TokenAndChain {
+  const paymentMethod = methods.find(method => (
+    method.contractAddress === symbolOrAddress || method.tokenSymbol === symbolOrAddress
+  ));
+  if (paymentMethod) {
+    return getTokenAndChainInfo(paymentMethod);
+  }
+  else {
+    const chain = getChainById(chainId);
+    if (!chain) {
+      throw new Error(`No chain found for chainId: ${chainId}`);
+    }
+    return {
+      chain,
+      canonicalLogo: TokenLogoPaths[symbolOrAddress as CryptoCurrency],
+      tokenName: TokenLogoPaths[symbolOrAddress as CryptoCurrency],
+      tokenSymbol: symbolOrAddress,
+      tokenLogo: CryptoCurrencyList[symbolOrAddress as CryptoCurrency],
+      isContract: false
+    };
+  }
+}
+
+export function getTokenAndChainInfo (paymentMethod: PaymentMethod): TokenAndChain {
+  const chain = getChainById(paymentMethod.chainId);
+  if (!chain) {
+    throw new Error(`No chain found for chainId: ${paymentMethod.chainId}`);
+  }
+  const tokenLogo = paymentMethod.tokenLogo || TokenLogoPaths[paymentMethod.tokenSymbol as CryptoCurrency];
+  return {
+    // prefer our standard iconUrl for native tokens that may have been saved to tokenInfo
+    canonicalLogo: paymentMethod.contractAddress ? tokenLogo : (chain.iconUrl || tokenLogo),
+    chain,
+    tokenName: paymentMethod.tokenName,
+    tokenSymbol: paymentMethod.tokenSymbol,
+    tokenLogo,
+    isContract: !!paymentMethod.contractAddress
+  };
 }

--- a/lib/tokens/tokenData.ts
+++ b/lib/tokens/tokenData.ts
@@ -92,29 +92,6 @@ export function getTokenInfo (paymentMethods: PaymentMethod[], symbolOrAddress: 
   return tokenInfo;
 }
 
-// /**
-//  * Returns a standardised shape for either a contract address, or a native currency
-//  * @param paymentMethods Call this function from a component that can access the usePaymentMethods hook which provides available methods to search through
-//  */
-//  export function getTokenInfoFromPayments (paymentMethods: PaymentMethod[], symbolOrAddress: string): TokenInfo {
-
-//   const paymentMethod = paymentMethods.find(method => (
-//     method.contractAddress === symbolOrAddress || method.tokenSymbol === symbolOrAddress
-//   ));
-
-//   if (paymentMethod) {
-//     return getTokenInfo(paymentMethod);
-//   }
-//   else {
-//     return {
-//       tokenName: TokenLogoPaths[symbolOrAddress as CryptoCurrency],
-//       tokenSymbol: symbolOrAddress,
-//       tokenLogo: CryptoCurrencyList[symbolOrAddress as CryptoCurrency],
-//       isContract: false
-//     };
-//   }
-// }
-
 type TokenAndChain = TokenInfo & { chain: IChainDetails, canonicalLogo: string };
 type getTokenAndChainInfoFromPaymentsProps = { chainId: number, methods: PaymentMethod[], symbolOrAddress: string }
 
@@ -133,9 +110,9 @@ export function getTokenAndChainInfoFromPayments ({ chainId, methods, symbolOrAd
     return {
       chain,
       canonicalLogo: TokenLogoPaths[symbolOrAddress as CryptoCurrency],
-      tokenName: TokenLogoPaths[symbolOrAddress as CryptoCurrency],
+      tokenName: CryptoCurrencyList[symbolOrAddress as CryptoCurrency],
       tokenSymbol: symbolOrAddress,
-      tokenLogo: CryptoCurrencyList[symbolOrAddress as CryptoCurrency],
+      tokenLogo: TokenLogoPaths[symbolOrAddress as CryptoCurrency],
       isContract: false
     };
   }
@@ -149,7 +126,7 @@ export function getTokenAndChainInfo (paymentMethod: PaymentMethod): TokenAndCha
   const tokenLogo = paymentMethod.tokenLogo || TokenLogoPaths[paymentMethod.tokenSymbol as CryptoCurrency];
   return {
     // prefer our standard iconUrl for native tokens that may have been saved to tokenInfo
-    canonicalLogo: paymentMethod.contractAddress ? tokenLogo : (chain.iconUrl || tokenLogo),
+    canonicalLogo: paymentMethod.contractAddress ? (tokenLogo || chain.iconUrl) : chain.iconUrl,
     chain,
     tokenName: paymentMethod.tokenName,
     tokenSymbol: paymentMethod.tokenSymbol,


### PR DESCRIPTION
This PR adds a default icon (the chain logo) for all tokens. I think it's better than leaving a whitespace... also mirrors what you see on Etherscan.

I also fixed a bug wehre when you select a custom token in InputSearchCrypto, we show the token address rather than the token name. I think that the code for this component could be simplified further, but saving for another day..

![image](https://user-images.githubusercontent.com/305398/176952777-d66cb037-bf41-41d3-8b85-a463af854a85.png)
