### PR TITLE
hide scrollbar on nexus sidebar

### DIFF
--- a/components/nexus/components/NexusSidebar.tsx
+++ b/components/nexus/components/NexusSidebar.tsx
@@ -12,6 +12,14 @@ const SidebarContainer = styled.div`
   background-color: ${({ theme }) => theme.palette.sidebar.background};
   height: 100%;
 
+  // hide scrollbar but allow scrolling
+  overflow: auto;
+  scrollbar-width: none;  /* Firefox */
+  -ms-overflow-style: none;  /* IE and Edge */
+  ::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera */
+  }
+
   &:hover {
     .sidebar-header {
       .MuiTypography-root {


### PR DESCRIPTION
I applied a fix for hiding the scrollbar in the sidebar that was not being used in the Nexus page (I needed to apply the same fix to a higher-level  component). The CSS hides the scrollbar, but the area is still scrollable/swipable.
See loom: https://www.loom.com/share/b62191ca98274e2bb37dbed3f0cabb65