### PR TITLE
Fix parent page call in the duplicatePage method

### DIFF
--- a/lib/pages/server/duplicatePage.ts
+++ b/lib/pages/server/duplicatePage.ts
@@ -21,11 +21,7 @@ export async function duplicatePage (pageId: string, userId: string, parentId?: 
   const transactions: PrismaPromise<any>[] = [prisma.page.create({
     data: {
       id: createdPageId,
-      parentPage: parentIdToAssign ? {
-        connect: {
-          id: parentIdToAssign
-        }
-      } : undefined,
+      parentId: parentIdToAssign,
       updatedBy: userId,
       title: `${page.title} (copy)`,
       content: page.content ?? undefined,


### PR DESCRIPTION
Fixes a call we forgot to revert when removing parentPage relationship