### PR TITLE
convert user wallet address to checksum when querying gnosis

### DIFF
--- a/lib/gnosis/gnosis.ts
+++ b/lib/gnosis/gnosis.ts
@@ -5,6 +5,7 @@ import type { UserGnosisSafe } from '@prisma/client';
 import { getChainById, RPC } from 'connectors';
 import type { Signer } from 'ethers';
 import { ethers } from 'ethers';
+import { getAddress } from 'ethers/lib/utils';
 import uniqBy from 'lodash/uniqBy';
 
 import log from 'lib/log';
@@ -56,7 +57,8 @@ export async function getSafesForAddress ({ signer, chainId, address }: GetSafes
   }
   const service = getGnosisService({ signer, serviceUrl });
   if (service) {
-    return service.getSafesByOwner(address)
+    const checksumAddress = getAddress(address); // convert to checksum address
+    return service.getSafesByOwner(checksumAddress)
       .then(r => Promise.all(r.safes.map(safeAddr => {
         return service.getSafeInfo(safeAddr)
           .then(info => ({ ...info, chainId }));


### PR DESCRIPTION
Now that wallets are stored in lowercase, we need to convert to checksum when requesting them on Gnosis. the wallets on 'gnosis safes' are in their checksum format, so we shouldn't need to mess with casing in that table.

I tested this with the example address, both the checksum and lowercase and get an error when requesting lowercase