### PR TITLE
include userId when looking for sent notifications

### DIFF
--- a/background/tasks/sendNotifications/sendNotifications.ts
+++ b/background/tasks/sendNotifications/sendNotifications.ts
@@ -74,7 +74,8 @@ export async function getNotifications (): Promise<PendingTasksProps[]> {
             ...voteTasks.map(voteTask => voteTask.id),
             ...workspaceEvents.map(workspaceEvent => workspaceEvent.id)
           ]
-        }
+        },
+        userId: user.id
       },
       select: {
         taskId: true


### PR DESCRIPTION
please double-check my logic. If/when we start sending notifications out based on user timezone or preference, we'd want to make sure that we query for userId as well I think? This should not have any major effect today... (and wouldn't be the cause of Chris's issue getting duplicates)