### PR TITLE
fix saving votes from inside a card

### DIFF
--- a/components/[pageId]/DocumentPage/components/CreateVoteBox.tsx
+++ b/components/[pageId]/DocumentPage/components/CreateVoteBox.tsx
@@ -2,11 +2,8 @@ import { useState } from 'react';
 import { Card, Stack, Typography } from '@mui/material';
 import Button from 'components/common/PrimaryButton';
 import CreateVoteModal from 'components/votes/components/CreateVoteModal';
-import { useVotes } from 'hooks/useVotes';
 
 export default function CreateVoteBox () {
-
-  const { createVote } = useVotes();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -25,10 +22,9 @@ export default function CreateVoteBox () {
         </Stack>
       </Card>
       <CreateVoteModal
-        createVote={createVote}
         isProposal={true}
         open={isModalOpen}
-        postCreateVote={() => {
+        onCreateVote={() => {
           setIsModalOpen(false);
         }}
         onClose={() => {

--- a/components/common/CharmEditor/components/inlineVote/components/InlineVoteSubmenu.tsx
+++ b/components/common/CharmEditor/components/inlineVote/components/InlineVoteSubmenu.tsx
@@ -3,20 +3,17 @@ import { useEditorViewContext } from '@bangle.dev/react';
 import { hideSelectionTooltip } from '@bangle.dev/tooltip/selection-tooltip';
 
 import CreateVoteModal from 'components/votes/components/CreateVoteModal';
-import { useVotes } from 'hooks/useVotes';
 import { updateInlineVote } from '../inlineVote.utils';
 
 export default function InlineVoteSubMenu ({ pluginKey }: { pluginKey: PluginKey }) {
   const view = useEditorViewContext();
-  const { createVote } = useVotes();
 
   return (
     <CreateVoteModal
-      createVote={createVote}
       onClose={() => {
         hideSelectionTooltip(pluginKey)(view.state, view.dispatch, view);
       }}
-      postCreateVote={(vote) => {
+      onCreateVote={(vote) => {
         updateInlineVote(vote.id)(view.state, view.dispatch);
         hideSelectionTooltip(pluginKey)(view.state, view.dispatch, view);
         const tr = view.state.tr.setSelection(new TextSelection(view.state.doc.resolve(view.state.selection.$to.pos)));

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -54,7 +54,7 @@ export const AppBar = styled(MuiAppBar, { shouldForwardProp: (prop: string) => p
   ` : ''}
 `;
 
-const Drawer = styled(MuiDrawer, { shouldForwardProp: prop => prop !== 'open' && prop !== 'sidebarWidth' && prop !== 'hideSidebarOnSmallScreen' })
+const Drawer = styled(MuiDrawer, { shouldForwardProp: prop => prop !== 'open' && prop !== 'sidebarWidth' })
   // @ts-ignore mixin isnt typesafe
   // eslint-disable-next-line no-unexpected-multiline
   <{ open: boolean, sidebarWidth: number }>(({ sidebarWidth, theme, open }) => ({

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -30,7 +30,6 @@ import { generateMarkdown } from 'lib/pages/generateMarkdown';
 import { useRouter } from 'next/router';
 import { useRef, useState } from 'react';
 import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
-import { useVotes } from 'hooks/useVotes';
 import CreateVoteModal from 'components/votes/components/CreateVoteModal';
 import Account from '../Account';
 import ShareButton from '../ShareButton';
@@ -49,16 +48,14 @@ export const StyledToolbar = styled(Toolbar)`
 interface HeaderProps {
   open: boolean;
   openSidebar: () => void;
-  hideSidebarOnSmallScreen?: boolean;
 }
 
-export default function Header ({ open, openSidebar, hideSidebarOnSmallScreen }: HeaderProps) {
+export default function Header ({ open, openSidebar }: HeaderProps) {
   const router = useRouter();
   const colorMode = useColorMode();
   const { pages, currentPageId, setPages } = usePages();
   const [user, setUser] = useUser();
   const theme = useTheme();
-  const { createVote } = useVotes();
   const [pageMenuOpen, setPageMenuOpen] = useState(false);
   const [pageMenuAnchorElement, setPageMenuAnchorElement] = useState<null | Element>(null);
   const pageMenuAnchor = useRef();
@@ -283,9 +280,8 @@ export default function Header ({ open, openSidebar, hideSidebarOnSmallScreen }:
       {/** inject the modal based on open status so it resets the form each time */}
       {isModalOpen && (
         <CreateVoteModal
-          createVote={createVote}
           open={isModalOpen}
-          postCreateVote={() => {
+          onCreateVote={() => {
             setIsModalOpen(false);
           }}
           onClose={() => {

--- a/components/votes/components/CreateVoteModal.tsx
+++ b/components/votes/components/CreateVoteModal.tsx
@@ -5,10 +5,11 @@ import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import Button from 'components/common/Button';
 import FieldLabel from 'components/common/form/FieldLabel';
 import Modal from 'components/common/Modal';
-import { VoteDTO, ExtendedVote } from 'lib/votes/interfaces';
+import { ExtendedVote } from 'lib/votes/interfaces';
 import { DateTime } from 'luxon';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { usePages } from 'hooks/usePages';
+import { useVotes } from 'hooks/useVotes';
 import AddCircle from '@mui/icons-material/AddCircle';
 import DeleteIcon from '@mui/icons-material/Delete';
 
@@ -78,19 +79,20 @@ function InlineVoteOptions (
 
 interface CreateVoteModalProps {
   onClose?: () => void;
-  createVote: (votePayload: Omit<VoteDTO, 'createdBy' | 'spaceId'>) => Promise<ExtendedVote>;
-  postCreateVote?: (vote: ExtendedVote) => void;
+  onCreateVote?: (vote: ExtendedVote) => void;
   open?: boolean;
   isProposal?: boolean;
 }
 
-export default function CreateVoteModal ({ open = true, onClose, createVote, postCreateVote, isProposal }: CreateVoteModalProps) {
+export default function CreateVoteModal ({ open = true, onClose, onCreateVote, isProposal }: CreateVoteModalProps) {
   const [voteTitle, setVoteTitle] = useState('');
   const [voteDescription, setVoteDescription] = useState('');
   const [passThreshold, setPassThreshold] = useState<number>(50);
   const [voteType, setVoteType] = useState<VoteType>(VoteType.Approval);
   const [options, setOptions] = useState<{ name: string }[]>([]);
   const [isDateTimePickerOpen, setIsDateTimePickerOpen] = useState(false);
+
+  const { createVote } = useVotes();
 
   useEffect(() => {
     if (voteType === VoteType.SingleChoice) {
@@ -128,8 +130,8 @@ export default function CreateVoteModal ({ open = true, onClose, createVote, pos
       type: voteType
     });
 
-    if (postCreateVote) {
-      postCreateVote(vote);
+    if (onCreateVote) {
+      onCreateVote(vote);
     }
   };
 

--- a/hooks/useVotes.tsx
+++ b/hooks/useVotes.tsx
@@ -87,7 +87,7 @@ export function VotesProvider ({ children }: { children: ReactNode }) {
     const extendedVote = await charmClient.createVote({
       ...votePayload,
       createdBy: user.id,
-      pageId: cardId ?? currentPageId,
+      pageId: votePayload.pageId ?? cardId ?? currentPageId,
       spaceId: currentSpace.id
     });
 

--- a/hooks/useVotes.tsx
+++ b/hooks/useVotes.tsx
@@ -87,7 +87,6 @@ export function VotesProvider ({ children }: { children: ReactNode }) {
     const extendedVote = await charmClient.createVote({
       ...votePayload,
       createdBy: user.id,
-      pageId: votePayload.pageId ?? cardId ?? currentPageId,
       spaceId: currentSpace.id
     });
 


### PR DESCRIPTION
I noticed I couldn't save a new vote when looking at a card view inside of focalboard. It's because the pageId was 'null' inside the hook - it doesn't seem to get upated when the URL changes.

I also moved the call to useVotes for `createVote` into the modal component because all the parents were having to do the same logic.