### PR TITLE
fix styling for nested pages and mentioned pages

### DIFF
--- a/components/common/CharmEditor/components/mention/components/Mention.tsx
+++ b/components/common/CharmEditor/components/mention/components/Mention.tsx
@@ -1,5 +1,6 @@
 import { NodeViewProps } from '@bangle.dev/core';
 import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
 import { Box, Typography } from '@mui/material';
 import { checkForEmpty } from 'components/common/CharmEditor/utils';
 import PageIcon from 'components/common/PageLayout/components/PageIcon';
@@ -7,13 +8,27 @@ import { useContributors } from 'hooks/useContributors';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
 import { PageContent } from 'models';
-import Link from 'next/link';
+import Link from 'components/common/Link';
 import { ReactNode } from 'react';
 import { MentionSpecSchemaAttrs } from '../mention.specs';
 
+const MentionContainer = styled(Link)`
+
+  border-radius: 1px;
+  display: inline-block;
+
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
+
+    &:hover {
+      box-shadow: ${({ theme }) => `0 0 0 2px ${theme.palette.background.light}`};
+      background-color: ${({ theme }) => theme.palette.background.light};
+    }
+  }
+`;
+
 export default function Mention ({ node }: NodeViewProps) {
   const attrs = node.attrs as MentionSpecSchemaAttrs;
-  const theme = useTheme();
   const [contributors] = useContributors();
   const { pages } = usePages();
   const contributor = contributors.find(_contributor => _contributor.id === attrs.value);
@@ -22,47 +37,28 @@ export default function Mention ({ node }: NodeViewProps) {
   if (attrs.type === 'page') {
     const page = pages[attrs.value];
     value = page && (
-      <Link
-        href={`/${space?.domain}/${page.path}`}
-        passHref
-      >
-        <Box sx={{
-          display: 'flex',
-          alignItems: 'center',
-          position: 'relative',
-          top: 5,
-          cursor: 'pointer'
-        }}
-        >
+      <MentionContainer color='inherit' href={`/${space?.domain}/${page.path}`}>
+        <Box display='flex' alignItems='center'>
           <PageIcon icon={page.icon} isEditorEmpty={checkForEmpty(page.content as PageContent)} pageType={page.type} />
-          <div>{page.title || 'Untitled'}</div>
+          <Typography component='span' fontWeight={600}>{page.title || 'Untitled'}</Typography>
         </Box>
-      </Link>
+      </MentionContainer>
     );
   }
   else if (attrs.type === 'user') {
     value = (
-      <Typography fontSize='inherit' fontWeight='inherit'>
-        <span style={{ opacity: 0.6 }}>@</span>
-        <span style={{ opacity: 0.75 }}>{contributor?.username}</span>
-      </Typography>
+      <MentionContainer color='secondary' href={`/u/${contributor?.path || contributor?.id}`}>
+        <Typography component='span' fontWeight={600}>
+          <span style={{ opacity: 0.5 }}>@</span>
+          {contributor?.username}
+        </Typography>
+      </MentionContainer>
     );
   }
 
   return value ? (
-    <Box
-      component='span'
-      sx={{
-        borderRadius: theme.spacing(0.5),
-        fontWeight: 600,
-        opacity: 0.75,
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 0.75
-      }}
-      id={`${attrs.type}-${attrs.id}`}
-    >
+    <span id={`${attrs.type}-${attrs.id}`}>
       {value}
-    </Box>
+    </span>
   ) : null;
 }

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -1,14 +1,14 @@
 import { NodeViewProps } from '@bangle.dev/core';
 import styled from '@emotion/styled';
-import { Box } from '@mui/material';
+import { Typography } from '@mui/material';
 import { checkForEmpty } from 'components/common/CharmEditor/utils';
 import PageIcon from 'components/common/PageLayout/components/PageIcon';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
 import { PageContent } from 'models';
-import Link from 'next/link';
+import Link from 'components/common/Link';
 
-const NestedPageContainer = styled((props: any) => <div {...props} />)`
+const NestedPageContainer = styled(Link)`
   align-items: center;
   cursor: pointer;
   display: flex;
@@ -47,24 +47,13 @@ export default function NestedPage ({ node }: NodeViewProps) {
   const fullPath = `${window.location.origin}/${appPath}`;
 
   return (
-    <NestedPageContainer data-id={`page-${nestedPage?.id}`} data-title={nestedPage?.title} data-path={fullPath}>
+    <NestedPageContainer href={nestedPage ? `/${appPath}` : ''} color='inherit' data-id={`page-${nestedPage?.id}`} data-title={nestedPage?.title} data-path={fullPath}>
       <div>
         {nestedPage && <PageIcon isEditorEmpty={isEditorEmpty} icon={nestedPage.icon} pageType={nestedPage.type} />}
       </div>
-      {nestedPage ? (
-        <Link
-          href={`/${appPath}`}
-          passHref
-        >
-          <Box fontWeight={600} component='div' width='100%'>
-            {nestedPage?.title || 'Untitled'}
-          </Box>
-        </Link>
-      ) : (
-        <Box fontWeight={600} component='div' width='100%'>
-          Page not found
-        </Box>
-      )}
+      <Typography fontWeight={600}>
+        {nestedPage ? nestedPage.title || 'Untitled' : 'Page not found'}
+      </Typography>
     </NestedPageContainer>
   );
 }

--- a/components/common/Link.tsx
+++ b/components/common/Link.tsx
@@ -8,9 +8,10 @@ import { SxProps } from '@mui/system';
 import styled from '@emotion/styled';
 
 const hoverStyle: { [key: string]: string } = {
-  blue: 'color: #111;',
-  white: 'color: #ccc;',
-  primary: 'opacity: 0.8;'
+  blue: 'color: #111',
+  white: 'color: #ccc',
+  primary: 'opacity: 0.8',
+  inherit: 'inherit'
 };
 
 const StyledMuiLink = styled(MuiLink)`
@@ -36,6 +37,10 @@ type Props = {
 };
 
 export default function Link ({ href, onClick, children, sx, className, color = 'primary', external, target }: Props) {
+
+  if (!href) {
+    return <div>{children}</div>;
+  }
 
   return (
     external ? (

--- a/components/common/PageLayout/components/PageIcon.tsx
+++ b/components/common/PageLayout/components/PageIcon.tsx
@@ -18,6 +18,10 @@ export const StyledPageIcon = styled(EmojiIcon)`
   width: 24px;
   margin-right: 4px;
   color: ${({ theme }) => theme.palette.secondary.light};
+  &::before {
+    // fixes vertical layout for svg icons
+    content: '\\200B';
+  }
   // style focalboard icons;
   .Icon {
     height: 22px;


### PR DESCRIPTION
Tested with Nested pages and Mentions, using custom icon and default page svg icons:

After fix:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/305398/190454052-9f4dc601-fe28-46c1-9b31-7825e974b115.png">


This was before (the mentioned page on the first line is vertically offset):
<img width="302" alt="image" src="https://user-images.githubusercontent.com/305398/190454413-65393000-b23f-405c-8e20-abf4952ec796.png">
