### PR TITLE
Rationalise permissions

### DIFF
--- a/__integration-tests__/server/pages/api/pages/index.spec.ts
+++ b/__integration-tests__/server/pages/api/pages/index.spec.ts
@@ -79,4 +79,104 @@ describe('POST /api/pages - create page', () => {
       .expect(401);
 
   });
+
+  it('should prevent creation of proposal templates', async () => {
+    const { user, space } = await generateUserAndSpaceWithApiToken(v4(), true);
+
+    const userCookie = await loginUser(user);
+
+    await addSpaceOperations({
+      forSpaceId: space.id,
+      spaceId: space.id,
+      operations: ['createPage', 'createVote']
+    });
+
+    const pageToCreate = generatePageToCreateStub({
+      userId: user.id,
+      spaceId: space.id,
+      type: 'proposal_template'
+    });
+
+    await request(baseUrl)
+      .post('/api/pages')
+      .set('Cookie', userCookie)
+      .send(pageToCreate)
+      .expect(401);
+  });
+});
+
+describe('POST /api/pages - create proposal page', () => {
+  it('should create a proposal page if the non-admin user has the permission and return it, responding with 201', async () => {
+
+    const { user, space } = await generateUserAndSpaceWithApiToken(v4(), false);
+
+    await addSpaceOperations({
+      forSpaceId: space.id,
+      spaceId: space.id,
+      operations: ['createVote']
+    });
+
+    const userCookie = await loginUser(user);
+
+    const pageToCreate = generatePageToCreateStub({
+      userId: user.id,
+      spaceId: space.id,
+      type: 'proposal'
+    });
+
+    const { body: createdPage } = await request(baseUrl)
+      .post('/api/pages')
+      .set('Cookie', userCookie)
+      .send(pageToCreate)
+      .expect(201) as {body: IPageWithPermissions};
+
+    expect(createdPage.spaceId).toBe(pageToCreate.spaceId as string);
+    expect(createdPage.path).toBe(pageToCreate.path);
+    expect(createdPage.createdBy).toBe(pageToCreate.createdBy as string);
+
+  });
+
+  it('should allow admins to create a page even if no permission exists, and return it, responding with 201', async () => {
+
+    const { user, space } = await generateUserAndSpaceWithApiToken(v4(), true);
+
+    const userCookie = await loginUser(user);
+
+    const pageToCreate = generatePageToCreateStub({
+      userId: user.id,
+      spaceId: space.id,
+      type: 'proposal'
+    });
+
+    const { body: createdPage } = await request(baseUrl)
+      .post('/api/pages')
+      .set('Cookie', userCookie)
+      .send(pageToCreate)
+      .expect(201) as {body: IPageWithPermissions};
+
+    expect(createdPage.spaceId).toBe(pageToCreate.spaceId as string);
+    expect(createdPage.path).toBe(pageToCreate.path);
+    expect(createdPage.createdBy).toBe(pageToCreate.createdBy);
+
+  });
+
+  it('should fail to create a page if the non-admin user does not have the permission and return it, responding with 401', async () => {
+
+    const { user, space } = await generateUserAndSpaceWithApiToken(v4(), false);
+
+    const userCookie = await loginUser(user);
+
+    const pageToCreate = generatePageToCreateStub({
+      userId: user.id,
+      spaceId: space.id,
+      type: 'proposal'
+    });
+
+    await request(baseUrl)
+      .post('/api/pages')
+      .set('Cookie', userCookie)
+      .send(pageToCreate)
+      .expect(401);
+
+  });
 });

--- a/__integration-tests__/server/pages/api/proposals/from-template.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/from-template.spec.ts
@@ -1,33 +1,30 @@
 import type { Page } from '@prisma/client';
-import { SpaceOperation } from '@prisma/client';
-import { addSpaceOperations, removeSpaceOperations } from 'lib/permissions/spaces';
+import { prisma } from 'db';
+import { addSpaceOperations } from 'lib/permissions/spaces';
 import { createProposalTemplate } from 'lib/templates/proposals/createProposalTemplate';
-import { typedKeys } from 'lib/utilities/objects';
 import request from 'supertest';
 import { baseUrl, loginUser } from 'testing/mockApiCall';
-import { generateSpaceUser, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
-import { prisma } from 'db';
+import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
 
 describe('POST /api/proposals/from-template - Instantiate a proposal template', () => {
-  it('should copy a proposal template if the user can create pages and respond with 201', async () => {
+  it('should copy a proposal template if the user has the space.createVotes permission and respond with 201', async () => {
 
-    const { user: adminUser, space } = await generateUserAndSpaceWithApiToken(undefined, true);
-    const nonAdminUser = await generateSpaceUser({ isAdmin: false, spaceId: space.id });
+    const { user: nonAdminUser, space } = await generateUserAndSpaceWithApiToken(undefined, false);
 
     await addSpaceOperations({
       spaceId: space.id,
       forSpaceId: space.id,
-      operations: ['createPage']
+      operations: ['createVote']
     });
 
     const nonAdminCookie = await loginUser(nonAdminUser);
 
     const proposalTemplate = await createProposalTemplate({
       spaceId: space.id,
-      userId: adminUser.id,
+      userId: nonAdminUser.id,
       reviewers: [{
         group: 'user',
-        id: adminUser.id
+        id: nonAdminUser.id
       }]
     });
 
@@ -49,27 +46,66 @@ describe('POST /api/proposals/from-template - Instantiate a proposal template', 
       }
     });
 
-    expect(proposal?.reviewers?.some(r => r.userId === adminUser.id)).toBe(true);
+    expect(proposal?.reviewers?.some(r => r.userId === nonAdminUser.id)).toBe(true);
 
   });
 
-  it('should fail if the user does not have create pages space permission and respond with 401', async () => {
+  it('should copy a proposal template if the user is an admin, even if the space has no createVote permissions and respond with 201', async () => {
 
     const { user: adminUser, space } = await generateUserAndSpaceWithApiToken(undefined, true);
-    const nonAdminUser = await generateSpaceUser({ isAdmin: false, spaceId: space.id });
+    const adminCookie = await loginUser(adminUser);
 
-    // Remove all space permissions
-    await removeSpaceOperations({
-      spaceId: space.id,
-      forSpaceId: space.id,
-      operations: typedKeys(SpaceOperation)
+    await prisma.spacePermission.deleteMany({
+      where: {
+        forSpaceId: space.id
+      }
     });
-
-    const nonAdminCookie = await loginUser(nonAdminUser);
 
     const proposalTemplate = await createProposalTemplate({
       spaceId: space.id,
       userId: adminUser.id,
+      reviewers: [{
+        group: 'user',
+        id: adminUser.id
+      }]
+    });
+
+    const createdProposal = (await request(baseUrl)
+      .post('/api/proposals/from-template')
+      .set('Cookie', adminCookie)
+      .send({
+        templateId: proposalTemplate.id,
+        spaceId: space.id
+      })
+      .expect(201)).body as Page;
+
+    const proposal = await prisma.proposal.findUnique({
+      where: {
+        id: createdProposal.proposalId as string
+      },
+      include: {
+        reviewers: true
+      }
+    });
+
+    expect(proposal?.reviewers?.some(r => r.userId === adminUser.id)).toBe(true);
+
+  });
+
+  it('should copy a proposal template if the user does not have createVote space permission and respond with 401', async () => {
+
+    const { user: nonAdminUser, space } = await generateUserAndSpaceWithApiToken(undefined, false);
+    const nonAdminCookie = await loginUser(nonAdminUser);
+
+    await prisma.spacePermission.deleteMany({
+      where: {
+        forSpaceId: space.id
+      }
+    });
+
+    const proposalTemplate = await createProposalTemplate({
+      spaceId: space.id,
+      userId: nonAdminUser.id,
       reviewers: [{
         group: 'user',
         id: nonAdminUser.id
@@ -84,7 +120,6 @@ describe('POST /api/proposals/from-template - Instantiate a proposal template', 
         spaceId: space.id
       })
       .expect(401);
-
   });
 
 });

--- a/__integration-tests__/server/pages/api/votes/index.spec.ts
+++ b/__integration-tests__/server/pages/api/votes/index.spec.ts
@@ -47,27 +47,24 @@ describe('GET /api/votes?id={id} - Get an individual vote', () => {
 describe('POST /api/votes - Create a new poll', () => {
   it('Should create the poll if the user has the create poll permission for the page and respond 201', async () => {
 
-    const nonAdminUser = await generateSpaceUser({ spaceId: space.id, isAdmin: false });
-    const nonAdminUserCookie = await loginUser(nonAdminUser);
-
     const pageForVote = await createPage({
-      createdBy: nonAdminUser.id,
+      createdBy: user.id,
       spaceId: space.id,
       pagePermissions: [{
         permissionLevel: 'custom',
         permissions: ['create_poll'],
-        userId: nonAdminUser.id
+        userId: user.id
       }]
     });
 
-    await request(baseUrl).post('/api/votes').set('Cookie', nonAdminUserCookie).send({
+    await request(baseUrl).post('/api/votes').set('Cookie', userCookie).send({
       deadline: new Date(),
       pageId: pageForVote.id,
       title: 'new vote',
       type: 'Approval',
       threshold: 50,
       voteOptions: ['1', '2', '3'],
-      createdBy: nonAdminUser.id
+      createdBy: user.id
     })
       .expect(201);
   });

--- a/__integration-tests__/server/pages/api/votes/index.spec.ts
+++ b/__integration-tests__/server/pages/api/votes/index.spec.ts
@@ -16,7 +16,7 @@ let vote: Vote;
 let userCookie: string;
 
 beforeAll(async () => {
-  const { space: generatedSpace, user: generatedUser } = await generateUserAndSpaceWithApiToken(undefined, true);
+  const { space: generatedSpace, user: generatedUser } = await generateUserAndSpaceWithApiToken(undefined, false);
   user = generatedUser;
   space = generatedSpace;
 
@@ -44,18 +44,54 @@ describe('GET /api/votes?id={id} - Get an individual vote', () => {
   });
 });
 
-describe('POST /api/votes - Create a new vote', () => {
-  it('Should create the vote respond 200', async () => {
-    await request(baseUrl).post('/api/votes').set('Cookie', userCookie).send({
+describe('POST /api/votes - Create a new poll', () => {
+  it('Should create the poll if the user has the create poll permission for the page and respond 201', async () => {
+
+    const nonAdminUser = await generateSpaceUser({ spaceId: space.id, isAdmin: false });
+    const nonAdminUserCookie = await loginUser(nonAdminUser);
+
+    const pageForVote = await createPage({
+      createdBy: nonAdminUser.id,
+      spaceId: space.id,
+      pagePermissions: [{
+        permissionLevel: 'custom',
+        permissions: ['create_poll'],
+        userId: nonAdminUser.id
+      }]
+    });
+
+    await request(baseUrl).post('/api/votes').set('Cookie', nonAdminUserCookie).send({
       deadline: new Date(),
-      pageId: page.id,
+      pageId: pageForVote.id,
       title: 'new vote',
       type: 'Approval',
       threshold: 50,
       voteOptions: ['1', '2', '3'],
-      createdBy: user.id
+      createdBy: nonAdminUser.id
     })
-      .expect(200);
+      .expect(201);
+  });
+
+  it('Should create the poll if the user is an admin for the page and respond 201', async () => {
+
+    const nonAdminUser = await generateSpaceUser({ spaceId: space.id, isAdmin: true });
+    const nonAdminUserCookie = await loginUser(nonAdminUser);
+
+    const pageForVote = await createPage({
+      createdBy: nonAdminUser.id,
+      spaceId: space.id
+    });
+
+    await request(baseUrl).post('/api/votes').set('Cookie', nonAdminUserCookie).send({
+      deadline: new Date(),
+      pageId: pageForVote.id,
+      title: 'new vote',
+      type: 'Approval',
+      threshold: 50,
+      voteOptions: ['1', '2', '3'],
+      createdBy: nonAdminUser.id
+    })
+      .expect(201);
   });
 
   it('Should fail if the vote body doesn\'t have correct fields and respond 400', async () => {

--- a/__integration-tests__/server/pages/api/votes/index.spec.ts
+++ b/__integration-tests__/server/pages/api/votes/index.spec.ts
@@ -155,7 +155,7 @@ describe('POST /api/votes - Create a proposal vote', () => {
         voteOptions: ['1', '2', '3'],
         createdBy: user.id
       })
-      .expect(200);
+      .expect(201);
 
   });
 
@@ -185,7 +185,7 @@ describe('POST /api/votes - Create a proposal vote', () => {
         voteOptions: ['1', '2', '3'],
         createdBy: user.id
       })
-      .expect(200);
+      .expect(201);
   });
 
   it('should not allow the user to create a proposal vote if they are not a proposal author', async () => {

--- a/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
@@ -30,10 +30,9 @@ export default function FloatingMenuComponent (
 
 ) {
   const { showMessage } = useSnackbar();
-  const [currentUserPermissions] = useCurrentSpacePermissions();
   const displayInlineCommentButton = !inline && pagePermissions?.comment && enableComments && pageType !== 'card_template';
 
-  const displayInlineVoteButton = !inline && pagePermissions?.comment && currentUserPermissions?.createVote && enableVoting && pageType !== 'card_template';
+  const displayInlineVoteButton = !inline && pagePermissions?.create_poll && enableVoting && pageType !== 'card_template';
   return (
     <FloatingMenu
       menuKey={pluginKey}

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -30,7 +30,6 @@ import { generateMarkdown } from 'lib/pages/generateMarkdown';
 import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
 import { useRef, useState } from 'react';
-import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
 import CreateVoteModal from 'components/votes/components/CreateVoteModal';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import ShareButton from './components/ShareButton';
@@ -55,18 +54,20 @@ export default function Header ({ open, openSidebar }: HeaderProps) {
 
   const router = useRouter();
   const colorMode = useColorMode();
-  const { pages, setPages } = usePages();
+  const { pages, setPages, getPagePermissions } = usePages();
   const { user, setUser } = useUser();
   const theme = useTheme();
   const [pageMenuOpen, setPageMenuOpen] = useState(false);
   const [pageMenuAnchorElement, setPageMenuAnchorElement] = useState<null | Element>(null);
   const pageMenuAnchor = useRef();
-  const [currentSpacePermissions] = useCurrentSpacePermissions();
   const { setCurrentPageActionDisplay } = usePageActionDisplay();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const basePageId = router.query.pageId as string;
   const basePage = Object.values(pages).find(page => page?.id === basePageId || page?.path === basePageId);
+
+  const pagePermissions = getPagePermissions(basePageId);
+
   const isFavorite = basePage && user?.favorites.some(({ pageId }) => pageId === basePage.id);
   const pageType = basePage?.type;
   const isExportablePage = pageType === 'card' || pageType === 'page' || pageType === 'proposal';
@@ -107,7 +108,7 @@ export default function Header ({ open, openSidebar }: HeaderProps) {
 
   const documentOptions = (
     <List dense>
-      {currentSpacePermissions?.createVote && (
+      {pagePermissions?.create_poll && (
         <ListItemButton
           onClick={() => {
             setPageMenuOpen(false);

--- a/components/votes/components/NewProposalButton.tsx
+++ b/components/votes/components/NewProposalButton.tsx
@@ -40,7 +40,7 @@ export default function NewProposalButton ({ mutateProposals }: {mutateProposals
 
   }, [pages]);
 
-  const canCreateProposal = !!userSpacePermissions?.createPage;
+  const canCreateProposal = !!userSpacePermissions?.createVote;
 
   async function deleteProposalTemplate (templateId: string) {
     await charmClient.deletePage(templateId);
@@ -115,21 +115,23 @@ export default function NewProposalButton ({ mutateProposals }: {mutateProposals
     <>
 
       <Tooltip title={!canCreateProposal ? 'You do not have the permission to create a proposal.' : ''}>
-        <Button disabled={!canCreateProposal} ref={buttonRef}>
-          <Box
-            onClick={onClickCreate}
-          >
-            Create Proposal
-          </Box>
+        <Box>
+          <Button disabled={!canCreateProposal} ref={buttonRef}>
+            <Box
+              onClick={onClickCreate}
+            >
+              Create Proposal
+            </Box>
 
-          <Box
+            <Box
             // Negative right margin fixes issue with too much whitespace on right of button
-            sx={{ pl: 1, mr: -2 }}
-            {...bindTrigger(popupState)}
-          >
-            <DownIcon />
-          </Box>
-        </Button>
+              sx={{ pl: 1, mr: -2 }}
+              {...bindTrigger(popupState)}
+            >
+              <DownIcon />
+            </Box>
+          </Button>
+        </Box>
       </Tooltip>
       <TemplatesMenu
         addPageFromTemplate={createProposalFromTemplate}

--- a/lib/permissions/meta/__tests__/getTemplateExplanation.spec.ts
+++ b/lib/permissions/meta/__tests__/getTemplateExplanation.spec.ts
@@ -15,7 +15,7 @@ describe('getTemplateExplanation', () => {
     const cannot = [
       'Workspace members cannot create new bounties.',
       'Workspace members cannot create new pages.',
-      'Workspace members cannot create new polls.',
+      'Workspace members cannot create new proposals.',
       'Workspace members cannot comment on, edit, share or delete new top-level pages by default.',
       'Anyone outside the workspace cannot see new top-level pages by default.',
       'Anyone outside the workspace cannot see bounties and bounty suggestions.'
@@ -38,7 +38,7 @@ describe('getTemplateExplanation', () => {
     const can = [
       'Workspace members can create new pages.',
       'Workspace members can create new bounties.',
-      'Workspace members can create new polls.',
+      'Workspace members can create new proposals.',
       'Workspace members can view, edit, comment on, share and delete new top-level pages by default.'
     ];
     const cannot = [
@@ -63,7 +63,7 @@ describe('getTemplateExplanation', () => {
     const can = [
       'Workspace members can create new pages.',
       'Workspace members can create new bounties.',
-      'Workspace members can create new polls.',
+      'Workspace members can create new proposals.',
       'Workspace members can view, edit, comment on, share and delete new top-level pages by default.',
       'Anyone can see new top-level pages by default.',
       'Anyone can see bounties and bounty suggestions visible to workspace members.'

--- a/lib/permissions/pages/available-page-permissions.class.ts
+++ b/lib/permissions/pages/available-page-permissions.class.ts
@@ -15,6 +15,8 @@ export class AllowedPagePermissions extends Permissions<PageOperationType> {
 
   comment: boolean = false;
 
+  create_poll: boolean = false;
+
   edit_position: boolean = false;
 
   edit_content: boolean = false;

--- a/lib/permissions/pages/page-permission-mapping.ts
+++ b/lib/permissions/pages/page-permission-mapping.ts
@@ -17,6 +17,7 @@ export const permissionDescriptions: Record<PageOperationType, string> = {
   delete: 'delete page',
   read: 'view page',
   comment: 'comment page content',
+  create_poll: 'create polls',
   edit_content: 'edit page content',
   edit_position: 'reposition page',
   edit_isPublic: 'share page',
@@ -26,8 +27,8 @@ export const permissionDescriptions: Record<PageOperationType, string> = {
 
 export const permissionTemplates: Record<keyof typeof PagePermissionLevel, PageOperationType []> = {
   full_access: Object.keys(PageOperations) as PageOperationType [],
-  proposal_editor: ['read', 'comment', 'edit_content', 'edit_isPublic', 'delete'],
-  editor: ['read', 'edit_content', 'comment'],
+  proposal_editor: ['read', 'comment', 'edit_content', 'edit_isPublic', 'delete', 'create_poll'],
+  editor: ['read', 'edit_content', 'comment', 'create_poll'],
   view_comment: ['read', 'comment'],
   view: ['read'],
   // Implemented at the database level

--- a/lib/permissions/spaces/mapping.ts
+++ b/lib/permissions/spaces/mapping.ts
@@ -3,7 +3,7 @@ import { SpaceOperation } from '@prisma/client';
 export const spaceOperationLabels: Record<SpaceOperation, string> = {
   createPage: 'Create new pages',
   createBounty: 'Create new bounties',
-  createVote: 'Create new polls'
+  createVote: 'Create new proposals'
 };
 
 export function spaceOperations () {

--- a/lib/votes/__tests__/deleteVote.spec.ts
+++ b/lib/votes/__tests__/deleteVote.spec.ts
@@ -38,21 +38,21 @@ describe('deleteVote', () => {
     })).toBeFalsy();
   });
 
-  it('should throw error if createVote space permission doesn\'t exist', async () => {
-    const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);
-    const page = await createPage({
-      createdBy: user.id,
-      spaceId: space.id
-    });
+  // it('should throw error if createVote space permission doesn\'t exist', async () => {
+  //   const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);
+  //   const page = await createPage({
+  //     createdBy: user.id,
+  //     spaceId: space.id
+  //   });
 
-    const vote = await createVote({
-      pageId: page.id,
-      createdBy: user.id,
-      spaceId: space.id
-    });
+  //   const vote = await createVote({
+  //     pageId: page.id,
+  //     createdBy: user.id,
+  //     spaceId: space.id
+  //   });
 
-    await expect(deleteVote(vote.id, user.id)).rejects.toBeInstanceOf(UnauthorisedActionError);
-  });
+  //   await expect(deleteVote(vote.id, user.id)).rejects.toBeInstanceOf(UnauthorisedActionError);
+  // });
 
   it('should throw error if a proposal context vote is being deleted', async () => {
     const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);

--- a/lib/votes/__tests__/deleteVote.spec.ts
+++ b/lib/votes/__tests__/deleteVote.spec.ts
@@ -38,22 +38,6 @@ describe('deleteVote', () => {
     })).toBeFalsy();
   });
 
-  // it('should throw error if createVote space permission doesn\'t exist', async () => {
-  //   const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);
-  //   const page = await createPage({
-  //     createdBy: user.id,
-  //     spaceId: space.id
-  //   });
-
-  //   const vote = await createVote({
-  //     pageId: page.id,
-  //     createdBy: user.id,
-  //     spaceId: space.id
-  //   });
-
-  //   await expect(deleteVote(vote.id, user.id)).rejects.toBeInstanceOf(UnauthorisedActionError);
-  // });
-
   it('should throw error if a proposal context vote is being deleted', async () => {
     const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);
     const page = await createPage({

--- a/lib/votes/__tests__/updateVote.spec.ts
+++ b/lib/votes/__tests__/updateVote.spec.ts
@@ -62,10 +62,10 @@ describe('updateVote', () => {
     await expect(updateVote(vote.id, v4(), 'InProgress')).rejects.toBeInstanceOf(UndesirableOperationError);
   });
 
-  it('should throw error if user don\'t have permission to update vote', async () => {
-    const { vote, user } = await setupVoteData();
-    await expect(updateVote(vote.id, user.id, 'Cancelled')).rejects.toBeInstanceOf(UnauthorisedActionError);
-  });
+  // it('should throw error if user don\'t have permission to update vote', async () => {
+  //   const { vote, user } = await setupVoteData();
+  //   await expect(updateVote(vote.id, user.id, 'Cancelled')).rejects.toBeInstanceOf(UnauthorisedActionError);
+  // });
 
   it('should throw error if a proposal context vote is being cancelled', async () => {
     const { vote, user, space } = await setupVoteData({

--- a/lib/votes/deleteVote.ts
+++ b/lib/votes/deleteVote.ts
@@ -1,8 +1,7 @@
 import type { Vote } from '@prisma/client';
 import { prisma } from 'db';
 import log from 'lib/log';
-import { hasAccessToSpace } from 'lib/users/hasAccessToSpace';
-import { UnauthorisedActionError, UndesirableOperationError } from 'lib/utilities/errors';
+import { UndesirableOperationError } from 'lib/utilities/errors';
 import { getVote } from './getVote';
 
 export async function deleteVote (id: string, userId: string): Promise<Vote | null> {
@@ -15,16 +14,6 @@ export async function deleteVote (id: string, userId: string): Promise<Vote | nu
 
   if (vote.context === 'proposal') {
     throw new UndesirableOperationError("Proposal votes can't be deleted");
-  }
-
-  const { error, isAdmin } = await hasAccessToSpace({
-    spaceId: vote.spaceId,
-    userId,
-    adminOnly: false
-  });
-
-  if (error || (vote.createdBy !== userId && !isAdmin)) {
-    throw new UnauthorisedActionError('You do not have permissions to update the vote.');
   }
 
   return prisma.vote.delete({

--- a/lib/votes/updateVote.ts
+++ b/lib/votes/updateVote.ts
@@ -1,7 +1,6 @@
 import type { Vote } from '@prisma/client';
 import { prisma } from 'db';
-import { DataNotFoundError, UnauthorisedActionError, UndesirableOperationError } from 'lib/utilities/errors';
-import { hasAccessToSpace } from '../middleware';
+import { DataNotFoundError, UndesirableOperationError } from 'lib/utilities/errors';
 import type { VoteStatusType } from './interfaces';
 import { VOTE_STATUS } from './interfaces';
 

--- a/lib/votes/updateVote.ts
+++ b/lib/votes/updateVote.ts
@@ -1,7 +1,7 @@
-import { prisma } from 'db';
 import type { Vote } from '@prisma/client';
-import { DataNotFoundError, UndesirableOperationError, UnauthorisedActionError } from 'lib/utilities/errors';
-import { computeSpacePermissions } from 'lib/permissions/spaces';
+import { prisma } from 'db';
+import { DataNotFoundError, UnauthorisedActionError, UndesirableOperationError } from 'lib/utilities/errors';
+import { hasAccessToSpace } from '../middleware';
 import type { VoteStatusType } from './interfaces';
 import { VOTE_STATUS } from './interfaces';
 
@@ -28,15 +28,6 @@ export async function updateVote (id: string, userId: string, status: VoteStatus
 
   if (existingVote.context === 'proposal') {
     throw new UndesirableOperationError("Proposal votes can't be cancelled");
-  }
-
-  const userPermissions = await computeSpacePermissions({
-    allowAdminBypass: true,
-    resourceId: existingVote.spaceId,
-    userId
-  });
-  if (!userPermissions.createVote) {
-    throw new UnauthorisedActionError('You do not have permissions to update the vote.');
   }
 
   const updatedVote = await prisma.vote.update({

--- a/pages/api/pages/index.ts
+++ b/pages/api/pages/index.ts
@@ -37,7 +37,10 @@ async function createPage (req: NextApiRequest, res: NextApiResponse<IPageWithPe
     userId
   });
 
-  if (!permissions.createPage) {
+  if (data.type === 'proposal' && !permissions.createVote) {
+    throw new UnauthorisedActionError('You do not have permission to create a page in this space');
+  }
+  else if (data.type !== 'proposal' && !permissions.createPage) {
     throw new UnauthorisedActionError('You do not have permissions to create a page.');
   }
 

--- a/pages/api/pages/index.ts
+++ b/pages/api/pages/index.ts
@@ -52,7 +52,10 @@ async function createPage (req: NextApiRequest, res: NextApiResponse<IPageWithPe
 
   let page: Page;
 
-  if (pageCreationData.type === 'proposal') {
+  if (pageCreationData.type === 'proposal_template') {
+    throw new UnauthorisedActionError('You cannot create a proposal template using this endpoint.');
+  }
+  else if (pageCreationData.type === 'proposal') {
     ({ page } = await createProposal({
       ...pageCreationData,
       spaceId,

--- a/pages/api/proposals/from-template.ts
+++ b/pages/api/proposals/from-template.ts
@@ -27,7 +27,7 @@ async function createProposalFromTemplateController (req: NextApiRequest, res: N
     userId
   });
 
-  if (!permissions.createPage) {
+  if (!permissions.createVote) {
     throw new UnauthorisedActionError('You cannot create new pages');
   }
 

--- a/pages/api/votes/[id]/index.ts
+++ b/pages/api/votes/[id]/index.ts
@@ -1,5 +1,5 @@
 import type { Vote } from '@prisma/client';
-import { onError, onNoMatch, requireUser } from 'lib/middleware';
+import { hasAccessToSpace, onError, onNoMatch, requireUser } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import {
@@ -9,6 +9,8 @@ import {
 } from 'lib/votes';
 import nc from 'next-connect';
 import type { UpdateVoteDTO } from 'lib/votes/interfaces';
+import { prisma } from 'db';
+import { DataNotFoundError, UnauthorisedActionError } from '../../../../lib/utilities/errors';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
@@ -30,6 +32,33 @@ async function getVote (req: NextApiRequest, res: NextApiResponse<Vote | { error
 async function updateVote (req: NextApiRequest, res: NextApiResponse<Vote | { error: any }>) {
   const voteId = req.query.id as string;
   const { status } = req.body as UpdateVoteDTO;
+  const userId = req.session.user.id;
+
+  const vote = await prisma.vote.findUnique({
+    where: {
+      id: voteId
+    },
+    select: {
+      id: true,
+      spaceId: true,
+      createdBy: true
+    }
+  });
+
+  if (!vote) {
+    throw new DataNotFoundError(`Cannot update vote as vote with id ${voteId} was not found.`);
+  }
+
+  const { error, isAdmin } = await hasAccessToSpace({
+    spaceId: vote.spaceId,
+    userId,
+    adminOnly: false
+  });
+
+  if (error || (vote.createdBy !== userId && !isAdmin)) {
+    throw new UnauthorisedActionError('You do not have permissions to update the vote.');
+  }
+
   const updatedVote = await updateVoteService(voteId, req.session.user.id, status);
 
   return res.status(200).json(updatedVote);
@@ -37,6 +66,34 @@ async function updateVote (req: NextApiRequest, res: NextApiResponse<Vote | { er
 
 async function deleteVote (req: NextApiRequest, res: NextApiResponse<Vote | null | { error: any }>) {
   const voteId = req.query.id as string;
+
+  const userId = req.session.user.id;
+
+  const vote = await prisma.vote.findUnique({
+    where: {
+      id: voteId
+    },
+    select: {
+      id: true,
+      spaceId: true,
+      createdBy: true
+    }
+  });
+
+  if (!vote) {
+    throw new DataNotFoundError(`Cannot update vote as vote with id ${voteId} was not found.`);
+  }
+
+  const { error, isAdmin } = await hasAccessToSpace({
+    spaceId: vote.spaceId,
+    userId,
+    adminOnly: false
+  });
+
+  if (error || (vote.createdBy !== userId && !isAdmin)) {
+    throw new UnauthorisedActionError('You do not have permissions to update the vote.');
+  }
+
   const deletedVote = await deleteVoteService(voteId, req.session.user.id);
 
   return res.status(200).json(deletedVote);

--- a/pages/api/votes/index.ts
+++ b/pages/api/votes/index.ts
@@ -80,7 +80,7 @@ async function createVote (req: NextApiRequest, res: NextApiResponse<ExtendedVot
     createdBy: userId
   } as VoteDTO);
 
-  return res.status(200).json(vote);
+  return res.status(201).json(vote);
 }
 
 export default withSessionRoute(handler);

--- a/pages/api/votes/index.ts
+++ b/pages/api/votes/index.ts
@@ -9,6 +9,7 @@ import nc from 'next-connect';
 import { prisma } from 'db';
 import { DataNotFoundError, UnauthorisedActionError } from 'lib/utilities/errors';
 import { computeSpacePermissions } from 'lib/permissions/spaces';
+import { computeUserPagePermissions } from 'lib/permissions/pages';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
@@ -62,13 +63,13 @@ async function createVote (req: NextApiRequest, res: NextApiResponse<ExtendedVot
     }
   }
   else {
-    const userPermissions = await computeSpacePermissions({
-      allowAdminBypass: true,
-      resourceId: existingPage.spaceId,
-      userId: createdBy
+    const userPagePermissions = await computeUserPagePermissions({
+      pageId,
+      userId,
+      allowAdminBypass: true
     });
 
-    if (!userPermissions.createVote) {
+    if (!userPagePermissions.create_poll) {
       throw new UnauthorisedActionError('You do not have permissions to create a vote.');
     }
   }

--- a/prisma/migrations/20220922184953_add_create_poll_operation/migration.sql
+++ b/prisma/migrations/20220922184953_add_create_poll_operation/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "PageOperations" ADD VALUE 'create_poll';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -112,6 +112,7 @@ enum PageOperations {
   edit_path
   grant_permissions
   comment
+  create_poll
 }
 
 enum SpaceOperation {


### PR DESCRIPTION
This PR moves the use of space permission "createVote" to be used for the creation of proposals

It adds a "create poll" ability at the page permission level so that inline poll creation depends on your access level to that page

For proposals, only proposal editors can create polls
