### PR TITLE
Show single comment count for multi line paragraphs

### DIFF
--- a/components/common/CharmEditor/components/inlineComment/inlineComment.plugins.tsx
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.plugins.tsx
@@ -120,22 +120,23 @@ export function plugin ({ key } :{
 
 function getDecorations ({ schema, doc }: { doc: Node, schema: Schema }) {
   const rows = extractInlineCommentRows(schema, doc);
+  const uniqueCommentIds: Set<string> = new Set();
   const decorations: Decoration[] = rows.map(row => {
     // inject decoration at the start of the paragraph/header
     const firstPos = row.pos + 1;
-    return Decoration.widget(firstPos, () => renderComponent(row.nodes), { key: firstPos.toString() + row.nodes.length });
+    return Decoration.widget(firstPos, () => {
+      const commentIds = row.nodes.map(node => node.marks[0]?.attrs.id).filter(Boolean);
+      const newIds = commentIds.filter(commentId => !uniqueCommentIds.has(commentId));
+      commentIds.map(commentId => uniqueCommentIds.add(commentId));
+
+      const container = document.createElement('div');
+      if (newIds.length !== 0) {
+        container.className = 'charm-row-decoration-comments charm-row-decoration';
+        container.setAttribute('data-ids', newIds.join(','));
+        reactDOM.render(<RowDecoration count={newIds.length} />, container);
+      }
+      return container;
+    }, { key: firstPos.toString() + row.nodes.length });
   });
   return DecorationSet.create(doc, decorations);
-}
-
-function renderComponent (nodesWithMark: Node[]) {
-
-  const ids = nodesWithMark.map(node => node.marks[0]?.attrs.id).filter(Boolean);
-
-  const container = document.createElement('div');
-  container.className = 'charm-row-decoration-comments charm-row-decoration';
-  container.setAttribute('data-ids', ids.join(','));
-  reactDOM.render(<RowDecoration count={ids.length} />, container);
-
-  return container;
 }

--- a/components/common/CharmEditor/components/inlineComment/inlineComment.plugins.tsx
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.plugins.tsx
@@ -121,14 +121,15 @@ export function plugin ({ key } :{
 function getDecorations ({ schema, doc }: { doc: Node, schema: Schema }) {
   const rows = extractInlineCommentRows(schema, doc);
   const uniqueCommentIds: Set<string> = new Set();
+
   const decorations: Decoration[] = rows.map(row => {
     // inject decoration at the start of the paragraph/header
     const firstPos = row.pos + 1;
+    const commentIds = row.nodes.map(node => node.marks[0]?.attrs.id).filter(Boolean);
+
     return Decoration.widget(firstPos, () => {
-      const commentIds = row.nodes.map(node => node.marks[0]?.attrs.id).filter(Boolean);
       const newIds = commentIds.filter(commentId => !uniqueCommentIds.has(commentId));
       commentIds.map(commentId => uniqueCommentIds.add(commentId));
-
       const container = document.createElement('div');
       if (newIds.length !== 0) {
         container.className = 'charm-row-decoration-comments charm-row-decoration';
@@ -136,7 +137,8 @@ function getDecorations ({ schema, doc }: { doc: Node, schema: Schema }) {
         reactDOM.render(<RowDecoration count={newIds.length} />, container);
       }
       return container;
-    }, { key: firstPos.toString() + row.nodes.length });
+    }, { key: commentIds.join(',') });
   });
+
   return DecorationSet.create(doc, decorations);
 }


### PR DESCRIPTION
This PR aims to fix the case where multiple comment count decoration is being shown for a single comment spanning across multiple nodes. This is a numbered list where I created a comment by dragging across all the lines. It should create a single comment decoration for the first node but instead creates it for all of them
**Current**
![image](https://user-images.githubusercontent.com/34683631/184858029-bb7189b1-04ae-49c0-b568-221f230efcdd.png)
**FIx**
![image](https://user-images.githubusercontent.com/34683631/184858261-8ad739b6-5af0-4fb0-a14d-f8f069e08bd8.png)
