### PR TITLE
Fix duplicate comments

### DIFF
--- a/background/tasks/sendNotifications/sendNotifications.ts
+++ b/background/tasks/sendNotifications/sendNotifications.ts
@@ -141,68 +141,28 @@ async function sendNotification (notification: PendingTasksProps & {
           channel: 'email',
           type: 'multisig'
         }
-      }))]
-    );
-  }
-  catch (err) {
-    log.debug(`GnosisSafe error with userId: ${notification.user.id}, taskIds: ${notification.gnosisSafeTasks.map(item => getGnosisSafeTaskId(item)).join(', ')}`, { error: err });
-    return undefined;
-  }
-
-  try {
-    await prisma.$transaction(
-      [...notification.proposalTasks.map(proposalTask => prisma.userNotification.create({
+      })), ...notification.proposalTasks.map(proposalTask => prisma.userNotification.create({
         data: {
           userId: notification.user.id,
           taskId: proposalTask.id,
           channel: 'email',
           type: 'proposal'
         }
-      }))]
-    );
-  }
-  catch (err) {
-    log.debug(`ProposalTasks error  with userId: ${notification.user.id} , taskIds: ${notification.proposalTasks.map(item => item.id).join(', ')}`, { error: err });
-    return undefined;
-  }
-
-  try {
-    await prisma.$transaction(
-      [...notification.unmarkedWorkspaceEvents.map(unmarkedWorkspaceEvent => prisma.userNotification.create({
+      })), ...notification.unmarkedWorkspaceEvents.map(unmarkedWorkspaceEvent => prisma.userNotification.create({
         data: {
           userId: notification.user.id,
           taskId: unmarkedWorkspaceEvent,
           channel: 'email',
           type: 'proposal'
         }
-      }))]
-    );
-  }
-  catch (err) {
-    log.debug(`Notifications task error with userId: ${notification.user.id} , taskIds: ${notification.unmarkedWorkspaceEvents.join(', ')}`, { error: err });
-    return undefined;
-  }
-
-  try {
-    await prisma.$transaction(
-      [...notification.voteTasks.map(voteTask => prisma.userNotification.create({
+      })), ...notification.voteTasks.map(voteTask => prisma.userNotification.create({
         data: {
           userId: notification.user.id,
           taskId: voteTask.id,
           channel: 'email',
           type: 'vote'
         }
-      }))]
-    );
-  }
-  catch (err) {
-    log.debug(`Votes Tasks error for  userId: ${notification.user.id}, taskIds: ${notification.voteTasks.map(voteTask => voteTask.id).join(', ')}`, { error: err });
-    return undefined;
-  }
-
-  try {
-    await prisma.$transaction(
-      [...notification.discussionTasks.map(discussionTask => prisma.userNotification.create({
+      })), ...notification.discussionTasks.map(discussionTask => prisma.userNotification.create({
         data: {
           userId: notification.user.id,
           taskId: discussionTask.mentionId ?? discussionTask.commentId ?? '',
@@ -212,8 +172,8 @@ async function sendNotification (notification: PendingTasksProps & {
       }))]
     );
   }
-  catch (err) {
-    log.debug(`Discussion Tasks error with userId:${notification.user.id} , tasksIds: ${notification.discussionTasks.map(item => `${item.mentionId}&${item.commentId}`).join(', ')}`, { error: err });
+  catch (error) {
+    log.error(`Updating notifications failed for the user ${notification.user.id}`, { error });
     return undefined;
   }
 

--- a/lib/discussion/__tests__/getDiscussionTasks.spec.ts
+++ b/lib/discussion/__tests__/getDiscussionTasks.spec.ts
@@ -306,7 +306,7 @@ describe('getDiscussionTasks', () => {
           userId: pageCommenter2.id,
           createdAt: new Date(),
           updatedAt: new Date(),
-          content: { type: 'doc', content: [{ type: 'paragraph', content: [{ text: '  ', type: 'text' }, { text: 'Another user just commented', type: 'text' }, { text: 'Another user just commented again', type: 'text' }] }] }
+          content: { type: 'doc', content: [{ type: 'paragraph', content: [{ text: 'Make this change ', type: 'text' }, { type: 'mention', attrs: { id: '9899800b-407e-4709-a15a-9b2bf1d6ad2d', type: 'user', track: [], value: pageCommenter.id, createdAt: '2022-11-03T09:37:26.670Z', createdBy: pageCommenter2.id } }, { text: ' dsadsadasd dsadsadsa', type: 'text' }] }] }
         }]
       }
     });
@@ -320,7 +320,7 @@ describe('getDiscussionTasks', () => {
     expectSome(newNotifications, (item) => (
       item.commentId === commentId
       && item.pageId === page.id
-      && item.text === 'Another user just commented'
+      && item.text === 'Make this change @Username dsadsadasd dsadsadsa'
     ));
   });
 });

--- a/lib/discussion/getDiscussionTasks.ts
+++ b/lib/discussion/getDiscussionTasks.ts
@@ -350,6 +350,7 @@ async function getComments ({ userId, spaceRecord, spaceIds }: GetDiscussionsInp
           createdAt: new Date(comment.createdAt).toISOString(),
           mentionId: null
         });
+        break;
       }
     }
   }
@@ -359,7 +360,6 @@ async function getComments ({ userId, spaceRecord, spaceIds }: GetDiscussionsInp
     discussionUserIds: textComments.map(comm => comm.userId).concat([userId]),
     comments: textComments
   };
-
 }
 
 async function getMentionsFromComments ({ userId, username, spaceRecord, spaceIds }: GetDiscussionsInput): Promise<GetDiscussionsResponse> {

--- a/scripts/sendNotifications.ts
+++ b/scripts/sendNotifications.ts
@@ -1,5 +1,5 @@
 
-import { getNotifications, sendUserNotifications } from 'background/tasks/sendNotifications/sendNotifications';
+import { sendUserNotifications } from 'background/tasks/sendNotifications/sendNotifications';
 
 (async () => {
   const r = await sendUserNotifications();


### PR DESCRIPTION
Found the issue:
If a comment had more then 1 blockNode because of the for loop it was doubled in the comments array.

Also if the prisma transactions fails, the email will not be sent.

Added a test to be sure if the code changes in the future not to forget about this.