### PR TITLE
fix datetimes for proposal tasks

### DIFF
--- a/lib/proposal/__tests__/getProposalTasks.spec.ts
+++ b/lib/proposal/__tests__/getProposalTasks.spec.ts
@@ -31,9 +31,10 @@ describe('getProposalTasks', () => {
 
     const proposalTasks = await getProposalTasks(user.id);
 
-    expect(proposalTasks.marked).toEqual(expect.arrayContaining([
+    // sd d
+    expect(proposalTasks.unmarked).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        status: privateDraftProposal1.proposal?.status,
+        status: privateDraftProposal1.proposal.status,
         action: 'start_review'
       })
     ]));
@@ -71,7 +72,7 @@ describe('getProposalTasks', () => {
 
     const proposalTasks = await getProposalTasks(user.id);
 
-    expect(proposalTasks.marked.length).toEqual(0);
+    expect(proposalTasks.unmarked.length).toEqual(0);
   });
 
   it('Should get all reviewed proposals where the user is one of the authors', async () => {
@@ -96,9 +97,9 @@ describe('getProposalTasks', () => {
 
     const proposalTasks = await getProposalTasks(user.id);
 
-    expect(proposalTasks.marked).toEqual(expect.arrayContaining([
+    expect(proposalTasks.unmarked).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        status: reviewedProposal1.proposal?.status,
+        status: reviewedProposal1.proposal.status,
         action: 'start_vote'
       })
     ]));
@@ -140,13 +141,13 @@ describe('getProposalTasks', () => {
 
     const proposalTasks = await getProposalTasks(user.id);
 
-    expect(proposalTasks.marked).toEqual(expect.arrayContaining([
+    expect(proposalTasks.unmarked).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        status: proposalToReviewViaRole.proposal?.status,
+        status: proposalToReviewViaRole.proposal.status,
         action: 'review'
       }),
       expect.objectContaining({
-        status: proposalToReviewViaUser.proposal?.status,
+        status: proposalToReviewViaUser.proposal.status,
         action: 'review'
       })
     ]));
@@ -236,23 +237,23 @@ describe('getProposalTasks', () => {
 
     const proposalTasks = await getProposalTasks(user.id);
 
-    expect(proposalTasks.marked).toEqual(expect.arrayContaining([
+    expect(proposalTasks.unmarked).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        status: discussionProposal1.proposal?.status,
+        status: discussionProposal1.proposal.status,
         action: 'start_review'
       }),
       expect.objectContaining({
-        status: activeVoteProposal.proposal?.status,
+        status: activeVoteProposal.proposal.status,
         action: 'vote'
       }),
       expect.objectContaining({
-        status: discussionProposal2.proposal?.status,
+        status: discussionProposal2.proposal.status,
         action: 'discuss'
       })
     ]));
 
     // Making double sure private draft wasn't fetched
-    expect(proposalTasks.marked).toEqual(expect.not.arrayContaining([
+    expect(proposalTasks.unmarked).toEqual(expect.not.arrayContaining([
       expect.objectContaining({
         status: 'private_draft'
       })

--- a/lib/proposal/__tests__/getProposalTasksFromWorkspaceEvents.spec.ts
+++ b/lib/proposal/__tests__/getProposalTasksFromWorkspaceEvents.spec.ts
@@ -34,7 +34,7 @@ describe('getProposalTasksFromWorkspaceEvents', () => {
     });
 
     const { proposal: updatedProposal } = await updateProposalStatus({
-      proposal: authoredDraftProposal.proposal!,
+      proposal: authoredDraftProposal.proposal,
       newStatus: 'discussion',
       userId: user1.id
     });
@@ -60,7 +60,7 @@ describe('getProposalTasksFromWorkspaceEvents', () => {
     });
 
     const { proposal: updatedReviewProposal, workspaceEvent: reviewProposalWorkspaceEvent } = await updateProposalStatus({
-      proposal: reviewProposal.proposal!,
+      proposal: reviewProposal.proposal,
       newStatus: 'discussion',
       userId: user2.id
     });
@@ -83,7 +83,7 @@ describe('getProposalTasksFromWorkspaceEvents', () => {
     });
 
     await updateProposalStatus({
-      proposal: authoredStartReviewProposal.proposal!,
+      proposal: authoredStartReviewProposal.proposal,
       newStatus: 'discussion',
       userId: user1.id
     });
@@ -100,7 +100,7 @@ describe('getProposalTasksFromWorkspaceEvents', () => {
     });
 
     await updateProposalStatus({
-      proposal: discussedProposal.proposal!,
+      proposal: discussedProposal.proposal,
       newStatus: 'discussion',
       userId: user2.id
     });
@@ -120,7 +120,7 @@ describe('getProposalTasksFromWorkspaceEvents', () => {
     });
 
     await updateProposalStatus({
-      proposal: reviewedProposal.proposal!,
+      proposal: reviewedProposal.proposal,
       newStatus: 'reviewed',
       userId: user1.id
     });
@@ -137,7 +137,7 @@ describe('getProposalTasksFromWorkspaceEvents', () => {
     });
 
     await updateProposalStatus({
-      proposal: voteActiveProposal.proposal!,
+      proposal: voteActiveProposal.proposal,
       newStatus: 'vote_active',
       userId: user2.id
     });

--- a/lib/proposal/__tests__/syncProposalPermissions.spec.ts
+++ b/lib/proposal/__tests__/syncProposalPermissions.spec.ts
@@ -7,7 +7,7 @@ import { getPage } from 'lib/pages/server';
 import { typedKeys } from 'lib/utilities/objects';
 import { createPage, generateProposal, generateRole, generateSpaceUser, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
 
-import type { ProposalReviewerInput, ProposalWithUsers } from '../interface';
+import type { ProposalReviewerInput } from '../interface';
 import { proposalPermissionMapping, syncProposalPermissions } from '../syncProposalPermissions';
 
 let space: Space;
@@ -50,13 +50,13 @@ describe('syncProposalPagePermissions', () => {
 
     const reviewers: ProposalReviewerInput[] = [{ group: 'user', id: reviewerUser.id }, { group: 'role', id: reviewerRole.id }];
 
-    let proposal = (await generateProposal({
+    let { proposal } = await generateProposal({
       proposalStatus: 'private_draft',
       spaceId: space.id,
       userId: user.id,
       authors,
       reviewers
-    })).proposal as ProposalWithUsers;
+    });
 
     const proposalChild = await createPage({
       createdBy: user.id,
@@ -139,13 +139,13 @@ describe('syncProposalPagePermissions', () => {
 
     const reviewers: ProposalReviewerInput[] = [{ group: 'user', id: reviewerUser.id }, { group: 'role', id: reviewerRole.id }];
 
-    const proposal = (await generateProposal({
+    const { proposal } = await generateProposal({
       proposalStatus: 'private_draft',
       spaceId: space.id,
       userId: user.id,
       authors,
       reviewers
-    })).proposal as ProposalWithUsers;
+    });
 
     const proposalChild = await createPage({
       createdBy: user.id,

--- a/lib/proposal/getProposalTasks.ts
+++ b/lib/proposal/getProposalTasks.ts
@@ -60,7 +60,7 @@ export async function getProposalTasks (userId: string): Promise<{
     return record;
   }, {});
 
-  const spaceRoles = (await prisma.spaceRole.findMany({
+  const spaceRoles = await prisma.spaceRole.findMany({
     where: {
       userId
     },
@@ -81,13 +81,11 @@ export async function getProposalTasks (userId: string): Promise<{
         }
       }
     }
-  }));
+  });
 
   const spaceIds = spaceRoles.map(spaceRole => spaceRole.spaceId);
-  // Get all the roleId assigned to this user
-  const roleIds = spaceRoles.map(spaceRole => spaceRole.spaceRoleToRole.length !== 0
-    ? spaceRole.spaceRoleToRole[0].role.id
-    : null).filter(isTruthy);
+  // Get all the roleId assigned to this user for each space
+  const roleIds = spaceRoles.map(spaceRole => spaceRole.spaceRoleToRole).flat().map(({ role }) => role.id);
 
   const pagesWithProposals = await prisma.page.findMany({
     where: {

--- a/testing/setupDatabase.ts
+++ b/testing/setupDatabase.ts
@@ -1,4 +1,4 @@
-import type { ApplicationStatus, Block, Bounty, BountyStatus, Comment, Page, Prisma, ProposalStatus, Role, RoleSource, Thread, Transaction, Vote, WorkspaceEvent } from '@prisma/client';
+import type { ApplicationStatus, Block, Bounty, BountyStatus, Comment, Page, Prisma, Proposal, ProposalStatus, Role, RoleSource, Thread, Transaction, Vote, WorkspaceEvent } from '@prisma/client';
 import { Wallet } from 'ethers';
 import { v4 } from 'uuid';
 
@@ -11,7 +11,7 @@ import { createPage as createPageDb } from 'lib/pages/server/createPage';
 import { getPagePath } from 'lib/pages/utils';
 import type { BountyPermissions } from 'lib/permissions/bounties';
 import type { TargetPermissionGroup } from 'lib/permissions/interfaces';
-import type { ProposalReviewerInput } from 'lib/proposal/interface';
+import type { ProposalReviewerInput, ProposalWithUsers } from 'lib/proposal/interface';
 import { syncProposalPermissions } from 'lib/proposal/syncProposalPermissions';
 import { createUserFromWallet } from 'lib/users/createUser';
 import { typedKeys } from 'lib/utilities/objects';
@@ -567,10 +567,10 @@ export function createBlock (options: Partial<Block> & Pick<Block, 'createdBy' |
  */
 export async function generateProposal ({ userId, spaceId, proposalStatus, authors, reviewers, deletedAt = null }:
   { deletedAt?: Page['deletedAt'], userId: string, spaceId: string, authors: string[], reviewers: ProposalReviewerInput[], proposalStatus: ProposalStatus }):
-  Promise<PageWithProposal> {
+  Promise<Page & { proposal: ProposalWithUsers, workspaceEvent: WorkspaceEvent }> {
   const proposalId = v4();
 
-  return createPageDb({
+  const result = await createPageDb<{ proposal: ProposalWithUsers }>({
     data: {
       id: proposalId,
       contentText: '',
@@ -627,6 +627,23 @@ export async function generateProposal ({ userId, spaceId, proposalStatus, autho
       }
     }
   });
+
+  const workspaceEvent = await prisma.workspaceEvent.create({
+    data: {
+      type: 'proposal_status_change',
+      meta: {
+        newStatus: proposalStatus
+      },
+      actorId: userId,
+      pageId: proposalId,
+      spaceId
+    }
+  });
+
+  return {
+    ...result,
+    workspaceEvent
+  };
 }
 
 export async function generateBoard ({ createdBy, spaceId, parentId, cardCount }:


### PR DESCRIPTION
I noticed that a new proposal event was showing up at the very bottom of my tasks. After reading the code, I figured out it's because we were never matching workspace events to the proposals, which are used for sorting.

One change I introduced is that we require at least one workspace event for proposals to appear. I think since we create an event whenver a proposal is created, this is good enough. Proposals prior to ~September won't appear, but they never had an event to trigger them anyway. We could backfill with 'created proposal' events but I don't think anyone but CharmVerse people would notice.