### PR TITLE
bug fix attempt: uncaught exception  while using inline charm editor

### DIFF
--- a/components/common/CharmEditor/components/@bangle.dev/tooltip/suggest-tooltip.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/tooltip/suggest-tooltip.ts
@@ -269,8 +269,9 @@ function tooltipController({ key, trigger, markName }: { key: PluginKey; trigger
           }
 
           if (!isMarkActive) {
+            const keyState = key.getState(state);
             // performance optimization to prevent unnecessary dispatches
-            if (key.getState(state).show === true) {
+            if (keyState?.show === true) {
               hideSuggestionsTooltip(key)(view.state, view.dispatch, view);
             }
             return;
@@ -365,14 +366,22 @@ function getTriggerText(state: EditorState, markName: string, trigger?: string) 
 
 export function queryTriggerText(key: PluginKey) {
   return (state: EditorState) => {
-    const { trigger, markName } = key.getState(state);
+    const keyState = key.getState(state);
+    if (!keyState) {
+      return '';
+    }
+    const { trigger, markName } = keyState;
     return getTriggerText(state, markName, trigger);
   };
 }
 
 export function queryIsSuggestTooltipActive(key: PluginKey) {
   return (state: EditorState) => {
-    return key.getState(state) && key.getState(state).show;
+    const keyState = key.getState(state);
+    if (keyState) {
+      return keyState.show;
+    }
+    return false;
   };
 }
 

--- a/components/common/CharmEditor/components/emojiSuggest/emojiSuggest.plugins.ts
+++ b/components/common/CharmEditor/components/emojiSuggest/emojiSuggest.plugins.ts
@@ -63,7 +63,11 @@ function getScrollContainer(view: EditorView) {
 
 export function getSuggestTooltipKey(key: PluginKey) {
   return (state: EditorState) => {
-    return key.getState(state).suggestTooltipKey as PluginKey;
+    const pluginState = key.getState(state);
+    if (pluginState) {
+      return pluginState.suggestTooltipKey as PluginKey;
+    }
+    return '';
   };
 }
 
@@ -71,7 +75,10 @@ export function getSuggestTooltipKey(key: PluginKey) {
 export function queryTriggerText(key: PluginKey) {
   return (state: EditorState) => {
     const suggestKey = getSuggestTooltipKey(key)(state);
-    return suggestTooltip.queryTriggerText(suggestKey)(state);
+    if (suggestKey) {
+      return suggestTooltip.queryTriggerText(suggestKey)(state);
+    }
+    return '';
   };
 }
 
@@ -82,7 +89,9 @@ export function selectEmoji(key: PluginKey, emoji: string): Command {
     });
 
     const suggestKey = getSuggestTooltipKey(key)(state);
-
-    return suggestTooltip.replaceSuggestMarkWith(suggestKey, emojiNode)(state, dispatch, view);
+    if (suggestKey) {
+      return suggestTooltip.replaceSuggestMarkWith(suggestKey, emojiNode)(state, dispatch, view);
+    }
+    return false;
   };
 }


### PR DESCRIPTION
Sometimes when I'm on production and adding a comment either inline or in the comments list for cards, the entire editor blows up. In the dev console, I can see there's an error `e.getState(...) is undefined`. The code is minified, and I haven't been able to reproduce w/unminified code, but I downloaded the compiled code and think it is related to one of our prosemirror plugins trying to access state from a plugin key that is missing. For now, I'm attempting to fix the issue by checking that the return of getState() is not defined before accessing properties on it.