### PR TITLE
fix extra space on focalboard in mobile view

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/gallery/gallery.scss
+++ b/components/common/BoardEditor/focalboard/src/components/gallery/gallery.scss
@@ -8,13 +8,18 @@
         border-radius: var(--default-rad);
         color: rgba(var(--center-channel-color-rgb), 0.3);
         cursor: pointer;
-        width: 280px;
         min-height: 160px;
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: center;
         margin-bottom: 10px;
+
+        width: 100%;
+        @media screen and (min-width: 600px) {
+          width: 280px;
+        }
+
 
         &.selected {
             background-color: rgba(90, 200, 255, 0.2);

--- a/components/common/BoardEditor/focalboard/src/components/gallery/galleryCard.scss
+++ b/components/common/BoardEditor/focalboard/src/components/gallery/galleryCard.scss
@@ -2,12 +2,16 @@
     position: relative;
     border: 1px solid rgba(var(--center-channel-color-rgb), 0.09);
     border-radius: var(--default-rad);
-    width: 280px;
+    width: 100%;
     display: flex;
     flex-direction: column;
-    margin-right: 10px;
     margin-bottom: 10px;
     cursor: pointer;
+
+    @media screen and (min-width: 600px) {
+      width: 280px;
+      margin-right: 10px;
+    }
 
     // HACK: Fixes Chrome drag and drop preview
     transform: translate3d(0, 0, 0);

--- a/components/common/BoardEditor/focalboard/src/components/viewTitle.scss
+++ b/components/common/BoardEditor/focalboard/src/components/viewTitle.scss
@@ -38,6 +38,7 @@
         margin-bottom: 0;
         flex-grow: 1;
         margin-bottom: 0px;
+        width: 100%;
     }
 
     .description {

--- a/components/common/BoardEditor/focalboard/src/components/viewTitle.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewTitle.tsx
@@ -24,7 +24,7 @@ type Props = {
     setPage: (page: Partial<Page>) => void
 }
 
-const ViewTitle = React.memo((props: Props) => {
+const ViewTitle = (props: Props) => {
     const {board} = props
 
     const [title, setTitle] = useState(board.title)
@@ -131,6 +131,6 @@ const ViewTitle = React.memo((props: Props) => {
             }
         </div>
     )
-})
+}
 
-export default ViewTitle
+export default React.memo(ViewTitle)


### PR DESCRIPTION
On mobile, you can scroll the focalboard view left and right  even though it's just whitespace. I figured out it was the title input being 500+ pixels wide was stretching the page. I don't know why it is that wide by default, but setting it to 100% fixes the problem. I found that normally it has a "100% width" when it's a child of CardDetail, so I figure this is a safe update.