### PR TITLE
Fix react key property

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
     "@typescript-eslint"
   ],
   "rules": {
+    "react/jsx-key": "error",
     "react/forbid-prop-types": 0,
     "@next/next/no-img-element": "off",
     "@typescript-eslint/array-type": "error",

--- a/components/WebSocketTester.tsx
+++ b/components/WebSocketTester.tsx
@@ -1,5 +1,4 @@
 import Grid from '@mui/material/Grid';
-import { useState } from 'react';
 
 import { PimpedButton as Button } from 'components/common/Button';
 import { useWebSocketClient } from 'hooks/useSocketClient';
@@ -20,11 +19,14 @@ export function WebSocketTester () {
         <Button css={{ backgroundColor: 'red' }} onClick={clearLog}>Clear</Button>
       </Grid>
       {
-      messageLog.map((message, index) => (
-        <Grid item xs={12}>
-          <p>{typeof message === 'object' ? JSON.stringify(message) : message}</p>
-        </Grid>
-      ))
+      messageLog.map((message) => {
+        const msgString = typeof message === 'object' ? JSON.stringify(message) : message;
+        return (
+          <Grid key={msgString} item xs={12}>
+            <p>{msgString}</p>
+          </Grid>
+        );
+      })
     }
     </Grid>
   );

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/MissingPagePermissions.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/MissingPagePermissions.tsx
@@ -46,14 +46,12 @@ export default function MissingPagePermissions ({ bountyPermissions, pagePermiss
     };
   });
 
-  const componentLabel = target === 'reviewer' ? 'Reviewers' : 'Submitters';
-
   return (
     <Alert severity='warning'>
       {
         missingPermissionsWithName.map(bountyPermissionAssignee => (
 
-          <Typography variant='caption' display='flex' sx={{ alignItems: 'center' }}>
+          <Typography key={bountyPermissionAssignee.id} variant='caption' display='flex' sx={{ alignItems: 'center' }}>
             {bountyPermissionAssignee.group === 'space' ? 'Workspace members' : bountyPermissionAssignee.group === 'role' ? `${bountyPermissionAssignee.name} role` : `${bountyPermissionAssignee.name}`} cannot view this page
           </Typography>
 

--- a/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
+++ b/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
@@ -29,12 +29,14 @@ export default function IFrameSelector (props: IFrameSelectorProps) {
             ...tabs,
             [
               'Link',
-              <Box sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 2,
-                alignItems: 'center'
-              }}
+              <Box
+                key='link'
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 2,
+                  alignItems: 'center'
+                }}
               >
                 <TextField
                   autoFocus

--- a/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
@@ -70,7 +70,7 @@ export default function InlineCommentThread ({ pluginKey }: { pluginKey: PluginK
           <Box display='flex' flexDirection='column' gap={1}>
 
             {unResolvedThreads.map(resolvedThread => (
-              <ThreadContainer elevation={4}>
+              <ThreadContainer key={resolvedThread.id} elevation={4}>
                 <PageThread inline={ids.length === 1} key={resolvedThread.id} threadId={resolvedThread?.id} />
               </ThreadContainer>
             ))}

--- a/components/common/ImageSelector/ImageSelector.tsx
+++ b/components/common/ImageSelector/ImageSelector.tsx
@@ -27,6 +27,7 @@ export default function ImageSelector ({ autoOpen = false, children, galleryImag
     tabs.push([
       'Gallery',
       <ImageSelectorGallery
+        key='gallery'
         onImageClick={onImageSelect}
         items={galleryImages}
       />
@@ -47,11 +48,13 @@ export default function ImageSelector ({ autoOpen = false, children, galleryImag
               ...tabs,
               [
                 'Upload',
-                <Box sx={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  width: '100%'
-                }}
+                <Box
+                  key='upload'
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    width: '100%'
+                  }}
                 >
                   <PimpedButton loading={isUploading} loadingMessage='Uploading image' disabled={isUploading} component='label' variant='contained'>
                     Choose an image
@@ -74,12 +77,14 @@ export default function ImageSelector ({ autoOpen = false, children, galleryImag
               ],
               [
                 'Link',
-                <Box sx={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 2,
-                  alignItems: 'center'
-                }}
+                <Box
+                  key='link'
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 2,
+                    alignItems: 'center'
+                  }}
                 >
                   <TextField autoFocus placeholder='Paste the image link...' value={embedLink} onChange={(e) => setEmbedLink(e.target.value)} />
                   <Button

--- a/components/common/PageLayout/components/SearchInWorkspaceModal.tsx
+++ b/components/common/PageLayout/components/SearchInWorkspaceModal.tsx
@@ -190,6 +190,7 @@ function SearchInWorkspaceModal (props: SearchInWorkspaceModalProps) {
                         parts.map((part: { text: string, highlight: boolean }) => {
                           return (
                             <span
+                              key={`${part.text}${part.highlight}`}
                               style={{
                                 fontWeight: part.highlight ? 700 : 400
                               }}

--- a/components/common/PdfSelector/PdfSelector.tsx
+++ b/components/common/PdfSelector/PdfSelector.tsx
@@ -27,11 +27,13 @@ export default function PdfSelector ({ autoOpen = false, children, onPdfSelect }
             ...tabs,
             [
               'Upload',
-              <Box sx={{
-                display: 'flex',
-                justifyContent: 'center',
-                width: '100%'
-              }}
+              <Box
+                key='upload'
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  width: '100%'
+                }}
               >
                 <Button component='label' variant='contained'>
                   Choose a PDF

--- a/components/members/components/MemberDirectoryProperties/MemberPropertySelectInput.tsx
+++ b/components/members/components/MemberDirectoryProperties/MemberPropertySelectInput.tsx
@@ -26,7 +26,7 @@ export function MemberPropertySelectInput ({
       {
             options.map((propertyOption, propertyOptionIndex) => {
               return (
-                <Stack flexDirection='row' justifyContent='space-between' mb={1}>
+                <Stack key={propertyOption.name} flexDirection='row' justifyContent='space-between' mb={1}>
                   <TextField
                     // Using name would cause textfield to lose focus on each stroke
                     key={`${propertyOptionIndex.toString()}`}

--- a/components/proposals/components/ProposalStepper.tsx
+++ b/components/proposals/components/ProposalStepper.tsx
@@ -269,6 +269,7 @@ function MobileStepper ({ openVoteModal, currentStatus, proposalUserGroups, upda
 
                 return (
                   <MenuItem
+                    key={status}
                     sx={{
                       p: 1
                     }}

--- a/components/settings/roles/components/RoleRow.tsx
+++ b/components/settings/roles/components/RoleRow.tsx
@@ -125,12 +125,14 @@ export default function RoleRow ({ isEditable, role, assignRoles, unassignRole, 
             {
               roleSpacePermissions.map(operation => (
 
-                <div style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  flexWrap: 'wrap',
-                  flexDirection: 'row'
-                }}
+                <div
+                  key={operation}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    flexWrap: 'wrap',
+                    flexDirection: 'row'
+                  }}
                 >
                   <DoneIcon sx={{ fontSize: '18px', mr: 0.5 }} />
                   <Typography variant='caption'>{spaceOperationLabels[operation]}</Typography>

--- a/components/settings/roles/components/SpacePermissions/components/DefaultPagePermissions.tsx
+++ b/components/settings/roles/components/SpacePermissions/components/DefaultPagePermissions.tsx
@@ -113,6 +113,7 @@ export default function DefaultSpacePagePermissions () {
 
               return (
                 <MenuItem
+                  key={permissionLevel}
                   selected={isSelected}
                   onClick={() => {
                     setSelectedPagePermission(permissionLevel);

--- a/components/settings/roles/components/SpacePermissions/components/PermissionConfigurationMode.tsx
+++ b/components/settings/roles/components/SpacePermissions/components/PermissionConfigurationMode.tsx
@@ -98,6 +98,7 @@ export default function PermissionConfigurationMode ({ permissionModeSelected = 
 
               return (
                 <MenuItem
+                  key={mode}
                   selected={isSelected}
                   onClick={() => {
                     setSelectedConfigurationMode(mode);
@@ -140,7 +141,7 @@ export default function PermissionConfigurationMode ({ permissionModeSelected = 
 
               {
               templateExplanation[0].map(canDo => (
-                <Grid item xs={12} display='flex'>
+                <Grid key={canDo} item xs={12} display='flex'>
                   <DoneIcon color='success' sx={{ fontSize: '18px', mr: 0.5 }} />
                   <Typography variant='caption'>{canDo}</Typography>
                 </Grid>
@@ -151,7 +152,7 @@ export default function PermissionConfigurationMode ({ permissionModeSelected = 
             <Grid container item sm={secondGridSmallColumnWidth} xs={12} sx={{ pr: 2 }}>
               {
               templateExplanation[1].map(cannotDo => (
-                <Grid item xs={12} display='flex'>
+                <Grid key={cannotDo} item xs={12} display='flex'>
                   <CloseIcon color='error' sx={{ fontSize: '18px', mr: 0.5 }} />
                   <Typography variant='caption'>{cannotDo}</Typography>
                 </Grid>

--- a/components/settings/workspace/ImportNotionWorkspace.tsx
+++ b/components/settings/workspace/ImportNotionWorkspace.tsx
@@ -150,7 +150,7 @@ export default function ImportNotionWorkspace () {
             }}
             >
               {notionState.failedImports.map(failedImport => (
-                <div>
+                <div key={failedImport.pageId}>
                   <Box sx={{
                     display: 'flex',
                     gap: 1
@@ -164,7 +164,8 @@ export default function ImportNotionWorkspace () {
                     <div>
                       Blocks that failed to import for the page
                       {failedImport.blocks.map((blockTrails, blockTrailsIndex) => (
-                        <div>
+                        // eslint-disable-next-line react/no-array-index-key
+                        <div key={blockTrailsIndex}>
                           {blockTrailsIndex + 1}. {blockTrails.map(([blockType, blockIndex]) => `${blockType}(${blockIndex + 1})`).join(' -> ')}
                         </div>
                       ))}


### PR DESCRIPTION
For some reason our eslint setup did not warn about missing `key` prop for children arrays. This is one of basic good react practises so I think it is worth to add it.
This pr adds eslint rule + fixes all the places where keys were missing.