### PR TITLE
fix: resizable image in readonly mode

### DIFF
--- a/components/common/CharmEditor/components/ResizableImage.tsx
+++ b/components/common/CharmEditor/components/ResizableImage.tsx
@@ -84,6 +84,12 @@ function EmptyImageContainer ({ readOnly, isSelected, ...props }: HTMLAttributes
   );
 }
 
+const StyledImageContainer = styled.div<{ size: number }>`
+  max-width: 100%;
+  width: ${({ size }) => size}px;
+  margin: 0 auto;
+`;
+
 const StyledImage = styled.img`
   object-fit: contain;
   max-width: 100%;
@@ -235,13 +241,14 @@ function ResizableImage ({ readOnly = false, onResizeStop, node, updateAttrs, se
   }
   else if (readOnly) {
     return (
-      <StyledImage
-        draggable={false}
-        src={node.attrs.src}
-        alt={node.attrs.alt}
-        width={node.attrs.size}
-        // height={node.attrs.size / aspectRatio}
-      />
+      <StyledImageContainer size={node.attrs.size}>
+        <StyledImage
+          draggable={false}
+          src={node.attrs.src}
+          alt={node.attrs.alt}
+          width={node.attrs.size}
+        />
+      </StyledImageContainer>
     );
   }
   else {


### PR DESCRIPTION
Resizable images weren't working in "read-only" mode because a simple css container was missing allowing them to resize and be responsive. I fixed it and it now has the same behaviour than in edit mode.

Edit mode:
<img width="921" alt="CleanShot 2022-10-19 at 17 39 20@2x" src="https://user-images.githubusercontent.com/19694603/196738960-6d6863eb-1bfa-4fc9-95da-0ea3fc9cc17b.png">

Read only mode:
<img width="905" alt="CleanShot 2022-10-19 at 17 40 10@2x" src="https://user-images.githubusercontent.com/19694603/196739036-3c5d3a68-61f9-4ab3-81aa-7ebdd03daaa0.png">
