### PR TITLE
only include favorites of pages not deleted

### DIFF
--- a/lib/discord/loginByDiscord.ts
+++ b/lib/discord/loginByDiscord.ts
@@ -1,6 +1,7 @@
 import { prisma } from 'db';
 import { getDiscordAccount } from 'lib/discord/getDiscordAccount';
 import { getUserS3Folder, uploadToS3 } from 'lib/aws/uploadToS3Server';
+import { sessionUserRelations } from 'lib/session/config';
 import { v4 as uuid } from 'uuid';
 import { IDENTITY_TYPES } from 'models';
 
@@ -13,20 +14,7 @@ export default async function loginByDiscord ({ code, hostName }: { code: string
     },
     include: {
       user: {
-        include: {
-          favorites: true,
-          spaceRoles: {
-            include: {
-              spaceRoleToRole: {
-                include: {
-                  role: true
-                }
-              }
-            }
-          },
-          discordUser: true,
-          telegramUser: true
-        }
+        include: sessionUserRelations
       }
     }
   });
@@ -58,20 +46,7 @@ export default async function loginByDiscord ({ code, hostName }: { code: string
           }
         }
       },
-      include: {
-        favorites: true,
-        spaceRoles: {
-          include: {
-            spaceRoleToRole: {
-              include: {
-                role: true
-              }
-            }
-          }
-        },
-        discordUser: true,
-        telegramUser: true
-      }
+      include: sessionUserRelations
     });
 
     return newUser;

--- a/lib/session/config.ts
+++ b/lib/session/config.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 
 declare module 'iron-session' {
   interface IronSessionData {
@@ -15,3 +16,29 @@ export const ironOptions = {
     secure: typeof process.env.DOMAIN === 'string' && process.env.DOMAIN.includes('https')
   }
 };
+
+// a map of relationships we pull in for the logged-in user (try to keep this small)
+export const sessionUserRelations = {
+  favorites: {
+    where: {
+      page: {
+        deletedAt: null
+      }
+    },
+    select: {
+      pageId: true
+    }
+  },
+  spaceRoles: {
+    include: {
+      spaceRoleToRole: {
+        include: {
+          role: true
+        }
+      }
+    }
+  },
+  discordUser: true,
+  telegramUser: true,
+  notificationState: true
+} as const;

--- a/lib/session/config.ts
+++ b/lib/session/config.ts
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client';
 
 declare module 'iron-session' {
   interface IronSessionData {

--- a/lib/users/createUser.ts
+++ b/lib/users/createUser.ts
@@ -2,6 +2,7 @@ import { prisma } from 'db';
 import { shortenHex } from 'lib/utilities/strings';
 import { IDENTITY_TYPES, LoggedInUser } from 'models';
 import getENSName from 'lib/blockchain/getENSName';
+import { sessionUserRelations } from 'lib/session/config';
 
 export async function createUserFromWallet (address: string): Promise<LoggedInUser> {
   const user = await prisma.user.findFirst({
@@ -10,20 +11,7 @@ export async function createUserFromWallet (address: string): Promise<LoggedInUs
         has: address
       }
     },
-    include: {
-      favorites: true,
-      spaceRoles: {
-        include: {
-          spaceRoleToRole: {
-            include: {
-              role: true
-            }
-          }
-        }
-      },
-      discordUser: true,
-      telegramUser: true
-    }
+    include: sessionUserRelations
   });
 
   if (user) {
@@ -38,18 +26,7 @@ export async function createUserFromWallet (address: string): Promise<LoggedInUs
         identityType: IDENTITY_TYPES[0],
         username: ens || shortenHex(address)
       },
-      include: {
-        favorites: true,
-        spaceRoles: {
-          include: {
-            spaceRoleToRole: {
-              include: {
-                role: true
-              }
-            }
-          }
-        }
-      }
+      include: sessionUserRelations
     });
 
     return newUser;

--- a/lib/users/getUser.ts
+++ b/lib/users/getUser.ts
@@ -1,6 +1,7 @@
 import { LoggedInUser } from 'models';
 import { User, Prisma } from '@prisma/client';
 import { prisma } from 'db';
+import { sessionUserRelations } from 'lib/session/config';
 
 type UserIdentifiers = Extract<keyof User, 'id' | 'addresses'>
 
@@ -25,20 +26,7 @@ export async function getUserProfile (key: UserIdentifiers, value: string): Prom
 
   const profile = await prisma.user.findFirst({
     where: query,
-    include: {
-      favorites: true,
-      spaceRoles: {
-        include: {
-          spaceRoleToRole: {
-            include: {
-              role: true
-            }
-          }
-        }
-      },
-      discordUser: true,
-      telegramUser: true
-    }
+    include: sessionUserRelations
   });
 
   if (!profile) {

--- a/models/User.ts
+++ b/models/User.ts
@@ -12,7 +12,7 @@ interface NestedMemberships {
 }
 
 export interface LoggedInUser extends User {
-  favorites: FavoritePage[];
+  favorites: { pageId: string }[];
   spaceRoles: (SpaceRole & NestedMemberships)[]
   ensName?: string;
   discordUser?: DiscordUser | null

--- a/pages/api/profile/favorites.ts
+++ b/pages/api/profile/favorites.ts
@@ -4,6 +4,7 @@ import nc from 'next-connect';
 import { prisma } from 'db';
 import { onError, onNoMatch, requireUser } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
+import { sessionUserRelations } from 'lib/session/config';
 import { LoggedInUser } from 'models';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
@@ -41,9 +42,7 @@ async function addFavoritePage (req: NextApiRequest, res: NextApiResponse<Partia
         }
       }
     },
-    include: {
-      favorites: true
-    }
+    include: sessionUserRelations
   });
   return res.status(200).json(user);
 }
@@ -65,9 +64,7 @@ async function unFavoritePage (req: NextApiRequest, res: NextApiResponse<Partial
         }
       }
     },
-    include: {
-      favorites: true
-    }
+    include: sessionUserRelations
   });
   return res.status(200).json(user);
 }

--- a/pages/api/profile/index.ts
+++ b/pages/api/profile/index.ts
@@ -2,10 +2,11 @@
 import { prisma } from 'db';
 import { updateGuildRolesForUser } from 'lib/guild-xyz/server/updateGuildRolesForUser';
 import { postToDiscord } from 'lib/log/userEvents';
-import { onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
+import { onError, onNoMatch, requireUser } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
 import { createUserFromWallet } from 'lib/users/createUser';
 import { getUserProfile } from 'lib/users/getUser';
+import { sessionUserRelations } from 'lib/session/config';
 import { LoggedInUser } from 'models';
 import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
@@ -44,21 +45,7 @@ async function getUser (req: NextApiRequest, res: NextApiResponse<LoggedInUser |
     where: {
       id: req.session.user.id
     },
-    include: {
-      favorites: true,
-      spaceRoles: {
-        include: {
-          spaceRoleToRole: {
-            include: {
-              role: true
-            }
-          }
-        }
-      },
-      discordUser: true,
-      telegramUser: true,
-      notificationState: true
-    }
+    include: sessionUserRelations
   });
   if (!profile) {
     return res.status(404).json({ error: 'No user found' });
@@ -72,20 +59,7 @@ async function updateUser (req: NextApiRequest, res: NextApiResponse<LoggedInUse
     where: {
       id: req.session.user.id
     },
-    include: {
-      favorites: true,
-      spaceRoles: {
-        include: {
-          spaceRoleToRole: {
-            include: {
-              role: true
-            }
-          }
-        }
-      },
-      discordUser: true,
-      telegramUser: true
-    },
+    include: sessionUserRelations,
     data: {
       ...req.body
     }

--- a/pages/api/session/login.ts
+++ b/pages/api/session/login.ts
@@ -5,6 +5,7 @@ import { onError, onNoMatch } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
 import { LoggedInUser } from 'models';
 import { updateGuildRolesForUser } from 'lib/guild-xyz/server/updateGuildRolesForUser';
+import { sessionUserRelations } from 'lib/session/config';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
@@ -18,20 +19,7 @@ async function login (req: NextApiRequest, res: NextApiResponse<LoggedInUser | {
         has: address
       }
     },
-    include: {
-      favorites: true,
-      telegramUser: true,
-      discordUser: true,
-      spaceRoles: {
-        include: {
-          spaceRoleToRole: {
-            include: {
-              role: true
-            }
-          }
-        }
-      }
-    }
+    include: sessionUserRelations
   });
 
   if (!user) {


### PR DESCRIPTION
I noticed Alex was seeing the "Favorites" label in his sidebar with no pages underneath. I don't know if this was his case, but I know it is a bug - that we don't check which favorites have been deleted. Once the page is deleted after 30 days, it should be cleared, but this check helps until that happens. 

Currently what it looks like:
![image](https://user-images.githubusercontent.com/305398/177450579-558fa73e-f4ab-4d64-ab5a-e3a6075feba8.png)


To test: add a page to your favorites and delete it. Reload the site.