### PR TITLE
include /members and /proposals pages as default redirect page

### DIFF
--- a/pages/[domain]/index.tsx
+++ b/pages/[domain]/index.tsx
@@ -15,7 +15,7 @@ export default function RedirectToMainPage () {
   const { pages } = usePages();
   const defaultPageKey: string = space?.domain ? getKey(`last-page-${space.domain}`) : '';
   const defaultPage = defaultPageKey ? (typeof window !== 'undefined' && localStorage.getItem(defaultPageKey)) : null;
-  const staticCommonPages = ['bounties', 'votes', 'settings/workspace', 'settings/members', 'settings/roles', 'settings/invites'];
+  const staticCommonPages = ['bounties', 'members', 'proposals', 'settings/workspace', 'settings/members', 'settings/roles', 'settings/invites'];
 
   useEffect(() => {
     const isCommonDefaultPage = defaultPage && staticCommonPages.some(page => defaultPage.includes(`/${page}`));


### PR DESCRIPTION
The bug is that if you're on /<domain>/members, then go back to just /<domain>, we won't send you back to /members and we just send you to the first page in the workspace.

And out of scope, but it seems odd we have to maintain a whitelist at all. This was broken for /proposals too without anyone knowing.