### PR TITLE
Enable viewing votes and comments on mobile

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -132,8 +132,9 @@ function DocumentPage ({ page, setPage, insideModal, readOnly = false }: Documen
     >
       <Box
         sx={{
+          transition: 'width ease-in 0.25s',
           width: {
-            md: showPageActionSidebar ? 'calc(100% - 425px)' : '100%'
+            md: showPageActionSidebar ? 'calc(100% - 416px)' : '100%'
           },
           height: {
             md: showPageActionSidebar ? 'calc(100vh - 65px)' : '100%'

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -280,6 +280,7 @@ const PageActionListBox = styled.div`
   position: fixed;
   right: 0px;
   width: 416px;
+  max-width: 100%;
   top: 56px; // height of MUI Toolbar
   z-index: var(--z-index-drawer);
   height: calc(100% - 80px);

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -279,17 +279,13 @@ const StyledReactBangleEditor = styled(ReactBangleEditor)<{disablePageSpecificFe
 const PageActionListBox = styled.div`
   position: fixed;
   right: 0px;
-  width: 400px;
-  top: 75px;
+  width: 416px;
+  top: 56px; // height of MUI Toolbar
   z-index: var(--z-index-drawer);
   height: calc(100% - 80px);
   overflow: auto;
-  margin-right: ${({ theme }) => theme.spacing(1)};
+  padding: 0 ${({ theme }) => theme.spacing(1)};
   background: ${({ theme }) => theme.palette.background.default};
-  display: none;
-  ${({ theme }) => theme.breakpoints.up('md')} {
-    display: block;
-  }
 `;
 
 const defaultContent: PageContent = {

--- a/hooks/usePageActionDisplay.tsx
+++ b/hooks/usePageActionDisplay.tsx
@@ -25,18 +25,12 @@ export function PageActionDisplayProvider ({ children }: { children: ReactNode }
   const { isValidating: isValidatingInlineComments } = useThreads();
   const { isValidating: isValidatingInlineVotes } = useVotes();
   const { cache } = useSWRConfig();
-  const [currentPageActionDisplay, _setCurrentPageActionDisplay] = useState<IPageActionDisplayContext['currentPageActionDisplay']>(null);
+  const [currentPageActionDisplay, setCurrentPageActionDisplay] = useState<IPageActionDisplayContext['currentPageActionDisplay']>(null);
 
-  const setCurrentPageActionDisplay: typeof _setCurrentPageActionDisplay = (value) => {
-    // dont show action for mobile screens
-    if (!smallScreen) {
-      _setCurrentPageActionDisplay(value);
-    }
-  };
-
+  // show page sidebar by default if there are comments or votes
   useEffect(() => {
     const highlightedCommentId = (new URLSearchParams(window.location.search)).get('commentId');
-    if (currentPageId && !isValidatingInlineComments && !isValidatingInlineVotes) {
+    if (currentPageId && !isValidatingInlineComments && !isValidatingInlineVotes && !smallScreen) {
       const cachedInlineVotesData: ExtendedVote[] = cache.get(`pages/${currentPageId}/votes`);
       const cachedInlineCommentData: ThreadWithCommentsAndAuthors[] | undefined = cache.get(`pages/${currentPageId}/threads`);
       // Vote takes precedence over comments, so if a page has in progress votes and unresolved comments, show the votes


### PR DESCRIPTION
I think I helped originally hide this on mobile because it would pop up automatically and hide the content at first. This allows users to open the comment sidebar from the context menu.