### PR TITLE
fix loading of new workspace

### DIFF
--- a/components/[pageId]/EditorPage/EditorPage.tsx
+++ b/components/[pageId]/EditorPage/EditorPage.tsx
@@ -12,7 +12,7 @@ import BoardPage from '../BoardPage';
 import DocumentPage from '../DocumentPage';
 
 export default function EditorPage ({ pageId }: { pageId: string }) {
-  const { setIsEditing, pages, setCurrentPageId, setPages, getPagePermissions } = usePages();
+  const { setIsEditing, pages, currentPageId, setCurrentPageId, setPages, getPagePermissions } = usePages();
   const [, setTitleState] = usePageTitle();
   const [pageNotFound, setPageNotFound] = useState(false);
   const [space] = useCurrentSpace();
@@ -25,7 +25,7 @@ export default function EditorPage ({ pageId }: { pageId: string }) {
   useEffect(() => {
     async function main () {
       setIsAccessDenied(false);
-      if (pageId && pagesLoaded && space) {
+      if (pageId && pagesLoaded && space && pageId !== currentPageId) {
         try {
           const page = await charmClient.getPage(pageId, space.id);
           if (page) {


### PR DESCRIPTION
This took me hours to figure out, basically when you create a new workspace from the sidebar, it would update the 'spaces' context, which would trigger an update inside both usePages and the EditorPage component. EditorPage calls 'setPages' from usePages() which overrides the API result from the call to charmClient inside of usePages().

I forget why we need to load the page here, I don't think we always need it, but it looks like it's only intended to load the first time the component is mounted, so I just check that the pageId is not equal to 'currentPageId'.