### PR TITLE
Fixed clicking outside emoji picker redirecting to page

### DIFF
--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -236,7 +236,12 @@ function EmojiMenu ({ popupState, pageId, pageType }: { popupState: any, pageId:
   }, [pageId, setPages]);
 
   return (
-    <Menu {...bindMenu(popupState)}>
+    <Menu
+      {...bindMenu(popupState)}
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
+    >
       <EmojiPicker onSelect={onSelectEmoji} />
     </Menu>
   );


### PR DESCRIPTION
Steps to reproduce:
1. Click on page icon on left sidebar
2. Once the emoji picker opens up click anywhere outside of it
3. You will be redirected to that page

corresponding [Card](https://app.charmverse.io/charmverse/page-49366552253645923?viewId=d15c9b90-8918-44da-bbd8-db8712faa723&cardId=8bacf788-2899-4d78-b56f-b65b526300b1)