### PR TITLE
Feat/analytics plausible

### DIFF
--- a/lib/analytics/constatnts.ts
+++ b/lib/analytics/constatnts.ts
@@ -1,1 +1,1 @@
-export const PLAUSIBLE_DOMAIN = 'charmverse.io';
+export const PLAUSIBLE_DOMAIN = ''; // TODO: setup plausible account and domain

--- a/lib/analytics/constatnts.ts
+++ b/lib/analytics/constatnts.ts
@@ -1,0 +1,1 @@
+export const PLAUSIBLE_DOMAIN = 'charmverse.io';

--- a/lib/analytics/plausible/PlausibleProvider.tsx
+++ b/lib/analytics/plausible/PlausibleProvider.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+import Plausible from 'next-plausible';
+import { PLAUSIBLE_DOMAIN } from 'lib/analytics/constatnts';
+
+type Props = { children: ReactNode; };
+
+const domain = process.env.NODE_ENV === 'production'
+  ? PLAUSIBLE_DOMAIN
+  : 'localhost:3000';
+const isLocalhost = domain.indexOf('localhost') !== -1;
+
+export default function PlausibleProvider ({ children }: Props) {
+  return (
+    <Plausible
+      domain={domain}
+      trackOutboundLinks
+      trackFileDownloads
+      // For testing purposes - set tracking localhost to true
+      enabled={isLocalhost || undefined}
+      trackLocalhost={isLocalhost}
+    >
+      {children}
+    </Plausible>
+  );
+}

--- a/lib/analytics/plausible/PlausibleProvider.tsx
+++ b/lib/analytics/plausible/PlausibleProvider.tsx
@@ -7,6 +7,7 @@ type Props = { children: ReactNode; };
 const domain = process.env.NODE_ENV === 'production'
   ? PLAUSIBLE_DOMAIN
   : 'localhost:3000';
+const isSetUp = !!PLAUSIBLE_DOMAIN;
 const isLocalhost = domain.indexOf('localhost') !== -1;
 
 export default function PlausibleProvider ({ children }: Props) {
@@ -16,7 +17,7 @@ export default function PlausibleProvider ({ children }: Props) {
       trackOutboundLinks
       trackFileDownloads
       // For testing purposes - set tracking localhost to true
-      enabled={isLocalhost || undefined}
+      enabled={isSetUp && (isLocalhost || undefined)}
       trackLocalhost={isLocalhost}
     >
       {children}

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
         "nanoevents": "^6.0.2",
         "next": "^12.2.3",
         "next-connect": "^0.12.2",
+        "next-plausible": "^3.6.2",
         "next-swagger-doc": "^0.2.1",
         "next-transpile-modules": "^9.0.0",
         "node-cron": "^3.0.0",
@@ -22121,6 +22122,19 @@
       "integrity": "sha512-B/zKHPs5S7XWvAVsZVLvOeY2eL2U3g0W/BgCDetEJRcNDzxX2vi8rzqBuEoLLPlI8LvtHwujDVUFFjSgOEZTbA==",
       "dependencies": {
         "trouter": "^3.2.0"
+      }
+    },
+    "node_modules/next-plausible": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.6.2.tgz",
+      "integrity": "sha512-WhyFo0ZjoActGHFtkBiTxgZ0ALLkrKEqpgH/G2JXFqfg2Dx6/ne2fjKvXDGyyL4IYIXnWz/UFJFq40TxbGa5zA==",
+      "funding": {
+        "url": "https://github.com/4lejandrito/next-plausible?sponsor=1"
+      },
+      "peerDependencies": {
+        "next": "^11.1.0 || ^12.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/next-swagger-doc": {
@@ -44918,6 +44932,12 @@
       "requires": {
         "trouter": "^3.2.0"
       }
+    },
+    "next-plausible": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.6.2.tgz",
+      "integrity": "sha512-WhyFo0ZjoActGHFtkBiTxgZ0ALLkrKEqpgH/G2JXFqfg2Dx6/ne2fjKvXDGyyL4IYIXnWz/UFJFq40TxbGa5zA==",
+      "requires": {}
     },
     "next-swagger-doc": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "nanoevents": "^6.0.2",
     "next": "^12.2.3",
     "next-connect": "^0.12.2",
+    "next-plausible": "^3.6.2",
     "next-swagger-doc": "^0.2.1",
     "next-transpile-modules": "^9.0.0",
     "node-cron": "^3.0.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -166,6 +166,7 @@ import 'theme/styles.scss';
 
 import charmClient from 'charmClient';
 import GlobalComponents from 'components/_app/GlobalComponents';
+import PlausibleProvider from 'lib/analytics/plausible/PlausibleProvider';
 
 const getLibrary = (provider: ExternalProvider | JsonRpcFetchFunc) => new Web3Provider(provider);
 
@@ -241,50 +242,52 @@ export default function App ({ Component, pageProps }: AppPropsWithLayout) {
 
   // DO NOT REMOVE CacheProvider - it protects MUI from Tailwind CSS in settings
   return (
-    <CacheProvider value={createCache({ key: 'app' })}>
-      <ColorModeContext.Provider value={colorModeContext}>
-        <ThemeProvider theme={theme}>
-          <LocalizationProvider dateAdapter={AdapterLuxon as any}>
-            <Web3ReactProvider getLibrary={getLibrary}>
-              <Web3ConnectionManager>
-                <ReactDndProvider>
-                  <DataProviders>
-                    <FocalBoardProvider>
-                      <IntlProvider>
-                        <SnackbarProvider>
-                          <PageMetaTags />
-                          <CssBaseline enableColorScheme={true} />
-                          <Global styles={cssVariables} />
-                          <RouteGuard>
-                            <ErrorBoundary>
-                              <Snackbar
-                                isOpen={isOldBuild}
-                                message='New CharmVerse platform update available. Please refresh.'
-                                actions={[
-                                  <IconButton key='reload' onClick={() => window.location.reload()} color='inherit'>
-                                    <RefreshIcon fontSize='small' />
-                                  </IconButton>
-                                ]}
-                                origin={{ vertical: 'top', horizontal: 'center' }}
-                                severity='warning'
-                                handleClose={() => setIsOldBuild(false)}
-                              />
-                              {getLayout(<Component {...pageProps} />)}
+    <PlausibleProvider>
+      <CacheProvider value={createCache({ key: 'app' })}>
+        <ColorModeContext.Provider value={colorModeContext}>
+          <ThemeProvider theme={theme}>
+            <LocalizationProvider dateAdapter={AdapterLuxon as any}>
+              <Web3ReactProvider getLibrary={getLibrary}>
+                <Web3ConnectionManager>
+                  <ReactDndProvider>
+                    <DataProviders>
+                      <FocalBoardProvider>
+                        <IntlProvider>
+                          <SnackbarProvider>
+                            <PageMetaTags />
+                            <CssBaseline enableColorScheme={true} />
+                            <Global styles={cssVariables} />
+                            <RouteGuard>
+                              <ErrorBoundary>
+                                <Snackbar
+                                  isOpen={isOldBuild}
+                                  message='New CharmVerse platform update available. Please refresh.'
+                                  actions={[
+                                    <IconButton key='reload' onClick={() => window.location.reload()} color='inherit'>
+                                      <RefreshIcon fontSize='small' />
+                                    </IconButton>
+                                  ]}
+                                  origin={{ vertical: 'top', horizontal: 'center' }}
+                                  severity='warning'
+                                  handleClose={() => setIsOldBuild(false)}
+                                />
+                                {getLayout(<Component {...pageProps} />)}
 
-                              <GlobalComponents />
-                            </ErrorBoundary>
-                          </RouteGuard>
-                        </SnackbarProvider>
-                      </IntlProvider>
-                    </FocalBoardProvider>
-                  </DataProviders>
-                </ReactDndProvider>
-              </Web3ConnectionManager>
-            </Web3ReactProvider>
-          </LocalizationProvider>
-        </ThemeProvider>
-      </ColorModeContext.Provider>
-    </CacheProvider>
+                                <GlobalComponents />
+                              </ErrorBoundary>
+                            </RouteGuard>
+                          </SnackbarProvider>
+                        </IntlProvider>
+                      </FocalBoardProvider>
+                    </DataProviders>
+                  </ReactDndProvider>
+                </Web3ConnectionManager>
+              </Web3ReactProvider>
+            </LocalizationProvider>
+          </ThemeProvider>
+        </ColorModeContext.Provider>
+      </CacheProvider>
+    </PlausibleProvider>
   );
 }
 


### PR DESCRIPTION
Base boilerplate for plausible analytics. Turned out there is official guide for adding them to nextjs so I used it to keep things simple: https://plausible.io/docs/nextjs-integration

TODO: I need to double check how plausible works, but we will most likely need an account for our domain: https://plausible.io/#pricing

NOTE: Code will keep plausible turned off until we set up domain, so it should be safe to merge.