### PR TITLE
Feat/typeform integration

### DIFF
--- a/lib/pages/__tests__/createFormResposnseCard.spec.ts
+++ b/lib/pages/__tests__/createFormResposnseCard.spec.ts
@@ -1,0 +1,74 @@
+import type { Space, User } from '@prisma/client';
+
+import { createFormResposnseCard } from 'lib/pages/createFormResposnseCard';
+import { getDatabaseDetails } from 'lib/pages/getDatabaseDetails';
+import { createDatabase } from 'lib/public-api/createDatabaseCardPage';
+import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+
+let user: User;
+let space: Space;
+
+beforeAll(async () => {
+  const generated = await generateUserAndSpaceWithApiToken();
+  user = generated.user;
+  space = generated.space;
+});
+
+describe('createFormResposnseCard', () => {
+  it('should create a card and add properties to board', async () => {
+    const createdDb = await createDatabase({
+      title: 'Example',
+      createdBy: user.id,
+      spaceId: space.id
+    });
+
+    const mockResponse1 = [
+      { question: 'Test q 1', answer: 'answer 1' },
+      { question: 'Test q 2', answer: 'answer 2' }
+    ];
+
+    const res1 = await createFormResposnseCard({
+      spaceId: space.id,
+      databaseIdorPath: createdDb.id,
+      userId: user.id,
+      data: mockResponse1
+    });
+
+    let udpatedDb = await getDatabaseDetails({ spaceId: space.id, idOrPath: createdDb.id });
+
+    expect((udpatedDb?.fields as any)?.cardProperties.length).toBe(2);
+    expect(Object.keys(res1.properties).length).toBe(2);
+
+    const mockResponse2 = [
+      { question: 'Test q 1', answer: 'answer 3' },
+      { question: 'Test q 2', answer: 'answer 4' }
+    ];
+
+    const res2 = await createFormResposnseCard({
+      spaceId: space.id,
+      databaseIdorPath: createdDb.id,
+      userId: user.id,
+      data: mockResponse2
+    });
+
+    udpatedDb = await getDatabaseDetails({ spaceId: space.id, idOrPath: createdDb.id });
+    expect((udpatedDb?.fields as any)?.cardProperties.length).toBe(2);
+    expect(Object.keys(res2.properties).length).toBe(2);
+
+    const mockResponse3 = [
+      { question: 'Test q 1', answer: 'answer 3' },
+      { question: 'Test q 3', answer: 'answer 4' }
+    ];
+
+    const res3 = await createFormResposnseCard({
+      spaceId: space.id,
+      databaseIdorPath: createdDb.id,
+      userId: user.id,
+      data: mockResponse3
+    });
+
+    udpatedDb = await getDatabaseDetails({ spaceId: space.id, idOrPath: createdDb.id });
+    expect((udpatedDb?.fields as any)?.cardProperties.length).toBe(3);
+    expect(Object.keys(res3.properties).length).toBe(2);
+  });
+});

--- a/lib/pages/__tests__/createFormResposnseCard.spec.ts
+++ b/lib/pages/__tests__/createFormResposnseCard.spec.ts
@@ -1,6 +1,6 @@
 import type { Space, User } from '@prisma/client';
 
-import { createFormResposnseCard } from 'lib/pages/createFormResposnseCard';
+import { createFormResponseCard } from 'lib/pages/createFormResponseCard';
 import { getDatabaseDetails } from 'lib/pages/getDatabaseDetails';
 import { createDatabase } from 'lib/public-api/createDatabaseCardPage';
 import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
@@ -27,7 +27,7 @@ describe('createFormResposnseCard', () => {
       { question: 'Test q 2', answer: 'answer 2' }
     ];
 
-    const res1 = await createFormResposnseCard({
+    const res1 = await createFormResponseCard({
       spaceId: space.id,
       databaseIdorPath: createdDb.id,
       userId: user.id,
@@ -44,7 +44,7 @@ describe('createFormResposnseCard', () => {
       { question: 'Test q 2', answer: 'answer 4' }
     ];
 
-    const res2 = await createFormResposnseCard({
+    const res2 = await createFormResponseCard({
       spaceId: space.id,
       databaseIdorPath: createdDb.id,
       userId: user.id,
@@ -60,7 +60,7 @@ describe('createFormResposnseCard', () => {
       { question: 'Test q 3', answer: 'answer 4' }
     ];
 
-    const res3 = await createFormResposnseCard({
+    const res3 = await createFormResponseCard({
       spaceId: space.id,
       databaseIdorPath: createdDb.id,
       userId: user.id,

--- a/lib/pages/createFormResponseCard.ts
+++ b/lib/pages/createFormResponseCard.ts
@@ -8,7 +8,7 @@ import { InvalidInputError } from 'lib/utilities/errors';
 import type { AddFormResponseInput, FormResponse } from 'lib/zapier/interfaces';
 import { parseFormData } from 'lib/zapier/parseFormData';
 
-export async function createFormResposnseCard({
+export async function createFormResponseCard({
   spaceId,
   databaseIdorPath,
   userId,
@@ -66,7 +66,7 @@ export async function createFormResposnseCard({
   return card;
 }
 
-function creteNewFormProperty(description: string, index: number = 0): FormResponseProperty {
+function createNewFormProperty(description: string, index: number = 0): FormResponseProperty {
   return {
     id: v4(),
     name: `Question ${index + 1}`,
@@ -85,7 +85,7 @@ function mapAndCreateProperties(formResponses: FormResponse[], existingResponseP
     let property = existingResponseProperties.find((p) => p.description === response.question);
     if (!property) {
       const propertyIndex = existingResponseProperties.length + newProperties.length;
-      property = creteNewFormProperty(response.question, propertyIndex);
+      property = createNewFormProperty(response.question, propertyIndex);
       newProperties.push(property);
     }
 

--- a/lib/pages/createFormResposnseCard.ts
+++ b/lib/pages/createFormResposnseCard.ts
@@ -1,0 +1,100 @@
+import { v4 } from 'uuid';
+
+import { prisma } from 'db';
+import type { FormResponseProperty } from 'lib/pages/interfaces';
+import { createDatabaseCardPage } from 'lib/public-api/createDatabaseCardPage';
+import { InvalidInputError } from 'lib/utilities/errors';
+import type { AddFormResponseInput, FormResponse } from 'lib/zapier/interfaces';
+import { parseFormData } from 'lib/zapier/parseFormData';
+
+export async function createFormResposnseCard({
+  spaceId,
+  databaseId,
+  userId,
+  data
+}: {
+  spaceId: string;
+  databaseId: string;
+  userId: string;
+  data: AddFormResponseInput;
+}) {
+  const formResponses = parseFormData(data);
+  if (!formResponses.length) {
+    throw new InvalidInputError('There are no form responses to create');
+  }
+
+  const board = await prisma.block.findFirst({
+    where: {
+      type: 'board',
+      id: databaseId,
+      spaceId
+    }
+  });
+
+  if (!board) {
+    throw new InvalidInputError('Database not found');
+  }
+
+  const fields = (board.fields as any) || {};
+  const cardProperties = fields?.cardProperties || [];
+  const existingResponseProperties: FormResponseProperty[] =
+    cardProperties.filter((p: FormResponseProperty) => p.isQuestion) || [];
+
+  const { newProperties, mappedProperties } = mapAndCreateProperties(formResponses, existingResponseProperties);
+
+  if (newProperties.length) {
+    // Save new question properties
+    await prisma.block.update({
+      where: {
+        id: databaseId
+      },
+      data: {
+        fields: {
+          ...fields,
+          cardProperties: [...cardProperties, ...newProperties]
+        }
+      }
+    });
+  }
+
+  const card = await createDatabaseCardPage({
+    title: 'Form Response',
+    properties: mappedProperties,
+    boardId: databaseId,
+    spaceId,
+    createdBy: userId
+  });
+
+  return card;
+}
+
+function creteNewFormProperty(description: string, index: number = 0): FormResponseProperty {
+  return {
+    id: v4(),
+    name: `Question ${index + 1}`,
+    type: 'text',
+    options: [],
+    description,
+    isQuestion: true
+  };
+}
+
+function mapAndCreateProperties(formResponses: FormResponse[], existingResponseProperties: FormResponseProperty[]) {
+  const newProperties: FormResponseProperty[] = [];
+  const mappedProperties: Record<string, string> = {};
+
+  formResponses.forEach((response) => {
+    let property = existingResponseProperties.find((p) => p.description === response.question);
+    if (!property) {
+      const propertyIndex = existingResponseProperties.length + newProperties.length;
+      property = creteNewFormProperty(response.question, propertyIndex);
+      newProperties.push(property);
+    }
+
+    if (property) {
+      mappedProperties[property.id] = response.answer;
+    }
+  });
+
+  return { newProperties, mappedProperties };
+}

--- a/lib/pages/createFormResposnseCard.ts
+++ b/lib/pages/createFormResposnseCard.ts
@@ -1,7 +1,7 @@
 import { v4 } from 'uuid';
 
 import { prisma } from 'db';
-import { getDatabaseDetails } from 'lib/pages/GetDatabaseDetails';
+import { getDatabaseDetails } from 'lib/pages/getDatabaseDetails';
 import type { FormResponseProperty } from 'lib/pages/interfaces';
 import { createDatabaseCardPage } from 'lib/public-api/createDatabaseCardPage';
 import { InvalidInputError } from 'lib/utilities/errors';

--- a/lib/pages/getDatabaseDetails.ts
+++ b/lib/pages/getDatabaseDetails.ts
@@ -27,7 +27,6 @@ export async function getDatabaseDetails({ idOrPath, spaceId }: { idOrPath: stri
   if (!dbId) {
     return null;
   }
-
   return prisma.block.findFirst({
     where: {
       type: 'board',

--- a/lib/pages/getDatabaseDetails.ts
+++ b/lib/pages/getDatabaseDetails.ts
@@ -1,0 +1,38 @@
+import { prisma } from 'db';
+import { isUUID } from 'lib/utilities/strings';
+
+export async function getDatabaseDetails({ idOrPath, spaceId }: { idOrPath: string; spaceId?: string }) {
+  let dbId: string | null | undefined = isUUID(idOrPath) ? idOrPath : null;
+
+  // We need a spaceId if looking up by path
+  if (!dbId && !spaceId) {
+    return null;
+  }
+
+  if (!dbId) {
+    // Get the database ID from the page
+    const page = await prisma.page.findFirst({
+      where: {
+        path: idOrPath,
+        spaceId
+      },
+      select: {
+        boardId: true
+      }
+    });
+
+    dbId = page?.boardId;
+  }
+
+  if (!dbId) {
+    return null;
+  }
+
+  return prisma.block.findFirst({
+    where: {
+      type: 'board',
+      id: dbId,
+      spaceId
+    }
+  });
+}

--- a/lib/pages/interfaces.ts
+++ b/lib/pages/interfaces.ts
@@ -1,6 +1,6 @@
 import type { Block, Page, PagePermission, Space } from '@prisma/client';
 
-import type { Board } from 'lib/focalboard/board';
+import type { Board, IPropertyTemplate } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';
 import type { Card } from 'lib/focalboard/card';
 import type { PagePermissionMeta } from 'lib/permissions/interfaces';
@@ -111,3 +111,8 @@ export type PagesMap<P extends PageMeta | PageNode = PageMeta> = Record<string, 
 
 export type PageUpdates = Partial<Page> & { id: string };
 export type PageDetailsUpdates = Partial<PageDetails> & { id: string };
+
+export type FormResponseProperty = IPropertyTemplate & {
+  description: string;
+  isQuestion?: true;
+};

--- a/lib/zapier/__tests__/validateFormRequestInput.spec.ts
+++ b/lib/zapier/__tests__/validateFormRequestInput.spec.ts
@@ -1,0 +1,107 @@
+import type { Space, User } from '@prisma/client';
+import { v4 } from 'uuid';
+
+import { createDatabase } from 'lib/public-api/createDatabaseCardPage';
+import { DatabasePageNotFoundError } from 'lib/public-api/errors';
+import { InvalidInputError } from 'lib/utilities/errors';
+import { validateFormRequestInput } from 'lib/zapier/validateFormRequestInput';
+import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+
+let user: User;
+let space: Space;
+
+beforeAll(async () => {
+  const generated = await generateUserAndSpaceWithApiToken();
+  user = generated.user;
+  space = generated.space;
+});
+
+describe('validateFormRequestInput', () => {
+  it('should validate string input', async () => {
+    const db = await createDatabase({
+      title: 'Example',
+      createdBy: user.id,
+      spaceId: space.id
+    });
+
+    expect(() =>
+      validateFormRequestInput({ spaceId: space.id, databaseId: db.id, data: '###Question\n\nAnswer' })
+    ).not.toThrow();
+  });
+
+  it('should validate object input', async () => {
+    const db = await createDatabase({
+      title: 'Example',
+      createdBy: user.id,
+      spaceId: space.id
+    });
+
+    expect(() =>
+      validateFormRequestInput({
+        spaceId: space.id,
+        databaseId: db.id,
+        data: { all_responses: '###Question\n\nAnswer' }
+      })
+    ).not.toThrow();
+  });
+
+  it('should validate array input', async () => {
+    const db = await createDatabase({
+      title: 'Example',
+      createdBy: user.id,
+      spaceId: space.id
+    });
+
+    expect(() =>
+      validateFormRequestInput({
+        spaceId: space.id,
+        databaseId: db.id,
+        data: [
+          { question: 'Question', answer: 'Answer' },
+          { question: 'Question 2', answer: 'Answer 2' }
+        ]
+      })
+    ).not.toThrow();
+  });
+
+  it('should not validate wrong data input', async () => {
+    const db = await createDatabase({
+      title: 'Example',
+      createdBy: user.id,
+      spaceId: space.id
+    });
+
+    await expect(
+      validateFormRequestInput({
+        spaceId: space.id,
+        databaseId: db.id,
+        data: ''
+      })
+    ).rejects.toBeInstanceOf(InvalidInputError);
+    await expect(
+      validateFormRequestInput({
+        spaceId: space.id,
+        databaseId: db.id,
+        data: {} as any
+      })
+    ).rejects.toBeInstanceOf(InvalidInputError);
+
+    await expect(
+      validateFormRequestInput({
+        spaceId: space.id,
+        databaseId: db.id,
+        data: [{ question: 'Question' }, { random: 'test' }] as any
+      })
+    ).rejects.toBeInstanceOf(InvalidInputError);
+  });
+
+  it('should not validate wrong db id', async () => {
+    await expect(
+      validateFormRequestInput({
+        spaceId: space.id,
+        databaseId: v4(),
+        data: '###Question\n\nAnswer'
+      })
+    ).rejects.toBeInstanceOf(DatabasePageNotFoundError);
+  });
+});

--- a/lib/zapier/__tests__/validateFormRequestInput.spec.ts
+++ b/lib/zapier/__tests__/validateFormRequestInput.spec.ts
@@ -25,7 +25,7 @@ describe('validateFormRequestInput', () => {
     });
 
     expect(() =>
-      validateFormRequestInput({ spaceId: space.id, databaseId: db.id, data: '###Question\n\nAnswer' })
+      validateFormRequestInput({ spaceId: space.id, databaseIdOrPath: db.id, data: '###Question\n\nAnswer' })
     ).not.toThrow();
   });
 
@@ -39,7 +39,7 @@ describe('validateFormRequestInput', () => {
     expect(() =>
       validateFormRequestInput({
         spaceId: space.id,
-        databaseId: db.id,
+        databaseIdOrPath: db.id,
         data: { all_responses: '###Question\n\nAnswer' }
       })
     ).not.toThrow();
@@ -55,7 +55,7 @@ describe('validateFormRequestInput', () => {
     expect(() =>
       validateFormRequestInput({
         spaceId: space.id,
-        databaseId: db.id,
+        databaseIdOrPath: db.id,
         data: [
           { question: 'Question', answer: 'Answer' },
           { question: 'Question 2', answer: 'Answer 2' }
@@ -74,14 +74,14 @@ describe('validateFormRequestInput', () => {
     await expect(
       validateFormRequestInput({
         spaceId: space.id,
-        databaseId: db.id,
+        databaseIdOrPath: db.id,
         data: ''
       })
     ).rejects.toBeInstanceOf(InvalidInputError);
     await expect(
       validateFormRequestInput({
         spaceId: space.id,
-        databaseId: db.id,
+        databaseIdOrPath: db.id,
         data: {} as any
       })
     ).rejects.toBeInstanceOf(InvalidInputError);
@@ -89,7 +89,7 @@ describe('validateFormRequestInput', () => {
     await expect(
       validateFormRequestInput({
         spaceId: space.id,
-        databaseId: db.id,
+        databaseIdOrPath: db.id,
         data: [{ question: 'Question' }, { random: 'test' }] as any
       })
     ).rejects.toBeInstanceOf(InvalidInputError);
@@ -99,7 +99,7 @@ describe('validateFormRequestInput', () => {
     await expect(
       validateFormRequestInput({
         spaceId: space.id,
-        databaseId: v4(),
+        databaseIdOrPath: v4(),
         data: '###Question\n\nAnswer'
       })
     ).rejects.toBeInstanceOf(DatabasePageNotFoundError);

--- a/lib/zapier/interfaces.ts
+++ b/lib/zapier/interfaces.ts
@@ -1,0 +1,6 @@
+export type FormResponse = {
+  question: string;
+  answer: string;
+};
+
+export type AddFormResponseInput = string | Record<'all_responses', string> | FormResponse[];

--- a/lib/zapier/parseFormData.ts
+++ b/lib/zapier/parseFormData.ts
@@ -8,6 +8,16 @@ export function parseFormData(data: AddFormResponseInput): FormResponse[] {
       return data.filter((entry) => entry.question);
     }
 
+    if (typeof data !== 'string' && !data.all_responses) {
+      // Object with questions as keys and answers as values
+      const isValid = Object.values(data).every((value) => typeof value === 'string');
+      if (!isValid) {
+        return [];
+      }
+
+      return Object.entries(data).map(([question, answer]) => ({ question, answer }));
+    }
+
     const questionsStr = typeof data === 'string' ? data : data.all_responses;
     const questionsArr = questionsStr.split('### ').filter(Boolean);
 

--- a/lib/zapier/parseFormData.ts
+++ b/lib/zapier/parseFormData.ts
@@ -1,0 +1,20 @@
+import type { AddFormResponseInput, FormResponse } from 'lib/zapier/interfaces';
+
+// Data markdown format from zapier:
+// ### Question 1?\n\nanswer1\n\n\n### Quesiton2?\n\nanswer2f\n\n\n
+export function parseFormData(data: AddFormResponseInput): FormResponse[] {
+  try {
+    if (Array.isArray(data)) {
+      return data.filter((entry) => entry.question);
+    }
+
+    const questionsStr = typeof data === 'string' ? data : data.all_responses;
+    const questionsArr = questionsStr.split('### ').filter(Boolean);
+
+    const questionPairs = questionsArr.map((question) => question.replaceAll(/(\n)+$/g, '').split('\n\n'));
+
+    return questionPairs.map(([q, a]) => ({ question: q.trim(), answer: a.trim() }));
+  } catch (e) {
+    return [];
+  }
+}

--- a/lib/zapier/validateFormRequestInput.ts
+++ b/lib/zapier/validateFormRequestInput.ts
@@ -1,4 +1,4 @@
-import { getDatabaseDetails } from 'lib/pages/GetDatabaseDetails';
+import { getDatabaseDetails } from 'lib/pages/getDatabaseDetails';
 import { DatabasePageNotFoundError } from 'lib/public-api/errors';
 import { InvalidInputError } from 'lib/utilities/errors';
 import type { AddFormResponseInput } from 'lib/zapier/interfaces';

--- a/lib/zapier/validateFormRequestInput.ts
+++ b/lib/zapier/validateFormRequestInput.ts
@@ -18,8 +18,9 @@ export async function validateFormRequestInput({
   } else if (Array.isArray(data)) {
     invalidData = !data.every((entry) => entry.question && 'answer' in entry);
   } else if (typeof data !== 'string') {
-    const isDictObject = Object.values(data).every((value) => typeof value === 'string');
-    invalidData = !isDictObject && !data.all_responses;
+    const values = Object.values(data);
+    const isDictObject = values.every((value) => typeof value === 'string');
+    invalidData = !values.length || (!isDictObject && !data.all_responses);
   }
 
   if (invalidData) {

--- a/lib/zapier/validateFormRequestInput.ts
+++ b/lib/zapier/validateFormRequestInput.ts
@@ -18,7 +18,8 @@ export async function validateFormRequestInput({
   } else if (Array.isArray(data)) {
     invalidData = !data.every((entry) => entry.question && 'answer' in entry);
   } else if (typeof data !== 'string') {
-    invalidData = !data.all_responses;
+    const isDictObject = Object.values(data).every((value) => typeof value === 'string');
+    invalidData = !isDictObject && !data.all_responses;
   }
 
   if (invalidData) {

--- a/lib/zapier/validateFormRequestInput.ts
+++ b/lib/zapier/validateFormRequestInput.ts
@@ -1,0 +1,46 @@
+import { prisma } from 'db';
+import { DatabasePageNotFoundError } from 'lib/public-api/errors';
+import { InvalidInputError } from 'lib/utilities/errors';
+import { isUUID } from 'lib/utilities/strings';
+import type { AddFormResponseInput } from 'lib/zapier/interfaces';
+
+export async function validateFormRequestInput({
+  spaceId,
+  databaseId,
+  data
+}: {
+  spaceId: string;
+  databaseId: string;
+  data: AddFormResponseInput;
+}) {
+  let invalidData = false;
+  if (!data) {
+    invalidData = true;
+  } else if (Array.isArray(data)) {
+    invalidData = !data.every((entry) => entry.question && 'answer' in entry);
+  } else if (typeof data !== 'string') {
+    invalidData = !data.all_responses;
+  }
+
+  if (invalidData) {
+    throw new InvalidInputError(`Invalid input data`);
+  }
+
+  if (!isUUID(databaseId)) {
+    throw new InvalidInputError(`Invalid database id: ${databaseId}`);
+  }
+
+  const board = await prisma.block.findFirst({
+    where: {
+      type: 'board',
+      id: databaseId,
+      spaceId
+    }
+  });
+
+  if (!board) {
+    throw new DatabasePageNotFoundError(databaseId);
+  }
+
+  return true;
+}

--- a/lib/zapier/validateFormRequestInput.ts
+++ b/lib/zapier/validateFormRequestInput.ts
@@ -1,17 +1,15 @@
-import { prisma } from 'db';
 import { getDatabaseDetails } from 'lib/pages/GetDatabaseDetails';
 import { DatabasePageNotFoundError } from 'lib/public-api/errors';
 import { InvalidInputError } from 'lib/utilities/errors';
-import { isUUID } from 'lib/utilities/strings';
 import type { AddFormResponseInput } from 'lib/zapier/interfaces';
 
 export async function validateFormRequestInput({
   spaceId,
-  databaseId,
+  databaseIdOrPath,
   data
 }: {
   spaceId: string;
-  databaseId: string;
+  databaseIdOrPath: string;
   data: AddFormResponseInput;
 }) {
   let invalidData = false;
@@ -27,14 +25,10 @@ export async function validateFormRequestInput({
     throw new InvalidInputError(`Invalid input data`);
   }
 
-  if (!isUUID(databaseId)) {
-    throw new InvalidInputError(`Invalid database id: ${databaseId}`);
-  }
-
-  const board = await getDatabaseDetails({ spaceId, idOrPath: databaseId });
+  const board = await getDatabaseDetails({ spaceId, idOrPath: databaseIdOrPath });
 
   if (!board) {
-    throw new DatabasePageNotFoundError(databaseId);
+    throw new DatabasePageNotFoundError(databaseIdOrPath);
   }
 
   return true;

--- a/lib/zapier/validateFormRequestInput.ts
+++ b/lib/zapier/validateFormRequestInput.ts
@@ -1,4 +1,5 @@
 import { prisma } from 'db';
+import { getDatabaseDetails } from 'lib/pages/GetDatabaseDetails';
 import { DatabasePageNotFoundError } from 'lib/public-api/errors';
 import { InvalidInputError } from 'lib/utilities/errors';
 import { isUUID } from 'lib/utilities/strings';
@@ -30,13 +31,7 @@ export async function validateFormRequestInput({
     throw new InvalidInputError(`Invalid database id: ${databaseId}`);
   }
 
-  const board = await prisma.block.findFirst({
-    where: {
-      type: 'board',
-      id: databaseId,
-      spaceId
-    }
-  });
+  const board = await getDatabaseDetails({ spaceId, idOrPath: databaseId });
 
   if (!board) {
     throw new DatabasePageNotFoundError(databaseId);

--- a/pages/api/v1/databases/[id]/form.ts
+++ b/pages/api/v1/databases/[id]/form.ts
@@ -40,7 +40,12 @@ export async function createFormResponse(req: NextApiRequest, res: NextApiRespon
   const body: AddFormResponseInput = req.body;
 
   await validateFormRequestInput({ spaceId, databaseId: id as string, data: body });
-  const card = await createFormResposnseCard({ spaceId, databaseId: id as string, data: body, userId: req.botUser.id });
+  const card = await createFormResposnseCard({
+    spaceId,
+    databaseIdorPath: id as string,
+    data: body,
+    userId: req.botUser.id
+  });
 
   return res.status(201).json(card);
 }

--- a/pages/api/v1/databases/[id]/form.ts
+++ b/pages/api/v1/databases/[id]/form.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
 import { onError, onNoMatch, requireApiKey } from 'lib/middleware';
-import { createFormResposnseCard } from 'lib/pages/createFormResposnseCard';
+import { createFormResposnseCard } from 'lib/pages/createFormResponseCard';
 import type { AddFormResponseInput } from 'lib/zapier/interfaces';
 import { validateFormRequestInput } from 'lib/zapier/validateFormRequestInput';
 

--- a/pages/api/v1/databases/[id]/form.ts
+++ b/pages/api/v1/databases/[id]/form.ts
@@ -1,0 +1,60 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
+
+import { prisma } from 'db';
+import { onError, onNoMatch, requireApiKey, requireKeys } from 'lib/middleware';
+import { setupPermissionsAfterPageCreated } from 'lib/permissions/pages';
+import type { Page } from 'lib/public-api';
+import { validateCreationData, DatabasePageNotFoundError, createDatabaseCardPage } from 'lib/public-api';
+import { InvalidInputError } from 'lib/utilities/errors';
+import { isUUID } from 'lib/utilities/strings';
+import type { AddFormResponseInput } from 'lib/zapier/interfaces';
+import { parseFormData } from 'lib/zapier/parseFormData';
+import { validateFormRequestInput } from 'lib/zapier/validateFormRequestInput';
+
+const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+
+handler
+  .use(requireApiKey)
+  .use(requireKeys(['all_responses'], 'body'))
+  .post(createFormResponse);
+
+/**
+ * @swagger
+ * /databases/{databaseId}/pages:
+ *   post:
+ *     summary: Create a new page in the database
+ *     description: Create a new page with a title and any set of values from the custom properties in your database.
+ *     requestBody:
+ *       content:
+ *          application/json:
+ *             schema:
+ *                $ref: '#/components/schemas/PageQuery'
+ *     responses:
+ *       200:
+ *         description: Summary of the database
+ *         content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/Page'
+ */
+export async function createFormResponse(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const spaceId = req.authorizedSpaceId;
+  const body: AddFormResponseInput = req.body;
+
+  await validateFormRequestInput({ spaceId, databaseId: id as string, data: body });
+  const formResponses = parseFormData(req.body);
+  console.log('🔥qqq', formResponses);
+
+  const card = await createDatabaseCardPage({
+    ...req.body,
+    boardId: id,
+    spaceId,
+    createdBy: req.botUser.id
+  });
+
+  return res.status(201).json({} as any);
+}
+
+export default handler;

--- a/pages/api/v1/databases/[id]/form.ts
+++ b/pages/api/v1/databases/[id]/form.ts
@@ -1,35 +1,31 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
-import { prisma } from 'db';
-import { onError, onNoMatch, requireApiKey, requireKeys } from 'lib/middleware';
-import { setupPermissionsAfterPageCreated } from 'lib/permissions/pages';
-import type { Page } from 'lib/public-api';
-import { validateCreationData, DatabasePageNotFoundError, createDatabaseCardPage } from 'lib/public-api';
-import { InvalidInputError } from 'lib/utilities/errors';
-import { isUUID } from 'lib/utilities/strings';
+import { onError, onNoMatch, requireApiKey } from 'lib/middleware';
+import { createFormResposnseCard } from 'lib/pages/createFormResposnseCard';
 import type { AddFormResponseInput } from 'lib/zapier/interfaces';
-import { parseFormData } from 'lib/zapier/parseFormData';
 import { validateFormRequestInput } from 'lib/zapier/validateFormRequestInput';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-handler
-  .use(requireApiKey)
-  .use(requireKeys(['all_responses'], 'body'))
-  .post(createFormResponse);
+handler.use(requireApiKey).post(createFormResponse);
 
 /**
  * @swagger
- * /databases/{databaseId}/pages:
+ * /databases/{databaseId}/form:
  *   post:
- *     summary: Create a new page in the database
- *     description: Create a new page with a title and any set of values from the custom properties in your database.
+ *     summary: Create a new form response in the database.
+ *     description: Create a new form response with array of questions and answers.
  *     requestBody:
  *       content:
  *          application/json:
  *             schema:
- *                $ref: '#/components/schemas/PageQuery'
+ *               oneOf:
+ *                  - type: object
+ *                    properties:
+ *                       all_responses:
+ *                          type: string
+ *                  - type: string
  *     responses:
  *       200:
  *         description: Summary of the database
@@ -44,17 +40,9 @@ export async function createFormResponse(req: NextApiRequest, res: NextApiRespon
   const body: AddFormResponseInput = req.body;
 
   await validateFormRequestInput({ spaceId, databaseId: id as string, data: body });
-  const formResponses = parseFormData(req.body);
-  console.log('🔥qqq', formResponses);
+  const card = await createFormResposnseCard({ spaceId, databaseId: id as string, data: body, userId: req.botUser.id });
 
-  const card = await createDatabaseCardPage({
-    ...req.body,
-    boardId: id,
-    spaceId,
-    createdBy: req.botUser.id
-  });
-
-  return res.status(201).json({} as any);
+  return res.status(201).json(card);
 }
 
 export default handler;

--- a/pages/api/v1/databases/[id]/form.ts
+++ b/pages/api/v1/databases/[id]/form.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
 import { onError, onNoMatch, requireApiKey } from 'lib/middleware';
-import { createFormResposnseCard } from 'lib/pages/createFormResponseCard';
+import { createFormResponseCard } from 'lib/pages/createFormResponseCard';
 import type { AddFormResponseInput } from 'lib/zapier/interfaces';
 import { validateFormRequestInput } from 'lib/zapier/validateFormRequestInput';
 
@@ -40,7 +40,7 @@ export async function createFormResponse(req: NextApiRequest, res: NextApiRespon
   const body: AddFormResponseInput = req.body;
 
   await validateFormRequestInput({ spaceId, databaseIdOrPath: id as string, data: body });
-  const card = await createFormResposnseCard({
+  const card = await createFormResponseCard({
     spaceId,
     databaseIdorPath: id as string,
     data: body,

--- a/pages/api/v1/databases/[id]/form.ts
+++ b/pages/api/v1/databases/[id]/form.ts
@@ -39,7 +39,7 @@ export async function createFormResponse(req: NextApiRequest, res: NextApiRespon
   const spaceId = req.authorizedSpaceId;
   const body: AddFormResponseInput = req.body;
 
-  await validateFormRequestInput({ spaceId, databaseId: id as string, data: body });
+  await validateFormRequestInput({ spaceId, databaseIdOrPath: id as string, data: body });
   const card = await createFormResposnseCard({
     spaceId,
     databaseIdorPath: id as string,


### PR DESCRIPTION
Integration with typeform via zapier.

In zapier you need to add typeform block + zapier webhook.
Webhook needs action POST `https://app.charmverse.io/api/v1/databases/:dbIdOrPath:/form`

It will automatically map quesitons and answers for data from zapier:

<img width="1271" alt="Screenshot 2022-12-15 at 12 53 04" src="https://user-images.githubusercontent.com/5198394/207854456-7c2f0821-83da-4967-ac78-6f0c470798e3.png">
