### PR TITLE
increase timeout for page permissions

### DIFF
--- a/pages/api/permissions/index.ts
+++ b/pages/api/permissions/index.ts
@@ -112,7 +112,7 @@ async function addPagePermission (req: NextApiRequest, res: NextApiResponse<IPag
 
     return newPermission;
   }, {
-    timeout: 10000
+    timeout: 20000
   });
 
   return res.status(201).json(createdPermission);

--- a/pages/api/permissions/index.ts
+++ b/pages/api/permissions/index.ts
@@ -111,6 +111,8 @@ async function addPagePermission (req: NextApiRequest, res: NextApiResponse<IPag
     updateTrackPageProfile(pageId);
 
     return newPermission;
+  }, {
+    timeout: 10000
   });
 
   return res.status(201).json(createdPermission);


### PR DESCRIPTION
The default timeout is 5 seconds. I tested on our workspace and it is almost taking 5 seconds to respond, and sometimes erroring out so I want to try extending that timeout.