### PR TITLE
Remove 0 from the start of max submissions

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
@@ -362,7 +362,7 @@ export default function BountyProperties (props: {
             </div>
             <TextField
               required
-              value={currentBounty?.maxSubmissions}
+              defaultValue={currentBounty?.maxSubmissions}
               type='number'
               size='small'
               inputProps={{ step: 1, min: 1 }}


### PR DESCRIPTION
TextField from MUI has an internal state to show the user his input when writing numbers in the input.
That means we don't need to handle a state that shows the value. Just need to show the first value the user sees when he opens the modal.