### PR TITLE
disable click listener on sidebar when its invisible

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -16,7 +16,7 @@ import { mutate } from 'swr';
 import charmClient from 'charmClient';
 import PageBanner, { randomBannerImage } from 'components/[pageId]/DocumentPage/components/PageBanner';
 import PageDeleteBanner from 'components/[pageId]/DocumentPage/components/PageDeleteBanner';
-import { getSortedBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
+import { getBoard } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import { getViewCardsSortedFilteredAndGrouped } from 'components/common/BoardEditor/focalboard/src/store/cards';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import { getCurrentViewDisplayBy, getCurrentViewGroupBy } from 'components/common/BoardEditor/focalboard/src/store/views';
@@ -91,14 +91,13 @@ function CenterPanel (props: Props) {
   const { pages, updatePage } = usePages();
   const _groupByProperty = useAppSelector(getCurrentViewGroupBy);
   const _dateDisplayProperty = useAppSelector(getCurrentViewDisplayBy);
-  const boards = useAppSelector(getSortedBoards);
 
   const isEmbedded = !!props.embeddedBoardPath;
   const boardPageType = pages[board.id]?.type;
 
   // for 'linked' boards, each view has its own board which we use to determine the cards to show
   const activeBoardId = props.activeView && (props.activeView?.fields.linkedSourceId || props.board.id);
-  const activeBoard = boards.find(b => b.id === activeBoardId);
+  const activeBoard = useAppSelector(getBoard(activeBoardId));
   const activePage = pages[activeBoardId];
 
   const _cards = useAppSelector(getViewCardsSortedFilteredAndGrouped({

--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSidebar.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSidebar.tsx
@@ -7,7 +7,7 @@ import ArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import PreviewIcon from '@mui/icons-material/Preview';
 import { Box, ClickAwayListener, Portal, Collapse, Divider, IconButton, ListItemIcon, ListItemText, MenuItem, Typography } from '@mui/material';
 import { capitalize } from 'lodash';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, memo } from 'react';
 
 import type { Board, IPropertyTemplate } from '../../blocks/board';
 import type { BoardView } from '../../blocks/boardView';
@@ -41,7 +41,7 @@ type SidebarView = 'view-options' | 'layout' | 'card-properties' | 'group-by';
 
 const initialState: SidebarView = 'view-options';
 
-export default function ViewOptionsSidebar (props: Props) {
+function ViewOptionsSidebar (props: Props) {
 
   const [sidebarView, setSidebarView] = useState<SidebarView>(initialState);
 
@@ -64,7 +64,7 @@ export default function ViewOptionsSidebar (props: Props) {
   const currentProperties = visiblePropertyIds.filter(id => props.board.fields.cardProperties.some(c => c.id === id)).length;
 
   return (
-    <ClickAwayListener onClickAway={props.closeSidebar}>
+    <ClickAwayListener mouseEvent={props.isOpen ? 'onClick' : false} onClickAway={props.closeSidebar}>
       <Collapse in={props.isOpen} orientation='horizontal' sx={{ position: 'absolute', right: 0, top: 0, bottom: 0, zIndex: 1000 }}>
 
         <StyledSidebar>
@@ -156,3 +156,5 @@ function SidebarHeader ({ closeSidebar, goBack, title }: { closeSidebar : () => 
     </Box>
   );
 }
+
+export default memo(ViewOptionsSidebar);

--- a/components/common/BoardEditor/focalboard/src/store/boards.ts
+++ b/components/common/BoardEditor/focalboard/src/store/boards.ts
@@ -88,9 +88,9 @@ export const getSortedTemplates = createSelector(
   }
 );
 
-export function getBoard (boardId: string): (state: RootState) => Board|null {
-  return (state: RootState): Board|null => {
-    return state.boards.boards[boardId] || state.boards.templates[boardId] || null;
+export function getBoard (boardId: string): (state: RootState) => Board | undefined {
+  return (state: RootState): Board | undefined => {
+    return state.boards.boards[boardId] || state.boards.templates[boardId] || undefined;
   };
 }
 


### PR DESCRIPTION
For some reason, ClickAwayListener is causing the CenterPanel component to re-render all the time. We can fix this by disabling the mouseEvent that gets triggered, and I wonder if there's something going on w/CenterPanel that we could also fix..