### PR TITLE
debugging guild.xyz api: check that roleids are returned

### DIFF
--- a/lib/guild-xyz/getGuildRoleIds.ts
+++ b/lib/guild-xyz/getGuildRoleIds.ts
@@ -1,12 +1,18 @@
 import { user } from '@guildxyz/sdk';
 
+import log from 'lib/log';
+
 export async function getGuildRoleIds(addresses: string[]) {
   const guildRoleIds: string[] = [];
   // Get all the guild roles associated with all of the addresses of the user
   const guildMembershipsResponses = await Promise.all(addresses.map((address) => user.getMemberships(address)));
   guildMembershipsResponses.forEach((guildMembershipsResponse) => {
     guildMembershipsResponse?.forEach((guildMemberships) => {
-      guildRoleIds.push(...guildMemberships.roleids.map(String));
+      if (!guildMemberships.roleids) {
+        log.warn('Guild.xyz response is mossing roleids', { addresses, guildMemberships });
+      } else {
+        guildRoleIds.push(...guildMemberships.roleids.map(String));
+      }
     });
   });
   return guildRoleIds;

--- a/lib/guild-xyz/server/updateGuildRolesForUser.ts
+++ b/lib/guild-xyz/server/updateGuildRolesForUser.ts
@@ -46,8 +46,8 @@ export async function updateGuildRolesForUser(
           spaceRoleId: spaceRole.id
         });
       }
-    } catch (err) {
-      log.warn('[guild.xyz]: Failed to import guild.xyz roles', err);
+    } catch (error) {
+      log.warn('[guild.xyz]: Failed to import guild.xyz roles', { error: (error as Error).stack || error });
     }
   }
 }

--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -153,7 +153,10 @@ export class DocumentEventHandler {
     try {
       await this.handleMessage(message);
     } catch (error) {
-      log.error('Error handling socket message', { error, userId: this.getSession().user.id });
+      log.error('Error handling socket message', {
+        error: (error as any).stack || error,
+        userId: this.getSession().user.id
+      });
     }
   }
 


### PR DESCRIPTION
I'm looking into this error:
```
[guild.xyz]: Failed to import guild.xyz roles TypeError: Cannot read properties of undefined (reading 'map')
```
I checked all the code that happens inside the try/catch, and my only guess is that guild.xyz's api is sometimes not returning a field.