### PR TITLE
upgrade prisma to support db tracing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -196,7 +196,7 @@
         "lint-staged": "^12.3.2",
         "nock": "^13.2.9",
         "prettier": "^2.5.1",
-        "prisma": "^4.1.0",
+        "prisma": "^4.2.1",
         "sass": "^1.49.0",
         "supertest": "^6.2.2",
         "ts-jest": "^28.0.5",
@@ -6967,9 +6967,9 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.1.0.tgz",
-      "integrity": "sha512-quqHXD3P83NBLVtRlts4SgKHmqgA8GMiyDTJ7af03Wg0gl6F5t65mBYvIuwmD+52vHm42JtIsp/fAO9YIV0JBA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.2.1.tgz",
+      "integrity": "sha512-0KqBwREUOjBiHwITsQzw2DWfLHjntvbqzGRawj4sBMnIiL5CXwyDUKeHOwXzKMtNr1rEjxEsypM14g0CzLRK3g==",
       "dev": true,
       "hasInstallScript": true
     },
@@ -21959,13 +21959,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.1.0.tgz",
-      "integrity": "sha512-iwqpAT6In1uvMSwQAM3PqmaBdhh2OaQ/2t+n3RjpW4vAKP3R7E1T34FZUU4zGOWtMWm5dt0sPThQkT/h87r6gw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.2.1.tgz",
+      "integrity": "sha512-HuYqnTDgH8atjPGtYmY0Ql9XrrJnfW7daG1PtAJRW0E6gJxc50lY3vrIDn0yjMR3TvRlypjTcspQX8DT+xD4Sg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.1.0"
+        "@prisma/engines": "4.2.1"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -31673,9 +31673,9 @@
       }
     },
     "@prisma/engines": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.1.0.tgz",
-      "integrity": "sha512-quqHXD3P83NBLVtRlts4SgKHmqgA8GMiyDTJ7af03Wg0gl6F5t65mBYvIuwmD+52vHm42JtIsp/fAO9YIV0JBA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.2.1.tgz",
+      "integrity": "sha512-0KqBwREUOjBiHwITsQzw2DWfLHjntvbqzGRawj4sBMnIiL5CXwyDUKeHOwXzKMtNr1rEjxEsypM14g0CzLRK3g==",
       "dev": true
     },
     "@prisma/engines-version": {
@@ -43360,12 +43360,12 @@
       }
     },
     "prisma": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.1.0.tgz",
-      "integrity": "sha512-iwqpAT6In1uvMSwQAM3PqmaBdhh2OaQ/2t+n3RjpW4vAKP3R7E1T34FZUU4zGOWtMWm5dt0sPThQkT/h87r6gw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.2.1.tgz",
+      "integrity": "sha512-HuYqnTDgH8atjPGtYmY0Ql9XrrJnfW7daG1PtAJRW0E6gJxc50lY3vrIDn0yjMR3TvRlypjTcspQX8DT+xD4Sg==",
       "dev": true,
       "requires": {
-        "@prisma/engines": "4.1.0"
+        "@prisma/engines": "4.2.1"
       }
     },
     "prismjs": {

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "lint-staged": "^12.3.2",
     "nock": "^13.2.9",
     "prettier": "^2.5.1",
-    "prisma": "^4.1.0",
+    "prisma": "^4.2.1",
     "sass": "^1.49.0",
     "supertest": "^6.2.2",
     "ts-jest": "^28.0.5",


### PR DESCRIPTION
I don't think that we'll get DB tracing for free ( I think we have to set up a library called OpenTelemetry), but this version is at least a requirement to set it up: https://www.prisma.io/docs/concepts/components/prisma-client/opentelemetry-tracing