### PR TITLE
fix page link when copying from modal

### DIFF
--- a/components/common/PageDialog/PageDialog.tsx
+++ b/components/common/PageDialog/PageDialog.tsx
@@ -139,7 +139,7 @@ export default function PageDialog (props: Props) {
               )}
               <ListItemButton
                 onClick={() => {
-                  Utils.copyTextToClipboard(window.location.href);
+                  Utils.copyTextToClipboard(window.location.origin + fullPageUrl);
                   showMessage('Copied card link to clipboard', 'success');
                 }}
               >


### PR DESCRIPTION
We can't use window.location for page link as this will just link to the main page you're on