### PR TITLE
fix double-click behavior on ios browsers for hover events

### DIFF
--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -15,14 +15,22 @@ const NestedPageContainer = styled((props: any) => <div {...props} />)`
   padding: 3px 3px 3px 2px;
   position: relative;
   transition: background 20ms ease-in 0s;
-  &:hover {
-    background-color: ${({ theme }) => theme.palette.background.light};
-  }
-  .actions-menu {
-    opacity: 0;
-  }
-  &:hover .actions-menu {
-    opacity: 1;
+
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
+
+    .actions-menu {
+      opacity: 0;
+    }
+
+    &:hover {
+
+      background-color: ${({ theme }) => theme.palette.background.light};
+
+      .actions-menu {
+        opacity: 1;
+      }
+    }
   }
 `;
 

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -13,6 +13,7 @@ import Menu from '@mui/material/Menu';
 import ListItemButton from '@mui/material/ListItemButton';
 import Tooltip from '@mui/material/Tooltip';
 import { Page, PageType } from '@prisma/client';
+import { isTouchScreen } from 'lib/browser';
 import charmClient from 'charmClient';
 import mutator from 'components/common/BoardEditor/focalboard/src/mutator';
 import { getSortedBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
@@ -138,7 +139,6 @@ const PageAnchor = styled.a`
     gap: 4px;
     align-items: center;
     justify-content: center;
-    opacity: 0;
     position: absolute;
     bottom: 0px;
     top: 0px;
@@ -150,11 +150,18 @@ const PageAnchor = styled.a`
       width: 20px;
     }
   }
-  &:hover .page-actions {
-    opacity: 1;
-  }
-  &:hover .MuiTypography-root {
-    width: calc(60%);
+
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
+    .page-actions {
+      opacity: 0;
+    }
+    &:hover .page-actions {
+      opacity: 1;
+    }
+    &:hover .MuiTypography-root {
+      width: calc(60%);
+    }
   }
 `;
 
@@ -168,7 +175,7 @@ interface PageLinkProps {
   showPicker?: boolean
 }
 
-export function PageLink ({ showPicker = true, children, href, label, labelIcon, pageType, pageId }: PageLinkProps) {
+export function PageLink ({ showPicker = !isTouchScreen(), children, href, label, labelIcon, pageType, pageId }: PageLinkProps) {
 
   const popupState = usePopupState({
     popupId: 'page-emoji',

--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -47,32 +47,34 @@ const SidebarContainer = styled.div`
   background-color: ${({ theme }) => theme.palette.sidebar.background};
   height: 100%;
 
-  .add-a-page {
-    opacity: 0;
-    transition: opacity 0.2s ease-in-out;
-  }
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
 
-  ${({ theme }) => theme.breakpoints.up('md')} {
+    .add-a-page {
+      opacity: 0;
+      transition: opacity 0.2s ease-in-out;
+    }
+
     .sidebar-header .MuiIconButton-root {
       opacity: 0;
     }
-  }
 
-  &:hover {
-    .sidebar-header {
-      .MuiTypography-root {
-        overflow: hidden;
-        text-overflow: ellipsis;
+    &:hover {
+      .sidebar-header {
+        .MuiTypography-root {
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .MuiIconButton-root {
+          opacity: 1;
+        }
       }
-      .MuiIconButton-root {
+      .add-a-page {
         opacity: 1;
       }
     }
   }
 
-  &:hover .add-a-page {
-    opacity: 1;
-  }
 `;
 
 const sidebarItemStyles = ({ theme }: { theme: Theme }) => css`

--- a/components/settings/roles/components/RoleMemberRow.tsx
+++ b/components/settings/roles/components/RoleMemberRow.tsx
@@ -11,12 +11,16 @@ export const StyledRow = styled(Box)`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  .row-actions {
-    opacity: 0;
-  }
-  &:hover {
+
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
     .row-actions {
-      opacity: 1;
+      opacity: 0;
+    }
+    &:hover {
+      .row-actions {
+        opacity: 1;
+      }
     }
   }
 `;


### PR DESCRIPTION
On IOS, if CSS triggers a change to the the opacity/display of a pseudo-element or child element, then it treats the first click as a hover event instead, requiring user to click the link twice. This update disables the hover effect and just displays the "..." all the time when possible (discussed w/Chris).

Here's more info: https://css-tricks.com/annoying-mobile-double-tap-link-issue/