### PR TITLE
Error fix for emails: 'mjml not found'

### DIFF
--- a/__integration-tests__/server/pages/api/email-templates/index.spec.ts
+++ b/__integration-tests__/server/pages/api/email-templates/index.spec.ts
@@ -1,0 +1,14 @@
+
+import request from 'supertest';
+import { baseUrl } from 'testing/mockApiCall';
+
+describe('GET /api/email-templates - renders email templates', () => {
+
+  it('should return 200', async () => {
+    await request(baseUrl)
+      .get('/api/email-templates')
+      .expect(200);
+
+  });
+
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "marked": "^4.0.12",
         "material-ui-popup-state": "^2.0.0",
         "millify": "^4.0.0",
+        "mjml": "^4.13.0",
         "mjml-react": "^2.0.8",
         "nanoevents": "^6.0.2",
         "next": "^12.1.6",
@@ -9334,6 +9335,11 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -9495,6 +9501,14 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -9533,7 +9547,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -10172,7 +10185,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10271,8 +10283,7 @@
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "node_modules/bowser": {
       "version": "2.11.0",
@@ -10542,6 +10553,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==",
+      "dependencies": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -10650,11 +10670,45 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "dependencies": {
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
+      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "dependencies": {
+        "css-select": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -10681,7 +10735,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -10731,6 +10784,25 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "node_modules/clean-css": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
+      "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/clean-css/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -11102,6 +11174,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -11435,7 +11516,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
       "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.0.1",
@@ -11482,7 +11562,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       },
@@ -11847,6 +11926,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+    },
     "node_modules/dezalgo": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -12207,6 +12291,47 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "node_modules/editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/editorconfig/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/editorconfig/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -12429,6 +12554,17 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
+      "integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escape-html": {
@@ -14382,7 +14518,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -14960,6 +15095,31 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/html-minifier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
+      "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+      "dependencies": {
+        "camel-case": "^3.0.0",
+        "clean-css": "^4.2.1",
+        "commander": "^2.19.0",
+        "he": "^1.2.0",
+        "param-case": "^2.1.1",
+        "relateurl": "^0.2.7",
+        "uglify-js": "^3.5.1"
+      },
+      "bin": {
+        "html-minifier": "cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/html-minifier/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/html-to-text": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.0.tgz",
@@ -15370,7 +15530,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -15492,7 +15651,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15536,7 +15694,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -18332,6 +18489,25 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-beautify": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.4.tgz",
+      "integrity": "sha512-+b4A9c3glceZEmxyIbxDOYB0ZJdReLvyU1077RqKsO4dZx9FUHjTOJn8VHwpg33QoucIykOiYbh7MfqBOghnrA==",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^0.15.3",
+        "glob": "^7.1.3",
+        "nopt": "^5.0.0"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-file-download": {
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
@@ -18655,6 +18831,32 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/juice": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/juice/-/juice-7.0.0.tgz",
+      "integrity": "sha512-AjKQX31KKN+uJs+zaf+GW8mBO/f/0NqSh2moTMyvwBY+4/lXIYTU8D8I2h6BAV3Xnz6GGsbalUyFqbYMe+Vh+Q==",
+      "dependencies": {
+        "cheerio": "^1.0.0-rc.3",
+        "commander": "^5.1.0",
+        "mensch": "^0.3.4",
+        "slick": "^1.12.2",
+        "web-resource-inliner": "^5.0.0"
+      },
+      "bin": {
+        "juice": "bin/juice"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/juice/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/keccak": {
@@ -19430,6 +19632,11 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
+    },
     "node_modules/lowlight": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
@@ -19636,6 +19843,11 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
+    "node_modules/mensch": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/mensch/-/mensch-0.3.4.tgz",
+      "integrity": "sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g=="
+    },
     "node_modules/merge-class-names": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.4.2.tgz",
@@ -19758,7 +19970,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -19868,6 +20079,335 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
     },
+    "node_modules/mjml": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml/-/mjml-4.13.0.tgz",
+      "integrity": "sha512-OnFKESouLshz8DPFSb6M/dE8GkhiJnoy6LAam5TiLA1anAj24yQ2ZH388LtQoEkvTisqwiTmc9ejDh5ctnFaJQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "mjml-cli": "4.13.0",
+        "mjml-core": "4.13.0",
+        "mjml-migrate": "4.13.0",
+        "mjml-preset-core": "4.13.0",
+        "mjml-validator": "4.13.0"
+      },
+      "bin": {
+        "mjml": "bin/mjml"
+      }
+    },
+    "node_modules/mjml-accordion": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-4.13.0.tgz",
+      "integrity": "sha512-E3yihZW5Oq2p+sWOcr8kWeRTROmiTYOGxB4IOxW/jTycdY07N3FX3e6vuh7Fv3rryHEUaydUQYto3ICVyctI7w==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-body": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-4.13.0.tgz",
+      "integrity": "sha512-S4HgwAuO9dEsyX9sr6WBf9/xr+H2ASVaLn22aurJm1S2Lvc1wifLPYBQgFmNdCjaesTCNtOMUDpG+Rbnavyaqg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-button": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-4.13.0.tgz",
+      "integrity": "sha512-3y8IAHCCxh7ESHh1aOOqobZKUgyNxOKAGQ9TlJoyaLpsKUFzkN8nmrD0KXF0ADSuzvhMZ1CdRIJuZ5mjv2TwWQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-carousel": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-4.13.0.tgz",
+      "integrity": "sha512-ORSY5bEYlMlrWSIKI/lN0Tz3uGltWAjG8DQl2Yr3pwjwOaIzGE+kozrDf+T9xItfiIIbvKajef1dg7B7XgP0zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-cli": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-4.13.0.tgz",
+      "integrity": "sha512-kAZxpH0QqlTF/CcLzELgKw1ljKRxrmWJ310CJQhbPAxHvwQ/nIb+q82U+zRJAelRPPKjnOb+hSrMRqTgk9rH3w==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "chokidar": "^3.0.0",
+        "glob": "^7.1.1",
+        "html-minifier": "^4.0.0",
+        "js-beautify": "^1.6.14",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0",
+        "mjml-migrate": "4.13.0",
+        "mjml-parser-xml": "4.13.0",
+        "mjml-validator": "4.13.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "mjml-cli": "bin/mjml"
+      }
+    },
+    "node_modules/mjml-column": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-4.13.0.tgz",
+      "integrity": "sha512-O8FrWKK/bCy9XpKxrKRYWNdgWNaVd4TK4RqMeVI/I70IbnYnc1uf15jnsPMxCBSbT+NyXyk8k7fn099797uwpw==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-4.13.0.tgz",
+      "integrity": "sha512-kU5AoVTlZaXR/EDi3ix66xpzUe+kScYus71lBH/wo/B+LZW70GHE1AYWtsog5oJp1MuTHpMFTNuBD/wePeEgWg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "cheerio": "1.0.0-rc.10",
+        "detect-node": "2.0.4",
+        "html-minifier": "^4.0.0",
+        "js-beautify": "^1.6.14",
+        "juice": "^7.0.0",
+        "lodash": "^4.17.21",
+        "mjml-migrate": "4.13.0",
+        "mjml-parser-xml": "4.13.0",
+        "mjml-validator": "4.13.0"
+      }
+    },
+    "node_modules/mjml-divider": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-4.13.0.tgz",
+      "integrity": "sha512-ooPCwfmxEC+wJduqObYezMp7W5UCHjL9Y1LPB5FGna2FrOejgfd6Ix3ij8Wrmycmlol7E2N4D7c5NDH5DbRCJg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-group": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-4.13.0.tgz",
+      "integrity": "sha512-U7E8m8aaoAE/dMqjqXPjjrKcwO36B4cquAy9ASldECrIZJBcpFYO6eYf5yLXrNCUM2P0id8pgVjrUq23s00L7Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-head": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-4.13.0.tgz",
+      "integrity": "sha512-sL2qQuoVALXBCiemu4DPo9geDr8DuUdXVJxm+4nd6k5jpLCfSDmFlNhgSsLPzsYn7VEac3/sxsjLtomQ+6/BHg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-head-attributes": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-4.13.0.tgz",
+      "integrity": "sha512-haggCafno+0lQylxJStkINCVCPMwfTpwE6yjCHeGOpQl/TkoNmjNkDr7DEEbNTZbt4Ekg070lQFn7clDy38EoA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-head-breakpoint": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-4.13.0.tgz",
+      "integrity": "sha512-D2iPDeUKQK1+rYSNa2HGOvgfPxZhNyndTG0iBEb/FxdGge2hbeDCZEN0mwDYE3wWB+qSBqlCuMI+Vr4pEjZbKg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-head-font": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-4.13.0.tgz",
+      "integrity": "sha512-mYn8aWnbrEap5vX2b4662hkUv6WifcYzYn++Yi6OHrJQi55LpzcU+myAGpfQEXXrpU8vGwExMTFKsJq5n2Kaow==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-head-html-attributes": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-4.13.0.tgz",
+      "integrity": "sha512-m30Oro297+18Zou/1qYjagtmCOWtYXeoS38OABQ5zOSzMItE3TcZI9JNcOueIIWIyFCETe8StrTAKcQ2GHwsDw==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-head-preview": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-4.13.0.tgz",
+      "integrity": "sha512-v0K/NocjFCbaoF/0IMVNmiqov91HxqT07vNTEl0Bt9lKFrTKVC01m1S4K7AB78T/bEeJ/HwmNjr1+TMtVNGGow==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-head-style": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-4.13.0.tgz",
+      "integrity": "sha512-tBa33GL9Atn5bAM2UwE+uxv4rI29WgX/e5lXX+5GWlsb4thmiN6rxpFTNqBqWbBNRbZk4UEZF78M7Da8xC1ZGQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-head-title": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-4.13.0.tgz",
+      "integrity": "sha512-Mq0bjuZXJlwxfVcjuYihQcigZSDTKeQaG3nORR1D0jsOH2BXU4XgUK1UOcTXn2qCBIfRoIMq7rfzYs+L0CRhdw==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-hero": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-4.13.0.tgz",
+      "integrity": "sha512-aWEOScdrhyjwdKBWG4XQaElRHP8LU5PtktkpMeBXa4yxrxNs25qRnDqMNkjSrnnmFKWZmQ166tfboY6RBNf0UA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-image": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-4.13.0.tgz",
+      "integrity": "sha512-agMmm2wRZTIrKwrUnYFlnAbtrKYSP0R2en+Vf92HPspAwmaw3/AeOW/QxmSiMhfGf+xsEJyzVvR/nd33jbT3sg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-migrate": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-migrate/-/mjml-migrate-4.13.0.tgz",
+      "integrity": "sha512-I1euHiAyNpaz+B5vH+Z4T+hg/YtI5p3PqQ3/zTLv8gi24V6BILjTaftWhH5+3R/gQkQhH0NUaWNnRmds+Mq5DQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "js-beautify": "^1.6.14",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0",
+        "mjml-parser-xml": "4.13.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "migrate": "lib/cli.js"
+      }
+    },
+    "node_modules/mjml-navbar": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-4.13.0.tgz",
+      "integrity": "sha512-0Oqyyk+OdtXfsjswRb/7Ql1UOjN4MbqFPKoyltJqtj+11MRpF5+Wjd74Dj9H7l81GFwkIB9OaP+ZMiD+TPECgg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-parser-xml": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-4.13.0.tgz",
+      "integrity": "sha512-phljtI8DaW++q0aybR/Ykv9zCyP/jCFypxVNo26r2IQo//VYXyc7JuLZZT8N/LAI8lZcwbTVxQPBzJTmZ5IfwQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "detect-node": "2.0.4",
+        "htmlparser2": "^4.1.0",
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/mjml-parser-xml/node_modules/domhandler": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+      "dependencies": {
+        "domelementtype": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/mjml-parser-xml/node_modules/htmlparser2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+      "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^3.0.0",
+        "domutils": "^2.0.0",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/mjml-preset-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-4.13.0.tgz",
+      "integrity": "sha512-gxzYaKkvUrHuzT1oqjEPSDtdmgEnN99Hf5f1r2CR5aMOB1x66EA3T8ATvF1o7qrBTVV4KMVlQem3IubMSYJZRw==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "mjml-accordion": "4.13.0",
+        "mjml-body": "4.13.0",
+        "mjml-button": "4.13.0",
+        "mjml-carousel": "4.13.0",
+        "mjml-column": "4.13.0",
+        "mjml-divider": "4.13.0",
+        "mjml-group": "4.13.0",
+        "mjml-head": "4.13.0",
+        "mjml-head-attributes": "4.13.0",
+        "mjml-head-breakpoint": "4.13.0",
+        "mjml-head-font": "4.13.0",
+        "mjml-head-html-attributes": "4.13.0",
+        "mjml-head-preview": "4.13.0",
+        "mjml-head-style": "4.13.0",
+        "mjml-head-title": "4.13.0",
+        "mjml-hero": "4.13.0",
+        "mjml-image": "4.13.0",
+        "mjml-navbar": "4.13.0",
+        "mjml-raw": "4.13.0",
+        "mjml-section": "4.13.0",
+        "mjml-social": "4.13.0",
+        "mjml-spacer": "4.13.0",
+        "mjml-table": "4.13.0",
+        "mjml-text": "4.13.0",
+        "mjml-wrapper": "4.13.0"
+      }
+    },
+    "node_modules/mjml-raw": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-4.13.0.tgz",
+      "integrity": "sha512-JbBYxwX1a/zbqnCrlDCRNqov2xqUrMCaEdTHfqE2athj479aQXvLKFM20LilTMaClp/dR0yfvFLfFVrC5ej4FQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
     "node_modules/mjml-react": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/mjml-react/-/mjml-react-2.0.8.tgz",
@@ -19913,6 +20453,75 @@
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
       "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+    },
+    "node_modules/mjml-section": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-4.13.0.tgz",
+      "integrity": "sha512-BLcqlhavtRakKtzDQPLv6Ae4Jt4imYWq/P0jo+Sjk7tP4QifgVA2KEQOirPK5ZUqw/lvK7Afhcths5rXZ2ItnQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-social": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-4.13.0.tgz",
+      "integrity": "sha512-zL2a7Wwsk8OXF0Bqu+1B3La1UPwdTMcEXptO8zdh2V5LL6Xb7Gfyvx6w0CmmBtG5IjyCtqaKy5wtrcpG9Hvjfg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-spacer": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-4.13.0.tgz",
+      "integrity": "sha512-Acw4QJ0MJ38W4IewXuMX7hLaW1BZaln+gEEuTfrv0xwPdTxX1ILqz4r+s9mYMxYkIDLWMCjBvXyQK6aWlid13A==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-table": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-4.13.0.tgz",
+      "integrity": "sha512-UAWPVMaGReQhf776DFdiwdcJTIHTek3zzQ1pb+E7VlypEYgIpFvdUJ39UIiiflhqtdBATmHwKBOtePwU0MzFMg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-text": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-4.13.0.tgz",
+      "integrity": "sha512-uDuraaQFdu+6xfuigCimbeznnOnJfwRdcCL1lTBTusTuEvW/5Va6m2D3mnMeEpl+bp4+cxesXIz9st6A9pcg5A==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "node_modules/mjml-validator": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-4.13.0.tgz",
+      "integrity": "sha512-uURYfyQYtHJ6Qz/1A7/+E9ezfcoISoLZhYK3olsxKRViwaA2Mm8gy/J3yggZXnsUXWUns7Qymycm5LglLEIiQg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6"
+      }
+    },
+    "node_modules/mjml-wrapper": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-4.13.0.tgz",
+      "integrity": "sha512-p/44JvHg04rAFR7QDImg8nZucEokIjFH6KJMHxsO0frJtLZ+IuakctzlZAADHsqiR52BwocDsXSa+o9SE2l6Ng==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0",
+        "mjml-section": "4.13.0"
+      }
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -20216,6 +20825,14 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node_modules/no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dependencies": {
+        "lower-case": "^1.1.1"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.15.0.tgz",
@@ -20320,11 +20937,24 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
       "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
     },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20365,7 +20995,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
       "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
-      "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -20730,6 +21359,14 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
       "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
+    "node_modules/param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==",
+      "dependencies": {
+        "no-case": "^2.2.0"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -20778,8 +21415,15 @@
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
     },
     "node_modules/parseley": {
       "version": "0.7.0",
@@ -21526,6 +22170,11 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+    },
     "node_modules/protobufjs": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
@@ -21550,6 +22199,11 @@
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
       }
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -22361,7 +23015,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -22539,6 +23192,14 @@
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/remarkable": {
@@ -23102,6 +23763,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -23225,6 +23891,14 @@
       "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
       "dependencies": {
         "readable-stream": "~1.0.31"
+      }
+    },
+    "node_modules/slick": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
+      "integrity": "sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/source-map": {
@@ -24710,6 +25384,17 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
+    "node_modules/uglify-js": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/uint8arrays": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
@@ -24903,6 +25588,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA=="
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -25025,6 +25715,14 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/valid-data-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-3.0.1.tgz",
+      "integrity": "sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/validator": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
@@ -25095,6 +25793,47 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-resource-inliner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-5.0.0.tgz",
+      "integrity": "sha512-AIihwH+ZmdHfkJm7BjSXiEClVt4zUFqX4YlFAzjL13wLtDuUneSaFvDBTbdYRecs35SiU7iNKbMnN+++wVfb6A==",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "escape-goat": "^3.0.0",
+        "htmlparser2": "^4.0.0",
+        "mime": "^2.4.6",
+        "node-fetch": "^2.6.0",
+        "valid-data-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/web-resource-inliner/node_modules/domhandler": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+      "dependencies": {
+        "domelementtype": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/web-resource-inliner/node_modules/htmlparser2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+      "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^3.0.0",
+        "domutils": "^2.0.0",
+        "entities": "^2.0.0"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -32844,6 +33583,11 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -32960,6 +33704,11 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
+    "ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
+    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -32986,7 +33735,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -33468,8 +34216,7 @@
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "bind-decorator": {
       "version": "1.0.11",
@@ -33550,8 +34297,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bowser": {
       "version": "2.11.0",
@@ -33770,6 +34516,15 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -33839,11 +34594,36 @@
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
+    "cheerio": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "requires": {
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "cheerio-select": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
+      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "requires": {
+        "css-select": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0"
+      }
+    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -33859,7 +34639,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -33902,6 +34681,21 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "clean-css": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
+      "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+      "requires": {
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -34197,6 +34991,15 @@
         }
       }
     },
+    "config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -34463,7 +35266,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
       "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
         "css-what": "^6.0.1",
@@ -34502,8 +35304,7 @@
     "css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
     },
     "css.escape": {
       "version": "1.5.1",
@@ -34766,6 +35567,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "dezalgo": {
       "version": "1.0.3",
@@ -35059,6 +35865,43 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+        }
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -35242,6 +36085,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "escape-goat": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
+      "integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -36752,7 +37600,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "fstream": {
@@ -37178,6 +38025,27 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "html-minifier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
+      "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+      "requires": {
+        "camel-case": "^3.0.0",
+        "clean-css": "^4.2.1",
+        "commander": "^2.19.0",
+        "he": "^1.2.0",
+        "param-case": "^2.1.1",
+        "relateurl": "^0.2.7",
+        "uglify-js": "^3.5.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
     "html-to-text": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.0.tgz",
@@ -37469,7 +38337,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -37549,8 +38416,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "4.0.0",
@@ -37576,7 +38442,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -39675,6 +40540,17 @@
         }
       }
     },
+    "js-beautify": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.4.tgz",
+      "integrity": "sha512-+b4A9c3glceZEmxyIbxDOYB0ZJdReLvyU1077RqKsO4dZx9FUHjTOJn8VHwpg33QoucIykOiYbh7MfqBOghnrA==",
+      "requires": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^0.15.3",
+        "glob": "^7.1.3",
+        "nopt": "^5.0.0"
+      }
+    },
     "js-file-download": {
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
@@ -39949,6 +40825,25 @@
           "requires": {
             "safe-buffer": "~5.1.0"
           }
+        }
+      }
+    },
+    "juice": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/juice/-/juice-7.0.0.tgz",
+      "integrity": "sha512-AjKQX31KKN+uJs+zaf+GW8mBO/f/0NqSh2moTMyvwBY+4/lXIYTU8D8I2h6BAV3Xnz6GGsbalUyFqbYMe+Vh+Q==",
+      "requires": {
+        "cheerio": "^1.0.0-rc.3",
+        "commander": "^5.1.0",
+        "mensch": "^0.3.4",
+        "slick": "^1.12.2",
+        "web-resource-inliner": "^5.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
         }
       }
     },
@@ -40553,6 +41448,11 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
+    },
     "lowlight": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
@@ -40721,6 +41621,11 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
+    "mensch": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/mensch/-/mensch-0.3.4.tgz",
+      "integrity": "sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g=="
+    },
     "merge-class-names": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.4.2.tgz",
@@ -40814,8 +41719,7 @@
     "mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
     },
     "mime-db": {
       "version": "1.52.0",
@@ -40892,6 +41796,322 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
     },
+    "mjml": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml/-/mjml-4.13.0.tgz",
+      "integrity": "sha512-OnFKESouLshz8DPFSb6M/dE8GkhiJnoy6LAam5TiLA1anAj24yQ2ZH388LtQoEkvTisqwiTmc9ejDh5ctnFaJQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "mjml-cli": "4.13.0",
+        "mjml-core": "4.13.0",
+        "mjml-migrate": "4.13.0",
+        "mjml-preset-core": "4.13.0",
+        "mjml-validator": "4.13.0"
+      }
+    },
+    "mjml-accordion": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-4.13.0.tgz",
+      "integrity": "sha512-E3yihZW5Oq2p+sWOcr8kWeRTROmiTYOGxB4IOxW/jTycdY07N3FX3e6vuh7Fv3rryHEUaydUQYto3ICVyctI7w==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-body": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-4.13.0.tgz",
+      "integrity": "sha512-S4HgwAuO9dEsyX9sr6WBf9/xr+H2ASVaLn22aurJm1S2Lvc1wifLPYBQgFmNdCjaesTCNtOMUDpG+Rbnavyaqg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-button": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-4.13.0.tgz",
+      "integrity": "sha512-3y8IAHCCxh7ESHh1aOOqobZKUgyNxOKAGQ9TlJoyaLpsKUFzkN8nmrD0KXF0ADSuzvhMZ1CdRIJuZ5mjv2TwWQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-carousel": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-4.13.0.tgz",
+      "integrity": "sha512-ORSY5bEYlMlrWSIKI/lN0Tz3uGltWAjG8DQl2Yr3pwjwOaIzGE+kozrDf+T9xItfiIIbvKajef1dg7B7XgP0zg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-cli": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-4.13.0.tgz",
+      "integrity": "sha512-kAZxpH0QqlTF/CcLzELgKw1ljKRxrmWJ310CJQhbPAxHvwQ/nIb+q82U+zRJAelRPPKjnOb+hSrMRqTgk9rH3w==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "chokidar": "^3.0.0",
+        "glob": "^7.1.1",
+        "html-minifier": "^4.0.0",
+        "js-beautify": "^1.6.14",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0",
+        "mjml-migrate": "4.13.0",
+        "mjml-parser-xml": "4.13.0",
+        "mjml-validator": "4.13.0",
+        "yargs": "^16.1.0"
+      }
+    },
+    "mjml-column": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-4.13.0.tgz",
+      "integrity": "sha512-O8FrWKK/bCy9XpKxrKRYWNdgWNaVd4TK4RqMeVI/I70IbnYnc1uf15jnsPMxCBSbT+NyXyk8k7fn099797uwpw==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-4.13.0.tgz",
+      "integrity": "sha512-kU5AoVTlZaXR/EDi3ix66xpzUe+kScYus71lBH/wo/B+LZW70GHE1AYWtsog5oJp1MuTHpMFTNuBD/wePeEgWg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "cheerio": "1.0.0-rc.10",
+        "detect-node": "2.0.4",
+        "html-minifier": "^4.0.0",
+        "js-beautify": "^1.6.14",
+        "juice": "^7.0.0",
+        "lodash": "^4.17.21",
+        "mjml-migrate": "4.13.0",
+        "mjml-parser-xml": "4.13.0",
+        "mjml-validator": "4.13.0"
+      }
+    },
+    "mjml-divider": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-4.13.0.tgz",
+      "integrity": "sha512-ooPCwfmxEC+wJduqObYezMp7W5UCHjL9Y1LPB5FGna2FrOejgfd6Ix3ij8Wrmycmlol7E2N4D7c5NDH5DbRCJg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-group": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-4.13.0.tgz",
+      "integrity": "sha512-U7E8m8aaoAE/dMqjqXPjjrKcwO36B4cquAy9ASldECrIZJBcpFYO6eYf5yLXrNCUM2P0id8pgVjrUq23s00L7Q==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-head": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-4.13.0.tgz",
+      "integrity": "sha512-sL2qQuoVALXBCiemu4DPo9geDr8DuUdXVJxm+4nd6k5jpLCfSDmFlNhgSsLPzsYn7VEac3/sxsjLtomQ+6/BHg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-head-attributes": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-4.13.0.tgz",
+      "integrity": "sha512-haggCafno+0lQylxJStkINCVCPMwfTpwE6yjCHeGOpQl/TkoNmjNkDr7DEEbNTZbt4Ekg070lQFn7clDy38EoA==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-head-breakpoint": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-4.13.0.tgz",
+      "integrity": "sha512-D2iPDeUKQK1+rYSNa2HGOvgfPxZhNyndTG0iBEb/FxdGge2hbeDCZEN0mwDYE3wWB+qSBqlCuMI+Vr4pEjZbKg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-head-font": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-4.13.0.tgz",
+      "integrity": "sha512-mYn8aWnbrEap5vX2b4662hkUv6WifcYzYn++Yi6OHrJQi55LpzcU+myAGpfQEXXrpU8vGwExMTFKsJq5n2Kaow==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-head-html-attributes": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-4.13.0.tgz",
+      "integrity": "sha512-m30Oro297+18Zou/1qYjagtmCOWtYXeoS38OABQ5zOSzMItE3TcZI9JNcOueIIWIyFCETe8StrTAKcQ2GHwsDw==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-head-preview": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-4.13.0.tgz",
+      "integrity": "sha512-v0K/NocjFCbaoF/0IMVNmiqov91HxqT07vNTEl0Bt9lKFrTKVC01m1S4K7AB78T/bEeJ/HwmNjr1+TMtVNGGow==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-head-style": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-4.13.0.tgz",
+      "integrity": "sha512-tBa33GL9Atn5bAM2UwE+uxv4rI29WgX/e5lXX+5GWlsb4thmiN6rxpFTNqBqWbBNRbZk4UEZF78M7Da8xC1ZGQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-head-title": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-4.13.0.tgz",
+      "integrity": "sha512-Mq0bjuZXJlwxfVcjuYihQcigZSDTKeQaG3nORR1D0jsOH2BXU4XgUK1UOcTXn2qCBIfRoIMq7rfzYs+L0CRhdw==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-hero": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-4.13.0.tgz",
+      "integrity": "sha512-aWEOScdrhyjwdKBWG4XQaElRHP8LU5PtktkpMeBXa4yxrxNs25qRnDqMNkjSrnnmFKWZmQ166tfboY6RBNf0UA==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-image": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-4.13.0.tgz",
+      "integrity": "sha512-agMmm2wRZTIrKwrUnYFlnAbtrKYSP0R2en+Vf92HPspAwmaw3/AeOW/QxmSiMhfGf+xsEJyzVvR/nd33jbT3sg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-migrate": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-migrate/-/mjml-migrate-4.13.0.tgz",
+      "integrity": "sha512-I1euHiAyNpaz+B5vH+Z4T+hg/YtI5p3PqQ3/zTLv8gi24V6BILjTaftWhH5+3R/gQkQhH0NUaWNnRmds+Mq5DQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "js-beautify": "^1.6.14",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0",
+        "mjml-parser-xml": "4.13.0",
+        "yargs": "^16.1.0"
+      }
+    },
+    "mjml-navbar": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-4.13.0.tgz",
+      "integrity": "sha512-0Oqyyk+OdtXfsjswRb/7Ql1UOjN4MbqFPKoyltJqtj+11MRpF5+Wjd74Dj9H7l81GFwkIB9OaP+ZMiD+TPECgg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-parser-xml": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-4.13.0.tgz",
+      "integrity": "sha512-phljtI8DaW++q0aybR/Ykv9zCyP/jCFypxVNo26r2IQo//VYXyc7JuLZZT8N/LAI8lZcwbTVxQPBzJTmZ5IfwQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "detect-node": "2.0.4",
+        "htmlparser2": "^4.1.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "htmlparser2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "domutils": "^2.0.0",
+            "entities": "^2.0.0"
+          }
+        }
+      }
+    },
+    "mjml-preset-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-4.13.0.tgz",
+      "integrity": "sha512-gxzYaKkvUrHuzT1oqjEPSDtdmgEnN99Hf5f1r2CR5aMOB1x66EA3T8ATvF1o7qrBTVV4KMVlQem3IubMSYJZRw==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "mjml-accordion": "4.13.0",
+        "mjml-body": "4.13.0",
+        "mjml-button": "4.13.0",
+        "mjml-carousel": "4.13.0",
+        "mjml-column": "4.13.0",
+        "mjml-divider": "4.13.0",
+        "mjml-group": "4.13.0",
+        "mjml-head": "4.13.0",
+        "mjml-head-attributes": "4.13.0",
+        "mjml-head-breakpoint": "4.13.0",
+        "mjml-head-font": "4.13.0",
+        "mjml-head-html-attributes": "4.13.0",
+        "mjml-head-preview": "4.13.0",
+        "mjml-head-style": "4.13.0",
+        "mjml-head-title": "4.13.0",
+        "mjml-hero": "4.13.0",
+        "mjml-image": "4.13.0",
+        "mjml-navbar": "4.13.0",
+        "mjml-raw": "4.13.0",
+        "mjml-section": "4.13.0",
+        "mjml-social": "4.13.0",
+        "mjml-spacer": "4.13.0",
+        "mjml-table": "4.13.0",
+        "mjml-text": "4.13.0",
+        "mjml-wrapper": "4.13.0"
+      }
+    },
+    "mjml-raw": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-4.13.0.tgz",
+      "integrity": "sha512-JbBYxwX1a/zbqnCrlDCRNqov2xqUrMCaEdTHfqE2athj479aQXvLKFM20LilTMaClp/dR0yfvFLfFVrC5ej4FQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
     "mjml-react": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/mjml-react/-/mjml-react-2.0.8.tgz",
@@ -40931,6 +42151,75 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
         }
+      }
+    },
+    "mjml-section": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-4.13.0.tgz",
+      "integrity": "sha512-BLcqlhavtRakKtzDQPLv6Ae4Jt4imYWq/P0jo+Sjk7tP4QifgVA2KEQOirPK5ZUqw/lvK7Afhcths5rXZ2ItnQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-social": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-4.13.0.tgz",
+      "integrity": "sha512-zL2a7Wwsk8OXF0Bqu+1B3La1UPwdTMcEXptO8zdh2V5LL6Xb7Gfyvx6w0CmmBtG5IjyCtqaKy5wtrcpG9Hvjfg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-spacer": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-4.13.0.tgz",
+      "integrity": "sha512-Acw4QJ0MJ38W4IewXuMX7hLaW1BZaln+gEEuTfrv0xwPdTxX1ILqz4r+s9mYMxYkIDLWMCjBvXyQK6aWlid13A==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-table": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-4.13.0.tgz",
+      "integrity": "sha512-UAWPVMaGReQhf776DFdiwdcJTIHTek3zzQ1pb+E7VlypEYgIpFvdUJ39UIiiflhqtdBATmHwKBOtePwU0MzFMg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-text": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-4.13.0.tgz",
+      "integrity": "sha512-uDuraaQFdu+6xfuigCimbeznnOnJfwRdcCL1lTBTusTuEvW/5Va6m2D3mnMeEpl+bp4+cxesXIz9st6A9pcg5A==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0"
+      }
+    },
+    "mjml-validator": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-4.13.0.tgz",
+      "integrity": "sha512-uURYfyQYtHJ6Qz/1A7/+E9ezfcoISoLZhYK3olsxKRViwaA2Mm8gy/J3yggZXnsUXWUns7Qymycm5LglLEIiQg==",
+      "requires": {
+        "@babel/runtime": "^7.14.6"
+      }
+    },
+    "mjml-wrapper": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-4.13.0.tgz",
+      "integrity": "sha512-p/44JvHg04rAFR7QDImg8nZucEokIjFH6KJMHxsO0frJtLZ+IuakctzlZAADHsqiR52BwocDsXSa+o9SE2l6Ng==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "lodash": "^4.17.21",
+        "mjml-core": "4.13.0",
+        "mjml-section": "4.13.0"
       }
     },
     "mkdirp": {
@@ -41159,6 +42448,14 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
     "node-abi": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.15.0.tgz",
@@ -41230,11 +42527,18 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
       "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
     },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "requires": {
+        "abbrev": "1"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -41268,7 +42572,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
       "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
-      "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
       }
@@ -41534,6 +42837,14 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
       "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -41569,8 +42880,15 @@
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "requires": {
+        "parse5": "^6.0.1"
+      }
     },
     "parseley": {
       "version": "0.7.0",
@@ -42130,6 +43448,11 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+    },
     "protobufjs": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
@@ -42149,6 +43472,11 @@
         "@types/node": ">=13.7.0",
         "long": "^4.0.0"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "psl": {
       "version": "1.8.0",
@@ -42743,7 +44071,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -42880,6 +44207,11 @@
           "dev": true
         }
       }
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
     },
     "remarkable": {
       "version": "2.0.1",
@@ -43300,6 +44632,11 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -43382,6 +44719,11 @@
       "requires": {
         "readable-stream": "~1.0.31"
       }
+    },
+    "slick": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
+      "integrity": "sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A=="
     },
     "source-map": {
       "version": "0.5.7",
@@ -44481,6 +45823,11 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
+    "uglify-js": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw=="
+    },
     "uint8arrays": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
@@ -44639,6 +45986,11 @@
         }
       }
     },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA=="
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -44747,6 +46099,11 @@
         "convert-source-map": "^1.6.0"
       }
     },
+    "valid-data-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-3.0.1.tgz",
+      "integrity": "sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA=="
+    },
     "validator": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
@@ -44805,6 +46162,40 @@
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
+      }
+    },
+    "web-resource-inliner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-5.0.0.tgz",
+      "integrity": "sha512-AIihwH+ZmdHfkJm7BjSXiEClVt4zUFqX4YlFAzjL13wLtDuUneSaFvDBTbdYRecs35SiU7iNKbMnN+++wVfb6A==",
+      "requires": {
+        "ansi-colors": "^4.1.1",
+        "escape-goat": "^3.0.0",
+        "htmlparser2": "^4.0.0",
+        "mime": "^2.4.6",
+        "node-fetch": "^2.6.0",
+        "valid-data-url": "^3.0.0"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "htmlparser2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "domutils": "^2.0.0",
+            "entities": "^2.0.0"
+          }
+        }
       }
     },
     "web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "marked": "^4.0.12",
     "material-ui-popup-state": "^2.0.0",
     "millify": "^4.0.0",
+    "mjml": "^4.13.0",
     "mjml-react": "^2.0.8",
     "nanoevents": "^6.0.2",
     "next": "^12.1.6",


### PR DESCRIPTION
looks like we never had mjml declraed as a dependency, but we are supposed to according to the react-mjml docs. It was working because it was somehow listed in package-lock.json until I upgrade Prisma.  I think I used a more recent version of npm (v8.11) which cleaned out undeclared dependencies like mjml :/

 I Found that I can trigger the error by vising https://app.charmverse.io/api/email-templates, so added a test on that endpoint

