### PR TITLE
fix background of lit protocol dropdown in dark mode

### DIFF
--- a/theme/lit-protocol/lit-protocol.scss
+++ b/theme/lit-protocol/lit-protocol.scss
@@ -4,6 +4,7 @@
 }
 
 // fix the background color in dark mode for the NFT select dropdown
-.lsm__menu-portal > div {
+.lsm__menu-portal > div,
+.lsm-ts__menu-portal > div {
   background-color: var(--background-default);
 }


### PR DESCRIPTION
Fixes the following:
![image](https://user-images.githubusercontent.com/305398/196262841-1c6eb971-ba4d-45b0-88e1-1fe1245d6bbb.png)
