### PR TITLE
Support OpenSea embed for NFT on Ethereum

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -59,6 +59,8 @@ import InlineVoteList from './components/inlineVote/components/InlineVoteList';
 import * as listItem from './components/listItem/listItem';
 import Mention, { mentionPluginKeyName, mentionPlugins, MentionSuggest } from './components/mention';
 import NestedPage, { nestedPagePluginKeyName, nestedPagePlugins, NestedPagesList } from './components/nestedPage';
+import * as nft from './components/nft/nft';
+import { NFTNodeView } from './components/nft/NFTNodeView';
 import type { CharmNodeViewProps } from './components/nodeView/nodeView';
 import * as orderedList from './components/orderedList';
 import paragraph from './components/paragraph';
@@ -217,6 +219,7 @@ export function charmEditorPlugins({
     // @ts-ignore missing type
     table.TableFiltersMenu(),
     disclosure.plugins(),
+    nft.plugins(),
     tweet.plugins(),
     trailingNode.plugins(),
     videoPlugins(),
@@ -595,6 +598,9 @@ function CharmEditor({
           }
           case 'tweet': {
             return <TweetNodeView {...allProps} />;
+          }
+          case 'nft': {
+            return <NFTNodeView {...allProps} />;
           }
           case 'video': {
             return <VideoNodeView {...allProps} />;

--- a/components/common/CharmEditor/components/inlinePalette/editorItems/embed.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/editorItems/embed.tsx
@@ -87,6 +87,31 @@ export function items(): PaletteItemTypeNoGroup[] {
       }
     },
     {
+      uid: 'nft',
+      title: 'OpenSea NFT',
+      icon: <TwitterIcon sx={{ fontSize: iconSize }} />,
+      description: 'Embed an NFT on OpenSea',
+      editorExecuteCommand: () => {
+        return (state, dispatch, view) => {
+          if (view) {
+            // Execute the animation
+            rafCommandExec(view!, (_state, _dispatch) => {
+              // let the node view know to show the tooltip by default
+              const tooltipMark = _state.schema.mark('tooltip-marker');
+              const node = _state.schema.nodes.nft.create(undefined, undefined, [tooltipMark]);
+
+              if (_dispatch && isAtBeginningOfLine(_state)) {
+                _dispatch(_state.tr.replaceSelectionWith(node, false));
+                return true;
+              }
+              return insertNode(_state, _dispatch, node);
+            });
+          }
+          return replaceSuggestionMarkWith(palettePluginKey, '')(state, dispatch, view);
+        };
+      }
+    },
+    {
       uid: 'tweet',
       title: 'Tweet',
       keywords: ['twitter', 'elon'],

--- a/components/common/CharmEditor/components/nft/NFTNodeView.tsx
+++ b/components/common/CharmEditor/components/nft/NFTNodeView.tsx
@@ -1,0 +1,144 @@
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+import TwitterIcon from '@mui/icons-material/Twitter';
+import { Box } from '@mui/material';
+import Script from 'next/script';
+import { useRef } from 'react';
+
+import log from 'lib/log';
+
+import BlockAligner from '../BlockAligner';
+import { MediaSelectionPopup } from '../common/MediaSelectionPopup';
+import { MediaUrlInput } from '../common/MediaUrlInput';
+import type { CharmNodeViewProps } from '../nodeView/nodeView';
+
+import type { NodeAttrs } from './nftSpec';
+import { extractAttrsFromUrl } from './nftUtils';
+
+// OpenSea embed plugin: https://github.com/ProjectOpenSea/embeddable-nfts
+export const widgetJS = 'https://unpkg.com/embeddable-nfts/dist/nft-card.min.js';
+
+type TweetOptions = {
+  theme?: 'dark' | 'light';
+};
+
+declare global {
+  interface Window {
+    twttr: {
+      widgets: {
+        // @ref https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference
+        createTweet: (id: string, el: HTMLElement, options: TweetOptions) => void;
+        // createTimeline - we might want this in the future?
+      };
+    };
+  }
+}
+
+const StyledContainer = styled.div`
+  nft-card > div,
+  nft-card-front > div {
+    background: transparent !important;
+  }
+`;
+
+export function NFTNodeView({ deleteNode, readOnly, node, updateAttrs }: CharmNodeViewProps) {
+  const attrs = node.attrs as Partial<NodeAttrs>;
+
+  // If there are no source for the node, return the image select component
+  if (!attrs.contract) {
+    if (readOnly) {
+      // hide the row completely
+      return <div />;
+    } else {
+      return (
+        <MediaSelectionPopup
+          node={node}
+          icon={<TwitterIcon fontSize='small' />}
+          buttonText='Embed a Tweet'
+          onDelete={deleteNode}
+        >
+          <Box py={3}>
+            <MediaUrlInput
+              helperText='Works with links to Tweets'
+              isValid={(url) => extractAttrsFromUrl(url) !== null}
+              onSubmit={(url) => {
+                const _attrs = extractAttrsFromUrl(url);
+                if (_attrs) {
+                  updateAttrs(_attrs);
+                }
+              }}
+              placeholder='https://twitter.com...'
+            />
+          </Box>
+        </MediaSelectionPopup>
+      );
+    }
+  }
+
+  // override css to support dark mode
+  function setCSSOverrides() {
+    try {
+      // main card
+      adjustShadowRootStyles(['nft-card'], '.card { background: var(--background-paper); width: 100% !important; }');
+      // card contents
+      adjustShadowRootStyles(
+        ['nft-card', 'nft-card-front'],
+        '.card-front { background: var(--background-paper); } .asset-link { color: var(--primary-text); } info-button { display: none; } .asset-image-container { border-color: var(--bg-gray); }'
+      );
+      // status pill
+      adjustShadowRootStyles(
+        ['nft-card', 'nft-card-front', 'pill-element'],
+        '.pill { border-color: var(--bg-gray) !important; }'
+      );
+    } catch (error) {
+      // silently fail
+    }
+  }
+
+  function initStyles() {
+    setTimeout(setCSSOverrides, 20);
+    setTimeout(setCSSOverrides, 100);
+    setTimeout(setCSSOverrides, 500);
+    setTimeout(setCSSOverrides, 1000);
+  }
+
+  return (
+    <>
+      <Script src={widgetJS} onReady={initStyles} />
+      <BlockAligner onDelete={deleteNode}>
+        <StyledContainer>
+          {/* @ts-ignore nft-card element is from OpenSea */}
+          <nft-card contractAddress={attrs.contract} tokenId={attrs.token}></nft-card>
+        </StyledContainer>
+      </BlockAligner>
+    </>
+  );
+}
+
+// main function - https://stackoverflow.com/questions/47625017/override-styles-in-a-shadow-root-element
+function adjustShadowRootStyles(hostsSelectorList: readonly string[], styles: string): void {
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync(styles);
+
+  const shadowRoot = queryShadowRootDeep(hostsSelectorList);
+  shadowRoot.adoptedStyleSheets = [...shadowRoot.adoptedStyleSheets, sheet];
+}
+
+// A helper function
+function queryShadowRootDeep(hostsSelectorList: readonly string[]): ShadowRoot | never {
+  let element: ShadowRoot | null | undefined;
+
+  hostsSelectorList.forEach((selector: string) => {
+    const root = element ?? document;
+    element = root.querySelector(selector)?.shadowRoot;
+    if (!element)
+      throw new Error(
+        `Cannot find a shadowRoot element with selector "${selector}". The selectors chain is: ${hostsSelectorList.join(
+          ', '
+        )}`
+      );
+  });
+
+  if (!element) throw new Error(`Cannot find a shadowRoot of this chain: ${hostsSelectorList.join(', ')}`);
+  return element;
+}

--- a/components/common/CharmEditor/components/nft/nft.ts
+++ b/components/common/CharmEditor/components/nft/nft.ts
@@ -1,0 +1,32 @@
+import { Plugin, NodeView } from '@bangle.dev/core';
+import type { EditorView, Slice } from '@bangle.dev/pm';
+
+import { insertNode } from 'lib/prosemirror/insertNode';
+
+import { name } from './nftSpec';
+import { extractAttrsFromEmbedCode } from './nftUtils';
+
+// inject a tweet node when pasting twitter url
+
+export function plugins() {
+  return [
+    NodeView.createPlugin({
+      name,
+      containerDOM: ['nft-embed']
+    }),
+    new Plugin({
+      props: {
+        handlePaste: (view: EditorView, rawEvent: ClipboardEvent, slice: Slice) => {
+          // @ts-ignore
+          const contentRow = slice.content.content?.[0]?.content.content?.[0] ?? slice.content.content?.[0];
+          const attrs = extractAttrsFromEmbedCode(contentRow?.text);
+          if (attrs) {
+            insertNode(name, view.state, view.dispatch, view, attrs);
+            return true;
+          }
+          return false;
+        }
+      }
+    })
+  ];
+}

--- a/components/common/CharmEditor/components/nft/nftSpec.ts
+++ b/components/common/CharmEditor/components/nft/nftSpec.ts
@@ -1,0 +1,68 @@
+import type { RawSpecs } from '@bangle.dev/core';
+import type { Node } from '@bangle.dev/pm';
+import type { supportedChainIds } from 'connectors';
+
+export const name = 'nft';
+
+export type NodeAttrs = {
+  chain: typeof supportedChainIds[number];
+  contract: string;
+  token: string;
+};
+
+export function spec(): RawSpecs {
+  return {
+    type: 'node',
+    name,
+    markdown: {
+      toMarkdown: (state, node) => {
+        const { chain, contract, token } = node.attrs as NodeAttrs;
+
+        const toRender = `Embedded NFT: ${contract} #${token}`;
+
+        // Ensure markdown html will be separated by newlines
+        state.ensureNewLine();
+        state.text(toRender);
+        state.ensureNewLine();
+      }
+    },
+    schema: {
+      attrs: {
+        chain: {
+          default: 1
+        },
+        contract: {
+          default: ''
+        },
+        token: {
+          default: ''
+        },
+        track: {
+          default: []
+        }
+      },
+      group: 'block',
+      inline: false,
+      draggable: false,
+      isolating: true, // dont allow backspace to delete
+      parseDOM: [
+        {
+          tag: 'nft-embed',
+          getAttrs: (dom: any) => {
+            return {
+              chain: parseInt(dom.getAttribute('data-chain'), 10),
+              contract: dom.getAttribute('data-contract'),
+              token: dom.getAttribute('data-token')
+            };
+          }
+        }
+      ],
+      toDOM: (node: Node) => {
+        return [
+          'nft-embed',
+          { 'data-chain': node.attrs.chain, 'data-token': node.attrs.token, 'data-contract': node.attrs.contract }
+        ];
+      }
+    }
+  };
+}

--- a/components/common/CharmEditor/components/nft/nftUtils.ts
+++ b/components/common/CharmEditor/components/nft/nftUtils.ts
@@ -1,0 +1,35 @@
+import type { NodeAttrs } from './nftSpec';
+
+// a function to extract user screen name and tweet id from a tweet url
+export function extractAttrsFromUrl(url: string): NodeAttrs | null {
+  if (!url) {
+    return null;
+  }
+
+  const match = url.match(/opensea\.io\/assets\/ethereum\/([^/]+)\/([^/]+)/);
+  if (!match) {
+    return null;
+  }
+  return {
+    chain: 1,
+    contract: match[1],
+    token: match[2]
+  };
+}
+
+// a function to extract user screen name and tweet id from a tweet url
+export function extractAttrsFromEmbedCode(url: string): NodeAttrs | null {
+  if (!url) {
+    return null;
+  }
+  const match = url.replaceAll(/\s/g, '').match(/<nft-cardcontractAddress="([^"]+)"tokenId="([^"]+)"/);
+  if (!match) {
+    return null;
+  }
+  return {
+    // embed only supports ethereum for now
+    chain: 1,
+    contract: match[1],
+    token: match[2]
+  };
+}

--- a/components/common/CharmEditor/specRegistry.ts
+++ b/components/common/CharmEditor/specRegistry.ts
@@ -22,6 +22,7 @@ import * as inlineVote from './components/inlineVote';
 import * as listItem from './components/listItem/listItem';
 import { mentionSpecs } from './components/mention';
 import { nestedPageSpec } from './components/nestedPage';
+import * as nft from './components/nft/nftSpec';
 import * as orderedList from './components/orderedList';
 import paragraph from './components/paragraph';
 import * as quote from './components/quote';
@@ -83,5 +84,6 @@ export const specRegistry = new SpecRegistry([
   insertion,
   formatChange,
   video.spec(),
-  textColor.spec()
+  textColor.spec(),
+  nft.spec()
 ]);

--- a/connectors.ts
+++ b/connectors.ts
@@ -395,4 +395,4 @@ export function getChainExplorerLink(
   }
 }
 
-export { RPC, supportedChains, injected, walletConnect, walletLink };
+export { RPC, supportedChains, supportedChainIds, injected, walletConnect, walletLink };


### PR DESCRIPTION
Had to do some really hacky stuff to make it work in dark mode, it only works for Eth mainnet, and the embed is archived as of last month. We should probably make our own or fork it at some point...

Example nft for test: https://opensea.io/assets/ethereum/0x35471f47c3c0bc5fc75025b97a19ecdde00f78f8/4274

Needs a logo