### PR TITLE
Refactor useUser to return object

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
@@ -49,7 +49,7 @@ export default function BountyProperties (props: {
   const [currentBounty, setCurrentBounty] = useState<(BountyCreationData & BountyWithDetails) | null>(null);
   const [capSubmissions, setCapSubmissions] = useState(currentBounty?.maxSubmissions !== null);
   const [space] = useCurrentSpace();
-  const [user] = useUser();
+  const { user } = useUser();
   const { setPages, pages } = usePages();
 
   const bountyPermissions = permissions?.bountyPermissions || currentBounty?.permissions;

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantForm/BountyApplicantForm.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantForm/BountyApplicantForm.tsx
@@ -21,7 +21,7 @@ export default function BountyApplicantForm (props: BountyApplicationFormProps) 
   const { refreshSubmissions, bounty, permissions, submissions } = props;
   const { refreshBounty } = useBounties();
   const [contributors] = useContributors();
-  const [user,, isUserLoaded] = useUser();
+  const { user, isLoaded: isUserLoaded } = useUser();
   const [showApplication, setShowApplication] = useState(false);
   const userApplication = submissions.find(s => s.createdBy === user?.id);
 

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantForm/components/ApplicationInput.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantForm/components/ApplicationInput.tsx
@@ -40,7 +40,7 @@ type FormValues = yup.InferType<typeof schema>;
 export default function ApplicationInput ({ readOnly = false, onCancel, onSubmit, bountyId, proposal, mode = 'create', alwaysExpanded, expandedOnLoad }: IApplicationFormProps) {
   const { refreshBounty } = useBounties();
   const [isVisible, setIsVisible] = useState(mode === 'create' || expandedOnLoad || alwaysExpanded);
-  const [user] = useUser();
+  const { user } = useUser();
 
   const [applicationMessage, setApplicationMessage] = useLocalStorage(`${bountyId}.${user?.id}.application`, '');
 

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantForm/components/BountySignupButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantForm/components/BountySignupButton.tsx
@@ -15,7 +15,7 @@ import charmClient from 'charmClient';
 export default function BountySignupButton () {
 
   const { account } = useWeb3React();
-  const [user, setUser] = useUser();
+  const { user, setUser } = useUser();
   const [space] = useCurrentSpace();
   const loginViaTokenGateModal = usePopupState({ variant: 'popover', popupId: 'login-via-token-gate' });
   const { openWalletSelectorModal } = useContext(Web3Connection);

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantForm/components/SubmissionInput.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantForm/components/SubmissionInput.tsx
@@ -47,7 +47,7 @@ interface Props {
 export default function SubmissionInput (
   { permissions, readOnly = false, submission, onSubmit: onSubmitProp, bountyId, alwaysExpanded, expandedOnLoad, onCancel = () => null }: Props
 ) {
-  const [user] = useUser();
+  const { user } = useUser();
   const [isVisible, setIsVisible] = useState(expandedOnLoad ?? alwaysExpanded ?? false);
 
   const {

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantTableRow.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantTableRow.tsx
@@ -44,7 +44,7 @@ export default function BountyApplicantTableRow ({
   refreshSubmissions
 }: Props) {
   const [contributors] = useContributors();
-  const [user] = useUser();
+  const { user } = useUser();
   const [isExpandedRow, setIsExpandedRow] = useState(false);
   const contributor = contributors.find(c => c.id === submission.createdBy);
   const { refreshBounty } = useBounties();

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantsTable.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantsTable.tsx
@@ -32,7 +32,7 @@ export default function BountySubmissionsTable ({ bounty, permissions }: Props) 
   const [applications, setListApplications] = useState<ApplicationWithTransactions[]>([]);
   const validSubmissions = countValidSubmissions(applications);
   const { refreshBounty } = useBounties();
-  const [user] = useUser();
+  const { user } = useUser();
 
   async function refreshSubmissions () {
     if (bounty) {

--- a/components/[pageId]/DocumentPage/components/CommentsSidebar.tsx
+++ b/components/[pageId]/DocumentPage/components/CommentsSidebar.tsx
@@ -68,7 +68,7 @@ function getCommentFromThreads (threads: (ThreadWithCommentsAndAuthors | undefin
 export default function CommentsSidebar ({ sx, inline, ...props }: BoxProps & {inline?: boolean}) {
 
   const { threads } = useThreads();
-  const [user] = useUser();
+  const { user } = useUser();
 
   const allThreads = Object.values(threads);
   const unResolvedThreads = allThreads.filter(thread => thread && !thread.resolved) as ThreadWithCommentsAndAuthors[];

--- a/components/[pageId]/EditorPage/EditorPage.tsx
+++ b/components/[pageId]/EditorPage/EditorPage.tsx
@@ -17,7 +17,7 @@ export default function EditorPage ({ pageId }: { pageId: string }) {
   const [pageNotFound, setPageNotFound] = useState(false);
   const [space] = useCurrentSpace();
   const [isAccessDenied, setIsAccessDenied] = useState(false);
-  const [user] = useUser();
+  const { user } = useUser();
   const currentPagePermissions = getPagePermissions(pageId);
 
   const pagesLoaded = Object.keys(pages).length > 0;

--- a/components/bounties/components/NewBountyButton.tsx
+++ b/components/bounties/components/NewBountyButton.tsx
@@ -11,7 +11,7 @@ import PageDialog from 'components/common/Page/PageDialog';
 import { usePages } from 'hooks/usePages';
 
 export default function NewBountyButton () {
-  const [user] = useUser();
+  const { user } = useUser();
   const [currentSpace] = useCurrentSpace();
   const [activeBountyPage, setActiveBountyPage] = useState<{page: Page, bounty: BountyWithDetails} | null>(null);
   const [currentUserPermissions] = useCurrentSpacePermissions();

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/commentsList.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/commentsList.tsx
@@ -23,7 +23,7 @@ type Props = {
 }
 
 const CommentsList = React.memo((props: Props) => {
-  const [currentUser] = useUser();
+  const {user} = useUser();
   const [contributors] = useContributors();
   const [editorKey, setEditorKey] = useState(0); // a key to allow us to reset charmeditor contents
 
@@ -51,8 +51,8 @@ const CommentsList = React.memo((props: Props) => {
       {!props.readonly && (
         <NewCommentInput
           key={editorKey}
-          avatar={currentUser?.avatar}
-          username={currentUser?.username}
+          avatar={user?.avatar}
+          username={user?.username}
           onSubmit={onSendClicked}
         />
       )}

--- a/components/common/BoardEditor/focalboard/src/components/cardDialog.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDialog.tsx
@@ -31,7 +31,7 @@ type Props = {
 function CreateBountyButton(props: { pageId: string }) {
   const { pageId } = props;
   const { createDraftBounty } = useBounties();
-  const [user] = useUser();
+  const { user } = useUser();
   const [space] = useCurrentSpace();
   const [userSpacePermissions] = useCurrentSpacePermissions();
 

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -348,7 +348,7 @@ function CharmEditor (
   // check empty state of page on first load
   const _isEmpty = checkForEmpty(content);
   const [isEmpty, setIsEmpty] = useState(_isEmpty);
-  const [currentUser] = useUser();
+  const { user } = useUser();
   // eslint-disable-next-line
   const onThreadResolveDebounced = debounce((pageId: string, doc: EditorState['doc'], prevDoc: EditorState['doc']) => {
     const deletedThreadIds = extractDeletedThreadIds(
@@ -399,7 +399,7 @@ function CharmEditor (
       enableVoting,
       pageId,
       spaceId: currentSpace?.id,
-      userId: currentUser?.id
+      userId: user?.id
     }),
     initialValue: content ? Node.fromJSON(specRegistry.schema, content) : '',
     dropCursorOpts: {

--- a/components/common/CharmEditor/InlineCharmEditor.tsx
+++ b/components/common/CharmEditor/InlineCharmEditor.tsx
@@ -142,7 +142,7 @@ export default function CharmEditor (
   CharmEditorProps
 ) {
   const [currentSpace] = useCurrentSpace();
-  const [currentUser] = useUser();
+  const { user } = useUser();
 
   const _isEmpty = !content || checkForEmpty(content);
   const [isEmpty, setIsEmpty] = useState(_isEmpty);
@@ -179,7 +179,7 @@ export default function CharmEditor (
       onContentChange: _onContentChange,
       readOnly,
       spaceId: currentSpace?.id,
-      userId: currentUser?.id
+      userId: user?.id
     }),
     initialValue,
     dropCursorOpts: {

--- a/components/common/CharmEditor/components/PageThread.tsx
+++ b/components/common/CharmEditor/components/PageThread.tsx
@@ -260,7 +260,7 @@ const CommentDate = memo<{createdAt: Date, updatedAt?: Date | null}>(({ createdA
 const PageThread = forwardRef<HTMLDivElement, PageThreadProps>(({ showFindButton = false, threadId, inline = false }, ref) => {
   showFindButton = showFindButton ?? (!inline);
   const { deleteThread, resolveThread, deleteComment, threads } = useThreads();
-  const [user] = useUser();
+  const { user } = useUser();
   const [isMutating, setIsMutating] = useState(false);
   const [editedCommentId, setEditedCommentId] = useState<null | string>(null);
   const { getPagePermissions, currentPageId } = usePages();

--- a/components/common/CharmEditor/components/inlineVote/components/VoteDetail.tsx
+++ b/components/common/CharmEditor/components/inlineVote/components/VoteDetail.tsx
@@ -42,7 +42,7 @@ const MAX_DESCRIPTION_LENGTH = 200;
 
 export default function VoteDetail ({ cancelVote, castVote, deleteVote, detailed = false, vote, isProposal }: VoteDetailProps) {
   const { deadline, totalVotes, description, id, title, userChoice, voteOptions, aggregatedResult } = vote;
-  const [user] = useUser();
+  const { user } = useUser();
   const view = useEditorViewContext();
   const { data: userVotes, mutate } = useSWR(detailed ? `/votes/${id}/user-votes` : null, () => charmClient.getUserVotes(id));
 

--- a/components/common/CharmEditor/components/nestedPage/hooks/useNestedPage.ts
+++ b/components/common/CharmEditor/components/nestedPage/hooks/useNestedPage.ts
@@ -11,7 +11,7 @@ import { Page } from '@prisma/client';
 
 export default function useNestedPage () {
   const [space] = useCurrentSpace();
-  const [user] = useUser();
+  const { user } = useUser();
   const { currentPageId } = usePages();
   const view = useEditorViewContext();
   const router = useRouter();

--- a/components/common/CreateSpaceForm.tsx
+++ b/components/common/CreateSpaceForm.tsx
@@ -47,7 +47,7 @@ interface Props {
 
 export default function WorkspaceSettings ({ defaultValues, onSubmit: _onSubmit, onCancel, submitText }: Props) {
 
-  const [user] = useUser();
+  const { user } = useUser();
   const [saveError, setSaveError] = useState<any | null>(null);
   const {
     register,

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -92,7 +92,7 @@ function PageLayout ({ sidebarWidth = 300, children, sidebar: SidebarOverride }:
 
   const smallScreen = React.useMemo(() => isSmallScreen(), []);
   const [open, setOpen] = React.useState(!smallScreen);
-  const [user] = useUser();
+  const { user } = useUser();
 
   const handleDrawerOpen = React.useCallback(() => {
     setOpen(true);

--- a/components/common/PageLayout/components/Account/Account.tsx
+++ b/components/common/PageLayout/components/Account/Account.tsx
@@ -56,7 +56,7 @@ function Account (): JSX.Element {
   const router = useRouter();
 
   const networkModalState = usePopupState({ variant: 'popover', popupId: 'network-modal' });
-  const [user, , isUserLoaded] = useUser();
+  const { user, isLoaded } = useUser();
 
   if (typeof window === 'undefined') {
     return (
@@ -66,7 +66,7 @@ function Account (): JSX.Element {
     );
   }
 
-  if (isUserLoaded && !user) {
+  if (isLoaded && !user) {
     return (
       <AccountCard>
         <AccountButton href='/'>

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -54,7 +54,7 @@ export default function Header ({ open, openSidebar }: HeaderProps) {
   const router = useRouter();
   const colorMode = useColorMode();
   const { pages, currentPageId, setPages } = usePages();
-  const [user, setUser] = useUser();
+  const { user, setUser } = useUser();
   const theme = useTheme();
   const [pageMenuOpen, setPageMenuOpen] = useState(false);
   const [pageMenuAnchorElement, setPageMenuAnchorElement] = useState<null | Element>(null);

--- a/components/common/PageLayout/components/Header/components/NotificationsBadge/NotificationsBadge.tsx
+++ b/components/common/PageLayout/components/Header/components/NotificationsBadge/NotificationsBadge.tsx
@@ -6,7 +6,7 @@ import { useUser } from 'hooks/useUser';
 
 export default function NotificationsBadge () {
 
-  const [user] = useUser();
+  const { user } = useUser();
   const { tasks } = useTasks();
 
   const userNotificationState = user?.notificationState;

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -90,7 +90,7 @@ function PageNavigation ({
   const router = useRouter();
   const { pages, currentPageId, setPages } = usePages();
   const [space] = useCurrentSpace();
-  const [user] = useUser();
+  const { user } = useUser();
   const [expanded, setExpanded] = useLocalStorage<string[]>(`${space!.id}.expanded-pages`, []);
 
   const pagesArray: MenuNode[] = filterVisiblePages(Object.values(pages))

--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -167,7 +167,7 @@ interface SidebarProps {
 
 export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
   const router = useRouter();
-  const [user] = useUser();
+  const { user } = useUser();
   const [space] = useCurrentSpace();
   const [userSpacePermissions] = useCurrentSpacePermissions();
   const [isScrolled, setIsScrolled] = useState(false);

--- a/components/common/PageLayout/components/Sidebar/Workspaces.tsx
+++ b/components/common/PageLayout/components/Sidebar/Workspaces.tsx
@@ -37,7 +37,7 @@ export default function Workspaces () {
   const [space] = useCurrentSpace();
   const [spaces, setSpaces] = useSpaces();
   const [spaceFormOpen, setSpaceFormOpen] = useState(false);
-  const [, setUser] = useUser();
+  const { setUser } = useUser();
 
   function showSpaceForm () {
     setSpaceFormOpen(true);

--- a/components/common/RouteGuard.tsx
+++ b/components/common/RouteGuard.tsx
@@ -20,11 +20,11 @@ export default function RouteGuard ({ children }: { children: ReactNode }) {
   const [authorized, setAuthorized] = useState(true);
   const { triedEager } = useContext(Web3Connection);
   const { account } = useWeb3React();
-  const [user, setUser, isUserRequestComplete] = useUser();
-  const [spaces, _, isSpacesLoaded] = useSpaces();
+  const { user, setUser, isLoaded } = useUser();
+  const [spaces,, isSpacesLoaded] = useSpaces();
   const isWalletLoading = (!triedEager && !account);
   const isRouterLoading = !router.isReady;
-  const isLoading = !isUserRequestComplete || isWalletLoading || isRouterLoading || !isSpacesLoaded;
+  const isLoading = !isLoaded || isWalletLoading || isRouterLoading || !isSpacesLoaded;
 
   if (typeof window !== 'undefined') {
     const pathSegments: string[] = router.asPath.split('?')[0].split('/').filter(segment => !!segment);

--- a/components/common/TokenGateForm/TokenGateForm.tsx
+++ b/components/common/TokenGateForm/TokenGateForm.tsx
@@ -27,7 +27,7 @@ export default function TokenGateForm ({ onSuccess, spaceDomain, joinButtonLabel
   const { account, chainId } = useWeb3React();
   const { showMessage } = useSnackbar();
   const [spaces, setSpaces] = useSpaces();
-  const [user, setUser] = useUser();
+  const { user, setUser } = useUser();
 
   const [tokenGates, setTokenGates] = useState<TokenGateWithRoles[] | null>(null);
 

--- a/components/integrations/components/DiscordProvider.tsx
+++ b/components/integrations/components/DiscordProvider.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 export default function DiscordProvider ({ children }: Props) {
 
-  const [user, setUser] = useUser();
+  const { user, setUser } = useUser();
   const { showMessage } = useSnackbar();
   const authCode = getCookie(AUTH_CODE_COOKIE);
   const authError = getCookie(AUTH_ERROR_COOKIE);

--- a/components/integrations/components/GnosisSafes.tsx
+++ b/components/integrations/components/GnosisSafes.tsx
@@ -39,7 +39,7 @@ export default function GnosisSafesList () {
   const { data: safeData, mutate } = useMultiWalletSigs();
 
   const gnosisSigner = useGnosisSigner();
-  const [user] = useUser();
+  const { user } = useUser();
   const [isLoadingSafes, setIsLoadingSafes] = useState(false);
 
   async function importSafes () {

--- a/components/integrations/components/IdentityProviders.tsx
+++ b/components/integrations/components/IdentityProviders.tsx
@@ -49,7 +49,7 @@ function ProviderRow ({ children }: { children: ReactNode }) {
 export default function IdentityProviders () {
   const { account, connector } = useWeb3React();
   const { openWalletSelectorModal } = useContext(Web3Connection);
-  const [user, setUser] = useUser();
+  const { user, setUser } = useUser();
   const [isConnectingTelegram, setIsConnectingTelegram] = useState(false);
   const [isLoggingOut] = useState(false);
   const [telegramError, setTelegramError] = useState('');

--- a/components/invite/InviteLinkPage.tsx
+++ b/components/invite/InviteLinkPage.tsx
@@ -13,7 +13,7 @@ import { CenteredBox } from './components/CenteredBox';
 
 export default function InvitationPage ({ invite }: { invite: InviteLinkPopulated }) {
 
-  const [user] = useUser();
+  const { user } = useUser();
   const { openWalletSelectorModal, triedEager } = useContext(Web3Connection);
   const { account } = useWeb3React();
 

--- a/components/nexus/GnosisTasksList.tsx
+++ b/components/nexus/GnosisTasksList.tsx
@@ -286,7 +286,7 @@ interface GnosisTasksSectionProps {
 export default function GnosisTasksSection ({ error, mutateTasks, tasks }: GnosisTasksSectionProps) {
   const { data: safeData, mutate } = useMultiWalletSigs();
   const { snoozedForDate } = useTasksState();
-  const [user] = useUser();
+  const { user } = useUser();
   const gnosisSigner = useGnosisSigner();
 
   const isSnoozed = snoozedForDate !== null;

--- a/components/nexus/TasksPage.tsx
+++ b/components/nexus/TasksPage.tsx
@@ -54,7 +54,7 @@ const TASK_TABS = [
 
 export default function TasksPage () {
   const router = useRouter();
-  const [user] = useUser();
+  const { user } = useUser();
   const [currentTask, setCurrentTask] = useState(router.query?.task ?? 'multisig');
   const { error, mutate: mutateTasks, tasks } = useTasks();
   const theme = useTheme();

--- a/components/nexus/TasksPageHeader.tsx
+++ b/components/nexus/TasksPageHeader.tsx
@@ -25,15 +25,15 @@ const TasksPageHeaderContainer = styled.div`
 `;
 
 export default function TasksPageHeader () {
-  const [currentUser] = useUser();
+  const { user } = useUser();
   const { account, active } = useWeb3React();
   const metamaskConnected = account && active;
-  const discordConnected = currentUser?.discordUser;
-  const telegramConnected = currentUser?.telegramUser;
+  const discordConnected = user?.discordUser;
+  const telegramConnected = user?.telegramUser;
   const totalIntegrations = (metamaskConnected ? 1 : 0) + (discordConnected ? 1 : 0) + (telegramConnected ? 1 : 0);
   const { data: safes } = useMultiWalletSigs();
 
-  return currentUser && (
+  return user && (
     <TasksPageHeaderContainer>
       <Grid container spacing={{ sm: 2, xs: 1 }}>
         <Grid item xs>
@@ -182,7 +182,7 @@ export default function TasksPageHeader () {
                     }
                   }}
                 >
-                  <Avatar size='large' variant='circular' name={currentUser.username} avatar={currentUser.avatar} />
+                  <Avatar size='large' variant='circular' name={user.username} avatar={user.avatar} />
                   <Typography fontWeight={500} color='secondary'>
                     My Profile
                   </Typography>

--- a/components/nexus/components/NexusLayout.tsx
+++ b/components/nexus/components/NexusLayout.tsx
@@ -9,7 +9,7 @@ const emptySidebar = () => <div></div>;
 export default function NexusLayout (props: { children: ReactNode }) {
 
   // hide sidebar for public users for now, since they can't create a workspace
-  const [user] = useUser();
+  const { user } = useUser();
 
   return (
     <PageLayout sidebarWidth={user ? 55 : 0} sidebar={user ? NexusSidebar : emptySidebar}>

--- a/components/nexus/components/NexusPageTitle.tsx
+++ b/components/nexus/components/NexusPageTitle.tsx
@@ -10,7 +10,7 @@ export default function PageTitle ({ subPage }: { subPage?: string }) {
   const MyNexus = 'My Nexus';
   const { account } = useWeb3React();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
-  const [, setUser] = useUser();
+  const { setUser } = useUser();
   const router = useRouter();
 
   return (

--- a/components/nexus/components/NotifyMeButton.tsx
+++ b/components/nexus/components/NotifyMeButton.tsx
@@ -9,7 +9,7 @@ import NotifyMeModal from './NotifyMeModal';
 
 export default function NotifyMeButton () {
 
-  const [user, setUser] = useUser();
+  const { user, setUser } = useUser();
 
   const popupState = usePopupState({
     popupId: 'snooze-transactions-message',

--- a/components/nexus/components/SnoozeButton.tsx
+++ b/components/nexus/components/SnoozeButton.tsx
@@ -17,7 +17,7 @@ import { LoggedInUser } from 'models';
 import useTasksState from '../hooks/useTasksState';
 
 export default function SnoozeButton () {
-  const [, setUser] = useUser();
+  const { setUser } = useUser();
   const { isLoading, snoozedForDate, snoozedMessage, mutate: mutateTasks } = useTasksState();
 
   const isSnoozed = snoozedForDate !== null;

--- a/components/nexus/hooks/useTasks.ts
+++ b/components/nexus/hooks/useTasks.ts
@@ -3,7 +3,7 @@ import charmClient from 'charmClient';
 import { useUser } from 'hooks/useUser';
 
 export default function useTasks () {
-  const [user] = useUser();
+  const { user } = useUser();
   const { data: tasks, error: serverError, mutate } = useSWRImmutable(user ? `/tasks/list/${user.id}` : null, () => charmClient.getTasks(), {
     // 10 minutes
     refreshInterval: 1000 * 10 * 60

--- a/components/profile/components/NftAvatarGallery/NftAvatarGallery.tsx
+++ b/components/profile/components/NftAvatarGallery/NftAvatarGallery.tsx
@@ -28,7 +28,7 @@ type Props = {
 };
 
 export default function NftAvatarGallery ({ onSelect, isVisible, onClose, isSaving }: Props) {
-  const [user] = useUser();
+  const { user } = useUser();
   const { nfts, isLoading } = useMyNfts();
 
   const getIsSelected = (nft: NftData) => {

--- a/components/settings/roles/components/ImportGuildRolesMenuItem.tsx
+++ b/components/settings/roles/components/ImportGuildRolesMenuItem.tsx
@@ -18,7 +18,7 @@ export default function ImportGuildRolesMenuItem ({ onClose }: {onClose: () => v
   const [importingRoles, setImportingRoles] = useState(false);
   const [selectedGuildIds, setSelectedGuildIds] = useState<number[]>([]);
   const [space] = useCurrentSpace();
-  const [currentUser] = useUser();
+  const { user: currentUser } = useUser();
   const addresses = currentUser?.addresses ?? [];
   const { showMessage } = useSnackbar();
 

--- a/components/share/PublicPage.tsx
+++ b/components/share/PublicPage.tsx
@@ -40,7 +40,7 @@ const LayoutContainer = styled.div`
 export default function PublicPage () {
 
   const { account } = useWeb3React();
-  const [, setUser] = useUser();
+  const { setUser } = useUser();
 
   const theme = useTheme();
   const colorMode = useColorMode();

--- a/components/signup/SignupForm.tsx
+++ b/components/signup/SignupForm.tsx
@@ -42,7 +42,7 @@ const ImageContainer = styled.div`
 export default function SignupPageContent () {
 
   const router = useRouter();
-  const [user] = useUser();
+  const { user } = useUser();
 
   async function createWorkspace () {
     router.push('/createWorkspace');

--- a/components/votes/components/NewProposalButton.tsx
+++ b/components/votes/components/NewProposalButton.tsx
@@ -7,7 +7,7 @@ import { addPage } from 'lib/pages/addPage';
 import { useState } from 'react';
 
 export default function NewProposalButton () {
-  const [user] = useUser();
+  const { user } = useUser();
   const [currentSpace] = useCurrentSpace();
   const [page, setPage] = useState<Page | null>(null);
 

--- a/components/votes/components/VoteActionsMenu.tsx
+++ b/components/votes/components/VoteActionsMenu.tsx
@@ -18,7 +18,7 @@ interface VoteActionsProps {
 
 export default function VoteActionsMenu ({ cancelVote, deleteVote, deleteProposal, editProposal, removeFromPage, vote }: VoteActionsProps) {
 
-  const [user] = useUser();
+  const { user } = useUser();
   const actionsPopup = usePopupState({ variant: 'popover', popupId: 'inline-votes-action' });
   const popupState = usePopupState({ variant: 'popover', popupId: 'delete-inline-vote' });
   const hasPassedDeadline = Boolean(vote.deadline && new Date(vote.deadline) <= new Date());

--- a/hooks/useBounties.tsx
+++ b/hooks/useBounties.tsx
@@ -40,7 +40,7 @@ export const BountiesContext = createContext<Readonly<IContext>>({
 export function BountiesProvider ({ children }: { children: ReactNode }) {
   const [space] = useCurrentSpace();
 
-  const [user] = useUser();
+  const { user } = useUser();
   const [bounties, bountiesRef, setBounties] = useRefState<BountyWithDetails[]>([]);
 
   const [isLoading, setIsLoading] = useState(false);

--- a/hooks/useCurrentSpacePermissions.ts
+++ b/hooks/useCurrentSpacePermissions.ts
@@ -8,7 +8,7 @@ export function useCurrentSpacePermissions () {
   const [space] = useCurrentSpace();
   // We want dependency on user so we refetch permissions on space or user change
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [user] = useUser();
+  const { user } = useUser();
 
   const { data } = useSWR(() => space ? `permissions-${space.id}` : null, () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/hooks/useIsAdmin.ts
+++ b/hooks/useIsAdmin.ts
@@ -6,7 +6,7 @@ import isSpaceAdmin from 'lib/users/isSpaceAdmin';
 export default function isAdmin () {
 
   const [space] = useCurrentSpace();
-  const [user] = useUser();
+  const { user } = useUser();
 
   return isSpaceAdmin(user, space?.id);
 }

--- a/hooks/useMyNfts.ts
+++ b/hooks/useMyNfts.ts
@@ -3,7 +3,7 @@ import { useUser } from 'hooks/useUser';
 import useSWR from 'swr';
 
 export const useMyNfts = () => {
-  const [user] = useUser();
+  const { user } = useUser();
   const { data, error: serverError } = useSWR(user && `/nfts/list/${user.id}`, () => charmClient.nft.list());
   const error = serverError?.message || serverError;
 

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -56,7 +56,7 @@ export function PagesProvider ({ children }: { children: ReactNode }) {
   const [pages, pagesRef, setPages] = useRefState<PagesContext['pages']>({});
   const [currentPageId, setCurrentPageId] = useState<string>('');
   const router = useRouter();
-  const [user] = useUser();
+  const { user } = useUser();
 
   // retrieve space for public pages
   const [spaces] = useSpaces();

--- a/hooks/useSpaces.tsx
+++ b/hooks/useSpaces.tsx
@@ -10,7 +10,7 @@ export const SpacesContext = createContext<Readonly<IContext>>([[], () => undefi
 
 export function SpacesProvider ({ children }: { children: ReactNode }) {
 
-  const [user, _, isUserLoaded] = useUser();
+  const { user, isLoaded: isUserLoaded } = useUser();
   const [spaces, setSpaces] = useState<Space[]>([]);
   const [isLoaded, setIsLoaded] = useState(false);
   const router = useRouter();

--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -3,14 +3,19 @@ import charmClient from 'charmClient';
 import { LoggedInUser } from 'models';
 import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
 
-type IContext = [
+type IContext = {
   user: LoggedInUser | null,
   setUser: (user: LoggedInUser | any) => void,
   isLoaded: boolean,
   setIsLoaded: (isLoaded: boolean) => void
-];
+};
 
-export const UserContext = createContext<Readonly<IContext>>([null, () => undefined, false, () => undefined]);
+export const UserContext = createContext<Readonly<IContext>>({
+  user: null,
+  setUser: () => undefined,
+  isLoaded: false,
+  setIsLoaded: () => undefined
+});
 
 export function UserProvider ({ children }: { children: ReactNode }) {
   const { account } = useWeb3React();
@@ -31,7 +36,7 @@ export function UserProvider ({ children }: { children: ReactNode }) {
     }
   }, [account]);
 
-  const value = useMemo(() => [user, setUser, isLoaded, setIsLoaded] as IContext, [user, isLoaded]);
+  const value = useMemo(() => ({ user, setUser, isLoaded, setIsLoaded }) as IContext, [user, isLoaded]);
 
   return (
     <UserContext.Provider value={value}>

--- a/hooks/useVotes.tsx
+++ b/hooks/useVotes.tsx
@@ -31,7 +31,7 @@ const VotesContext = createContext<Readonly<IContext>>({
 export function VotesProvider ({ children }: { children: ReactNode }) {
   const { currentPageId } = usePages();
   const [votes, setVotes] = useState<IContext['votes']>({});
-  const [user] = useUser();
+  const { user } = useUser();
 
   const cardId = typeof window !== 'undefined' ? (new URLSearchParams(window.location.href)).get('cardId') : null;
 

--- a/pages/[domain]/settings/workspace.tsx
+++ b/pages/[domain]/settings/workspace.tsx
@@ -31,7 +31,7 @@ export default function WorkspaceSettings () {
   const router = useRouter();
   const [space, setSpace] = useCurrentSpace();
   const [spaces, setSpaces] = useSpaces();
-  const [user] = useUser();
+  const { user } = useUser();
   const isAdmin = isSpaceAdmin(user, space?.id);
   const workspaceRemoveModalState = usePopupState({ variant: 'popover', popupId: 'workspace-remove' });
   const workspaceLeaveModalState = usePopupState({ variant: 'popover', popupId: 'workspace-leave' });

--- a/pages/createWorkspace.tsx
+++ b/pages/createWorkspace.tsx
@@ -11,7 +11,7 @@ import { AlternateRouteButton } from './join';
 
 export default function CreateSpace () {
 
-  const [user, setUser] = useUser();
+  const { user, setUser } = useUser();
   const [spaces, setSpaces] = useSpaces();
   const router = useRouter();
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,12 +16,12 @@ export default function LoginPage () {
   const router = useRouter();
   const defaultWorkspace = typeof window !== 'undefined' && localStorage.getItem(getKey('last-workspace'));
   const [, setTitleState] = usePageTitle();
-  const [user, setUser, isUserLoaded] = useUser();
-  const [spaces, setSpaces, isSpacesLoaded] = useSpaces();
+  const { user, isLoaded } = useUser();
+  const [spaces,, isSpacesLoaded] = useSpaces();
   const [showLogin, setShowLogin] = useState(false); // capture isLoaded state to prevent render on route change
   const isLogInWithDiscord = typeof router.query.code === 'string' && router.query.discord === '1' && router.query.type === 'login';
 
-  const isDataLoaded = triedEager && isSpacesLoaded && isUserLoaded;
+  const isDataLoaded = triedEager && isSpacesLoaded && isLoaded;
   useEffect(() => {
     setTitleState('Welcome');
   }, []);

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -9,7 +9,7 @@ export default function PublicProfilePage () {
 
   setTitle('My Profile');
 
-  const [user, setUser] = useUser();
+  const { user, setUser } = useUser();
 
   if (!user) {
     return null;


### PR DESCRIPTION
Refactor `useUser` to return object instead of array.
Pros of this solution:
- naming consistency
- you do not need to take care about order of props to use
- easier to extend hook when needed