### PR TITLE
remove use-pages from kanban card components

### DIFF
--- a/components/common/BoardEditor/focalboard/src/blocks/board.ts
+++ b/components/common/BoardEditor/focalboard/src/blocks/board.ts
@@ -4,7 +4,7 @@ import { IDType, Utils } from '../utils';
 
 import type { Block } from './block';
 import { createBlock } from './block';
-import type { Card } from './card';
+import type { Card, CardAndPage } from './card';
 
 type PropertyType = 'text' | 'number' | 'select' | 'multiSelect' | 'date' | 'person' | 'file' | 'checkbox' | 'url' | 'email' | 'phone' | 'createdTime' | 'createdBy' | 'updatedTime' | 'updatedBy'
 
@@ -88,6 +88,7 @@ function createBoard ({ block, addDefaultProperty }: { block?: Block, addDefault
 type BoardGroup = {
     option: IPropertyOption;
     cards: Card[];
+    cardPages: CardAndPage[];
 }
 
 export { createBoard };

--- a/components/common/BoardEditor/focalboard/src/blocks/card.ts
+++ b/components/common/BoardEditor/focalboard/src/blocks/card.ts
@@ -1,4 +1,7 @@
 
+import type { PageMeta } from 'lib/pages';
+import type { IPagePermissionFlags } from 'lib/permissions/pages';
+
 import type { Block } from './block';
 import { createBlock } from './block';
 
@@ -12,6 +15,8 @@ type CardFields = {
 type Card = Block & {
     fields: CardFields;
 }
+
+type CardAndPage = { card: Card, page: PageMeta, permissions: IPagePermissionFlags };
 
 /**
  * Returns a focalboard-ready card data stub
@@ -44,5 +49,5 @@ function createCard (block?: Partial<Block>): Card {
 }
 
 export { createCard };
-export type { Card };
+export type { Card, CardAndPage };
 


### PR DESCRIPTION
Since we are already calling usePages in CenterPanel, I just gathered pages and permissions there and pass them down into the kanban cards. If this is helpful, we could remove usePages from the other views also.