### PR TITLE
Stop overriding identity type, username and avatar on other integrations

### DIFF
--- a/components/integrations/components/IdentityProviders.tsx
+++ b/components/integrations/components/IdentityProviders.tsx
@@ -96,7 +96,7 @@ export default function IdentityProviders () {
       if (telegramAccount) {
         try {
           const telegramUser = await charmClient.connectTelegram(telegramAccount);
-          setUser((_user: LoggedInUser) => ({ ..._user, telegramUser, username: telegramAccount.username, avatar: telegramAccount.photo_url }));
+          setUser((_user: LoggedInUser) => ({ ..._user, telegramUser }));
         }
         catch (err: any) {
           setTelegramError(err.message || err.error || 'Something went wrong. Please try again');

--- a/pages/api/telegram/connect.ts
+++ b/pages/api/telegram/connect.ts
@@ -43,24 +43,6 @@ async function connectTelegram (req: NextApiRequest, res: NextApiResponse<Telegr
         }
       }
     });
-
-    const userFields: Partial<User> = {
-      username: telegramAccount.username,
-      identityType: IDENTITY_TYPES[2]
-    };
-
-    if (telegramAccount.photo_url) {
-      const pathInS3 = getUserS3FilePath({ userId, url: telegramAccount.photo_url });
-      const { url } = await uploadUrlToS3({ pathInS3, url: telegramAccount.photo_url });
-      userFields.avatar = url;
-    }
-
-    await prisma.user.update({
-      where: {
-        id: userId
-      },
-      data: userFields
-    });
   }
   catch (error) {
     log.warn('Error while connecting to Telegram', error);


### PR DESCRIPTION
Stop overriding username and avatar on connecting with telegram or discord.