### PR TITLE
sanitize inputs for mentions

### DIFF
--- a/components/common/CharmEditor/components/mention/components/MentionSuggest.tsx
+++ b/components/common/CharmEditor/components/mention/components/MentionSuggest.tsx
@@ -10,6 +10,7 @@ import { usePages } from 'hooks/usePages';
 import type { Member } from 'lib/members/interfaces';
 import type { PageMeta } from 'lib/pages';
 import { safeScrollIntoViewIfNeeded } from 'lib/utilities/browser';
+import { sanitizeForRegex } from 'lib/utilities/strings';
 
 import type { PluginState as SuggestTooltipPluginState } from '../../@bangle.dev/tooltip/suggest-tooltip';
 import { hideSuggestionsTooltip } from '../../@bangle.dev/tooltip/suggest-tooltip';
@@ -41,22 +42,24 @@ function MentionSuggestMenu({ pluginKey }: { pluginKey: PluginKey }) {
     [view, pluginKey]
   );
 
+  const triggerTextRegex = sanitizeForRegex(triggerText).toLowerCase();
+
   const filterByUserCustomName = (member: Member) =>
     member.properties
       .find((prop) => prop.type === 'name')
       ?.value?.toString()
       .toLowerCase()
-      .match(triggerText.toLowerCase());
+      .match(triggerTextRegex);
 
   const filterByDiscordName = (member: Member) =>
     (member.profile?.social as Record<string, string>)?.discordUsername
       ?.toString()
       .toLowerCase()
-      .match(triggerText.toLowerCase());
+      .match(triggerTextRegex);
 
-  const filterByUsername = (member: Member) => member.username.toLowerCase().match(triggerText.toLowerCase());
+  const filterByUsername = (member: Member) => member.username.toLowerCase().match(triggerTextRegex);
 
-  const filterByPath = (member: Member) => member.path?.toLowerCase().match(triggerText.toLowerCase());
+  const filterByPath = (member: Member) => member.path?.toLowerCase().match(triggerTextRegex);
 
   const filteredMembers =
     triggerText.length !== 0

--- a/lib/utilities/__tests__/strings.spec.ts
+++ b/lib/utilities/__tests__/strings.spec.ts
@@ -1,0 +1,9 @@
+import { sanitizeForRegex } from '../strings';
+
+describe('strings', () => {
+  it('should sanitize parenthesis in a regex', () => {
+    const text = sanitizeForRegex('test (test)');
+
+    expect(text).toBe('test \\(test\\)');
+  });
+});

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -128,3 +128,8 @@ export function conditionalPlural({ word = '', count = 1 }: { word: string; coun
 export function lowerCaseEqual(firstString?: string | null, secondString?: string | null): boolean {
   return firstString?.toLowerCase() === secondString?.toLowerCase();
 }
+
+// ref: https://stackoverflow.com/questions/6300183/sanitize-string-of-regex-characters-before-regexp-build
+export function sanitizeForRegex(string: string) {
+  return string.replace(/[#-.]|[[-^]|[?|{}]/g, '\\$&');
+}


### PR DESCRIPTION
Type "@(" into the charm editor to cause a crash. The "@" triggers the mention logic, and the "(" becomes invalid input to `String.match()`, the error is "SyntaxError: unterminated parenthetical".