### PR TITLE
Fix floating menu in comments

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -96,6 +96,7 @@ const nestedPagePluginKey = new PluginKey(nestedPagePluginKeyName);
 const inlineCommentPluginKey = new PluginKey(inlineComment.pluginKeyName);
 const inlineVotePluginKey = new PluginKey(inlineVote.pluginKeyName);
 const suggestionsPluginKey = new PluginKey('suggestions');
+const inlinePalettePluginKey = new PluginKey('inlinePalette');
 
 export function charmEditorPlugins({
   onContentChange,
@@ -160,7 +161,7 @@ export function charmEditorPlugins({
     mentionPlugins({
       key: mentionPluginKey
     }),
-    inlinePalettePlugins(),
+    inlinePalettePlugins({ key: inlinePalettePluginKey }),
     bold.plugins(),
     bulletList.plugins(),
     code.plugins(),
@@ -646,7 +647,11 @@ function CharmEditor({
       <NestedPagesList pluginKey={nestedPagePluginKey} />
       <EmojiSuggest pluginKey={emojiPluginKey} />
       {!readOnly && <RowActionsMenu pluginKey={actionsPluginKey} />}
-      <InlineCommandPalette nestedPagePluginKey={nestedPagePluginKey} disableNestedPage={disableNestedPage} />
+      <InlineCommandPalette
+        nestedPagePluginKey={nestedPagePluginKey}
+        disableNestedPage={disableNestedPage}
+        palettePluginKey={inlinePalettePluginKey}
+      />
       {children}
       {!disablePageSpecificFeatures && (
         <>

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -96,7 +96,6 @@ const nestedPagePluginKey = new PluginKey(nestedPagePluginKeyName);
 const inlineCommentPluginKey = new PluginKey(inlineComment.pluginKeyName);
 const inlineVotePluginKey = new PluginKey(inlineVote.pluginKeyName);
 const suggestionsPluginKey = new PluginKey('suggestions');
-const inlinePalettePluginKey = new PluginKey('inlinePalette');
 
 export function charmEditorPlugins({
   onContentChange,
@@ -161,7 +160,7 @@ export function charmEditorPlugins({
     mentionPlugins({
       key: mentionPluginKey
     }),
-    inlinePalettePlugins({ key: inlinePalettePluginKey }),
+    inlinePalettePlugins(),
     bold.plugins(),
     bulletList.plugins(),
     code.plugins(),
@@ -647,11 +646,7 @@ function CharmEditor({
       <NestedPagesList pluginKey={nestedPagePluginKey} />
       <EmojiSuggest pluginKey={emojiPluginKey} />
       {!readOnly && <RowActionsMenu pluginKey={actionsPluginKey} />}
-      <InlineCommandPalette
-        nestedPagePluginKey={nestedPagePluginKey}
-        disableNestedPage={disableNestedPage}
-        palettePluginKey={inlinePalettePluginKey}
-      />
+      <InlineCommandPalette nestedPagePluginKey={nestedPagePluginKey} disableNestedPage={disableNestedPage} />
       {children}
       {!disablePageSpecificFeatures && (
         <>

--- a/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
@@ -86,20 +86,20 @@ function MenuByType(props: MenuProps) {
   if (type === 'defaultMenu') {
     return (
       <Menu hideMenu={hideMenu} type={type}>
-        <MenuGroup>
-          <Tooltip title={<Typography component='div'>Turn into</Typography>}>
-            <Button
-              {...bindTrigger(popupState)}
-              endIcon={<KeyboardArrowDown sx={{ marginLeft: '-4px' }} />}
-              disableElevation
-              variant='text'
-              color='inherit'
-              sx={{ padding: 0 }}
-            >
-              {activeItem}
-            </Button>
-          </Tooltip>
-          {!inline && (
+        {!inline && (
+          <MenuGroup>
+            <Tooltip title={<Typography component='div'>Turn into</Typography>}>
+              <Button
+                {...bindTrigger(popupState)}
+                endIcon={<KeyboardArrowDown sx={{ marginLeft: '-4px' }} />}
+                disableElevation
+                variant='text'
+                color='inherit'
+                sx={{ padding: 0 }}
+              >
+                {activeItem}
+              </Button>
+            </Tooltip>
             <InlineCommandPalette
               menuKey={pluginKey}
               nestedPagePluginKey={nestedPagePluginKey}
@@ -108,8 +108,8 @@ function MenuByType(props: MenuProps) {
               size='small'
               handleActiveItem={handleActiveItem}
             />
-          )}
-        </MenuGroup>
+          </MenuGroup>
+        )}
         <MenuGroup isLastGroup={inline}>
           <BoldButton />
           <ItalicButton />
@@ -120,11 +120,13 @@ function MenuByType(props: MenuProps) {
           {displayInlineCommentButton && <InlineCommentButton enableComments menuKey={pluginKey} />}
           {displayInlineVoteButton && <InlineVoteButton enableVotes menuKey={pluginKey} />}
         </MenuGroup>
-        <MenuGroup>
-          <TextColorMenuDropdown>
-            <TextColorButton />
-          </TextColorMenuDropdown>
-        </MenuGroup>
+        {!inline && (
+          <MenuGroup>
+            <TextColorMenuDropdown>
+              <TextColorButton />
+            </TextColorMenuDropdown>
+          </MenuGroup>
+        )}
         {!inline && (
           <MenuGroup isLastGroup>
             <ParagraphButton />

--- a/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
@@ -99,14 +99,16 @@ function MenuByType(props: MenuProps) {
               {activeItem}
             </Button>
           </Tooltip>
-          <InlineCommandPalette
-            menuKey={pluginKey}
-            nestedPagePluginKey={nestedPagePluginKey}
-            disableNestedPage={disableNestedPage}
-            externalPopupState={popupState}
-            size='small'
-            handleActiveItem={handleActiveItem}
-          />
+          {!inline && (
+            <InlineCommandPalette
+              menuKey={pluginKey}
+              nestedPagePluginKey={nestedPagePluginKey}
+              disableNestedPage={disableNestedPage}
+              externalPopupState={popupState}
+              size='small'
+              handleActiveItem={handleActiveItem}
+            />
+          )}
         </MenuGroup>
         <MenuGroup isLastGroup={inline}>
           <BoldButton />


### PR DESCRIPTION
To reproduce the bug: highlight some tet in CharmEditor, create a comment. Now type some text in the comment input and try to highlight your comment. It crashes the page.

I think the issue is that the "inline palette" (aka slash command menu) is using a static plugin key. This broke the floating menu for inline comments. I removed the inline palette from comments (as well as text color) since it's unecessary.

I made another PR to pass the palette plugin key in dynamically: https://github.com/charmverse/app.charmverse.io/pull/1352