### PR TITLE
Allow non-native tokens thru Gnosis safe

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantTableRow.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantTableRow.tsx
@@ -206,6 +206,7 @@ export default function BountyApplicantTableRow ({
                       setIsExpandedRow(false);
                     }}
                     permissions={permissions}
+                    expandedOnLoad={submission.status === 'review'}
                     alwaysExpanded={false}
                   />
                   {/* disabled - maybe we dont need to show address here? <Box mb={3}>

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantTableRow.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantTableRow.tsx
@@ -23,7 +23,6 @@ import type { ReviewDecision, SubmissionReview } from 'lib/applications/interfac
 import type { AssignedBountyPermissions, BountyWithDetails } from 'lib/bounties';
 import { humanFriendlyDate } from 'lib/utilities/dates';
 import type { SystemError } from 'lib/utilities/errors';
-import { shortenHex } from 'lib/utilities/strings';
 
 import ApplicationInput from '../BountyApplicantForm/components/ApplicationInput';
 import SubmissionInput from '../BountyApplicantForm/components/SubmissionInput';

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
@@ -82,7 +82,7 @@ function SafeMenuItem ({
     chainId: safeInfo.chainId,
     onSuccess: onPaymentSuccess,
     safeAddress: safeInfo.address,
-    transactions
+    transactions: transactions.map(getTransaction => getTransaction(safeInfo.address))
   });
 
   return (

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
@@ -1,4 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Divider, Menu, MenuItem } from '@mui/material';
 import type { AlertColor } from '@mui/material/Alert';
 import Button from '@mui/material/Button';
@@ -86,22 +87,24 @@ function SafeMenuItem ({
   });
 
   return (
-    <MenuItem onClick={async () => {
-      onClick();
-      try {
-        await makePayment();
-      }
-      catch (error: any) {
-        const errorMessage = extractWalletErrorMessage(error);
+    <MenuItem
+      dense
+      onClick={async () => {
+        onClick();
+        try {
+          await makePayment();
+        }
+        catch (error: any) {
+          const errorMessage = extractWalletErrorMessage(error);
 
-        if (errorMessage === 'underlying network changed') {
-          onError("You've changed your active network.\r\nRe-select 'Make payment' to complete this transaction", 'warning');
+          if (errorMessage === 'underlying network changed') {
+            onError("You've changed your active network.\r\nRe-select 'Make payment' to complete this transaction", 'warning');
+          }
+          else {
+            onError(errorMessage);
+          }
         }
-        else {
-          onError(errorMessage);
-        }
-      }
-    }}
+      }}
     >{label}
     </MenuItem>
   );
@@ -234,13 +237,16 @@ export default function BountyPaymentButton ({
     }
   };
 
+  const hasSafes = safeInfos?.length > 0;
+
   return (
     <>
       <Button
         color='primary'
+        endIcon={hasSafes ? <KeyboardArrowDownIcon /> : null}
         size='small'
         onClick={(e) => {
-          if (safeInfos?.length === 0) {
+          if (!hasSafes) {
             onClick();
             makePayment();
           }
@@ -251,25 +257,26 @@ export default function BountyPaymentButton ({
       >
         Send Payment
       </Button>
-      {safeInfos?.length !== 0 && (
+      {hasSafes && (
         <Menu
           id='bounty-payment'
           anchorEl={anchorEl}
           open={open}
           onClose={handleClose}
         >
-          <MenuItem onClick={() => {
-            onClick();
-            makePayment();
-            handleClose();
-          }}
-          >Metamask Wallet
+          <MenuItem dense sx={{ pointerEvents: 'none', color: 'secondary.main' }}>Connected wallet</MenuItem>
+          <MenuItem
+            dense
+            onClick={() => {
+              onClick();
+              makePayment();
+              handleClose();
+            }}
+          >
+            {shortenHex(account ?? '')}
           </MenuItem>
-          {
-          safeInfos && (
-            <Divider />
-          )
-        }
+          <Divider />
+          <MenuItem dense sx={{ pointerEvents: 'none', color: 'secondary.main' }}>Gnosis wallets</MenuItem>
           {
           safeInfos?.map(safeInfo => (
             <SafeMenuItem

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
@@ -237,7 +237,7 @@ export default function BountyPaymentButton ({
     }
   };
 
-  const hasSafes = safeInfos?.length > 0;
+  const hasSafes = Boolean(safeInfos?.length);
 
   return (
     <>

--- a/hooks/useGnosisPayment.ts
+++ b/hooks/useGnosisPayment.ts
@@ -28,6 +28,7 @@ export function useGnosisPayment ({
   if (!network?.gnosisUrl) {
     throw new Error(`Unsupported Gnosis network: ${chainId}`);
   }
+
   async function makePayment () {
 
     if (chainId !== connectedChainId) {
@@ -37,7 +38,6 @@ export function useGnosisPayment ({
     if (!safe || !account || !network?.gnosisUrl) {
       return;
     }
-
     const safeTransaction = await safe.createTransaction(transactions.map(transaction => (
       {
         data: transaction.data,

--- a/hooks/useMultiBountyPayment.ts
+++ b/hooks/useMultiBountyPayment.ts
@@ -19,7 +19,7 @@ import { useBounties } from './useBounties';
 import { useCurrentSpace } from './useCurrentSpace';
 
 const ERC20_ABI = [
-  'function transferFrom(address sender, address to, uint256 value)'
+  'function transfer(address to, uint256 value)'
 ];
 
 export interface TransactionWithMetadata extends MetaTransactionData, Pick<Bounty, 'rewardToken' | 'rewardAmount' | 'chainId'>{
@@ -74,8 +74,8 @@ export function useMultiBountyPayment ({ bounties, postPaymentSuccess }:
                 const erc20 = new ethers.utils.Interface(ERC20_ABI);
                 const parsedAmount = ethers.utils.parseUnits(eToNumber(bounty.rewardAmount), paymentMethod?.tokenDecimals).toString();
                 data = erc20.encodeFunctionData(
-                  'transferFrom',
-                  [safeAddress, application.walletAddress, parsedAmount]
+                  'transfer',
+                  [application.walletAddress, parsedAmount]
                 );
                 // send the request to the token contract
                 to = bounty.rewardToken;

--- a/hooks/useMultiBountyPayment.ts
+++ b/hooks/useMultiBountyPayment.ts
@@ -63,7 +63,6 @@ export function useMultiBountyPayment ({ bounties, postPaymentSuccess }:
           .filter(application => application.walletAddress && application.status === 'complete')
           .map(application => {
             return (safeAddress?: string) => {
-
               let data = '0x';
               let to = application.walletAddress as string;
               let value = ethers.utils.parseUnits(eToNumber(bounty.rewardAmount), 18).toString();

--- a/hooks/useMultiBountyPayment.ts
+++ b/hooks/useMultiBountyPayment.ts
@@ -13,7 +13,6 @@ import type { BountyWithDetails } from 'lib/bounties';
 import type { SafeData } from 'lib/gnosis';
 import { getSafesForAddress } from 'lib/gnosis';
 import { eToNumber } from 'lib/utilities/numbers';
-import { isTruthy } from 'lib/utilities/types';
 
 import { useBounties } from './useBounties';
 import { useCurrentSpace } from './useCurrentSpace';
@@ -48,7 +47,7 @@ export function useMultiBountyPayment ({ bounties, postPaymentSuccess }:
   const gnosisSafeChainId = gnosisSafeData?.chainId;
 
   // If the bounty is on the same chain as the gnosis safe and the rewardToken of the bounty is the same as the native currency of the gnosis safe chain
-  const transactions: ((safeAddress: string) => TransactionWithMetadata)[] = useMemo(
+  const transactions: ((safeAddress?: string) => TransactionWithMetadata)[] = useMemo(
     () => bounties
       .filter(bounty => {
         return safeData ? safeData.some(safe => bounty.chainId === safe.chainId) : false;

--- a/lib/payment-methods/defaultPaymentMethods.ts
+++ b/lib/payment-methods/defaultPaymentMethods.ts
@@ -4,6 +4,7 @@ import { prisma } from 'db';
 import { DataNotFoundError } from 'lib/utilities/errors';
 
 const defaultPaymentMethods: Pick<PaymentMethod, 'chainId' | 'contractAddress' | 'tokenLogo' | 'tokenSymbol' | 'tokenName' | 'tokenDecimals'> [] = [
+  // ethereum
   {
     chainId: 1,
     contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
@@ -12,14 +13,16 @@ const defaultPaymentMethods: Pick<PaymentMethod, 'chainId' | 'contractAddress' |
     tokenSymbol: 'USDC',
     tokenLogo: 'https://cryptologos.cc/logos/usd-coin-usdc-logo.png'
   },
+  // goerli
   {
-    chainId: 4,
-    contractAddress: '0xeb8f08a975Ab53E34D8a0330E0D34de942C95926',
+    chainId: 5,
+    contractAddress: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
     tokenDecimals: 6,
     tokenName: 'USD Coin',
     tokenSymbol: 'USDC',
     tokenLogo: 'https://cryptologos.cc/logos/usd-coin-usdc-logo.png'
   },
+  // polygon
   {
     chainId: 137,
     contractAddress: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',


### PR DESCRIPTION
I noticed the transaction URL is invalid, but not sure if it's because that I was using Goerli testnet: https://goerli.etherscan.io/tx/0x4439dc2f8f12b73a7bad020100605c701e8f0ae85ba4c1191f7c11b8e682738c. The transaction was executed on my gnosis safe fine. Gnosis also was unable to 'decode' the transaction, so I am not 100% confident in how I did it.

References:
- how to send a POAP thru Gnosis
https://ethereum.stackexchange.com/questions/138352/transfer-poap-erc-721-out-of-gnosis-safe-via-sdk
- how to use ethers to generate a call to a contract method
https://github.com/ethers-io/ethers.js/issues/478