### PR TITLE
Make websockets more resiliant to errors

### DIFF
--- a/lib/prosemirror/__tests__/applyStepsToNode.spec.ts
+++ b/lib/prosemirror/__tests__/applyStepsToNode.spec.ts
@@ -1,0 +1,142 @@
+import { applyStepsToNode } from '../applyStepsToNode';
+import { getNodeFromJson } from '../getNodeFromJson';
+
+const testDoc = {
+  type: 'doc',
+  content: [
+    {
+      type: 'disclosureDetails',
+      content: [
+        {
+          type: 'disclosureSummary',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'mention',
+                  attrs: {
+                    id: 'e19f34b7-2833-4805-8989-60f2bfd6a92b',
+                    type: 'page',
+                    value: '30980dd8-9ef1-43ad-83f5-f5ff64db193f',
+                    createdAt: '2022-06-15T15:38',
+                    createdBy: '30980dd8-9ef1-43ad-83f5-f5ff64db193f'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'mention',
+                  attrs: {
+                    id: 'e19f34b7-2833-4805-8989-60f2bfd6a92b',
+                    type: 'user',
+                    value: '30980dd8-9ef1-43ad-83f5-f5ff64db193f',
+                    createdAt: '2022-06-15T15:38',
+                    createdBy: '30980dd8-9ef1-43ad-83f5-f5ff64db193f'
+                  }
+                },
+                { text: ' ', type: 'text' }
+              ]
+            }
+          ]
+        },
+        {
+          type: 'paragraph',
+          content: [
+            { text: 'Mention inside ', type: 'text' },
+            {
+              type: 'mention',
+              attrs: {
+                id: 'e5ac7eef-c212-4e3c-b5be-64ad7a57f3da',
+                type: 'user',
+                value: '30980dd8-9ef1-43ad-83f5-f5ff64db193f'
+              }
+            },
+            { text: ' toggle', type: 'text' }
+          ]
+        }
+      ]
+    },
+    {
+      type: 'heading',
+      attrs: { level: 1, collapseContent: null },
+      content: [
+        { text: 'Heading ', type: 'text' },
+        {
+          type: 'mention',
+          attrs: {
+            id: 'd3067f54-0a1c-439a-8317-694056cc25bc',
+            type: 'user',
+            value: '30980dd8-9ef1-43ad-83f5-f5ff64db193f',
+            createdAt: '2022-06-15T15:38:53.905Z',
+            createdBy: '30980dd8-9ef1-43ad-83f5-f5ff64db193f'
+          }
+        },
+        { text: ' mentions', type: 'text' }
+      ]
+    },
+    { type: 'paragraph' },
+    {
+      type: 'blockquote',
+      attrs: { emoji: '😃' },
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { text: 'Mentioned in ', type: 'text' },
+            {
+              type: 'mention',
+              attrs: {
+                id: '4845e106-273f-45aa-9118-239699901663',
+                type: 'user',
+                value: '30980dd8-9ef1-43ad-83f5-f5ff64db193f',
+                createdAt: '2022-06-14T16:23:53.337Z',
+                createdBy: '30980dd8-9ef1-43ad-83f5-f5ff64db193f'
+              }
+            },
+            { text: ' Callout', type: 'text' }
+          ]
+        }
+      ]
+    },
+    { type: 'paragraph' },
+    {
+      type: 'orderedList',
+      attrs: { order: 1, tight: false },
+      content: [
+        {
+          type: 'listItem',
+          attrs: { todoChecked: null },
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { text: 'Bullet list ', type: 'text' },
+                {
+                  type: 'mention',
+                  attrs: {
+                    id: '0c76a79e-fde4-4f52-b626-cb34adb57ae0',
+                    type: 'user',
+                    value: '30980dd8-9ef1-43ad-83f5-f5ff64db193f',
+                    createdAt: '2022-06-14T16:24:05.723Z',
+                    createdBy: '30980dd8-9ef1-43ad-83f5-f5ff64db193f'
+                  }
+                },
+                { text: ' Mentions', type: 'text' }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+describe('applyStepsToNode', () => {
+  it('Should be able to parse an existing document', () => {
+    expect(applyStepsToNode([], getNodeFromJson(testDoc))).toNotThrow();
+  });
+});

--- a/lib/prosemirror/__tests__/applyStepsToNode.spec.ts
+++ b/lib/prosemirror/__tests__/applyStepsToNode.spec.ts
@@ -137,6 +137,6 @@ const testDoc = {
 
 describe('applyStepsToNode', () => {
   it('Should be able to parse an existing document', () => {
-    expect(applyStepsToNode([], getNodeFromJson(testDoc))).toNotThrow();
+    expect(() => applyStepsToNode([], getNodeFromJson(testDoc))).not.toThrow();
   });
 });

--- a/lib/prosemirror/applyStepsToNode.ts
+++ b/lib/prosemirror/applyStepsToNode.ts
@@ -2,6 +2,7 @@ import type { Node } from '@bangle.dev/pm';
 import { Step } from '@bangle.dev/pm';
 
 import { specRegistry } from 'components/common/CharmEditor/specRegistry';
+import log from 'lib/log';
 import type { ProsemirrorJSONStep } from 'lib/websockets/documentEvents/interfaces';
 
 export function applyStepsToNode(steps: ProsemirrorJSONStep[], node: Node): Node {
@@ -11,6 +12,7 @@ export function applyStepsToNode(steps: ProsemirrorJSONStep[], node: Node): Node
     if (res.doc) {
       return res.doc;
     } else {
+      log.warn('Could not apply step', { res });
       throw new Error('Failed to apply step');
     }
   }, node);

--- a/scripts/query.ts
+++ b/scripts/query.ts
@@ -1,10 +1,10 @@
 import { prisma } from 'db';
 
-prisma.pageDiff.deleteMany({
+prisma.page.findUnique({
   where: {
-    pageId: '4bd13deb-57eb-4c1f-8939-1a0ce886f2a9'
+    id: '0c4a865a-9b5d-469c-a4ae-a2b34fd62d7e'
   }
-}).then(space => {
+}).then(record => {
   // eslint-disable-next-line no-console
-  console.log('Found space', space);
+  console.log( JSON.stringify(record?.content));
 });


### PR DESCRIPTION
I'm still trying to understand whath appened, but socker server started returning a 502 bad gateway and no one could load page content. 

This PR adds more logging, particularly userId so that i can see if issues are related to one person or not, it also adds a try/catch around the place that probably blew up the server so that doesn't happen again.

1) The most recent update was at 8am: https://github.com/charmverse/app.charmverse.io/pull/1324. This was just moving code around, nothing about the prosemirror schema should have changed.
2) Around 9:30am, I see a rapid increase (thousands) of logs saying "Ignore duplicate diff message from client"
3) Around 9:33-9:35am, I see about 20 errors "Error: Failed to apply step"
3) 9:35am - last log from websockets: "Argument where of type PageWhereUniqueInput needs at least one argument.". It looks like the container tries to restart but doesn't actually get there... 
4) 10:22 I reverted to previous version of sockets and it starts working again

