### PR TITLE
Stop clearing input in join space autocomplete

### DIFF
--- a/components/common/TokenGateForm/JoinDynamicSpaceForm.tsx
+++ b/components/common/TokenGateForm/JoinDynamicSpaceForm.tsx
@@ -72,6 +72,9 @@ export function JoinDynamicSpaceForm () {
         }}
         getOptionLabel={(space) => space.name}
         fullWidth
+        filterOptions={(x) => x}
+        clearOnEscape={false}
+        clearOnBlur={false}
         PopperComponent={StyledPopper}
         renderOption={(props, space) => (
           <Box component='li' sx={{ display: 'flex', gap: 1 }} {...props}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34683631/195071163-061def37-dd6f-4dd8-a8cf-d9c1487cb380.png)
Previously when the autocomplete textinput was out of focus, it was cleared. Thus the user had to write the workspace name again, which lead to suboptimal ux