### PR TITLE
enable deleted page to be viewed

### DIFF
--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -15,10 +15,6 @@ export default function BlocksEditorPage () {
   const pageIdList = Object.values(pages ?? {}) as PageMeta[];
   const pageId = pageIdList.find(p => p.path === pagePath)?.id;
 
-  if (!pageId) {
-    return null;
-  }
-
   return <EditorPage pageId={pageId ?? pagePath} />;
 
 }


### PR DESCRIPTION
I think at some point we stopped returning 'deletedAt' pages into usePages() context, and this broke the single-page view of a deleted page (it would just appear white). I am not sure why we checked for pageId in the first place, but the EditorPage component can handle missing pages (404) already.