### PR TITLE
fix: make date editable from table view

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/properties/dateRange/dateRange.scss
+++ b/components/common/BoardEditor/focalboard/src/components/properties/dateRange/dateRange.scss
@@ -43,8 +43,8 @@
     }
 
     .Button {
+        display: flex;
         height: 100%;
-        width: calc(100% - 16px);
         justify-content: left;
         padding: 0;
 

--- a/components/common/BoardEditor/focalboard/src/components/properties/dateRange/dateRange.scss
+++ b/components/common/BoardEditor/focalboard/src/components/properties/dateRange/dateRange.scss
@@ -43,8 +43,8 @@
     }
 
     .Button {
-        width: 100%;
         height: 100%;
+        width: calc(100% - 16px);
         justify-content: left;
         padding: 0;
 

--- a/components/common/BoardEditor/focalboard/src/components/table/table.scss
+++ b/components/common/BoardEditor/focalboard/src/components/table/table.scss
@@ -169,6 +169,9 @@
             text-align: left;
             width: inherit;
         }
+        .DateRange.octo-propertyvalue {
+          overflow: unset;
+      }
     }
 
     .octo-table-body {


### PR DESCRIPTION
https://app.charmverse.io/charmverse/page-49366552253645923?viewId=44c79006-57dd-4e78-808f-b21ae0323b8c&cardId=4c086e40-ceab-4ea5-be8e-9184b2edf64f

<img width="691" alt="Screenshot 2022-11-09 at 5 08 02 PM" src="https://user-images.githubusercontent.com/5186937/200952479-cb1323f1-2ed0-4023-83f9-0ffb041d84dd.png">
