### PR TITLE
Update Sidebar.tsx to remove Members from Settings & Members

### DIFF
--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -260,7 +260,7 @@ export default function Sidebar ({ closeSidebar, favorites }: SidebarProps) {
               active={router.pathname.startsWith('/[domain]/settings/workspace')}
               href={`/${space.domain}/settings/workspace`}
               icon={<SettingsIcon color='secondary' fontSize='small' />}
-              label='Settings & Members'
+              label='Settings'
             />
             <SidebarLink
               active={false}


### PR DESCRIPTION
Change sidebar from "Settings & Members" to "Settings" since we already have Member Directory and Invite Members on the Sidebar.