### PR TITLE
fix scrollbar css

### DIFF
--- a/components/common/RouteGuard.tsx
+++ b/components/common/RouteGuard.tsx
@@ -131,5 +131,5 @@ export default function RouteGuard({ children }: { children: ReactNode }) {
   if (!authorized || !router.isReady) {
     return null;
   }
-  return <span style={{ display: isLoading ? 'none' : 'inherit' }}>{children}</span>;
+  return <span style={{ display: isLoading ? 'none' : 'inline' }}>{children}</span>;
 }


### PR DESCRIPTION
'inherit' inherits the parent component's style, causing this span to have a 'block' display and which ultimately somehow prevented the scrollbar from appearing on the focalboard element with class 'full-page'. I think 'inline' should be safe, that is the original display rule for span tags