### PR TITLE
Fetch individual discord user when importing roles

### DIFF
--- a/components/integrations/components/DiscordProvider.tsx
+++ b/components/integrations/components/DiscordProvider.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { useUser } from 'hooks/useUser';
 import log from 'lib/log';
-import { getCookie, deleteCookie } from 'lib/browser';
+import { getCookie, deleteCookie, silentlyUpdateURL } from 'lib/browser';
 import { AUTH_CODE_COOKIE, AUTH_ERROR_COOKIE } from 'lib/discord/constants';
 
 interface State {
@@ -84,6 +84,7 @@ export default function DiscordProvider ({ children }: Props) {
           setDiscordError(err.message || err.error || 'Something went wrong. Please try again');
         })
         .finally(() => {
+          silentlyUpdateURL(window.location.href.split('?')[0]);
           setIsConnectDiscordLoading(false);
         });
     }

--- a/pages/api/discord/importRoles.ts
+++ b/pages/api/discord/importRoles.ts
@@ -7,7 +7,6 @@ import { handleDiscordResponse } from 'lib/discord/handleDiscordResponse';
 import { findOrCreateRoles } from 'lib/roles/createRoles';
 import { assignRolesFromDiscord, DiscordGuildMember } from 'lib/discord/assignRoles';
 import { DiscordServerRole } from 'lib/discord/interface';
-import { RateLimit } from 'async-sema';
 
 const handler = nc({
   onError,
@@ -20,8 +19,6 @@ export interface ImportDiscordRolesPayload {
 }
 
 export type ImportRolesResponse = { importedRoleCount: number };
-
-const MEMBERS_PER_REQUEST = 100;
 
 async function importRoles (req: NextApiRequest, res: NextApiResponse<ImportRolesResponse | { error: string }>) {
   const { spaceId, guildId } = req.body as ImportDiscordRolesPayload;
@@ -55,34 +52,41 @@ async function importRoles (req: NextApiRequest, res: NextApiResponse<ImportRole
     return;
   }
 
-  let lastUserId = '0';
-  let discordGuildMembersResponse = await handleDiscordResponse<DiscordGuildMember[]>(`https://discord.com/api/v8/guilds/${guildId}/members?limit=${MEMBERS_PER_REQUEST}`);
-
-  while (discordGuildMembersResponse.status === 'success' && discordGuildMembersResponse.data.length > 0) {
-    discordGuildMembers.push(...discordGuildMembersResponse.data);
-    const guildMember = discordGuildMembersResponse.data[discordGuildMembersResponse.data.length - 1];
-    if (!guildMember.user) {
-      throw new Error('Guild member does not have a user property');
-    }
-    lastUserId = guildMember.user.id;
-    discordGuildMembersResponse = await handleDiscordResponse<DiscordGuildMember[]>(`https://discord.com/api/v8/guilds/${guildId}/members?limit=${MEMBERS_PER_REQUEST}&after=${lastUserId}`);
-  }
-
-  if (discordGuildMembersResponse.status !== 'success') {
-    res.status(discordGuildMembersResponse.status).json({ error: discordGuildMembersResponse.error });
-  }
-  else {
-    const rolesRecord = await findOrCreateRoles(discordServerRoles, spaceId, req.session.user.id);
-    // Remove the roles imported from guild.xyz
-    for (const roleId of Object.keys(rolesRecord)) {
-      const role = rolesRecord[roleId];
-      if (role?.sourceId && role.source === 'guild_xyz') {
-        delete rolesRecord[roleId];
+  const discordConnectedMembers = await prisma.user.findMany({
+    where: {
+      spaceRoles: {
+        some: {
+          spaceId
+        }
+      },
+      discordUser: {
+        isNot: null
       }
+    },
+    select: {
+      discordUser: {
+        select: {
+          discordId: true
+        }
+      },
+      id: true
     }
-    await assignRolesFromDiscord(rolesRecord, discordGuildMembers, spaceId);
-    res.status(200).json({ importedRoleCount: discordServerRoles.length });
+  });
+
+  // TODO: How to handle error fetching a single user
+  const discordGuildMemberResponses = await Promise.all(discordConnectedMembers.map(discordConnectedMember => (handleDiscordResponse<DiscordGuildMember>(`https://discord.com/api/v8/guilds/${guildId}/members/${discordConnectedMember.discordUser!.discordId}`) as Promise<{status: 'success', data: DiscordGuildMember}>)));
+  discordGuildMembers.push(...discordGuildMemberResponses.filter(discordGuildMemberResponse => discordGuildMemberResponse.status === 'success').map((discordGuildMemberResponse) => discordGuildMemberResponse.data));
+
+  const rolesRecord = await findOrCreateRoles(discordServerRoles, spaceId, req.session.user.id);
+  // Remove the roles imported from guild.xyz
+  for (const roleId of Object.keys(rolesRecord)) {
+    const role = rolesRecord[roleId];
+    if (role?.sourceId && role.source === 'guild_xyz') {
+      delete rolesRecord[roleId];
+    }
   }
+  await assignRolesFromDiscord(rolesRecord, discordGuildMembers, spaceId);
+  res.status(200).json({ importedRoleCount: discordServerRoles.length });
 }
 
 handler.use(requireUser).use(requireSpaceMembership({ adminOnly: true })).post(importRoles);


### PR DESCRIPTION
Some considerations
1. Fetching all users that have their discord account connected to charmverse for a specific space could cause some bottleneck if there are lots of them. Should we be careful about that or is that something we can skip for now?
2. How to handle the case when failing to fetch an individual user? When the import is done should there be a message that says failed to import/connect `X` users?
3. Right now as soon as you authorize your server the import starts and you are redirected to where you came from (settings/roles), and we show a loader underneath the `Roles` section indicating that roles are being imported. Should that be more prominent via a modal that says `Discord roles import is in progress. Please wait...`? 