### PR TITLE
Fix bounty sending emails all the time

### DIFF
--- a/background/tasks/sendNotifications/sendNotifications.ts
+++ b/background/tasks/sendNotifications/sendNotifications.ts
@@ -169,6 +169,13 @@ async function sendNotification (notification: PendingTasksProps & {
           channel: 'email',
           type: 'mention'
         }
+      })), ...notification.bountyTasks.map(bountyTask => prisma.userNotification.create({
+        data: {
+          userId: notification.user.id,
+          taskId: bountyTask.id,
+          channel: 'email',
+          type: 'bounty'
+        }
       }))]
     );
   }


### PR DESCRIPTION
The problem was that when I was sending the emails I didn't register the notification in the userNotifications table.