### PR TITLE
Fix templates menu warnings

### DIFF
--- a/components/common/TemplatesMenu/TemplatesMenu.tsx
+++ b/components/common/TemplatesMenu/TemplatesMenu.tsx
@@ -94,14 +94,13 @@ export function TemplatesMenu ({
 }
       {
     enableNewTemplates && (
-      <>
-        <Divider />
-        <MenuItem dense sx={{ color: `${theme.palette.primary.main} !important` }} onClick={createTemplate}>
+      [
+        <Divider key='templates-menu-divider' />,
+        <MenuItem key='templates-menu-new-item' dense sx={{ color: `${theme.palette.primary.main} !important` }} onClick={createTemplate}>
           <AddIcon />
           <ListItemText>New template</ListItemText>
         </MenuItem>
-      </>
-
+      ]
     )
   }
     </Menu>


### PR DESCRIPTION
Fix annoying warnings spamming console, related to templates menu list

<img width="542" alt="Screenshot 2022-09-29 at 10 20 26" src="https://user-images.githubusercontent.com/5198394/192979928-32cb616d-378f-48bb-9a7a-ac0118b09e12.png">
<img width="557" alt="Screenshot 2022-09-29 at 10 19 56" src="https://user-images.githubusercontent.com/5198394/192979937-5317226e-b2ff-4e99-8563-7e42dc7af231.png">
