### PR TITLE
Fix the parentId of null error

### DIFF
--- a/lib/pages/__tests__/mapPageTree.spec.ts
+++ b/lib/pages/__tests__/mapPageTree.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { Pages } from '@mui/icons-material';
 import { Page, Space, User } from '@prisma/client';
 import { generatePageNode, generatePageToCreateStub } from 'testing/generate-stubs';
 import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
@@ -191,6 +192,66 @@ describe('reducePagesToPageTree', () => {
 
     // No children should have been passed
     expect(rootNodes[0].children.length).toBe(0);
+  });
+
+  it('should filter out deleted pages by default', async () => {
+
+    const root_3 = generatePageNode({
+      parentId: null,
+      title: 'Root 3',
+      deletedAt: new Date(),
+      index: 2
+    });
+
+    const page_3_1 = generatePageNode({
+      parentId: root_3.id,
+      title: 'Page 3.1',
+      deletedAt: new Date()
+    });
+
+    const { rootNodes } = reducePagesToPageTree({
+      items: [...pages, root_3, page_3_1]
+    });
+
+    expect(rootNodes.length).toBe(2);
+
+    expect(rootNodes.every(node => node.id !== root_3.id)).toBe(true);
+  });
+
+  it('should include deleted pages if this option is requested', async () => {
+
+    const root_3 = generatePageNode({
+      parentId: null,
+      title: 'Root 3',
+      deletedAt: new Date(),
+      index: 2
+    });
+
+    const page_3_1 = generatePageNode({
+      parentId: root_3.id,
+      title: 'Page 3.1',
+      deletedAt: new Date()
+    });
+
+    const page_3_1_1 = generatePageNode({
+      parentId: page_3_1.id,
+      title: 'Page 3.1.1',
+      deletedAt: new Date()
+    });
+
+    const { rootNodes } = reducePagesToPageTree({
+      items: [...pages, root_3, page_3_1, page_3_1_1],
+      includeDeletedPages: true
+    });
+
+    expect(rootNodes.length).toBe(3);
+
+    expect(rootNodes[2].id).toBe(root_3.id);
+
+    expect(rootNodes[2].children.length).toBe(1);
+    expect(rootNodes[2].children[0].id).toBe(page_3_1.id);
+    expect(rootNodes[2].children[0].children.length).toBe(1);
+    expect(rootNodes[2].children[0].children[0].id).toBe(page_3_1_1.id);
   });
 
   it('should include card type pages if this setting is provided', async () => {

--- a/lib/pages/interfaces.ts
+++ b/lib/pages/interfaces.ts
@@ -48,12 +48,20 @@ export type PageNodeWithPermissions = PageNode<{permissions: (PagePermission & {
  * @rootPageIds The list of roots we want to track
  * @targetPageId Overrides root pageIds. Ensures only the root containing the target page ID will be returned
  * @includeCards Whether to include focalboard cards in the children. Should default to false. These were originally cards left out as mapPageTree was only used for showing page tree in the User Interface, and we did not want to show the actual cards
+ * @includeDeletedPages By default, we want to drop deleted pages from the tree.
  */
 export interface PageTreeMappingInput<T extends PageNode> {
   items: T[],
   rootPageIds?: string[],
   targetPageId?: string,
-  includeCards?: boolean
+  includeCards?: boolean,
+  includeDeletedPages?: boolean
+}
+
+export interface PageTreeResolveInput {
+  pageId: string,
+  flattenChildren?: boolean,
+  includeDeletedPages?: boolean
 }
 
 export type TargetPageTree<T extends PageNode = PageNode> = {

--- a/lib/pages/modifyChildPages.ts
+++ b/lib/pages/modifyChildPages.ts
@@ -8,7 +8,8 @@ export async function modifyChildPages (parentId: string, userId: string, action
 
   const { flatChildren } = await resolvePageTree({
     pageId: parentId,
-    flattenChildren: true
+    flattenChildren: true,
+    includeDeletedPages: true
   });
 
   const modifiedChildPageIds: string[] = [parentId, ...flatChildren.map(p => p.id)];

--- a/lib/pages/server/__tests__/resolvePageTree_v2.spec.ts
+++ b/lib/pages/server/__tests__/resolvePageTree_v2.spec.ts
@@ -167,4 +167,79 @@ describe('resolvePageTree', () => {
     validateRootNode(targetPage);
 
   });
+
+  it('should ignore deleted pages by default', async () => {
+
+    const rootPage = await createPage({
+      createdBy: user.id,
+      spaceId: space.id
+    });
+
+    const childPage_1 = await createPage({
+      createdBy: user.id,
+      spaceId: space.id,
+      parentId: rootPage.id
+    });
+
+    const childPage_1_1 = await createPage({
+      createdBy: user.id,
+      spaceId: space.id,
+      parentId: childPage_1.id,
+      deletedAt: new Date()
+    });
+
+    const childPage_1_1_1 = await createPage({
+      createdBy: user.id,
+      spaceId: space.id,
+      parentId: childPage_1_1.id,
+      deletedAt: new Date()
+    });
+
+    const { parents, targetPage } = await resolvePageTree({ pageId: childPage_1.id });
+
+    expect(parents.length).toBe(1);
+    expect(parents[0].id).toBe(rootPage.id);
+
+    expect(targetPage.children.length).toBe(0);
+
+  });
+
+  it('should include deleted pages if requested', async () => {
+    const rootPage = await createPage({
+      createdBy: user.id,
+      spaceId: space.id
+    });
+
+    const childPage_1 = await createPage({
+      createdBy: user.id,
+      spaceId: space.id,
+      parentId: rootPage.id
+    });
+
+    const childPage_1_1 = await createPage({
+      createdBy: user.id,
+      spaceId: space.id,
+      parentId: childPage_1.id,
+      deletedAt: new Date()
+    });
+
+    const childPage_1_1_1 = await createPage({
+      createdBy: user.id,
+      spaceId: space.id,
+      parentId: childPage_1_1.id,
+      deletedAt: new Date()
+    });
+
+    const { parents, targetPage } = await resolvePageTree({ pageId: childPage_1.id, includeDeletedPages: true });
+
+    expect(parents.length).toBe(1);
+    expect(parents[0].id).toBe(rootPage.id);
+
+    expect(targetPage.children.length).toBe(1);
+    expect(targetPage.children[0].id).toBe(childPage_1_1.id);
+
+    expect(targetPage.children[0].children.length).toBe(1);
+    expect(targetPage.children[0].children[0].id).toBe(childPage_1_1_1.id);
+
+  });
 });

--- a/testing/generate-stubs.ts
+++ b/testing/generate-stubs.ts
@@ -36,7 +36,7 @@ export function generatePageNode ({
   deletedAt = null,
   createdAt = new Date(),
   title = 'Untitled'
-}: Partial<PageNode<Pick<Page, 'title' | 'type'>>>): PageNode<Pick<Page, 'title' | 'type'>> {
+}: Partial<PageNode<Pick<Page, 'title' | 'type' | 'deletedAt'>>>): PageNode<Pick<Page, 'title' | 'type' | 'deletedAt'>> {
   return {
     id,
     type,


### PR DESCRIPTION
Fixes the issue where we were getting "Cannot read properties of undefined (reading 'parentId')" we were getting on page deletion related endpoints