### PR TITLE
Small fix - invites modal

### DIFF
--- a/components/settings/invites/components/InviteLinks/InviteLinks.tsx
+++ b/components/settings/invites/components/InviteLinks/InviteLinks.tsx
@@ -1,11 +1,11 @@
 import type { InviteLink } from '@prisma/client';
 import type { PopupState } from 'material-ui-popup-state/hooks';
-import { bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
+import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useState } from 'react';
 import useSWR from 'swr';
 
 import charmClient from 'charmClient';
-import { Modal } from 'components/common/Modal';
+import Modal from 'components/common/Modal';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import type { InviteLinkPopulated } from 'pages/api/invites/index';
 
@@ -23,6 +23,7 @@ export default function InviteLinkList ({ isAdmin, spaceId, popupState }: Invite
   const [removedInviteLink, setRemovedInviteLink] = useState<InviteLink | null>(null);
   const { data = [], mutate } = useSWR(`inviteLinks/${spaceId}`, () => charmClient.getInviteLinks(spaceId));
 
+  const { isOpen: isOpenInviteModal, close: closeInviteModal } = popupState;
   const {
     isOpen: isInviteLinkDeleteOpen,
     open: openInviteLinkDelete,
@@ -41,7 +42,7 @@ export default function InviteLinkList ({ isAdmin, spaceId, popupState }: Invite
     });
     // update the list of links
     await mutate();
-    popupState.close();
+    closeInviteModal();
   }
 
   async function deleteLink (link: InviteLinkPopulated) {
@@ -52,8 +53,8 @@ export default function InviteLinkList ({ isAdmin, spaceId, popupState }: Invite
   return (
     <>
       <InvitesTable isAdmin={isAdmin} invites={data} refetchInvites={mutate} onDelete={deleteLink} />
-      <Modal {...bindPopover(popupState)}>
-        <InviteForm onSubmit={createLink} onClose={popupState.close} />
+      <Modal open={isOpenInviteModal} onClose={closeInviteModal}>
+        <InviteForm onSubmit={createLink} onClose={closeInviteModal} />
       </Modal>
       {removedInviteLink && (
         <ConfirmDeleteModal

--- a/components/settings/invites/components/TokenGates/TokenGates.tsx
+++ b/components/settings/invites/components/TokenGates/TokenGates.tsx
@@ -69,11 +69,13 @@ export default function TokenGates ({ isAdmin, spaceId, popupState }: TokenGates
   const [apiError, setApiError] = useState<string>('');
   const { data = [], mutate } = useSWR(`tokenGates/${spaceId}`, () => charmClient.getTokenGates({ spaceId }));
 
+  const { isOpen: isOpenTokenGateModal, close: closeTokenGateModal } = popupState;
+
   function onSubmit (conditions: ConditionsModalResult) {
     setApiError('');
     return saveTokenGate(conditions)
       .then(() => {
-        popupState.close();
+        closeTokenGateModal();
       })
       .catch(error => {
         setApiError(error.message || error);
@@ -123,7 +125,7 @@ export default function TokenGates ({ isAdmin, spaceId, popupState }: TokenGates
   return (
     <>
       <TokenGatesTable isAdmin={isAdmin} tokenGates={data} onDelete={deleteTokenGate} />
-      <Modal {...bindPopover(popupState)} noPadding size='large'>
+      <Modal open={isOpenTokenGateModal} onClose={closeTokenGateModal} noPadding size='large'>
         <ShareModalContainer>
           <LitShareModal
             darkMode={theme.palette.mode === 'dark'}


### PR DESCRIPTION
Fix for a console warning from React:
Warning: React does not recognize the `anchorEl` prop on a DOM element.

Looks like it is not a good idea to spread all the bindPopover props on a mui Modal. It also includes anchorEl and the Modal does not accept that prop.