### PR TITLE
dont create redis client if redis_uri is not set

### DIFF
--- a/adapters/redis/redisClient.ts
+++ b/adapters/redis/redisClient.ts
@@ -11,13 +11,14 @@ declare global {
 
 let redisClientInstance: RedisClientType | null = null;
 
-try {
-
-  redisClientInstance = global.redisClient ?? createClient({ url: process.env.REDIS_URI });
-  redisClientInstance.on('error', (err) => log.debug(`Redis Client Error ${err}`));
-}
-catch (err) {
-  log.debug(`Could not instantiate Redis. Error occurred: ${err}`);
+if (process.env.REDIS_URI) {
+  try {
+    redisClientInstance = global.redisClient ?? createClient({ url: process.env.REDIS_URI });
+    redisClientInstance.on('error', (err) => log.debug(`Redis Client Error ${err}`));
+  }
+  catch (err) {
+    log.debug(`Could not instantiate Redis. Error occurred: ${err}`);
+  }
 }
 
 // remember this instance of prisma in development to avoid too many clients


### PR DESCRIPTION
I'm still getting lots of connection errors. This PR fixes that:
```
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
Redis Client Error Error: connect ECONNREFUSED ::1:6379
```