### PR TITLE
Fix Firefox drag and drop for kanban card

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 import { BountyStatusChip } from 'components/bounties/components/BountyStatusBadge';
 import { checkForEmpty } from 'components/common/CharmEditor/utils';
 import { useRouter } from 'next/router';
-import Link from 'components/common/Link';
+import Link from '@mui/material/Link';
 import PageIcon from 'components/common/PageLayout/components/PageIcon';
 import { CryptoCurrency, TokenLogoPaths } from 'connectors';
 import { useBounties } from 'hooks/useBounties';
@@ -119,7 +119,7 @@ const KanbanCard = React.memo((props: Props) => {
 
   return (
     <>
-      <Link href={fullPageUrl} external>
+      <Link href={fullPageUrl} draggable={false}>
         <div
           ref={props.readOnly ? () => null : cardRef}
           className={className}


### PR DESCRIPTION
For some reason, the a wrapped link with a prevent default & react-dnd library & Firefox don't go well with each other.
The onDrag works but onDrop does not.
I am making the assumption from what I've read in the issues column in react-dnd library, that onDrop is not working because the of the preventDefault.
This seems to be an issue just for Firefox.