### PR TITLE
Disable submit snapshot btn after submitting

### DIFF
--- a/components/common/PageLayout/components/Header/components/Snapshot/ConnectSnapshot.tsx
+++ b/components/common/PageLayout/components/Header/components/Snapshot/ConnectSnapshot.tsx
@@ -61,6 +61,8 @@ export default function ConnectSnapshot () {
 
   const values = watch();
 
+  const snapshotIsDefault = space?.snapshotDomain === values.snapshotDomain;
+
   async function onSubmit (formValues: FormValues) {
 
     setFormError(null);
@@ -131,7 +133,7 @@ export default function ConnectSnapshot () {
         {
           isAdmin && (
             <Grid item display='flex' justifyContent='space-between'>
-              <PrimaryButton disabled={!isValid} type='submit'>
+              <PrimaryButton disabled={!isValid || snapshotIsDefault} type='submit'>
                 Save
               </PrimaryButton>
             </Grid>


### PR DESCRIPTION
If the user changes the snapshot eth address, the button should be disabled after submitting it.
Also if the user deletes the input value and adds exactly the same value, the button will be disabled.

https://app.charmverse.io/charmverse/page-8924516118275596