### PR TITLE
fix toggle for edit mode disappearing

### DIFF
--- a/components/[pageId]/EditorPage/EditorPage.tsx
+++ b/components/[pageId]/EditorPage/EditorPage.tsx
@@ -29,7 +29,7 @@ export default function EditorPage ({ pageId }: { pageId: string }) {
   const pagesLoaded = Object.keys(pages).length > 0;
 
   const parentProposalId = findParentOfType({ pageId, pageType: 'proposal', pageMap: pages });
-  const readOnly = (currentPagePermissions?.edit_content === false && editMode !== 'suggesting') || editMode === 'viewing';
+  const readOnly = (currentPagePermissions.edit_content === false && editMode !== 'suggesting') || editMode === 'viewing';
 
   useEffect(() => {
     async function main () {
@@ -69,8 +69,12 @@ export default function EditorPage ({ pageId }: { pageId: string }) {
 
   // set page attributes of the primary charm editor
   useEffect(() => {
+    if (!pagesLoaded) {
+      // wait for pages loaded for permissions to be correct
+      return;
+    }
     if (!editMode) {
-      if (currentPagePermissions?.edit_content) {
+      if (currentPagePermissions.edit_content) {
         setPageProps({ permissions: currentPagePermissions, editMode: 'editing' });
       }
       else {
@@ -78,12 +82,13 @@ export default function EditorPage ({ pageId }: { pageId: string }) {
       }
     }
     else {
-      setPageProps({ permissions: currentPagePermissions });
+      // pass editMode thru to fix hot-reloading which resets the prop
+      setPageProps({ permissions: currentPagePermissions, editMode });
     }
     return () => {
       resetPageProps();
     };
-  }, [currentPagePermissions]);
+  }, [currentPagePermissions, pagesLoaded]);
 
   const debouncedPageUpdate = debouncePromise(async (updates: PageUpdates) => {
     setPageProps({ isSaving: true });

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -52,6 +52,8 @@ interface HeaderProps {
   openSidebar: () => void;
 }
 
+const documentTypes = ['page', 'card', 'proposal', 'proposal_template', 'bounty'];
+
 export default function Header ({ open, openSidebar }: HeaderProps) {
 
   const router = useRouter();
@@ -112,7 +114,7 @@ export default function Header ({ open, openSidebar }: HeaderProps) {
   }
 
   const isFullWidth = basePage?.fullWidth ?? false;
-  const isBasePageDocument = ['page', 'card', 'proposal', 'proposal_template', 'bounty'].includes(basePage?.type ?? '');
+  const isBasePageDocument = documentTypes.includes(basePage?.type ?? '');
   const isBasePageDatabase = /board/.test(basePage?.type ?? '');
 
   const onSwitchChange = () => {

--- a/components/common/PageLayout/components/Header/components/EditingModeToggle.tsx
+++ b/components/common/PageLayout/components/Header/components/EditingModeToggle.tsx
@@ -1,6 +1,7 @@
 import { ArrowDropDown } from '@mui/icons-material';
 import { ListItemIcon, ListItemText, Menu, MenuItem, Tooltip } from '@mui/material';
 import PopupState, { bindMenu, bindTrigger } from 'material-ui-popup-state';
+import { memo } from 'react';
 
 import Button from 'components/common/Button';
 import { usePrimaryCharmEditor, EDIT_MODE_CONFIG } from 'hooks/usePrimaryCharmEditor';
@@ -21,7 +22,7 @@ const editModeConfig = {
   }
 } as const;
 
-export default function EditModeToggle () {
+function EditModeToggle () {
 
   const { availableEditModes, editMode, setPageProps } = usePrimaryCharmEditor();
 
@@ -81,3 +82,5 @@ export default function EditModeToggle () {
     </PopupState>
   );
 }
+
+export default memo(EditModeToggle);


### PR DESCRIPTION
Fixes two cases:
- when de-registering the EditorPage component, we would set editMode to null. I don't fully understand why 'editMode' would be still defined in EditorPage, but setting it again seems to fix it back to the correct state. I could reproduce this 50% of the time with Next.js hot-reloading.
- we get the 'default' page permissions at first and we set mode to Viewing. Because mode is set, we never update it to Editing. I just added a wait for the pages to be loaded