### PR TITLE
Support assigned user roles on private invite links

### DIFF
--- a/charmClient/charmClient.ts
+++ b/charmClient/charmClient.ts
@@ -218,6 +218,10 @@ class CharmClient {
     return http.GET<PublicPageResponse>(`/api/public/pages/${pageIdOrPath}`);
   }
 
+  updateInviteLinkRoles (inviteLinkId: string, spaceId: string, roleIds: string[]) {
+    return http.POST<InviteLinkPopulated[]>(`/api/invites/${inviteLinkId}/roles`, { spaceId, roleIds });
+  }
+
   createInviteLink (link: Partial<InviteLink>) {
     return http.POST<InviteLinkPopulated[]>('/api/invites', link);
   }

--- a/components/settings/contributors/InviteLinks/InviteLinks.tsx
+++ b/components/settings/contributors/InviteLinks/InviteLinks.tsx
@@ -58,7 +58,7 @@ export default function InviteLinkList ({ isAdmin, spaceId }: { isAdmin: boolean
         {isAdmin && <Button sx={{ float: 'right' }} onClick={open}>Add a link</Button>}
       </Legend>
       {data && data.length === 0 && <Typography color='secondary'>No invite links yet</Typography>}
-      {data && data?.length > 0 && <InvitesTable isAdmin={isAdmin} invites={data} onDelete={deleteLink} />}
+      {data && data?.length > 0 && <InvitesTable isAdmin={isAdmin} invites={data} refetchInvites={mutate} onDelete={deleteLink} />}
       <Modal open={isOpen} onClose={close}>
         <InviteForm onSubmit={createLink} onClose={close} />
       </Modal>

--- a/components/settings/contributors/InviteLinks/InviteLinksTable.tsx
+++ b/components/settings/contributors/InviteLinks/InviteLinksTable.tsx
@@ -11,7 +11,6 @@ import Typography from '@mui/material/Typography';
 import { useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import Countdown from 'react-countdown';
-import type { KeyedMutator } from 'swr';
 
 import charmClient from 'charmClient';
 import ButtonChip from 'components/common/ButtonChip';
@@ -25,7 +24,7 @@ interface Props {
   isAdmin: boolean;
   invites: InviteLinkPopulated[];
   onDelete: (invite: InviteLinkPopulated) => void;
-  refetchInvites: KeyedMutator<InviteLinkPopulated[]>;
+  refetchInvites: VoidFunction;
 }
 
 export default function InvitesTable ({
@@ -51,13 +50,12 @@ export default function InvitesTable ({
   }
 
   async function deleteRoleFromInviteLink (inviteLinkId: string, roleId: string) {
-    const inviteLink = invites.find(_tokenGate => _tokenGate.id === inviteLinkId);
+    const inviteLink = invites.find(invite => invite.id === inviteLinkId);
     if (inviteLink && space) {
       const roleIds = inviteLink.inviteLinkToRoles
         .map(inviteLinkToRole => inviteLinkToRole.roleId)
         .filter(inviteLinkRoleId => inviteLinkRoleId !== roleId);
-      await charmClient.updateInviteLinkRoles(inviteLinkId, space.id, roleIds);
-      refetchInvites();
+      await updateInviteLinkRoles(inviteLinkId, roleIds);
     }
   }
 

--- a/components/settings/contributors/InviteLinks/InviteLinksTable.tsx
+++ b/components/settings/contributors/InviteLinks/InviteLinksTable.tsx
@@ -11,25 +11,54 @@ import Typography from '@mui/material/Typography';
 import { useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import Countdown from 'react-countdown';
+import type { KeyedMutator } from 'swr';
 
+import charmClient from 'charmClient';
 import ButtonChip from 'components/common/ButtonChip';
 import TableRow from 'components/common/Table/TableRow';
 import UserDisplay from 'components/common/UserDisplay';
+import TokenGateRolesSelect from 'components/settings/roles/components/TokenGates/components/TokenGateRolesSelect';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import type { InviteLinkPopulated } from 'pages/api/invites/index';
 
 interface Props {
   isAdmin: boolean;
   invites: InviteLinkPopulated[];
   onDelete: (invite: InviteLinkPopulated) => void;
+  refetchInvites: KeyedMutator<InviteLinkPopulated[]>;
 }
 
-export default function InvitesTable (props: Props) {
+export default function InvitesTable ({
+  invites,
+  isAdmin,
+  refetchInvites,
+  onDelete
+}: Props) {
+  const [space] = useCurrentSpace();
 
   const [copied, setCopied] = useState<{ [id: string]: boolean }>({});
 
   function onCopy (id: string) {
     setCopied({ [id]: true });
     setTimeout(() => setCopied({ [id]: false }), 1000);
+  }
+
+  async function updateInviteLinkRoles (inviteLinkId: string, roleIds: string[]) {
+    if (space) {
+      await charmClient.updateInviteLinkRoles(inviteLinkId, space.id, roleIds);
+      refetchInvites();
+    }
+  }
+
+  async function deleteRoleFromInviteLink (inviteLinkId: string, roleId: string) {
+    const inviteLink = invites.find(_tokenGate => _tokenGate.id === inviteLinkId);
+    if (inviteLink && space) {
+      const roleIds = inviteLink.inviteLinkToRoles
+        .map(inviteLinkToRole => inviteLinkToRole.roleId)
+        .filter(inviteLinkRoleId => inviteLinkRoleId !== roleId);
+      await charmClient.updateInviteLinkRoles(inviteLinkId, space.id, roleIds);
+      refetchInvites();
+    }
   }
 
   return (
@@ -40,46 +69,58 @@ export default function InvitesTable (props: Props) {
           {/* <TableCell>Invite Code</TableCell> */}
           <TableCell>Uses</TableCell>
           <TableCell>Expires</TableCell>
+          <TableCell>Assigned Roles</TableCell>
           <TableCell>{/* actions */}</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
-        {props.invites.map((row) => (
-          <TableRow key={row.id} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
+        {invites.map((invite) => (
+          <TableRow key={invite.id} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
             <TableCell sx={{ px: 0 }}>
-              <UserDisplay sx={{ my: 1 }} user={row.author} avatarSize='small' />
+              <UserDisplay sx={{ my: 1 }} user={invite.author} avatarSize='small' />
             </TableCell>
-            {/* <TableCell><Typography>{row.code}</Typography></TableCell> */}
+            {/* <TableCell><Typography>{invite.code}</Typography></TableCell> */}
             <TableCell>
               <Typography>
-                {row.useCount}
-                {row.maxUses > 0 ? ` / ${row.maxUses}` : ''}
+                {invite.useCount}
+                {invite.maxUses > 0 ? ` / ${invite.maxUses}` : ''}
               </Typography>
             </TableCell>
-            <TableCell width={150}>{getExpires(row)}</TableCell>
+            <TableCell width={150}>{getExpires(invite)}</TableCell>
+            <TableCell>
+              <TokenGateRolesSelect
+                selectedRoleIds={invite.inviteLinkToRoles.map(inviteLinkToRole => inviteLinkToRole.roleId)}
+                onChange={(roleIds) => {
+                  updateInviteLinkRoles(invite.id, roleIds);
+                }}
+                onDelete={(roleId) => {
+                  deleteRoleFromInviteLink(invite.id, roleId);
+                }}
+              />
+            </TableCell>
             <TableCell width={150} sx={{ px: 0 }} align='right'>
               <Tooltip
                 arrow
                 placement='top'
-                title={copied[row.id] ? 'Copied!' : 'Click to copy link'}
+                title={copied[invite.id] ? 'Copied!' : 'Click to copy link'}
                 disableInteractive
               >
                 <Box component='span' pr={1}>
-                  <CopyToClipboard text={getInviteLink(row.code)} onCopy={() => onCopy(row.id)}>
-                    <Chip sx={{ width: 70 }} clickable color='secondary' size='small' variant='outlined' label={copied[row.id] ? 'Copied!' : 'Share'} />
+                  <CopyToClipboard text={getInviteLink(invite.code)} onCopy={() => onCopy(invite.id)}>
+                    <Chip sx={{ width: 70 }} clickable color='secondary' size='small' variant='outlined' label={copied[invite.id] ? 'Copied!' : 'Share'} />
                   </CopyToClipboard>
                 </Box>
               </Tooltip>
-              {props.isAdmin && (
+              {isAdmin && (
                 <Tooltip arrow placement='top' title='Delete'>
                   <ButtonChip
-                    className='row-actions'
+                    className='invite-actions'
                     icon={<DeleteIcon />}
                     clickable
                     color='secondary'
                     size='small'
                     variant='outlined'
-                    onClick={() => props.onDelete(row)}
+                    onClick={() => onDelete(invite)}
                   />
                 </Tooltip>
               )}
@@ -95,9 +136,9 @@ function getInviteLink (code: string) {
   return `${window.location.origin}/invite/${code}`;
 }
 
-function getExpires (row: InviteLinkPopulated) {
-  if (row.maxAgeMinutes > 0) {
-    const expireDate = new Date(row.createdAt).getTime() + (row.maxAgeMinutes * 60 * 1000);
+function getExpires (invite: InviteLinkPopulated) {
+  if (invite.maxAgeMinutes > 0) {
+    const expireDate = new Date(invite.createdAt).getTime() + (invite.maxAgeMinutes * 60 * 1000);
     if (expireDate < Date.now()) {
       return (
         <Tooltip arrow placement='top' title={`Expired on ${new Date(expireDate).toDateString()}`}>

--- a/lib/invites/updateTokenGateRoles.ts
+++ b/lib/invites/updateTokenGateRoles.ts
@@ -1,0 +1,48 @@
+import { prisma } from 'db';
+
+export async function updateInviteLinkRoles (roleIds: string[], inviteLinkId: string) {
+  const roleIdsSet = new Set(roleIds);
+
+  const inviteLinkRoles = await prisma.inviteLinkToRole.findMany({
+    where: {
+      inviteLinkId
+    },
+    select: {
+      roleId: true
+    }
+  });
+
+  const inviteLinkRoleIds = new Set(inviteLinkRoles.map(role => role.roleId));
+  const inviteLinkRoleIdsToAdd = roleIds.filter(roleId => !inviteLinkRoleIds.has(roleId));
+  const inviteLinkRoleIdsToRemove = Array.from(inviteLinkRoleIds).filter(inviteLinkRoleId => !roleIdsSet.has(inviteLinkRoleId));
+
+  if (inviteLinkRoleIdsToAdd.length !== 0) {
+    await prisma.inviteLinkToRole.createMany({
+      data: inviteLinkRoleIdsToAdd.map(inviteLinkRoleIdToAdd => ({
+        roleId: inviteLinkRoleIdToAdd,
+        inviteLinkId
+      }))
+    });
+  }
+
+  if (inviteLinkRoleIdsToRemove.length !== 0) {
+    await prisma.inviteLinkToRole.deleteMany({
+      where: {
+        inviteLinkId,
+        roleId: {
+          in: inviteLinkRoleIdsToRemove
+        }
+      }
+    });
+  }
+
+  // Return the updated inviteLink to role records attached with the token gate
+  // This will help in updating the cache on the client side
+  const inviteLinkToRoles = await prisma.inviteLinkToRole.findMany({
+    where: {
+      inviteLinkId
+    }
+  });
+
+  return inviteLinkToRoles;
+}

--- a/pages/api/invites/[id]/roles.ts
+++ b/pages/api/invites/[id]/roles.ts
@@ -1,0 +1,26 @@
+
+import type { InviteLinkToRole } from '@prisma/client';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
+
+import { updateInviteLinkRoles } from 'lib/invites/updateTokenGateRoles';
+import { onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
+import { requireSpaceMembership } from 'lib/middleware/requireSpaceMembership';
+import { withSessionRoute } from 'lib/session/withSession';
+
+const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+
+handler.use(requireUser)
+  .use(requireKeys(['roleIds', 'spaceId'], 'body'))
+  .use(requireSpaceMembership({ adminOnly: true }))
+  .post(updateInviteLinkRolesHandler);
+
+async function updateInviteLinkRolesHandler (req: NextApiRequest, res: NextApiResponse<InviteLinkToRole[]>) {
+  const { roleIds } = req.body as { roleIds: string[] };
+  const inviteLinkId = req.query.id as string;
+  const inviteLinkToRoles = await updateInviteLinkRoles(roleIds, inviteLinkId);
+
+  return res.status(200).json(inviteLinkToRoles);
+}
+
+export default withSessionRoute(handler);

--- a/pages/api/invites/index.ts
+++ b/pages/api/invites/index.ts
@@ -1,5 +1,5 @@
 
-import type { InviteLink, User } from '@prisma/client';
+import type { InviteLink, InviteLinkToRole, Role, User } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
@@ -8,7 +8,7 @@ import { createInviteLink } from 'lib/invites';
 import { onError, onNoMatch, requireSpaceMembership } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
 
-export type InviteLinkPopulated = InviteLink & { author: User };
+export type InviteLinkPopulated = InviteLink & { author: User, inviteLinkToRoles: (InviteLinkToRole & { role: Role })[] };
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
@@ -40,7 +40,12 @@ async function getInviteLinks (req: NextApiRequest, res: NextApiResponse<InviteL
       spaceId
     },
     include: {
-      author: true
+      author: true,
+      inviteLinkToRoles: {
+        include: {
+          role: true
+        }
+      }
     }
   });
   return res.status(200).json(invites);

--- a/prisma/migrations/20221007084158_invite_links_role/migration.sql
+++ b/prisma/migrations/20221007084158_invite_links_role/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "InviteLinkToRole" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "inviteLinkId" UUID NOT NULL,
+    "roleId" UUID NOT NULL,
+
+    CONSTRAINT "InviteLinkToRole_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InviteLinkToRole_inviteLinkId_roleId_key" ON "InviteLinkToRole"("inviteLinkId", "roleId");
+
+-- AddForeignKey
+ALTER TABLE "InviteLinkToRole" ADD CONSTRAINT "InviteLinkToRole_roleId_fkey" FOREIGN KEY ("roleId") REFERENCES "Role"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InviteLinkToRole" ADD CONSTRAINT "InviteLinkToRole_inviteLinkId_fkey" FOREIGN KEY ("inviteLinkId") REFERENCES "InviteLink"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -438,16 +438,17 @@ model SpaceRole {
 }
 
 model InviteLink {
-  id            String   @id @default(uuid()) @db.Uuid
-  code          String   @unique
-  createdAt     DateTime @default(now())
-  createdBy     String   @db.Uuid
-  spaceId       String   @db.Uuid
-  maxAgeMinutes Int      @default(60)
-  maxUses       Int      @default(-1)
-  useCount      Int      @default(0)
-  author        User     @relation(fields: [createdBy], references: [id], onDelete: Cascade)
-  space         Space    @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  id                String             @id @default(uuid()) @db.Uuid
+  code              String             @unique
+  createdAt         DateTime           @default(now())
+  createdBy         String             @db.Uuid
+  spaceId           String             @db.Uuid
+  maxAgeMinutes     Int                @default(60)
+  maxUses           Int                @default(-1)
+  useCount          Int                @default(0)
+  author            User               @relation(fields: [createdBy], references: [id], onDelete: Cascade)
+  space             Space              @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  inviteLinkToRoles InviteLinkToRole[]
 }
 
 model Bounty {
@@ -580,6 +581,7 @@ model Role {
   spaceRolesToRole  SpaceRoleToRole[]
   TokenGateToRole   TokenGateToRole[]
   proposalReviewer  ProposalReviewer[]
+  InviteLinkToRole  InviteLinkToRole[]
 
   @@unique([spaceId, name])
 }
@@ -593,6 +595,17 @@ model TokenGateToRole {
   tokenGate   TokenGate @relation(fields: [tokenGateId], references: [id], onDelete: Cascade)
 
   @@unique([tokenGateId, roleId])
+}
+
+model InviteLinkToRole {
+  id           String     @id @default(uuid()) @db.Uuid
+  createdAt    DateTime   @default(now())
+  inviteLinkId String     @db.Uuid
+  roleId       String     @db.Uuid
+  role         Role       @relation(fields: [roleId], references: [id], onDelete: Cascade)
+  inviteLink   InviteLink @relation(fields: [inviteLinkId], references: [id], onDelete: Cascade)
+
+  @@unique([inviteLinkId, roleId])
 }
 
 model SpaceRoleToRole {


### PR DESCRIPTION
This PR allows us to assign roles to private links, just like we do for token gates. You can select the roles that you want to assign, and when any user joins the workspace via that invite link they will automatically get assigned those roles.