### PR TITLE
add media query for link hover effects

### DIFF
--- a/components/common/ActionsMenu.tsx
+++ b/components/common/ActionsMenu.tsx
@@ -12,8 +12,11 @@ const StyledActionsMenu = styled(Box)`
   width: 26px;
   height: 26px;
   border-radius: 2px;
-  &:hover {
-    background: ${({ theme }) => theme.palette.action.hover};
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
+    &:hover {
+      background: ${({ theme }) => theme.palette.action.hover};
+    }
   }
   text-align: center;
   display: flex;

--- a/components/common/BoardEditor/components/properties/SelectProperty/SelectProperty.tsx
+++ b/components/common/BoardEditor/components/properties/SelectProperty/SelectProperty.tsx
@@ -35,9 +35,12 @@ const SelectPreviewContainer = styled(Stack)<ContainerProps>`
     return '';
   }}
 
-  &:hover {
-    cursor: pointer;
-    background-color: ${({ theme, displayType }) => displayType === 'details' ? theme.palette.action.hover : 'transparent'};
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
+    &:hover {
+      cursor: pointer;
+      background-color: ${({ theme, displayType }) => displayType === 'details' ? theme.palette.action.hover : 'transparent'};
+    }
   }
 
   div {

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/menu.scss
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/menu.scss
@@ -1,176 +1,179 @@
 .status-dropdown-menu {
-    > .Menu {
-        position: inherit;
-    }
+  > .Menu {
+    position: inherit;
+  }
 }
 
 .Menu {
+  display: flex;
+  overflow-x: hidden;
+  overflow-y: auto;
+  flex-direction: column;
+  background-color: rgb(var(--center-channel-bg-rgb));
+  color: rgb(var(--center-channel-color-rgb));
+  border-radius: var(--default-rad);
+  box-shadow: var(--elevation-4);
+
+  .menu-contents {
     display: flex;
-    overflow-x: hidden;
-    overflow-y: auto;
     flex-direction: column;
-    background-color: rgb(var(--center-channel-bg-rgb));
+    padding: 8px 0;
+    min-width: 240px;
+  }
+
+  .menu-options {
+    display: flex;
+    flex-direction: column;
+
+    flex-grow: 1;
+    position: relative;
+
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
     color: rgb(var(--center-channel-color-rgb));
-    border-radius: var(--default-rad);
-    box-shadow: var(--elevation-4);
 
-    .menu-contents {
-        display: flex;
-        flex-direction: column;
-        padding: 8px 0;
-        min-width: 240px;
-    }
+    .CompassIcon {
+      font-size: 18px;
+      opacity: 0.56;
+      width: 18px;
 
-    .menu-options {
-        display: flex;
-        flex-direction: column;
-
-        flex-grow: 1;
-        position: relative;
-
-        list-style: none;
-        padding: 0;
+      &::before {
         margin: 0;
-
-        color: rgb(var(--center-channel-color-rgb));
-
-        .CompassIcon {
-            font-size: 18px;
-            opacity: 0.56;
-            width: 18px;
-
-            &::before {
-                margin: 0;
-            }
-        }
-
-        > .menu-option {
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-
-            font-size: 14px;
-            line-height: 24px;
-            font-weight: 400;
-            height: 32px;
-            padding: 4px 20px;
-            cursor: pointer;
-
-            &.disabled-option {
-                background: transparent !important;
-                cursor: default;
-            }
-
-            &:hover {
-                background: rgba(var(--button-bg-rgb), 0.08);
-            }
-
-            > * {
-                margin-left: 16px;
-            }
-
-            > *:first-child {
-                margin-left: 0;
-            }
-
-            > .menu-name {
-                display: flex;
-                flex-grow: 1;
-                white-space: nowrap;
-            }
-
-            > .SubmenuTriangleIcon {
-                fill: rgba(var(--center-channel-color-rgb), 0.7);
-            }
-
-            > .Icon {
-                opacity: 0.56;
-                width: 18px;
-                height: 18px;
-            }
-
-            > .IconButton .Icon {
-                margin-right: 0;
-            }
-        }
-
-        > .menu-option.bold-menu-text {
-            font-weight: bold;
-        }
+      }
     }
 
-    .menu-spacer {
-        height: 20px;
-        width: 20px;
-        flex: 0 0 auto;
+    > .menu-option {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      font-size: 14px;
+      line-height: 24px;
+      font-weight: 400;
+      height: 32px;
+      padding: 4px 20px;
+      cursor: pointer;
+
+      &.disabled-option {
+        background: transparent !important;
+        cursor: default;
+      }
+
+      // disable hover UX on ios which converts first click to a hover event
+      @media (pointer: fine) {
+        &:hover {
+          background: rgba(var(--button-bg-rgb), 0.08);
+        }
+      }
+
+      > * {
+        margin-left: 16px;
+      }
+
+      > *:first-child {
+        margin-left: 0;
+      }
+
+      > .menu-name {
+        display: flex;
+        flex-grow: 1;
+        white-space: nowrap;
+      }
+
+      > .SubmenuTriangleIcon {
+        fill: rgba(var(--center-channel-color-rgb), 0.7);
+      }
+
+      > .Icon {
+        opacity: 0.56;
+        width: 18px;
+        height: 18px;
+      }
+
+      > .IconButton .Icon {
+        margin-right: 0;
+      }
     }
 
-    @media not screen and (max-width: 430px) {
-        &.top {
-            bottom: 100%;
-        }
-
-        &.left {
-            right: 0;
-        }
+    > .menu-option.bold-menu-text {
+      font-weight: bold;
     }
+  }
+
+  .menu-spacer {
+    height: 20px;
+    width: 20px;
+    flex: 0 0 auto;
+  }
+
+  @media not screen and (max-width: 430px) {
+    &.top {
+      bottom: 100%;
+    }
+
+    &.left {
+      right: 0;
+    }
+  }
 }
 
 .Menu,
 .SubMenuOption .SubMenu {
-    @media screen and (max-width: 430px) {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        min-width: 0;
-        background-color: rgba(var(--center-channel-color-rgb), 0.5);
-        border-radius: 0;
-        padding: 10px;
+  @media screen and (max-width: 430px) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    min-width: 0;
+    background-color: rgba(var(--center-channel-color-rgb), 0.5);
+    border-radius: 0;
+    padding: 10px;
 
-        display: block;
-        overflow-y: auto;
+    display: block;
+    overflow-y: auto;
 
-        .menu-contents {
-            justify-content: flex-end;
-            min-height: 100%;
-        }
-
-        .menu-options {
-            align-items: center;
-            border-radius: 10px;
-            overflow: hidden;
-
-            flex: 0 0 auto;
-
-            > .menu-option {
-                min-height: 44px;
-                width: 100%;
-                padding: 0 20px;
-                background-color: rgb(var(--center-channel-bg-rgb));
-
-                > * {
-                    flex: 0 0 auto;
-                }
-
-                > .noicon {
-                    width: 16px;
-                    height: 16px;
-                }
-
-                > .menu-name {
-                    font-size: 16px;
-                    justify-content: center;
-                }
-            }
-        }
+    .menu-contents {
+      justify-content: flex-end;
+      min-height: 100%;
     }
 
-    @media not screen and (max-width: 430px) {
-        .hideOnWidescreen {
-            /* Hide controls (e.g. close button) on larger screens */
-            display: none !important;
+    .menu-options {
+      align-items: center;
+      border-radius: 10px;
+      overflow: hidden;
+
+      flex: 0 0 auto;
+
+      > .menu-option {
+        min-height: 44px;
+        width: 100%;
+        padding: 0 20px;
+        background-color: rgb(var(--center-channel-bg-rgb));
+
+        > * {
+          flex: 0 0 auto;
         }
+
+        > .noicon {
+          width: 16px;
+          height: 16px;
+        }
+
+        > .menu-name {
+          font-size: 16px;
+          justify-content: center;
+        }
+      }
     }
+  }
+
+  @media not screen and (max-width: 430px) {
+    .hideOnWidescreen {
+      /* Hide controls (e.g. close button) on larger screens */
+      display: none !important;
+    }
+  }
 }

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -293,8 +293,12 @@ const StyledReactBangleEditor = styled(ReactBangleEditor)<{ disablePageSpecificF
       background: rgba(255,212,0,0.14);
       border-bottom: 2px solid rgb(255, 212, 0);
       padding-bottom: 2px;
-      &:hover {
-        background: rgba(255,212,0,0.56) !important;
+
+      // disable hover UX on ios which converts first click to a hover event
+      @media (pointer: fine) {
+        &:hover {
+          background: rgba(255,212,0,0.56) !important;
+        }
       }
       cursor: pointer;
     }
@@ -303,8 +307,11 @@ const StyledReactBangleEditor = styled(ReactBangleEditor)<{ disablePageSpecificF
       background: rgba(0,171,255,0.14);
       border-bottom: 2px solid rgb(0,171,255);
       padding-bottom: 2px;
-      &:hover {
-        background: rgba(0,171,255,0.56) !important;
+      // disable hover UX on ios which converts first click to a hover event
+      @media (pointer: fine) {
+        &:hover {
+          background: rgba(0,171,255,0.56) !important;
+        }
       }
       cursor: pointer;
     }

--- a/components/common/CharmEditor/components/BlockAligner.tsx
+++ b/components/common/CharmEditor/components/BlockAligner.tsx
@@ -13,9 +13,12 @@ const StyledBlockAligner = styled.div`
   position: relative;
   max-width: 100%;
   text-align: center;
-  &:hover .controls {
-    opacity: 1;
-    transition: opacity 250ms ease-in-out;
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
+    &:hover .controls {
+      opacity: 1;
+      transition: opacity 250ms ease-in-out;
+    }
   }
 `;
 

--- a/components/common/Emoji.tsx
+++ b/components/common/Emoji.tsx
@@ -27,8 +27,11 @@ export const Emoji = styled.div<{ size?: ImgSize }>`
   ${({ onClick, theme }) => {
     if (onClick) {
       return `
-        &:hover {
-          background-color: ${theme.palette.background.light};
+        // disable hover UX on ios which converts first click to a hover event
+        @media (pointer: fine) {
+          &:hover {
+            background-color: ${theme.palette.background.light};
+          }
         }
       `;
     }

--- a/components/common/Link.tsx
+++ b/components/common/Link.tsx
@@ -17,10 +17,13 @@ const StyledMuiLink = styled(MuiLink)`
   ${props => props.color
     // @ts-ignore
     ? `color: ${props.theme.palette[props.color]?.main};` : ''}
-  &:hover {
-    color: ${props => typeof props.color === 'string'
-    // @ts-ignore
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
+    &:hover {
+      color: ${props => typeof props.color === 'string'
+  // @ts-ignore
     ? (hoverStyle[props.color] || props.theme.palette[props.color]?.main) : props.theme.palette[props.color]?.main};
+    }
   }
 `;
 

--- a/components/common/PrimaryButton.tsx
+++ b/components/common/PrimaryButton.tsx
@@ -25,10 +25,13 @@ const StyledButton = styled(Button)`
     font-size: .85em;
   }
 
-  &:hover {
-    background: ${darken(blueColor, 0.1)};
-    color: white;
-    border: 0 none;
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
+    &:hover {
+      background: ${darken(blueColor, 0.1)};
+      color: white;
+      border: 0 none;
+    }
   }
 `;
 

--- a/theme/focalboard/focalboard.main.scss
+++ b/theme/focalboard/focalboard.main.scss
@@ -166,47 +166,10 @@ html {
       rgba(15, 15, 15, 0.1) 0 3px 6px, rgba(15, 15, 15, 0.2) 0 9px 24px;
   }
 
-  .octo-block img {
-    margin: 5px 0;
-    object-fit: contain;
-    flex: none;
-  }
-
   .octo-content {
     width: 100%;
   }
 
-  .octo-block {
-    width: 100%;
-
-    &:hover {
-      position: relative;
-      z-index: 1;
-    }
-
-    > * {
-      flex: 1 1 auto;
-    }
-
-    > .octo-block-margin {
-      flex: 0 0 auto;
-    }
-
-    @media screen and (max-width: 975px) {
-      padding-right: 10px;
-    }
-  }
-
-  .octo-block-margin {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    justify-content: flex-end;
-
-    @media not screen and (max-width: 975px) {
-      width: 48px;
-    }
-  }
 }
 
 .CalendarContainer {


### PR DESCRIPTION
This might fix more issues with the iPhone. I noticed that nested pages use the Link component, and inside it has a hover CSS effect. I did a search for "&:hover" and added media queries to a lot more places.

It'd be nice if we found a solution that didn't require special queries on all hover effects!