### PR TITLE
update alchemy api and fix Deep Dao env var

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,4 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/charmverse
 AUTH_SECRET=4sjrrA4kJwa4jCcLNMXN6xvpGwa4MHn3
 NEXT_TELEMETRY_DISABLED=1
 DOMAIN=http://localhost:3000
-DEEP_DAO_BASE_URL=https://api.deepdao.io
+DEEPDAO_BASE_URL=https://api.deepdao.io

--- a/lib/blockchain/provider/alchemy.ts
+++ b/lib/blockchain/provider/alchemy.ts
@@ -71,7 +71,7 @@ export const getAlchemyBaseUrl = (chainId: SupportedChainId = 1, apiSuffix: Alch
 // Docs: https://docs.alchemy.com/reference/getnfts
 export const getAddressNfts = async (address: string, chainId: SupportedChainId = 1) => {
   const url = `${getAlchemyBaseUrl(chainId, 'nft')}/getNFTs`;
-  const res = await GET<AlchemyNftResponse>(url, { owner: address, filters: ['AIRDROPS', 'SPAM'] });
+  const res = await GET<AlchemyNftResponse>(url, { owner: address, excludeFilters: ['AIRDROPS', 'SPAM'] });
   return res.ownedNfts;
 };
 


### PR DESCRIPTION
I was debugging Alchemy and noticed that their API has changed. "filters" is now "excludeFilters" when excluding spam from NFTs - it still seems to work, but not sure for how long: https://docs.alchemy.com/reference/getnfts.

I also fixed the env var name for Deep DAO. I changed it everywhere but in the default .env file.