### PR TITLE
UI Tweak: add spacing and smaller avatar in focalboard

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
@@ -33,7 +33,9 @@ function UserProperty (props: Props): JSX.Element | null {
   if (props.readonly) {
     if (contributorMap[props.value]) {
       return (
-        <UserDisplay user={contributorMap[props.value]} avatarSize='small' fontSize='small' />
+        <div className='UserProperty octo-propertyvalue'>
+          <UserDisplay user={contributorMap[props.value]} avatarSize='xSmall' fontSize='small' />
+        </div>
       );
     }
     return null;

--- a/components/common/UserDisplay.tsx
+++ b/components/common/UserDisplay.tsx
@@ -2,14 +2,14 @@ import { memo } from 'react';
 import { Box, BoxProps, Typography } from '@mui/material';
 import useENSName from 'hooks/useENSName';
 import { User } from '@prisma/client';
-import Avatar from 'components/common/Avatar';
+import Avatar, { InitialAvatarProps } from 'components/common/Avatar';
 import Link from 'components/common/Link';
 import { hasNftAvatar } from 'lib/users/hasNftAvatar';
 
 interface StyleProps extends BoxProps {
   fontSize?: string | number;
   fontWeight?: number | string;
-  avatarSize?: 'small' | 'medium';
+  avatarSize?: InitialAvatarProps['size'];
 }
 
 interface BaseComponentProps extends StyleProps {


### PR DESCRIPTION
Before:
<img width="280" alt="image" src="https://user-images.githubusercontent.com/305398/186110395-d3483eb2-8a57-4a38-8e16-fd89e47f5ee2.png">

After:
<img width="270" alt="image" src="https://user-images.githubusercontent.com/305398/186110302-b96f1f8b-7834-401a-ab3e-fc97752e9c5b.png">
