### PR TITLE
suppress warning about contenteditable

### DIFF
--- a/components/common/CharmEditor/components/Paragraph.tsx
+++ b/components/common/CharmEditor/components/Paragraph.tsx
@@ -54,7 +54,7 @@ export default function Paragraph (
   return (
     <>
       {children}
-      <CursorBoundary contentEditable='false'>
+      <CursorBoundary contentEditable='false' suppressContentEditableWarning>
         <InlineActionCountContainer>
           {totalInlineComments > 0 && (
           <Box


### PR DESCRIPTION
Fixes a warning I saw in dev mode, but the icons are working:

Warning: A component is `contentEditable` and contains `children` managed by React. It is now your responsibility to guarantee that none of those nodes are unexpectedly modified or duplicated. This is probably not intentional.

