### PR TITLE
copy emojis when copying callouts

### DIFF
--- a/components/common/CharmEditor/components/callout/callout.ts
+++ b/components/common/CharmEditor/components/callout/callout.ts
@@ -1,22 +1,47 @@
 import { NodeView, type BaseRawNodeSpec, type RawPlugins } from '@bangle.dev/core';
-
-import { spec as quoteSpec } from '../quote';
+import type { DOMOutputSpec, Node } from '@bangle.dev/pm';
+import type { MarkdownSerializerState } from 'prosemirror-markdown';
 
 const name = 'blockquote';
 
 const defaultIcon = '😃';
 
 export function spec(): BaseRawNodeSpec {
-  const _spec = quoteSpec();
-  _spec.name = 'blockquote';
-  _spec.schema.attrs = {
-    emoji: { default: defaultIcon },
-    track: { default: [] }
+  return {
+    type: 'node',
+    name,
+    schema: {
+      attrs: {
+        emoji: { default: defaultIcon },
+        track: { default: [] }
+      },
+      content: 'block*',
+      group: 'block',
+      defining: true,
+      draggable: false,
+      parseDOM: [
+        {
+          tag: 'blockquote.charm-callout',
+          getAttrs: (dom: any) => ({
+            emoji: dom.getAttribute('data-emoji')
+          })
+        }
+      ],
+      toDOM(node): DOMOutputSpec {
+        return ['blockquote', { class: 'charm-callout', 'data-emoji': node.attrs.emoji }, 0];
+      }
+    },
+    markdown: {
+      toMarkdown: (state: MarkdownSerializerState, node: Node) => {
+        state.wrapBlock('> ', null, node, () => state.renderContent(node));
+      },
+      parseMarkdown: {
+        blockquote: {
+          block: name
+        }
+      }
+    }
   };
-  if (_spec.markdown?.parseMarkdown) {
-    _spec.markdown.parseMarkdown.blockquote.block = name;
-  }
-  return _spec;
 }
 
 export function plugins(): RawPlugins {

--- a/components/common/CharmEditor/components/quote/quote.ts
+++ b/components/common/CharmEditor/components/quote/quote.ts
@@ -16,9 +16,9 @@ export function spec(): BaseRawNodeSpec {
       group: 'block',
       defining: true,
       draggable: false,
-      parseDOM: [{ tag: 'blockquote' }],
+      parseDOM: [{ tag: 'blockquote.charm-quote' }],
       toDOM: (): DOMOutputSpec => {
-        return ['blockquote', 0];
+        return ['blockquote', { class: 'charm-quote' }, 0];
       }
     },
     markdown: {

--- a/components/common/CharmEditor/components/tabIndent.tsx
+++ b/components/common/CharmEditor/components/tabIndent.tsx
@@ -12,7 +12,7 @@ export function spec(): RawSpecs {
       inline: true,
       group: 'inline',
       parseDOM: [{ tag: 'span.charm-tab' }],
-      toDOM: (): DOMOutputSpec => ['span', { className: 'charm-tab', style: 'white-space:pre' }, '\t'],
+      toDOM: (): DOMOutputSpec => ['span', { class: 'charm-tab', style: 'white-space:pre' }, '\t'],
       attrs: {}
     },
     markdown: {


### PR DESCRIPTION
in order to carry attributes when copying prosemirror components, we have to make sure they are mapped in toDOM and parseDOM