### PR TITLE
fix popup modal for public pages

### DIFF
--- a/__integration-tests__/server/pages/api/pages/[id]/index.spec.ts
+++ b/__integration-tests__/server/pages/api/pages/[id]/index.spec.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Prisma, Space, User } from '@prisma/client';
+import { IPageWithPermissions } from 'lib/pages';
+import { addSpaceOperations } from 'lib/permissions/spaces';
+import request from 'supertest';
+import { generatePageToCreateStub } from 'testing/generate-stubs';
+import { baseUrl, loginUser } from 'testing/mockApiCall';
+import { generateBounty, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+import { v4 } from 'uuid';
+import { prisma } from 'db';
+
+describe('GET /api/pages/{pageId} - get page', () => {
+
+  it('should return a bounty page to a non workspace member if the page is a bounty accessible to the workspace, and the space has enabled the public bounty board', async () => {
+
+    const { user, space } = await generateUserAndSpaceWithApiToken(v4(), false);
+
+    const bounty = await generateBounty({
+      approveSubmitters: false,
+      createdBy: user.id,
+      spaceId: space.id,
+      status: 'open',
+      bountyPermissions: {
+        submitter: [{
+          group: 'space',
+          id: space.id
+        }]
+      }
+    });
+
+    await prisma.space.update({
+      where: {
+        id: space.id
+      },
+      data: {
+        publicBountyBoard: true
+      }
+    });
+
+    const { body: createdPage } = await request(baseUrl)
+      .get(`/api/pages/${bounty.page.id}`)
+      .send()
+      .expect(200) as {body: IPageWithPermissions};
+
+    expect(createdPage.id).toBe(bounty.page.id);
+  });
+
+});

--- a/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
@@ -40,10 +40,11 @@ export default function BountyProperties (props: {
   const { bountyId, pageId, readOnly = false, permissions, refreshBountyPermissions } = props;
   const [paymentMethods] = usePaymentMethods();
   const { draftBounty, bounties, cancelDraftBounty, setBounties, updateBounty } = useBounties();
-  const [availableCryptos, setAvailableCryptos] = useState<Array<string | CryptoCurrency>>([]);
+  const [availableCryptos, setAvailableCryptos] = useState<Array<string | CryptoCurrency>>(['ETH']);
   const [isShowingAdvancedSettings, setIsShowingAdvancedSettings] = useState(false);
   const bountyFromContext = bounties.find(b => b.id === bountyId);
   const [currentBounty, setCurrentBounty] = useState<(BountyCreationData & BountyWithDetails) | null>(null);
+
   const [capSubmissions, setCapSubmissions] = useState(currentBounty?.maxSubmissions !== null);
   const [space] = useCurrentSpace();
   const { user } = useUser();

--- a/components/bounties/components/BountiesKanbanView.tsx
+++ b/components/bounties/components/BountiesKanbanView.tsx
@@ -42,9 +42,9 @@ export default function BountiesKanbanView ({ bounties }: Omit<Props, 'publicMod
   function showBounty (bounty: BountyWithDetails) {
     const newUrl = getUriWithParam(window.location.href, { bountyId: bounty.id });
     silentlyUpdateURL(newUrl);
-    if (bounty?.page.id) {
+    if (bounty?.id) {
       showPage({
-        pageId: bounty?.page.id,
+        bountyId: bounty.id,
         onClose: closePopup
       });
     }

--- a/components/common/PageDialog/hooks/usePageDialog.tsx
+++ b/components/common/PageDialog/hooks/usePageDialog.tsx
@@ -34,7 +34,6 @@ export function PageDialogProvider ({ children }: { children: ReactNode }) {
 
   function showPage (_context: PageDialogContext) {
     setProps(_context);
-    return 2;
   }
 
   const value = useMemo(() => ({

--- a/components/common/PageDialog/hooks/usePageDialog.tsx
+++ b/components/common/PageDialog/hooks/usePageDialog.tsx
@@ -34,6 +34,7 @@ export function PageDialogProvider ({ children }: { children: ReactNode }) {
 
   function showPage (_context: PageDialogContext) {
     setProps(_context);
+    return 2;
   }
 
   const value = useMemo(() => ({

--- a/components/share/PublicPage.tsx
+++ b/components/share/PublicPage.tsx
@@ -6,6 +6,8 @@ import { Box, IconButton, Tooltip } from '@mui/material';
 import { Space } from '@prisma/client';
 import { useWeb3React } from '@web3-react/core';
 import charmClient from 'charmClient';
+import { PageDialogProvider } from 'components/common/PageDialog/hooks/usePageDialog';
+import PageDialogGlobalModal from 'components/common/PageDialog/PageDialogGlobal';
 import { updateBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import { addCard } from 'components/common/BoardEditor/focalboard/src/store/cards';
 import { useAppDispatch } from 'components/common/BoardEditor/focalboard/src/store/hooks';
@@ -182,11 +184,11 @@ export default function PublicPage () {
           </StyledToolbar>
         </AppBar>
 
-        <PageContainer>
-          <HeaderSpacer />
+        <PageDialogProvider>
+          <PageContainer>
+            <HeaderSpacer />
 
-          {
-            isBountiesPage
+            {isBountiesPage
               ? <PublicBountiesPage />
               : (currentPage?.type.match(/board/)
                 ? (
@@ -194,10 +196,11 @@ export default function PublicPage () {
                 ) : (
                   currentPage && <DocumentPage page={currentPage} setPage={() => {}} readOnly={true} parentProposalId={parentProposalId} />
                 )
-              )
-          }
+              )}
+            <PageDialogGlobalModal />
 
-        </PageContainer>
+          </PageContainer>
+        </PageDialogProvider>
 
       </LayoutContainer>
     </>

--- a/pages/api/pages/[id]/index.ts
+++ b/pages/api/pages/[id]/index.ts
@@ -38,8 +38,31 @@ async function getPageRoute (req: NextApiRequest, res: NextApiResponse<IPageWith
     userId
   });
 
-  if (permissions.read !== true) {
+  if (permissions.read !== true && page.type !== 'bounty') {
     throw new ActionNotPermittedError('You do not have permission to view this page');
+  }
+  else if (permissions.read !== true && page.type === 'bounty') {
+    const bounty = await prisma.bounty.findUnique({
+      where: {
+        id: page.bountyId as string
+      },
+      include: {
+        permissions: true,
+        space: true
+      }
+    });
+
+    if (!bounty) {
+      throw new NotFoundError(`Bounty with id ${page.bountyId} not found`);
+    }
+
+    // We surface space-accessible bounties to the public if the space has enabled the public bounty board option
+    if (bounty.space.publicBountyBoard && bounty.permissions.some(p => p.spaceId === bounty.spaceId)) {
+      return res.status(200).json(page);
+    }
+    else {
+      throw new NotFoundError(`Bounty with id ${page.bountyId} not found`);
+    }
   }
 
   return res.status(200).json(page);


### PR DESCRIPTION
I needed to add the 'PageDialogProvider' around the public page component. The methods from `usePageDialog()` just silently fail without it (the methods values are no-ops). We could just put it inside _app so it's always there, but I didn't because it relies on Comments and Votes providers which are added in PageLayout.tsx, and I'd have to move those into _app as well.