### PR TITLE
disable auto-focus on touch screen devices because it pops the keyboard

### DIFF
--- a/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
@@ -72,7 +72,7 @@ export default function PageTitle ({ value, onChange, readOnly }: PageTitleProps
       value={title}
       onChange={_onChange}
       placeholder='Untitled'
-      autoFocus={!readOnly && isTouchScreen()}
+      autoFocus={!readOnly && !isTouchScreen()}
       multiline
       variant='standard'
       onKeyDown={(e) => {

--- a/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { TextField, Typography } from '@mui/material';
 import { TextSelection } from 'prosemirror-state';
 import { ChangeEvent, useContext, useEffect, useRef, useState } from 'react';
+import { isTouchScreen } from 'lib/browser';
 
 const StyledPageTitle = styled(TextField)`
   &.MuiFormControl-root {
@@ -71,7 +72,7 @@ export default function PageTitle ({ value, onChange, readOnly }: PageTitleProps
       value={title}
       onChange={_onChange}
       placeholder='Untitled'
-      autoFocus={!readOnly}
+      autoFocus={!readOnly && isTouchScreen()}
       multiline
       variant='standard'
       onKeyDown={(e) => {

--- a/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
@@ -9,6 +9,7 @@ import { objectUid } from '@bangle.dev/utils';
 import React, { ReactNode, RefObject, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import reactDOM from 'react-dom';
 import { NodeViewWrapper, RenderNodeViewsFunction } from './NodeViewWrapper';
+import { isTouchScreen } from 'lib/browser';
 
 interface BangleEditorProps<PluginMetadata = any>
   extends CoreBangleEditorProps<PluginMetadata> {
@@ -33,7 +34,7 @@ export const BangleEditor = React.forwardRef<
       id,
       state,
       children,
-      focusOnInit = true,
+      focusOnInit = !isTouchScreen(),
       pmViewOpts,
       renderNodeViews,
       className,


### PR DESCRIPTION
I may have missed some places, I intentionally left alone text inputs for new content where the user probably does want to type (like adding a row to a database).

Places fixed:
- the comments input when opening a database card
- the page title input