### PR TITLE
Keep tree closed when card is open

### DIFF
--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -230,7 +230,7 @@ function PageNavigation ({
     const currentPage = pages[currentPageId];
     // expand the parent of the active page
     if (currentPage?.parentId && !isFavorites) {
-      if (!expanded.includes(currentPage.parentId)) {
+      if (!expanded.includes(currentPage.parentId) && currentPage.type !== 'card') {
         setExpanded(expanded.concat(currentPage.parentId));
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "typescript-49",
+  "name": "charmverse.io",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "charmverse.io",
       "hasInstallScript": true,
       "dependencies": {
         "@apollo/client": "^3.6.2",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "charmverse.io",
   "scripts": {
     "build": "NODE_OPTIONS=\"--max_old_space_size=4096\" next build",
     "build:win": "npx next build",


### PR DESCRIPTION
Don't open dropdown if the page is a card

https://app.charmverse.io/charmverse/page-2438463783291298.

I also added the package.json name to not accidentally commit a name in package-lock.json