### PR TITLE
Make entire area of new proposal button clickable

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/newCardButton.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/newCardButton.tsx
@@ -1,5 +1,7 @@
 
+import { KeyboardArrowDown } from '@mui/icons-material';
 import Box from '@mui/material/Box';
+import ButtonGroup from '@mui/material/ButtonGroup';
 import { bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
 import React from 'react';
 
@@ -26,7 +28,7 @@ type Props = {
 const NewCardButton = React.memo(({ addCard, addCardFromTemplate, addCardTemplate, deleteCardTemplate, editCardTemplate, showCard, boardId }: Props):
   JSX.Element => {
   const cardTemplates: Card[] = useAppSelector(getCurrentBoardTemplates);
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const buttonRef = React.useRef<HTMLDivElement>(null);
   const { pages, getPagePermissions } = usePages();
 
   const cardTemplatesPages = cardTemplates.map(c => pages[c.id]).filter(p => p !== undefined) as PageMeta[];
@@ -39,26 +41,15 @@ const NewCardButton = React.memo(({ addCard, addCardFromTemplate, addCardTemplat
 
   return (
     <>
-      <Button
-        sx={{ p: 0 }}
-        ref={buttonRef}
-      >
-        <Box
-          sx={{ pl: '15px' }}
-          onClick={() => {
-            addCard();
-          }}
-        >
+      <ButtonGroup variant='contained' ref={buttonRef}>
+        <Button onClick={addCard}>
           New
-        </Box>
+        </Button>
+        <Button size='small' onClick={popupState.open}>
+          <KeyboardArrowDown />
+        </Button>
+      </ButtonGroup>
 
-        <Box
-          sx={{ pl: 1 }}
-          {...bindTrigger(popupState)}
-        >
-          <DownIcon />
-        </Box>
-      </Button>
       <TemplatesMenu
         addPageFromTemplate={addCardFromTemplate}
         createTemplate={addCardTemplate}

--- a/components/votes/components/NewProposalButton.tsx
+++ b/components/votes/components/NewProposalButton.tsx
@@ -6,7 +6,6 @@ import type { KeyedMutator } from 'swr';
 
 import charmClient from 'charmClient';
 import Button from 'components/common/Button';
-import { DownIcon } from 'components/common/Icons/DownIcon';
 import { usePageDialog } from 'components/common/PageDialog/hooks/usePageDialog';
 import { TemplatesMenu } from 'components/common/TemplatesMenu';
 import useTasks from 'components/nexus/hooks/useTasks';

--- a/components/votes/components/NewProposalButton.tsx
+++ b/components/votes/components/NewProposalButton.tsx
@@ -104,17 +104,16 @@ export default function NewProposalButton ({ mutateProposals }: { mutateProposal
 
       <Tooltip title={!canCreateProposal ? 'You do not have the permission to create a proposal.' : ''}>
         <Box>
-          <Button disabled={!canCreateProposal} ref={buttonRef}>
-            <Box
-              onClick={onClickCreate}
-            >
-              Create Proposal
-            </Box>
-
+          <Button disabled={!canCreateProposal} ref={buttonRef} onClick={onClickCreate}>
+            Create Proposal
             <Box
             // Negative right margin fixes issue with too much whitespace on right of button
-              sx={{ pl: 1, mr: -2 }}
-              {...bindTrigger(popupState)}
+              pl={1}
+              mr={-2}
+              onClick={e => {
+                e.stopPropagation();
+                popupState.open();
+              }}
             >
               <DownIcon />
             </Box>

--- a/components/votes/components/NewProposalButton.tsx
+++ b/components/votes/components/NewProposalButton.tsx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
-import { bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
+import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useEffect, useRef, useState } from 'react';
 import type { KeyedMutator } from 'swr';
 
@@ -101,7 +101,6 @@ export default function NewProposalButton ({ mutateProposals }: { mutateProposal
   return (
 
     <>
-
       <Tooltip title={!canCreateProposal ? 'You do not have the permission to create a proposal.' : ''}>
         <Box>
           <Button disabled={!canCreateProposal} ref={buttonRef} onClick={onClickCreate}>

--- a/components/votes/components/NewProposalButton.tsx
+++ b/components/votes/components/NewProposalButton.tsx
@@ -1,5 +1,5 @@
-import Box from '@mui/material/Box';
-import Tooltip from '@mui/material/Tooltip';
+import { KeyboardArrowDown } from '@mui/icons-material';
+import { Box, ButtonGroup, Tooltip } from '@mui/material';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useEffect, useRef, useState } from 'react';
 import type { KeyedMutator } from 'swr';
@@ -29,7 +29,7 @@ export default function NewProposalButton ({ mutateProposals }: { mutateProposal
   const { mutate } = useTasks();
 
   // MUI Menu specific content
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const buttonRef = useRef<HTMLDivElement>(null);
   const popupState = usePopupState({ variant: 'popover', popupId: 'templates-menu' });
 
   const [proposalTemplates, setProposalTemplates] = useState<PageMeta[]>([]);
@@ -103,20 +103,14 @@ export default function NewProposalButton ({ mutateProposals }: { mutateProposal
     <>
       <Tooltip title={!canCreateProposal ? 'You do not have the permission to create a proposal.' : ''}>
         <Box>
-          <Button disabled={!canCreateProposal} ref={buttonRef} onClick={onClickCreate}>
-            Create Proposal
-            <Box
-            // Negative right margin fixes issue with too much whitespace on right of button
-              pl={1}
-              mr={-2}
-              onClick={e => {
-                e.stopPropagation();
-                popupState.open();
-              }}
-            >
-              <DownIcon />
-            </Box>
-          </Button>
+          <ButtonGroup variant='contained' ref={buttonRef}>
+            <Button disabled={!canCreateProposal} onClick={onClickCreate}>
+              Create Proposal
+            </Button>
+            <Button size='small' disabled={!canCreateProposal} onClick={popupState.open}>
+              <KeyboardArrowDown />
+            </Button>
+          </ButtonGroup>
         </Box>
       </Tooltip>
       <TemplatesMenu

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -251,6 +251,13 @@ export const createThemeLightSensitive = (mode: PaletteMode) => {
       MuiButtonGroup: {
         defaultProps: {
           disableRipple: true
+        },
+        styleOverrides: {
+          groupedContained: {
+            '&:not(:last-child)': {
+              borderRightColor: 'rgba(0, 0, 0, .2)'
+            }
+          }
         }
       },
       MuiButton: {


### PR DESCRIPTION
Using MUI styles for the button UX: https://mui.com/material-ui/api/button-group/
<img width="706" alt="image" src="https://user-images.githubusercontent.com/305398/195471098-09e76271-ca7c-48f2-b5b0-ae0fb9102648.png">
