### PR TITLE
Create an unique taskid for discussion notifications

### DIFF
--- a/background/tasks/sendNotifications/sendNotifications.ts
+++ b/background/tasks/sendNotifications/sendNotifications.ts
@@ -141,79 +141,39 @@ async function sendNotification (notification: PendingTasksProps & {
           channel: 'email',
           type: 'multisig'
         }
-      }))]
-    );
-  }
-  catch (err) {
-    log.debug(`GnosisSafe error with userId: ${notification.user.id}, taskIds: ${notification.gnosisSafeTasks.map(item => getGnosisSafeTaskId(item)).join(', ')}`, { error: err });
-    return undefined;
-  }
-
-  try {
-    await prisma.$transaction(
-      [...notification.proposalTasks.map(proposalTask => prisma.userNotification.create({
+      })), ...notification.proposalTasks.map(proposalTask => prisma.userNotification.create({
         data: {
           userId: notification.user.id,
           taskId: proposalTask.id,
           channel: 'email',
           type: 'proposal'
         }
-      }))]
-    );
-  }
-  catch (err) {
-    log.debug(`ProposalTasks error  with userId: ${notification.user.id} , taskIds: ${notification.proposalTasks.map(item => item.id).join(', ')}`, { error: err });
-    return undefined;
-  }
-
-  try {
-    await prisma.$transaction(
-      [...notification.unmarkedWorkspaceEvents.map(unmarkedWorkspaceEvent => prisma.userNotification.create({
+      })), ...notification.unmarkedWorkspaceEvents.map(unmarkedWorkspaceEvent => prisma.userNotification.create({
         data: {
           userId: notification.user.id,
           taskId: unmarkedWorkspaceEvent,
           channel: 'email',
           type: 'proposal'
         }
-      }))]
-    );
-  }
-  catch (err) {
-    log.debug(`Notifications task error with userId: ${notification.user.id} , taskIds: ${notification.unmarkedWorkspaceEvents.join(', ')}`, { error: err });
-    return undefined;
-  }
-
-  try {
-    await prisma.$transaction(
-      [...notification.voteTasks.map(voteTask => prisma.userNotification.create({
+      })), ...notification.voteTasks.map(voteTask => prisma.userNotification.create({
         data: {
           userId: notification.user.id,
           taskId: voteTask.id,
           channel: 'email',
           type: 'vote'
         }
-      }))]
-    );
-  }
-  catch (err) {
-    log.debug(`Votes Tasks error for  userId: ${notification.user.id}, taskIds: ${notification.voteTasks.map(voteTask => voteTask.id).join(', ')}`, { error: err });
-    return undefined;
-  }
-
-  try {
-    await prisma.$transaction(
-      [...notification.discussionTasks.map(discussionTask => prisma.userNotification.create({
+      })), ...notification.discussionTasks.map(discussionTask => prisma.userNotification.create({
         data: {
           userId: notification.user.id,
-          taskId: discussionTask.mentionId ?? discussionTask.commentId ?? '',
+          taskId: discussionTask.taskId,
           channel: 'email',
           type: 'mention'
         }
       }))]
     );
   }
-  catch (err) {
-    log.debug(`Discussion Tasks error with userId:${notification.user.id} , tasksIds: ${notification.discussionTasks.map(item => `${item.mentionId}&${item.commentId}`).join(', ')}`, { error: err });
+  catch (error) {
+    log.error(`Adding user notifications in db failed for user ${notification.user.id}.`, { error });
     return undefined;
   }
 

--- a/components/nexus/DiscussionTasksList.tsx
+++ b/components/nexus/DiscussionTasksList.tsx
@@ -119,7 +119,7 @@ export default function DiscussionTasksList ({ tasks, error, mutateTasks }: Disc
   useEffect(() => {
     async function main () {
       if (tasks?.discussions && tasks.discussions.unmarked.length !== 0) {
-        await charmClient.tasks.markTasks(tasks.discussions.unmarked.map(unmarkedDiscussion => ({ id: unmarkedDiscussion.mentionId ?? unmarkedDiscussion.commentId ?? '', type: 'mention' })));
+        await charmClient.tasks.markTasks(tasks.discussions.unmarked.map(unmarkedDiscussion => ({ id: unmarkedDiscussion.taskId, type: 'mention' })));
       }
     }
 

--- a/lib/discussion/getDiscussionTasks.ts
+++ b/lib/discussion/getDiscussionTasks.ts
@@ -12,7 +12,7 @@ export type DiscussionTasksGroup = {
   unmarked: DiscussionTask[];
 }
 
-type Discussion = Omit<DiscussionTask, 'createdBy'> & { userId: string };
+type Discussion = Omit<DiscussionTask, 'createdBy' | 'taskId'> & { userId: string };
 type SpaceRecord = Record<string, Pick<Space, 'name' | 'domain' | 'id'>>;
 
 interface GetDiscussionsInput {
@@ -126,10 +126,11 @@ export async function getDiscussionTasks (userId: string): Promise<DiscussionTas
 
     const mentionedTask = {
       ...mentionedTaskWithoutUser,
-      createdBy: usersRecord[mentionedTaskWithoutUser.userId]
+      createdBy: usersRecord[mentionedTaskWithoutUser.userId],
+      taskId: mentionedTaskWithoutUser.mentionId // MentionId is unique enough for UserNotifications
     } as DiscussionTask;
 
-    const taskList = notifiedTaskIds.has(mentionedTask.mentionId ?? '') ? acc.marked : acc.unmarked;
+    const taskList = notifiedTaskIds.has(mentionedTask.taskId) ? acc.marked : acc.unmarked;
     taskList.push(mentionedTask);
 
     return acc;
@@ -140,10 +141,11 @@ export async function getDiscussionTasks (userId: string): Promise<DiscussionTas
 
     const commentTask = {
       ...commentTaskWithoutUser,
-      createdBy: usersRecord[commentTaskWithoutUser.userId]
+      createdBy: usersRecord[commentTaskWithoutUser.userId],
+      taskId: `${commentTaskWithoutUser.commentId}.${userId}` // Creating an unique identifier for Prisma UserNotifications
     } as DiscussionTask;
 
-    const taskList = notifiedTaskIds.has(commentTask.commentId ?? '') ? acc.marked : acc.unmarked;
+    const taskList = notifiedTaskIds.has(commentTask.taskId) ? acc.marked : acc.unmarked;
     taskList.push(commentTask);
 
     return acc;

--- a/lib/discussion/interfaces.ts
+++ b/lib/discussion/interfaces.ts
@@ -1,6 +1,7 @@
 import type { User } from '@prisma/client';
 
 export interface DiscussionTask {
+  taskId: string;
   spaceId: string;
   spaceDomain: string;
   spaceName: string;


### PR DESCRIPTION
The problem was that a commentId can't be a unique id in the UserNotifications table.
FIY: mentionId is unique so I left it as it is.