### PR TITLE
More explicitly store only user id in session cookies

### DIFF
--- a/lib/session/config.ts
+++ b/lib/session/config.ts
@@ -2,7 +2,7 @@
 declare module 'iron-session' {
   interface IronSessionData {
     // this data is only useful for authentication - it is not kept up-to-date!
-    user: { id: string, addresses: string[] };
+    user: { id: string };
   }
 }
 

--- a/pages/api/discord/callback.ts
+++ b/pages/api/discord/callback.ts
@@ -32,11 +32,8 @@ handler.get(async (req, res) => {
   if (type === 'login') {
     try {
       const user = await loginByDiscord({ code: tempAuthCode, hostName: req.headers.host });
-      // strip out large fields so we dont break the cookie
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { discordUser, spaceRoles, telegramUser, ...userData } = user;
-      req.session.user = userData;
-      await updateGuildRolesForUser(userData.addresses, spaceRoles);
+      req.session.user = { id: user.id };
+      await updateGuildRolesForUser(user.addresses, user.spaceRoles);
     }
     catch (error) {
       log.warn('Error while connecting to Discord', error);

--- a/pages/api/profile/index.ts
+++ b/pages/api/profile/index.ts
@@ -35,9 +35,8 @@ async function createUser (req: NextApiRequest, res: NextApiResponse<LoggedInUse
     logSignupViaWallet();
   }
 
-  const { spaceRoles, ...userData } = user;
-  req.session.user = userData;
-  await updateGuildRolesForUser(userData.addresses, spaceRoles);
+  req.session.user = { id: user.id };
+  await updateGuildRolesForUser(user.addresses, user.spaceRoles);
   await req.session.save();
 
   res.status(200).json(user);

--- a/pages/api/session/login.ts
+++ b/pages/api/session/login.ts
@@ -28,10 +28,8 @@ async function login (req: NextApiRequest, res: NextApiResponse<LoggedInUser | {
     return res.status(401).send({ error: 'No user has been associated with this wallet address' });
   }
 
-  // strip out large fields so we dont break the cookie
-  const { discordUser, spaceRoles, telegramUser, ...userData } = user;
-  req.session.user = userData;
-  await updateGuildRolesForUser(userData.addresses, spaceRoles);
+  req.session.user = { id: user.id };
+  await updateGuildRolesForUser(user.addresses, user.spaceRoles);
   await req.session.save();
 
   return res.status(200).json(user);


### PR DESCRIPTION
We only need to know the user id from the session state. I'd rename req.session.user.id to req.session.userId but that would invalidate all existing sessions, I think, and i'd rather not support two formats...

Storing and using other user data on the session has presented two separate issues int he past:
1) the session is not updated (we'd ideally re-query the user on every request)
2) the data from relational tables was so large we couldn't set the cookie, and users could not log in