### PR TITLE
Fix double click issue on iOS

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/gallery/galleryCard.scss
+++ b/components/common/BoardEditor/focalboard/src/components/gallery/galleryCard.scss
@@ -20,12 +20,15 @@
         background-color: rgba(90, 200, 255, 0.2);
     }
 
-    &:hover {
-        background-color: rgba(var(--center-channel-color-rgb), 0.05);
+    // Disable hover on iOS so that cards popup on first click
+    @media (pointer: fine) {
+      &:hover {
+          background-color: rgba(var(--center-channel-color-rgb), 0.05);
 
-        .optionsMenu {
-            display: block;
-        }
+          .optionsMenu {
+              display: block;
+          }
+      }
     }
 
     .optionsMenu {

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanban.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanban.tsx
@@ -7,8 +7,8 @@ import { bindMenu, bindTrigger } from 'material-ui-popup-state';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import React, { useCallback, useState } from 'react';
 import withScrolling, { createHorizontalStrength, createVerticalStrength } from 'react-dnd-scrolling';
-import { FormattedMessage, injectIntl } from 'react-intl';
 import type { IntlShape } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 
 import { isTouchScreen } from 'lib/utilities/browser';
 
@@ -225,10 +225,6 @@ function Kanban (props: Props) {
     setShowCalculationsMenu(newShowOptions);
   };
 
-  const ScrollingComponent = withScrolling('div');
-  const hStrength = createHorizontalStrength(isTouchScreen() ? 60 : 250);
-  const vStrength = createVerticalStrength(isTouchScreen() ? 60 : 250);
-
   const menuTriggerProps = !props.readOnly ? bindTrigger(popupState) : {};
   return (
     <Box
@@ -298,10 +294,7 @@ function Kanban (props: Props) {
 
       {/* Main content */}
 
-      <ScrollingComponent
-        horizontalStrength={hStrength}
-        verticalStrength={vStrength}
-      >
+      <Box>
         <div
           className='octo-board-body'
           id='mainBoardBody'
@@ -375,7 +368,7 @@ function Kanban (props: Props) {
               </div>
             )}
         </div>
-      </ScrollingComponent>
+      </Box>
     </Box>
   );
 }

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanban.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanban.tsx
@@ -6,11 +6,8 @@ import { Box } from '@mui/system';
 import { bindMenu, bindTrigger } from 'material-ui-popup-state';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import React, { useCallback, useState } from 'react';
-import withScrolling, { createHorizontalStrength, createVerticalStrength } from 'react-dnd-scrolling';
 import type { IntlShape } from 'react-intl';
 import { FormattedMessage, injectIntl } from 'react-intl';
-
-import { isTouchScreen } from 'lib/utilities/browser';
 
 import type { Board, BoardGroup, IPropertyOption, IPropertyTemplate } from '../../blocks/board';
 import type { BoardView } from '../../blocks/boardView';

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.scss
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.scss
@@ -25,11 +25,14 @@
     border-color: transparent;
   }
 
-  &:hover {
-    background-color: rgba(var(--center-channel-color-rgb), 0.1);
-
-    .optionsMenu {
-      display: block;
+  // Disable hover on iOS so that cards popup on first click
+  @media (pointer: fine) {
+    &:hover {
+      background-color: rgba(var(--center-channel-color-rgb), 0.1);
+  
+      .optionsMenu {
+        display: block;
+      }
     }
   }
 

--- a/components/common/BoardEditor/focalboard/src/components/table/tableRow.scss
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableRow.scss
@@ -20,6 +20,7 @@
         background-color: rgba(90, 200, 255, 0.2);
     }
 
+    // Unlike cards and gallery, table rows allow inline editing, so we won't disable this style on iOS (see kanbanCard.scss and galleryCard.scss)
     &:hover {
         background-color: rgba(var(--center-channel-color-rgb), 0.05);
 
@@ -27,4 +28,5 @@
             display: block;
         }
     }
+  
 }

--- a/next.base.js
+++ b/next.base.js
@@ -16,7 +16,6 @@ const esmModules = [
   '@fullcalendar/interaction',
   '@fullcalendar/react',
   'react-dnd',
-  // 'react-dnd-scrolling',
   'react-pdf',
   '@hookform/resolvers',
   'lit-share-modal-v3-react-17',

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,6 @@
         "react-day-picker": "^7.4.10",
         "react-dnd": "^16.0.0",
         "react-dnd-html5-backend": "^16.0.0",
-        "react-dnd-scrolling": "^1.2.4",
         "react-dnd-touch-backend": "^16.0.0",
         "react-dom": "^17.0.2",
         "react-hook-form": "^7.25.0",
@@ -20500,11 +20499,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-    },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -22657,7 +22651,9 @@
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -23599,14 +23595,6 @@
         }
       ]
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -23718,11 +23706,6 @@
         "react": "^15.3.0 || 16 || 17 || 18"
       }
     },
-    "node_modules/react-display-name": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/react-display-name/-/react-display-name-0.2.5.tgz",
-      "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
-    },
     "node_modules/react-dnd": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
@@ -23758,23 +23741,6 @@
       "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
       "dependencies": {
         "dnd-core": "^16.0.1"
-      }
-    },
-    "node_modules/react-dnd-scrolling": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/react-dnd-scrolling/-/react-dnd-scrolling-1.2.4.tgz",
-      "integrity": "sha512-twjfyP+S6cZu/ualBUAOHXiHTFATz0EmTwunP3KA4W4lNwTlp3lWJQtRWFlzPXYXY8sChRPfFb5psTgORFSVZA==",
-      "dependencies": {
-        "hoist-non-react-statics": "3.x",
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "15.x",
-        "raf": "^3.4.1",
-        "react-display-name": "^0.2.5"
-      },
-      "peerDependencies": {
-        "react": "16.x || 17.x || 18.x",
-        "react-dnd": "10.x || 11.x || 14.x || 15.x || 16.x",
-        "react-dom": "16.x || 17.x || 18.x"
       }
     },
     "node_modules/react-dnd-touch-backend": {
@@ -43124,11 +43090,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -44830,7 +44791,9 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
+      "peer": true
     },
     "picocolors": {
       "version": "1.0.0",
@@ -45538,14 +45501,6 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -45634,11 +45589,6 @@
         "prop-types": "^15.8.1"
       }
     },
-    "react-display-name": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/react-display-name/-/react-display-name-0.2.5.tgz",
-      "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
-    },
     "react-dnd": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
@@ -45657,18 +45607,6 @@
       "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
       "requires": {
         "dnd-core": "^16.0.1"
-      }
-    },
-    "react-dnd-scrolling": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/react-dnd-scrolling/-/react-dnd-scrolling-1.2.4.tgz",
-      "integrity": "sha512-twjfyP+S6cZu/ualBUAOHXiHTFATz0EmTwunP3KA4W4lNwTlp3lWJQtRWFlzPXYXY8sChRPfFb5psTgORFSVZA==",
-      "requires": {
-        "hoist-non-react-statics": "3.x",
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "15.x",
-        "raf": "^3.4.1",
-        "react-display-name": "^0.2.5"
       }
     },
     "react-dnd-touch-backend": {

--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "react-day-picker": "^7.4.10",
     "react-dnd": "^16.0.0",
     "react-dnd-html5-backend": "^16.0.0",
-    "react-dnd-scrolling": "^1.2.4",
     "react-dnd-touch-backend": "^16.0.0",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.25.0",


### PR DESCRIPTION
We were forced to double click links to navigate elsewhere to the app inside iOS.

The specific issue came from a component inside Kanban.tsx that was preventing click events being propagated