### PR TITLE
make tooltips always visible in proposal stepper

### DIFF
--- a/components/proposals/components/ProposalStepper.tsx
+++ b/components/proposals/components/ProposalStepper.tsx
@@ -81,7 +81,7 @@ export default function ProposalStepper (
                   height='100%'
                   gap={1}
                 >
-                  <Tooltip title={canChangeStatus ? proposalStatusTooltips[status] : ''}>
+                  <Tooltip title={proposalStatusTooltips[status]}>
                     <Box
                       sx={{
                         width: stepperDimension,


### PR DESCRIPTION
This was requested by product team. Tooltips help users understand the flow even if they can't jump to a particular step