### PR TITLE
update member properties config

### DIFF
--- a/components/members/components/AddMemberPropertyButton.tsx
+++ b/components/members/components/AddMemberPropertyButton.tsx
@@ -11,7 +11,7 @@ import Modal from 'components/common/Modal';
 import isAdmin from 'hooks/useIsAdmin';
 import { useMemberProperties } from 'hooks/useMemberProperties';
 import { useMembers } from 'hooks/useMembers';
-import { DEFAULT_MEMBER_PROPERTIES, MEMBER_PROPERTY_LABELS } from 'lib/members/constants';
+import { MEMBER_PROPERTY_CONFIG } from 'lib/members/constants';
 
 import { MemberPropertyItem } from './MemberDirectoryProperties/MemberPropertyItem';
 
@@ -46,6 +46,8 @@ export function AddMemberPropertyButton () {
     }
   }
 
+  const configurableProperties = Object.entries(MEMBER_PROPERTY_CONFIG).filter(([, propertyConfig]) => propertyConfig.default);
+
   return (
     <>
       <Button
@@ -72,21 +74,17 @@ export function AddMemberPropertyButton () {
           }
         }}
       >
-        {Object.keys(MEMBER_PROPERTY_LABELS).map((memberPropertyType) => (
-          !DEFAULT_MEMBER_PROPERTIES.includes(memberPropertyType as any) && (
-            <MenuItem
-              key={memberPropertyType}
-              onClick={() => {
-                setSelectedPropertyType(memberPropertyType as MemberPropertyType);
-                propertyNamePopupState.open();
-                addMemberPropertyPopupState.close();
-              }}
-            >
-              <MemberPropertyItem
-                type={memberPropertyType as MemberPropertyType}
-              />
-            </MenuItem>
-          )
+        {configurableProperties.map(([propertyType]) => (
+          <MenuItem
+            key={propertyType}
+            onClick={() => {
+              setSelectedPropertyType(propertyType as MemberPropertyType);
+              propertyNamePopupState.open();
+              addMemberPropertyPopupState.close();
+            }}
+          >
+            <MemberPropertyItem type={propertyType as MemberPropertyType} />
+          </MenuItem>
         ))}
       </Menu>
       <Modal size='large' open={propertyNamePopupState.isOpen} onClose={propertyNamePopupState.close} title='Name your property'>

--- a/components/members/components/MemberDirectoryProperties/MemberPropertiesSidebar.tsx
+++ b/components/members/components/MemberDirectoryProperties/MemberPropertiesSidebar.tsx
@@ -19,7 +19,7 @@ import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import { MemberPropertySidebarDetails } from 'components/members/components/MemberDirectoryProperties/MemberPropertySidebarDetails';
 import isAdmin from 'hooks/useIsAdmin';
 import { useMemberProperties } from 'hooks/useMemberProperties';
-import { DEFAULT_MEMBER_PROPERTIES } from 'lib/members/constants';
+import { MEMBER_PROPERTY_CONFIG } from 'lib/members/constants';
 import type { MemberPropertyWithPermissions } from 'lib/members/interfaces';
 import { mergeRefs } from 'lib/utilities/react';
 
@@ -222,7 +222,7 @@ export function MemberPropertySidebarItem ({
                 }}
               />
             </Tooltip>
-            {!DEFAULT_MEMBER_PROPERTIES.includes(property.type as any) && (
+            {!MEMBER_PROPERTY_CONFIG[property.type]?.default && (
               <Tooltip title={`Delete ${property.name} property.`}>
                 <DeleteIcon
                   cursor='pointer'

--- a/components/members/components/MemberDirectoryProperties/MemberPropertyItem.tsx
+++ b/components/members/components/MemberDirectoryProperties/MemberPropertyItem.tsx
@@ -16,7 +16,7 @@ import { ListItemIcon, ListItemText } from '@mui/material';
 import type { MemberPropertyType } from '@prisma/client';
 import type { ReactNode } from 'react';
 
-import { MEMBER_PROPERTY_LABELS } from 'lib/members/constants';
+import { MEMBER_PROPERTY_CONFIG } from 'lib/members/constants';
 import DiscordIcon from 'public/images/discord_logo.svg';
 
 export const MemberPropertyIcons: Record<MemberPropertyType, ReactNode> = {
@@ -58,7 +58,7 @@ export function MemberPropertyItem ({
           }
         }}
       >
-        {name ?? MEMBER_PROPERTY_LABELS[type]}
+        {name ?? MEMBER_PROPERTY_CONFIG[type]?.label}
       </ListItemText>
     </>
   );

--- a/components/members/components/MemberDirectoryProperties/MemberPropertyVisibility.tsx
+++ b/components/members/components/MemberDirectoryProperties/MemberPropertyVisibility.tsx
@@ -7,7 +7,7 @@ import GalleryIcon from 'components/common/BoardEditor/focalboard/src/widgets/ic
 import TableIcon from 'components/common/BoardEditor/focalboard/src/widgets/icons/table';
 import isAdmin from 'hooks/useIsAdmin';
 import { useMemberProperties } from 'hooks/useMemberProperties';
-import { UNHIDEABLE_MEMBER_PROPERTIES } from 'lib/members/constants';
+import { MEMBER_PROPERTY_CONFIG } from 'lib/members/constants';
 import type { MemberPropertyWithPermissions } from 'lib/members/interfaces';
 
 function VisibilityViewIcon ({
@@ -74,7 +74,7 @@ export function MemberPropertyVisibility ({
   property: MemberPropertyWithPermissions;
 }) {
   const enabledViews = property.enabledViews;
-  if (UNHIDEABLE_MEMBER_PROPERTIES.includes(property.type)) {
+  if (MEMBER_PROPERTY_CONFIG[property.type]?.unhideable) {
     return null;
   }
 

--- a/hooks/useMemberPropertyValues.ts
+++ b/hooks/useMemberPropertyValues.ts
@@ -3,7 +3,7 @@ import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import { useUser } from 'hooks/useUser';
-import { DEFAULT_MEMBER_PROPERTIES } from 'lib/members/constants';
+import { MEMBER_PROPERTY_CONFIG } from 'lib/members/constants';
 import type { UpdateMemberPropertyValuePayload } from 'lib/members/interfaces';
 
 export function useMemberPropertyValues (memberId: string) {
@@ -21,7 +21,7 @@ export function useMemberPropertyValues (memberId: string) {
 
     const isAdmin = user.spaceRoles.find(sr => sr.spaceId === spaceId)?.isAdmin || false;
     const spaceProps = getValuesForSpace(spaceId)?.properties || [];
-    const hasEditableProps = spaceProps.some(prop => prop.type === 'name' || !DEFAULT_MEMBER_PROPERTIES.includes(prop.type as any));
+    const hasEditableProps = spaceProps.some(prop => prop.type === 'name' || !MEMBER_PROPERTY_CONFIG[prop.type]?.default);
 
     return hasEditableProps && (isAdmin || memberId === user.id);
   }, [user, memberPropertyValues]);

--- a/lib/members/constants.ts
+++ b/lib/members/constants.ts
@@ -1,38 +1,71 @@
 import type { MemberPropertyType } from '@prisma/client';
 
-export const READONLY_MEMBER_PROPERTIES: MemberPropertyType[] = [
-  'profile_pic',
-  'role',
-  'discord',
-  'twitter',
-  'timezone',
-  'bio'
-];
+type MemberPropertyConfig = { label: string, readonly?: boolean, default?: boolean, unhideable?: boolean };
 
-export const DEFAULT_MEMBER_PROPERTIES = [
-  ...READONLY_MEMBER_PROPERTIES,
-  'name'
-] as const;
-
-export const MEMBER_PROPERTY_LABELS: Record<MemberPropertyType, string> = {
-  discord: 'Discord',
-  name: 'Name',
-  profile_pic: 'Profile pic',
-  role: 'Role',
-  timezone: 'Timezone',
-  twitter: 'Twitter',
-  email: 'Email',
-  multiselect: 'Multi-select',
-  number: 'Number',
-  phone: 'Phone',
-  select: 'Select',
-  text: 'Text',
-  text_multiline: 'Multiline text',
-  url: 'URL',
-  bio: 'Bio'
+// the following properties are listed in the order they should appear in the UI. Chronological sort is guaranteed since es2015
+export const MEMBER_PROPERTY_CONFIG: Record<MemberPropertyType, MemberPropertyConfig> = {
+  profile_pic: {
+    label: 'Avatar',
+    default: true,
+    readonly: true,
+    unhideable: true
+  },
+  name: {
+    label: 'Name',
+    default: true,
+    unhideable: true
+  },
+  role: {
+    label: 'Roles',
+    default: true,
+    readonly: true
+  },
+  bio: {
+    label: 'Bio'
+  },
+  discord: {
+    label: 'Discord',
+    default: true,
+    readonly: true
+  },
+  twitter: {
+    label: 'Twitter',
+    default: true,
+    readonly: true
+  },
+  timezone: {
+    label: 'Timezone',
+    default: true,
+    readonly: true
+  },
+  email: {
+    label: 'Email'
+  },
+  multiselect: {
+    label: 'Multi-select'
+  },
+  number: {
+    label: 'Number'
+  },
+  phone: {
+    label: 'Phone'
+  },
+  select: {
+    label: 'Select'
+  },
+  text: {
+    label: 'Text'
+  },
+  text_multiline: {
+    label: 'Multiline text'
+  },
+  url: {
+    label: 'URL'
+  }
 };
 
-export const UNHIDEABLE_MEMBER_PROPERTIES = [
-  'name',
-  'profile_pic'
-];
+const propertyTypes = Object.keys(MEMBER_PROPERTY_CONFIG) as MemberPropertyType[];
+
+export const READONLY_MEMBER_PROPERTIES = propertyTypes.filter(prop => MEMBER_PROPERTY_CONFIG[prop].readonly);
+
+export const DEFAULT_MEMBER_PROPERTIES = propertyTypes.filter(prop => MEMBER_PROPERTY_CONFIG[prop].default);

--- a/lib/members/deleteMemberProperty.ts
+++ b/lib/members/deleteMemberProperty.ts
@@ -6,7 +6,7 @@ export function deleteMemberProperty (id: string) {
     where: {
       id,
       type: {
-        notIn: [...DEFAULT_MEMBER_PROPERTIES]
+        notIn: DEFAULT_MEMBER_PROPERTIES
       }
     }
   });

--- a/lib/members/generateDefaultPropertiesInput.ts
+++ b/lib/members/generateDefaultPropertiesInput.ts
@@ -1,11 +1,11 @@
 import type { MemberPropertyType } from '@prisma/client';
 
-import { DEFAULT_MEMBER_PROPERTIES, MEMBER_PROPERTY_LABELS } from 'lib/members/constants';
+import { DEFAULT_MEMBER_PROPERTIES, MEMBER_PROPERTY_CONFIG } from 'lib/members/constants';
 
 export function generateDefaultPropertiesInput ({ userId, spaceId }: { userId: string, spaceId: string }) {
-  const defaultPropertiesInput = [...DEFAULT_MEMBER_PROPERTIES].sort().map((memberProperty, memberPropertyIndex) => ({
+  const defaultPropertiesInput = DEFAULT_MEMBER_PROPERTIES.map((memberProperty, memberPropertyIndex) => ({
     createdBy: userId,
-    name: MEMBER_PROPERTY_LABELS[memberProperty],
+    name: MEMBER_PROPERTY_CONFIG[memberProperty].label,
     index: memberPropertyIndex,
     type: (memberProperty as MemberPropertyType),
     updatedBy: userId,

--- a/lib/members/updateMemberPropertyVisibility.ts
+++ b/lib/members/updateMemberPropertyVisibility.ts
@@ -2,7 +2,7 @@ import { prisma } from 'db';
 import { NotFoundError } from 'lib/middleware';
 import { UndesirableOperationError } from 'lib/utilities/errors';
 
-import { UNHIDEABLE_MEMBER_PROPERTIES } from './constants';
+import { MEMBER_PROPERTY_CONFIG } from './constants';
 import type { UpdateMemberPropertyVisibilityPayload } from './interfaces';
 
 export async function updateMemberPropertyVisibility ({
@@ -26,7 +26,7 @@ export async function updateMemberPropertyVisibility ({
 
   const enabledViews = memberProperty?.enabledViews ?? [];
 
-  if (UNHIDEABLE_MEMBER_PROPERTIES.includes(memberProperty.type)) {
+  if (MEMBER_PROPERTY_CONFIG[memberProperty.type]?.unhideable) {
     throw new UndesirableOperationError(`${memberProperty.type} property visibility can't be updated`);
   }
 


### PR DESCRIPTION
having a single map for all member types prevents duplication of configs, and makes the checks faster since we aren't constantly looking for matches in a list