### PR TITLE
fix check for member property on user profiles

### DIFF
--- a/components/profile/components/SpacesMemberDetails/components/SpaceDetailsAccordion.tsx
+++ b/components/profile/components/SpacesMemberDetails/components/SpaceDetailsAccordion.tsx
@@ -88,8 +88,8 @@ export function SpaceDetailsAccordion ({ spaceName, properties, spaceImage, read
               }
               case 'multiselect':
               case 'select': {
-                const propertyValue = property.value as string | string[];
-                if (propertyValue.length === 0) {
+                const propertyValue = property.value as string | undefined | string[];
+                if (!propertyValue || propertyValue?.length === 0) {
                   return null;
                 }
                 return (


### PR DESCRIPTION
here's the property JSON that had 'null' for value:

```
{
  "memberPropertyId": "3af1d898-e8e5-45ab-a5df-247f1221997b",
  "spaceId": "db74b5db-c1f2-4ac5-b5f7-28ee98a9075b",
  "type": "multiselect",
  "name": "test",
  "value": null,
  "options": [
    {
      "id": "17c40e3a-8742-47bb-8e87-406e7babcb30",
      "name": "foo",
      "color": "orange",
      "index": 0
    },
    {
      "id": "8a4b56f4-40c0-4914-9a00-ca54bc14e5b7",
      "name": "bar",
      "color": "blue",
      "index": 1
    },
    {
      "id": "73ca8f4c-962b-495f-b97f-0ab1148a8fdd",
      "name": "yes",
      "color": "turquoise",
      "index": 2
    }
  ],
  "enabledViews": [
    "gallery",
    "table",
    "profile"
  ]
}
```