### PR TITLE
Fallback to default pages socket and enable UD

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,7 +42,8 @@ jobs:
           NEXT_PUBLIC_DD_RUM_APP_ID: ${{ secrets.NEXT_PUBLIC_DD_RUM_APP_ID }}
           NEXT_PUBLIC_TELEGRAM_BOT_ID: ${{ secrets.NEXT_PUBLIC_TELEGRAM_BOT_ID }}
           # NEXT_PUBLIC_DISCORD_WEBHOOK_ERRORS: ${{ secrets.NEXT_PUBLIC_DISCORD_WEBHOOK_ERRORS }} comment for now
-          NEXT_PUBLIC_WEBSOCKETS_HOST: https://sockets.charmverse.io
+          # Comment out websocket connection till we get it working (fallback to single node socket)
+          # NEXT_PUBLIC_WEBSOCKETS_HOST: https://sockets.charmverse.io
           NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_CLIENT_ID }}
           NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_REDIRECT_URI: ${{ secrets.NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_REDIRECT_URI }}
 


### PR DESCRIPTION
This reverts commit 89858ffed5d6c86b1ea7472fdf2848849299320e.

This commit contains the fix for client side Env Vars.

Websockets url temporarily commented out till we fix URL. (Will operate as it has been so far, single node, till then)