### PR TITLE
remove admin bypass when viewing permission for a bounty

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties.tsx
@@ -370,7 +370,7 @@ export default function BountyProperties (props: {children: ReactNode, readOnly?
         }
       }}
     >
-      {permissions && (user?.id === bounty.createdBy || isAdmin) && (
+      {permissions && (user?.id === bounty.createdBy) && (
         <BountyHeader
           bounty={bounty}
           permissions={permissions}

--- a/pages/api/bounties/[id]/permissions.ts
+++ b/pages/api/bounties/[id]/permissions.ts
@@ -21,7 +21,7 @@ async function computeBountyGroupPermissionsController (req: NextApiRequest, res
 
   const [permissions, groups] = await Promise.all([
     computeBountyPermissions({
-      allowAdminBypass: true,
+      allowAdminBypass: false,
       resourceId: bounty.id,
       userId
     }),


### PR DESCRIPTION
We don't want to take 'admin' status into account when letting someone apply to a bounty. I think this is the only place I actually need to change?

I'm not sure what we've discussed thus far, but maybe we can just remove the admin override to bounty permissions since they already have the ability to delete the page itself.