### PR TITLE
allow editing long tags in multi-select

### DIFF
--- a/components/common/form/fields/Select/SelectOptionItem.tsx
+++ b/components/common/form/fields/Select/SelectOptionItem.tsx
@@ -1,4 +1,4 @@
-import { Chip, MenuItem, Stack } from '@mui/material';
+import { Box, Chip, MenuItem, Stack } from '@mui/material';
 import type { HTMLAttributes } from 'react';
 
 import type { SelectOptionType } from 'components/common/form/fields/Select/interfaces';
@@ -19,9 +19,13 @@ export function SelectOptionItem ({ option, onChange, onDelete, onToggleOptionEd
   return (
     <MenuItem {...menuItemProps} sx={{ display: 'flex' }}>
       <Stack flexDirection='row' justifyContent='space-between' alignItems='center' flex={1}>
-        <Chip label={option.name} color={option.color} size='small' sx={{ px: 0.5 }} />
+        <Chip label={option.name} color={option.color} size='small' sx={{ px: 0.5, zIndex: 0, position: 'relative' }} />
 
-        {!readOnly && <SelectOptionEdit option={option} onChange={onChange} onDelete={onDelete} onToggleOptionEdit={onToggleOptionEdit} />}
+        {!readOnly && (
+          <Box position='absolute' right='5px'>
+            <SelectOptionEdit option={option} onChange={onChange} onDelete={onDelete} onToggleOptionEdit={onToggleOptionEdit} />
+          </Box>
+        )}
       </Stack>
     </MenuItem>
   );


### PR DESCRIPTION
I made it so that the dots are always on top, even if they are overlapping... ideally, the dropdown should stretch itself based on content but i wanted Marek's input on how to do that...
![image](https://user-images.githubusercontent.com/305398/204061057-e7e6b8d1-a146-4167-87be-4f65c0e2d397.png)
