### PR TITLE
Feat - better discord account association

### DIFF
--- a/lib/users/mergeUserDiscordAccounts.ts
+++ b/lib/users/mergeUserDiscordAccounts.ts
@@ -8,7 +8,7 @@ export async function mergeUserDiscordAccounts ({ currentUserId, toDeleteUserId,
   discordId: string;
 }): Promise<DiscordUser> {
 
-  const [discordUser] = await Promise.all([
+  const [discordUser] = await prisma.$transaction([
     prisma.discordUser.update({
       where: {
         discordId

--- a/lib/users/mergeUserDiscordAccounts.ts
+++ b/lib/users/mergeUserDiscordAccounts.ts
@@ -1,0 +1,39 @@
+import type { DiscordUser } from '@prisma/client';
+
+import { prisma } from 'db';
+
+export async function mergeUserDiscordAccounts ({ currentUserId, toDeleteUserId, discordId }: {
+  currentUserId: string;
+  toDeleteUserId: string;
+  discordId: string;
+}): Promise<DiscordUser> {
+
+  const [discordUser] = await Promise.all([
+    prisma.discordUser.update({
+      where: {
+        discordId
+      },
+      data: {
+        user: {
+          connect: {
+            id: currentUserId
+          }
+        }
+      }
+    }),
+    prisma.user.update({
+      where: {
+        id: toDeleteUserId
+      },
+      data: {
+        // Soft delete user
+        deletedAt: new Date(),
+        // Update their name for ref in DB
+        username: `Replaced with user id: ${currentUserId}`
+      }
+    })
+  ]);
+
+  return discordUser;
+}
+

--- a/pages/api/discord/connect.ts
+++ b/pages/api/discord/connect.ts
@@ -14,6 +14,7 @@ import log from 'lib/log';
 import { onError, onNoMatch, requireUser } from 'lib/middleware';
 import { findOrCreateRoles } from 'lib/roles/createRoles';
 import { withSessionRoute } from 'lib/session/withSession';
+import { mergeUserDiscordAccounts } from 'lib/users/mergeUserDiscordAccounts';
 import { IDENTITY_TYPES } from 'models';
 
 const handler = nc({
@@ -60,23 +61,44 @@ async function connectDiscord (req: NextApiRequest, res: NextApiResponse<Connect
   let discordUser: DiscordUser;
 
   try {
-    discordUser = await prisma.discordUser.create({
-      data: {
-        account: rest as any,
-        discordId: id,
-        user: {
-          connect: {
-            id: userId
-          }
-        }
+    // discordUser =
+
+    // We check if a user was already created using discord oauth
+    const existingDiscordUser = await prisma.discordUser.findFirst({
+      where: {
+        discordId: id
       }
     });
+
+    // If the entry exists we merge the user accounts
+    if (existingDiscordUser) {
+      discordUser = await mergeUserDiscordAccounts({
+        discordId: existingDiscordUser.discordId,
+        currentUserId: userId,
+        toDeleteUserId: existingDiscordUser.userId
+      });
+    }
+    else {
+      // If not created we create a new entry
+      discordUser = await prisma.discordUser.create({
+        data: {
+          account: rest as any,
+          discordId: id,
+          user: {
+            connect: {
+              id: userId
+            }
+          }
+        }
+      });
+    }
+
   }
   catch (error) {
-    log.warn('Error while creating Discord record - probably a duplicate account', error);
+    log.warn('Error while creating Discord record', error);
     // If the discord user is already connected to a charmverse account this code will be run
     res.status(400).json({
-      error: 'Connection to Discord failed. Another CharmVerse account is already associated with this Discord account.'
+      error: 'Connection to Discord failed.'
     });
     return;
   }

--- a/pages/api/email-templates/index.ts
+++ b/pages/api/email-templates/index.ts
@@ -42,7 +42,8 @@ const createMentionTask = ({ pageTitle, spaceName, mentionText }: { spaceName: s
       identityType: 'Discord',
       avatarContract: null,
       avatarTokenId: null,
-      avatarChain: null
+      avatarChain: null,
+      deletedAt: null
     }
   };
 };

--- a/pages/api/spaces/[id]/members/index.ts
+++ b/pages/api/spaces/[id]/members/index.ts
@@ -131,6 +131,7 @@ async function getMembers (req: NextApiRequest, res: NextApiResponse<Member[]>) 
       roles
     } as Member;
   })
+    .filter(member => !member.deletedAt) // filter out deleted members
     .sort((a, b) => b.createdAt > a.createdAt ? -1 : 1); // sort oldest first
 
   return res.status(200).json(members);

--- a/prisma/migrations/20221025120519_user_deleted_at_field/migration.sql
+++ b/prisma/migrations/20221025120519_user_deleted_at_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "deletedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -318,6 +318,7 @@ model User {
   createdAt                 DateTime                   @default(now())
   updatedAt                 DateTime                   @default(now())
   addresses                 String[]
+  deletedAt                 DateTime?
   avatar                    String?
   avatarContract            String?
   avatarTokenId             String?


### PR DESCRIPTION
Worked on this ticket: https://app.charmverse.io/charmverse/page-09977184042575171

The issue was that if a user previously created an account using discord oauth and would try to sync their discord with another account, they were prompted with an error.

This features allows to merge the two accounts in a non-blocking flow.

I had to create a migration to add the `deletedAt` field on the `User` table, I'm using it to soft delete the old user account.