### PR TITLE
converting the cronjob metrics to count

### DIFF
--- a/background/tasks/deleteArchivedPages/task.ts
+++ b/background/tasks/deleteArchivedPages/task.ts
@@ -1,6 +1,6 @@
 
 import log from 'lib/log';
-import { gauge } from 'lib/metrics';
+import { count } from 'lib/metrics';
 import { deleteArchivedPages } from 'lib/pages/server/deleteArchivedPages';
 
 const MAX_ARCHIVE_DAYS = process.env.MAX_ARCHIVE_DAYS ? parseInt(process.env.MAX_ARCHIVE_DAYS) : 30;
@@ -21,12 +21,12 @@ export default async function task () {
 
     log.info(`Deleted ${deletedPagesCount} pages, ${deletedBlocksCount} blocks`);
 
-    gauge('cron.delete-archived.deleted-proposals', deletedProposalsCount);
-    gauge('cron.delete-archived.deleted-bounties', deletedBountiesCount);
-    gauge('cron.delete-archived.deleted-pages', deletedPagesCount);
-    gauge('cron.delete-archived.deleted-blocks', deletedBlocksCount);
-    gauge('cron.delete-archived.archived-pages', archivedPagesCount);
-    gauge('cron.delete-archived.archived-blocks', archivedBlocksCount);
+    count('cron.delete-archived.deleted-proposals', deletedProposalsCount);
+    count('cron.delete-archived.deleted-bounties', deletedBountiesCount);
+    count('cron.delete-archived.deleted-pages', deletedPagesCount);
+    count('cron.delete-archived.deleted-blocks', deletedBlocksCount);
+    count('cron.delete-archived.archived-pages', archivedPagesCount);
+    count('cron.delete-archived.archived-blocks', archivedBlocksCount);
   }
   catch (error: any) {
     log.error(`Error deleting archived pages: ${error.stack || error.message || error}`, { error });

--- a/background/tasks/sendNotifications/task.ts
+++ b/background/tasks/sendNotifications/task.ts
@@ -1,6 +1,6 @@
 
 import log from 'lib/log';
-import { gauge } from 'lib/metrics';
+import { count } from 'lib/metrics';
 import { sendUserNotifications } from './sendNotifications';
 
 export default async function task () {
@@ -12,7 +12,7 @@ export default async function task () {
 
     log.info(`Sent ${notificationCount} notifications`);
 
-    gauge('cron.user-notifications.sent', notificationCount);
+    count('cron.user-notifications.sent', notificationCount);
   }
   catch (error: any) {
     log.error(`Error running notifications: ${error.stack || error.message || error}`, { error });


### PR DESCRIPTION
Dunno if this was a mistake... but here's the doc on diff between count and gauge
https://docs.datadoghq.com/metrics/types/?tab=count

Gauge should be like, temperature, a measurement of a condition that exists between executions of a job. 

In this case, you're submitting the number of items you've processed after each cronjob. If you were to record, say, the total number of pages that the system has deleted since the dawn of time, then this can be a gauge. 