### PR TITLE
Allow navigating backwards

### DIFF
--- a/components/[pageId]/BoardPage/BoardPage.tsx
+++ b/components/[pageId]/BoardPage/BoardPage.tsx
@@ -114,7 +114,7 @@ export default function BoardPage ({ page, setPage, readOnly = false, pagePermis
   const showCard = useCallback((cardId?: string) => {
     const newUrl = `${router.pathname}?viewId=${router.query.viewId}&cardId=${cardId ?? ''}`;
 
-    const asUrl = `${router.asPath.split('?')[0]}?viewId=${router.query.viewId}&cardId=${cardId ?? ''}`;
+    const asUrl = getUriWithParam(`${router.asPath}`, { viewId: router.query.viewId, cardId }).split(window.location.origin)[1];
 
     silentlyUpdateURL(newUrl, asUrl);
     setShownCardId(cardId);

--- a/components/[pageId]/BoardPage/BoardPage.tsx
+++ b/components/[pageId]/BoardPage/BoardPage.tsx
@@ -114,9 +114,7 @@ export default function BoardPage ({ page, setPage, readOnly = false, pagePermis
   const showCard = useCallback((cardId?: string) => {
     const newUrl = `${router.pathname}?viewId=${router.query.viewId}&cardId=${cardId}`;
 
-    const pageIdString = typeof router.query.pageId === 'string' ? `&pageId=${router.query.pageId}` : router.query.pageId instanceof Array ? `&pageId=${router.query.pageId[0]}&pageId=${router.query.pageId[1]}` : '';
-
-    const asUrl = `${router.asPath.split('?')[0]}?viewId=${router.query.viewId}&cardId=${cardId}${pageIdString}`;
+    const asUrl = `${router.asPath.split('?')[0]}?viewId=${router.query.viewId}&cardId=${cardId}`;
 
     silentlyUpdateURL(newUrl, asUrl);
     setShownCardId(cardId);

--- a/components/[pageId]/BoardPage/BoardPage.tsx
+++ b/components/[pageId]/BoardPage/BoardPage.tsx
@@ -112,9 +112,9 @@ export default function BoardPage ({ page, setPage, readOnly = false, pagePermis
   });
 
   const showCard = useCallback((cardId?: string) => {
-    const newUrl = `${router.pathname}?viewId=${router.query.viewId}&cardId=${cardId}`;
+    const newUrl = `${router.pathname}?viewId=${router.query.viewId}&cardId=${cardId ?? ''}`;
 
-    const asUrl = `${router.asPath.split('?')[0]}?viewId=${router.query.viewId}&cardId=${cardId}`;
+    const asUrl = `${router.asPath.split('?')[0]}?viewId=${router.query.viewId}&cardId=${cardId ?? ''}`;
 
     silentlyUpdateURL(newUrl, asUrl);
     setShownCardId(cardId);

--- a/components/[pageId]/BoardPage/BoardPage.tsx
+++ b/components/[pageId]/BoardPage/BoardPage.tsx
@@ -54,7 +54,7 @@ export default function BoardPage ({ page, setPage, readOnly = false, pagePermis
         query: {
           ...router.query,
           viewId: boardViews[0].id,
-          cardId: router.query.cardId
+          cardId: router.query.cardId ?? ''
         }
       });
       return;
@@ -112,8 +112,13 @@ export default function BoardPage ({ page, setPage, readOnly = false, pagePermis
   });
 
   const showCard = useCallback((cardId?: string) => {
-    const newUrl = getUriWithParam(window.location.href, { cardId });
-    silentlyUpdateURL(newUrl);
+    const newUrl = `${router.pathname}?viewId=${router.query.viewId}&cardId=${cardId}`;
+
+    const pageIdString = typeof router.query.pageId === 'string' ? `&pageId=${router.query.pageId}` : router.query.pageId instanceof Array ? `&pageId=${router.query.pageId[0]}&pageId=${router.query.pageId[1]}` : '';
+
+    const asUrl = `${router.asPath.split('?')[0]}?viewId=${router.query.viewId}&cardId=${cardId}${pageIdString}`;
+
+    silentlyUpdateURL(newUrl, asUrl);
     setShownCardId(cardId);
   }, [router.query]);
 

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -116,8 +116,8 @@ function scrollIntoViewIfNeededPolyfill (
 
 // source: https://github.com/vercel/next.js/discussions/18072
 // update URL without Next.js re-rendering the page
-export function silentlyUpdateURL (newUrl: string) {
-  window.history.replaceState({ ...window.history.state, as: newUrl, url: newUrl }, '', newUrl);
+export function silentlyUpdateURL (newUrl: string, as?: string) {
+  window.history.replaceState({ ...window.history.state, as: as ?? newUrl, url: newUrl }, '', as ?? newUrl);
 }
 
 export function getCookie (name: string): string {

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -53,7 +53,7 @@ export function getUriWithParam (
   baseUrl: string,
   params: Record<string, any>
 ): string {
-  const Url = new URL(baseUrl);
+  const Url = new URL(baseUrl, baseUrl.match('http') ? undefined : window.location.origin);
   const urlParams: URLSearchParams = new URLSearchParams(Url.search);
   for (const key in params) {
     if (params.hasOwnProperty(key)) {


### PR DESCRIPTION
This PR resolves a bug where navigating using browser front / back history to a board page  where the card had been opened would cause a fatal error preventing navigation.

The source issue was due to wrongly setting the browser history in a non Next.js compliant format