### PR TITLE
turning off datadog agent using compose profile

### DIFF
--- a/.ebextensions/00_env_vars.config
+++ b/.ebextensions/00_env_vars.config
@@ -13,4 +13,5 @@ option_settings:
         NODE_ENV: "staging"
         NPM_SCRIPT: "start:staging"
         COMPOSE_PROJECT_NAME: "stg"
+        COMPOSE_PROFILES: "stg"
 #        COMPOSE_PROFILES: "webapp"    # nice to have in the future but not now

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,12 @@ services:
       - ".env"
     environment:
       DATABASE_URL: "postgres://${DB_USER}:${DB_PASSWD}@${DB_HOSTNAME}:5432/${DB_NAME}"
+    profiles:
+      - dev
+      - stg
+      - tst
+      - prd
+      - webapp
 
   datadog-agent:
     image: public.ecr.aws/datadog/agent
@@ -29,3 +35,6 @@ services:
       DD_APM_ENABLED: "true"
       DD_APM_NON_LOCAL_TRAFFIC: "true"
       DD_ENV: "${SERVICE_ENV}"
+    profiles:
+      - prd
+      - tst


### PR DESCRIPTION
adding COMPOSE_PROFILE env variable and specified profiles of which service to run when running a specific profile. This should allow us to easily turn on/off datadog agent