### PR TITLE
Sshrayber figma

### DIFF
--- a/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
+++ b/components/common/CharmEditor/components/iframe/IFrameSelector.tsx
@@ -10,7 +10,7 @@ interface IFrameSelectorProps {
   onIFrameSelect: (videoSrc: string) => void;
   children: ReactNode;
   tabs?: [string, ReactNode][];
-  type: 'embed' | 'video';
+  type: 'embed' | 'video' | 'figma';
 }
 
 export default function IFrameSelector (props: IFrameSelectorProps) {
@@ -54,7 +54,21 @@ export default function IFrameSelector (props: IFrameSelectorProps) {
                     setEmbedLink('');
                   }}
                 >
-                  {type === 'embed' ? 'Embed link' : 'Insert Video'}
+
+                  {(() => {
+                    switch (type) {
+                      case 'embed':
+                        return 'Embed Link';
+                      case 'video':
+                        return 'Insert Video';
+                      case 'figma':
+                        return 'Insert Figma';
+
+                      default:
+                        return null;
+                    }
+                  })()}
+
                 </Button>
               </Box>
             ]

--- a/components/common/CharmEditor/components/iframe/IframeComponent.tsx
+++ b/components/common/CharmEditor/components/iframe/IframeComponent.tsx
@@ -254,7 +254,7 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
   }
   else if (node.attrs.type === 'figma') {
 
-    const src = `https://www.figma.com/embed?embed_host=astra&url=${node.attrs.src}`;
+    const src = `https://www.figma.com/embed?embed_host=charmverse&url=${node.attrs.src}`;
     return (
       <BlockAligner onDelete={onDelete}>
         <VerticalResizer

--- a/components/common/CharmEditor/components/iframe/IframeComponent.tsx
+++ b/components/common/CharmEditor/components/iframe/IframeComponent.tsx
@@ -194,6 +194,7 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
   NodeViewProps & { readOnly: boolean, onResizeStop?: (view: EditorView) => void }) {
   const [height, setHeight] = useState(node.attrs.height);
   const view = useEditorViewContext();
+  const figmaSrc = `https://www.figma.com/embed?embed_host=charmverse&url=${node.attrs.src}`;
 
   // If there are no source for the node, return the image select component
   if (!node.attrs.src) {
@@ -220,7 +221,11 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
   if (readOnly) {
     return (
       <StyledIFrame>
-        <iframe allowFullScreen title='iframe' src={node.attrs.src} style={{ height: node.attrs.size ?? MIN_EMBED_HEIGHT, border: '0 solid transparent', width: '100%' }} />
+        {node.attrs.type === 'figma' ? (
+          <iframe allowFullScreen title='iframe' src={figmaSrc} style={{ height: '100%', border: '0 solid transparent', width: '100%' }} />
+        ) : (
+          <iframe allowFullScreen title='iframe' src={node.attrs.src} style={{ height: node.attrs.size ?? MIN_EMBED_HEIGHT, border: '0 solid transparent', width: '100%' }} />
+        )}
       </StyledIFrame>
     );
   }
@@ -253,8 +258,6 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
     );
   }
   else if (node.attrs.type === 'figma') {
-
-    const src = `https://www.figma.com/embed?embed_host=charmverse&url=${node.attrs.src}`;
     return (
       <BlockAligner onDelete={onDelete}>
         <VerticalResizer
@@ -275,7 +278,7 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
           minConstraints={[MAX_EMBED_WIDTH, MIN_EMBED_HEIGHT]}
         >
           <StyledIFrame>
-            <iframe allowFullScreen title='iframe' src={src} style={{ height: '100%', border: '0 solid transparent', width: '100%' }} />
+            <iframe allowFullScreen title='iframe' src={figmaSrc} style={{ height: '100%', border: '0 solid transparent', width: '100%' }} />
           </StyledIFrame>
         </VerticalResizer>
       </BlockAligner>

--- a/components/common/CharmEditor/components/iframe/IframeComponent.tsx
+++ b/components/common/CharmEditor/components/iframe/IframeComponent.tsx
@@ -10,6 +10,7 @@ import { ListItem, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import type { HTMLAttributes } from 'react';
 import { useState, memo } from 'react';
+import { FiFigma } from 'react-icons/fi';
 
 import { MAX_EMBED_WIDTH, MIN_EMBED_HEIGHT, MAX_EMBED_HEIGHT, VIDEO_ASPECT_RATIO, MIN_EMBED_WIDTH } from 'lib/embed/constants';
 import { extractEmbedLink } from 'lib/embed/extractEmbedLink';
@@ -126,7 +127,7 @@ const StyledEmptyIframeContainer = styled(Box)`
   opacity: 0.5;
 `;
 
-function EmptyIframeContainer (props: HTMLAttributes<HTMLDivElement> & { readOnly: boolean, type: 'video' | 'embed' }) {
+function EmptyIframeContainer (props: HTMLAttributes<HTMLDivElement> & { readOnly: boolean, type: 'video' | 'embed' | 'figma' }) {
   const theme = useTheme();
   const { type, readOnly, ...rest } = props;
   return (
@@ -144,9 +145,34 @@ function EmptyIframeContainer (props: HTMLAttributes<HTMLDivElement> & { readOnl
       {...rest}
     >
       <StyledEmptyIframeContainer>
-        {type === 'embed' ? <PreviewIcon fontSize='small' /> : <VideoLibraryIcon fontSize='small' />}
+        {(() => {
+          switch (type) {
+            case 'embed':
+              return <PreviewIcon fontSize='small' />;
+            case 'video':
+              return <VideoLibraryIcon fontSize='small' />;
+            case 'figma':
+              return <FiFigma style={{ fontSize: 'small' }} />;
+
+            default:
+              return null;
+          }
+        })()}
         <Typography>
-          {type === 'video' ? 'Insert a video' : 'Insert an embed'}
+          {(() => {
+            switch (type) {
+              case 'embed':
+                return 'Insert an embed';
+              case 'video':
+                return 'Insert a video';
+              case 'figma':
+                return 'Insert a Figma';
+
+              default:
+                return null;
+            }
+          })()}
+
         </Typography>
       </StyledEmptyIframeContainer>
     </ListItem>
@@ -221,6 +247,34 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
         >
           <StyledIFrame>
             <iframe allowFullScreen title='iframe' src={node.attrs.src} style={{ height: '100%', border: '0 solid transparent', width: '100%' }} />
+          </StyledIFrame>
+        </VerticalResizer>
+      </BlockAligner>
+    );
+  }
+  else if (node.attrs.type === 'figma') {
+    return (
+
+      <BlockAligner onDelete={onDelete}>
+        <VerticalResizer
+          onResizeStop={(_, data) => {
+            updateAttrs({
+              height: data.size.height
+            });
+            if (onResizeStop) {
+              onResizeStop(view);
+            }
+          }}
+          width={node.attrs.width}
+          height={height}
+          onResize={(_, data) => {
+            setHeight(data.size.height);
+          }}
+          maxConstraints={[MAX_EMBED_WIDTH, MAX_EMBED_HEIGHT]}
+          minConstraints={[MAX_EMBED_WIDTH, MIN_EMBED_HEIGHT]}
+        >
+          <StyledIFrame>
+            <iframe allowFullScreen title='iframe' src={`https://www.figma.com/embed?embed_host=charmverse&url=${node.attrs.src}`} style={{ height: '100%', border: '0 solid transparent', width: '100%' }} />
           </StyledIFrame>
         </VerticalResizer>
       </BlockAligner>

--- a/components/common/CharmEditor/components/iframe/IframeComponent.tsx
+++ b/components/common/CharmEditor/components/iframe/IframeComponent.tsx
@@ -253,8 +253,9 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
     );
   }
   else if (node.attrs.type === 'figma') {
-    return (
 
+    const src = `https://www.figma.com/embed?embed_host=astra&url=${node.attrs.src}`;
+    return (
       <BlockAligner onDelete={onDelete}>
         <VerticalResizer
           onResizeStop={(_, data) => {
@@ -274,7 +275,7 @@ function ResizableIframe ({ readOnly, node, updateAttrs, onResizeStop }:
           minConstraints={[MAX_EMBED_WIDTH, MIN_EMBED_HEIGHT]}
         >
           <StyledIFrame>
-            <iframe allowFullScreen title='iframe' src={`https://www.figma.com/embed?embed_host=charmverse&url=${node.attrs.src}`} style={{ height: '100%', border: '0 solid transparent', width: '100%' }} />
+            <iframe allowFullScreen title='iframe' src={src} style={{ height: '100%', border: '0 solid transparent', width: '100%' }} />
           </StyledIFrame>
         </VerticalResizer>
       </BlockAligner>

--- a/components/common/CharmEditor/components/inlinePalette/editorItems/embed.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/editorItems/embed.tsx
@@ -2,6 +2,7 @@ import { rafCommandExec } from '@bangle.dev/utils';
 import InsertChartIcon from '@mui/icons-material/InsertChart';
 import PreviewIcon from '@mui/icons-material/Preview';
 import TwitterIcon from '@mui/icons-material/Twitter';
+import { FiFigma } from 'react-icons/fi';
 
 import { MAX_EMBED_WIDTH, MIN_EMBED_HEIGHT } from 'lib/embed/constants';
 
@@ -28,6 +29,40 @@ export function items (): PaletteItemTypeNoGroup[] {
               const node = _state.schema.nodes.iframe.create({
                 src: null,
                 type: 'embed',
+                width: MAX_EMBED_WIDTH,
+                height: MIN_EMBED_HEIGHT
+              });
+
+              if (_dispatch && isAtBeginningOfLine(_state)) {
+                _dispatch(_state.tr.replaceSelectionWith(node));
+                return true;
+              }
+              return insertNode(_state, _dispatch, node);
+            });
+            return replaceSuggestionMarkWith(palettePluginKey, '')(
+              state,
+              dispatch,
+              view
+            );
+          }
+          return false;
+        };
+      }
+    },
+    {
+      uid: 'figma',
+      title: 'Figma',
+      icon: <FiFigma style={{ fontSize: iconSize }} />,
+      keywords: ['iframe'],
+      description: 'Embed Figma',
+      editorExecuteCommand: () => {
+        return (state, dispatch, view) => {
+          if (view) {
+            rafCommandExec(view, (_state, _dispatch) => {
+
+              const node = _state.schema.nodes.iframe.create({
+                src: null,
+                type: 'figma',
                 width: MAX_EMBED_WIDTH,
                 height: MIN_EMBED_HEIGHT
               });

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,7 @@
         "react-hook-form": "^7.25.0",
         "react-hot-keys": "^2.7.1",
         "react-hotkeys-hook": "^3.4.4",
+        "react-icons": "^4.6.0",
         "react-intl": "^5.24.4",
         "react-pdf": "^5.7.2",
         "react-redux": "^7.2.6",
@@ -23858,6 +23859,14 @@
       "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.7.tgz",
       "integrity": "sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-immutable-proptypes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.2.0.tgz",
@@ -45728,6 +45737,12 @@
           "integrity": "sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg=="
         }
       }
+    },
+    "react-icons": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
+      "requires": {}
     },
     "react-immutable-proptypes": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "react-hook-form": "^7.25.0",
     "react-hot-keys": "^2.7.1",
     "react-hotkeys-hook": "^3.4.4",
+    "react-icons": "^4.6.0",
     "react-intl": "^5.24.4",
     "react-pdf": "^5.7.2",
     "react-redux": "^7.2.6",


### PR DESCRIPTION
https://app.charmverse.io/charmverse/page-49366552253645923?viewId=44c79006-57dd-4e78-808f-b21ae0323b8c&cardId=bd01584a-09f2-45e3-a887-0b00538940f2

![Screenshot 2022-11-14 at 12 22 54 AM](https://user-images.githubusercontent.com/5186937/201582925-5ce06a22-0ccb-461e-9979-f677829241c5.png)

Material UI does not have a Figma Icon. I used Feather icons via [React Icons](https://react-icons.github.io/react-icons).