### PR TITLE
Disable new proposals button if user cannot create pages

### DIFF
--- a/components/votes/components/NewProposalButton.tsx
+++ b/components/votes/components/NewProposalButton.tsx
@@ -1,4 +1,6 @@
 import Button from 'components/common/Button';
+import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useUser } from 'hooks/useUser';
 import { usePageDialog } from 'components/common/PageDialog/hooks/usePageDialog';
@@ -6,12 +8,16 @@ import { addPage } from 'lib/pages/addPage';
 import { usePages } from 'hooks/usePages';
 import { KeyedMutator } from 'swr';
 import { ProposalWithUsers } from 'lib/proposal/interface';
+import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
 
 export default function NewProposalButton ({ mutateProposals }: {mutateProposals: KeyedMutator<ProposalWithUsers[]>}) {
   const { user } = useUser();
   const [currentSpace] = useCurrentSpace();
+  const [userSpacePermissions] = useCurrentSpacePermissions();
   const { showPage } = usePageDialog();
   const { setPages } = usePages();
+
+  const canCreateProposal = !!userSpacePermissions?.createPage;
 
   async function onClickCreate () {
     if (currentSpace && user) {
@@ -34,8 +40,12 @@ export default function NewProposalButton ({ mutateProposals }: {mutateProposals
   }
 
   return (
-    <Button onClick={onClickCreate}>
-      Create Proposal
-    </Button>
+    <Tooltip title={!canCreateProposal ? 'You do not have the permission to create a proposal.' : ''}>
+      <Box>
+        <Button disabled={!canCreateProposal} onClick={onClickCreate}>
+          Create Proposal
+        </Button>
+      </Box>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
Usability fixes for permissions
- Disable create proposal button if new page creation is disabled

- TODO: Don't allow admin override in editing proposal content (They can still delete a proposal and toggle it public)