### PR TITLE
Add /u/ prefix in edit mode of user profile link

### DIFF
--- a/components/profile/components/UserPathModal.tsx
+++ b/components/profile/components/UserPathModal.tsx
@@ -69,7 +69,7 @@ export default function UserPathModal (props: Props) {
     save(values.path);
   }
 
-  const hostname = typeof window !== 'undefined' ? window.location.origin : '';
+  const hostname = typeof window !== 'undefined' ? `${window.location.origin}/u` : '';
   const pathValue = watch('path');
 
   let statusIcon = null;


### PR DESCRIPTION
The edit mode input of user profile was not showing the /u/ prefix, which led to confusion about which url a user mentioned they were having trouble editing

**Before**
![image](https://user-images.githubusercontent.com/18669748/186484603-202ff9b4-8bb1-418e-8b75-21ef2e6d5053.png)

**After**
![image](https://user-images.githubusercontent.com/18669748/186484624-923da7f0-d5f4-446b-a7fc-c476b53dc661.png)
