### PR TITLE
Always show Gnosis even with 0 tasks

### DIFF
--- a/components/nexus/GnosisTasksList.tsx
+++ b/components/nexus/GnosisTasksList.tsx
@@ -331,7 +331,7 @@ export default function GnosisTasksSection ({ error, mutateTasks, tasks }: Gnosi
           safeUrl={safe.safeUrl}
         />
       ))}
-      {safeData?.length && tasks.length === 0 && (
+      {(safeData?.length !== undefined && safeData.length >= 1) && tasks.length === 0 && (
         <EmptyTaskState taskType='transactions' />
       )}
       {gnosisSigner && user && safeData?.length === 0 ? (


### PR DESCRIPTION
Also fixes this bug where a 0 would display if no Gnosis safes were connected

<img width="1029" alt="Screenshot 2022-11-25 at 23 42 11" src="https://user-images.githubusercontent.com/18669748/204057839-c513ddb9-9354-4f14-b03e-6473f5c9d862.png">
