### PR TITLE
add a delete icon to Tweets and make deleting embeds easier

### DIFF
--- a/components/common/CharmEditor/components/ResizableImage.tsx
+++ b/components/common/CharmEditor/components/ResizableImage.tsx
@@ -128,7 +128,15 @@ interface ResizableImageProps extends NodeViewProps {
   onResizeStop?: (view: EditorView) => void;
 }
 
-function ResizableImage({ readOnly = false, onResizeStop, node, updateAttrs, selected }: ResizableImageProps) {
+function ResizableImage({
+  readOnly = false,
+  getPos,
+  view,
+  onResizeStop,
+  node,
+  updateAttrs,
+  selected
+}: ResizableImageProps) {
   const imageSource = node.attrs.src;
   const autoOpen = node.marks.some((mark) => mark.type.name === 'tooltip-marker');
 
@@ -136,12 +144,11 @@ function ResizableImage({ readOnly = false, onResizeStop, node, updateAttrs, sel
 
   const [uploadFailed, setUploadFailed] = useState(false);
 
-  const onDelete = useCallback(() => {
-    updateAttrs({
-      src: null,
-      aspectRatio: 1
-    });
-  }, []);
+  function onDelete() {
+    const start = getPos();
+    const end = start + 1;
+    view.dispatch(view.state.tr.deleteRange(start, end));
+  }
 
   // If there are no source for the node, return the image select component
   if (!imageSource) {

--- a/components/common/CharmEditor/components/iframe/IframeComponent.tsx
+++ b/components/common/CharmEditor/components/iframe/IframeComponent.tsx
@@ -207,9 +207,9 @@ function ResizableIframe({
   }
 
   function onDelete() {
-    updateAttrs({
-      src: null
-    });
+    const start = getPos();
+    const end = start + 1;
+    view.dispatch(view.state.tr.deleteRange(start, end));
   }
 
   if (readOnly) {

--- a/components/common/CharmEditor/components/tweet/components/Tweet.tsx
+++ b/components/common/CharmEditor/components/tweet/components/Tweet.tsx
@@ -6,6 +6,7 @@ import { useRef } from 'react';
 
 import log from 'lib/log';
 
+import BlockAligner from '../../BlockAligner';
 import type { TweetNodeAttrs } from '../tweet';
 import { extractTweetAttrs } from '../tweet';
 import { twitterWidgetJs } from '../twitterJSUrl';
@@ -34,6 +35,9 @@ const StyledTweet = styled.div`
   iframe {
     color-scheme: light;
   }
+  .twitter-tweet {
+    margin: 0 !important;
+  }
 `;
 
 // embed Twitter
@@ -52,7 +56,7 @@ function render(tweetId: string, el: HTMLElement, options: TweetOptions) {
   window.twttr.widgets.createTweet(tweetId, el, options);
 }
 
-export function TweetComponent({ readOnly, node, updateAttrs }: NodeViewProps & { readOnly: boolean }) {
+export function TweetComponent({ readOnly, node, view, getPos, updateAttrs }: NodeViewProps & { readOnly: boolean }) {
   const ref = useRef<HTMLDivElement | null>(null);
   const theme = useTheme();
   const attrs = node.attrs as Partial<TweetNodeAttrs>;
@@ -62,6 +66,12 @@ export function TweetComponent({ readOnly, node, updateAttrs }: NodeViewProps & 
     if (ref.current && attrs.id) {
       render(attrs.id, ref.current, { theme: theme.palette.mode });
     }
+  }
+
+  function onDelete() {
+    const start = getPos();
+    const end = start + 1;
+    view.dispatch(view.state.tr.deleteRange(start, end));
   }
 
   // If there are no source for the node, return the image select component
@@ -88,7 +98,9 @@ export function TweetComponent({ readOnly, node, updateAttrs }: NodeViewProps & 
   return (
     <>
       <Script src={twitterWidgetJs} onReady={onLoadScript} />
-      <StyledTweet ref={ref} />
+      <BlockAligner onDelete={onDelete}>
+        <StyledTweet ref={ref} />
+      </BlockAligner>
     </>
   );
 }

--- a/components/common/ImageSelector/ImageSelector.tsx
+++ b/components/common/ImageSelector/ImageSelector.tsx
@@ -71,8 +71,12 @@ export default function ImageSelector({
                         setIsUploading(true);
                         const firstFile = e.target.files?.[0];
                         if (firstFile) {
-                          const { url } = await uploadToS3(firstFile);
-                          onImageSelect(url);
+                          try {
+                            const { url } = await uploadToS3(firstFile);
+                            onImageSelect(url);
+                          } catch (error) {
+                            log.error('Error uploading image to s3', { error });
+                          }
                         }
                         setIsUploading(false);
                       }}


### PR DESCRIPTION
I added a trash icon when u hover over Tweets, and also fixed it so that the delete action on other embeds removes the element completely, not just unset the source, which requires user to take a 2nd action to fully delete the embed