### PR TITLE
Handle N/A and empty fields for member directory

### DIFF
--- a/components/profile/components/SpacesMemberDetails/components/SpaceDetailsAccordion.tsx
+++ b/components/profile/components/SpacesMemberDetails/components/SpaceDetailsAccordion.tsx
@@ -73,18 +73,28 @@ export function SpaceDetailsAccordion ({ spaceName, properties, spaceImage, read
               case 'url':
               case 'email':
               case 'number': {
-                return (
+                return property.value && (
                   <Stack key={property.memberPropertyId}>
                     <Typography fontWeight='bold'>{property.name}</Typography>
-                    <Typography whiteSpace={property.type === 'text_multiline' ? 'pre-wrap' : 'initial'}>{property.value ?? 'N/A'}</Typography>
+                    <Typography
+                      sx={{
+                        wordBreak: 'break-word'
+                      }}
+                      whiteSpace={property.type === 'text_multiline' ? 'pre-wrap' : 'initial'}
+                    >{property.value}
+                    </Typography>
                   </Stack>
                 );
               }
               case 'multiselect':
               case 'select': {
+                const propertyValue = property.value as string | string[];
+                if (propertyValue.length === 0) {
+                  return null;
+                }
                 return (
                   <SelectPreview
-                    value={property.value as (string | string[])}
+                    value={propertyValue}
                     name={property.name}
                     options={property.options}
                   />
@@ -93,11 +103,11 @@ export function SpaceDetailsAccordion ({ spaceName, properties, spaceImage, read
 
               case 'role': {
                 const roles = property.value as string[];
-                return (
-                  <Stack gap={0.5} key={property.memberPropertyId}>
+                return roles.length !== 0 && (
+                  <Stack key={property.memberPropertyId}>
                     <Typography fontWeight='bold'>{property.name}</Typography>
                     <Stack gap={1} flexDirection='row' flexWrap='wrap'>
-                      {roles.length === 0 ? 'N/A' : roles.map(role => <Chip label={role} key={role} size='small' variant='outlined' />)}
+                      {roles.map(role => <Chip label={role} key={role} size='small' variant='outlined' />)}
                     </Stack>
                   </Stack>
                 );


### PR DESCRIPTION
This PR handles three lightweight tasks.
[Replace N/A in Gallery View by not showing the property at all](https://app.charmverse.io/charmverse/page-49366552253645923?viewId=d15c9b90-8918-44da-bbd8-db8712faa723&cardId=c93d339d-ce33-4d49-b3e9-57e3ab946f03)
[Change N/A in Member Directory to " - " in table](https://app.charmverse.io/charmverse/page-49366552253645923?viewId=d15c9b90-8918-44da-bbd8-db8712faa723&cardId=846cdc45-b984-49cc-9b12-9b176e47eab6)
[Do not show N/A fields on a users profile](https://app.charmverse.io/charmverse/page-49366552253645923?viewId=d15c9b90-8918-44da-bbd8-db8712faa723&cardId=58684028-28f9-469b-8373-0eb2ab9eda07)