### PR TITLE
dont always wrap buttons in a tooltip

### DIFF
--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -30,16 +30,23 @@ export const PimpedButton = forwardRef<HTMLButtonElement, InputProps<ElementType
 
   const { children, loading, loadingMessage, disabledTooltip, ...props } = _props;
 
-  return (
-    <Tooltip title={props.disabled ? disabledTooltip : ''}>
-      <span>
-        <StyledButton ref={ref} disabled={loading} {...props}>
-          {(loading && loadingMessage) ? loadingMessage : children}
-          {loading && <StyledSpinner color='inherit' size={15} />}
-        </StyledButton>
-      </span>
-    </Tooltip>
+  const buttonComponent = (
+    <StyledButton ref={ref} disabled={loading} {...props}>
+      {(loading && loadingMessage) ? loadingMessage : children}
+      {loading && <StyledSpinner color='inherit' size={15} />}
+    </StyledButton>
   );
+
+  if (disabledTooltip) {
+    return (
+      <Tooltip title={props.disabled ? disabledTooltip : ''}>
+        <span>
+          {buttonComponent}
+        </span>
+      </Tooltip>
+    );
+  }
+  return buttonComponent;
 });
 
 // make sure teh id prop is on the same element as onClick


### PR DESCRIPTION
This addresses some funny UI when wrapping buttons w/a span tag, for exmaple with ButtonGroup:
![image](https://user-images.githubusercontent.com/305398/198138455-9184205a-0504-40dc-bf33-4d1d28aabf79.png)


It also addresses a warning from the tooltip when disabledTooltip is undefined and disabled = true