### PR TITLE
make opensea embed look decent inside of column

### DIFF
--- a/components/common/CharmEditor/components/nft/NFTNodeView.tsx
+++ b/components/common/CharmEditor/components/nft/NFTNodeView.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
 import Script from 'next/script';
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import BlockAligner from '../BlockAligner';
 import { MediaSelectionPopup } from '../common/MediaSelectionPopup';
@@ -22,11 +22,13 @@ const StyledContainer = styled.div`
   nft-card-front > div {
     background: transparent !important;
   }
+  width: 100%;
 `;
 
 export function NFTNodeView({ deleteNode, readOnly, node, updateAttrs }: CharmNodeViewProps) {
   const ref = useRef<HTMLDivElement>(null);
   const attrs = node.attrs as Partial<NodeAttrs>;
+  const [width, setWidth] = useState(0);
 
   useEffect(() => {
     if (ref.current) {
@@ -34,6 +36,14 @@ export function NFTNodeView({ deleteNode, readOnly, node, updateAttrs }: CharmNo
     }
   }, [ref.current]);
 
+  useLayoutEffect(() => {
+    const elm = ref.current;
+    if (elm) {
+      setTimeout(() => {
+        setWidth(elm.clientWidth);
+      }, 0);
+    }
+  }, [ref.current]);
   // If there are no source for the node, return the image select component
   if (!attrs.contract) {
     if (readOnly) {
@@ -65,15 +75,23 @@ export function NFTNodeView({ deleteNode, readOnly, node, updateAttrs }: CharmNo
     }
   }
 
+  const forceMobile = width < 400; // default width of document is 700
+
   return (
-    <>
+    <div>
       <Script id='opensea-script' src={widgetJS} />
       <BlockAligner onDelete={deleteNode}>
         <StyledContainer ref={ref}>
           {/* @ts-ignore nft-card element is from OpenSea */}
-          <nft-card contractAddress={attrs.contract} tokenId={attrs.token} width='100%'></nft-card>
+          <nft-card
+            contractAddress={attrs.contract}
+            orientationMode='manual' // it has to be manual since we set width
+            vertical={forceMobile === true ? true : undefined}
+            tokenId={attrs.token}
+            width='100%'
+          />
         </StyledContainer>
       </BlockAligner>
-    </>
+    </div>
   );
 }

--- a/components/common/CharmEditor/components/nft/NFTNodeView.tsx
+++ b/components/common/CharmEditor/components/nft/NFTNodeView.tsx
@@ -38,6 +38,7 @@ export function NFTNodeView({ deleteNode, readOnly, node, updateAttrs }: CharmNo
   useLayoutEffect(() => {
     const elm = ref.current;
     if (elm) {
+      // add a timeout so that the DOM has a chance to render. Otherwise clientWidth is 0
       setTimeout(() => {
         setWidth(elm.clientWidth);
       }, 0);

--- a/components/common/CharmEditor/components/nft/NFTNodeView.tsx
+++ b/components/common/CharmEditor/components/nft/NFTNodeView.tsx
@@ -22,7 +22,6 @@ const StyledContainer = styled.div`
   nft-card-front > div {
     background: transparent !important;
   }
-  width: 100%;
 `;
 
 export function NFTNodeView({ deleteNode, readOnly, node, updateAttrs }: CharmNodeViewProps) {

--- a/components/common/CharmEditor/components/nft/NFTNodeView.tsx
+++ b/components/common/CharmEditor/components/nft/NFTNodeView.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
 import Script from 'next/script';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import BlockAligner from '../BlockAligner';
 import { MediaSelectionPopup } from '../common/MediaSelectionPopup';
@@ -30,20 +30,16 @@ export function NFTNodeView({ deleteNode, readOnly, node, updateAttrs }: CharmNo
   const [width, setWidth] = useState(0);
 
   useEffect(() => {
-    if (ref.current) {
-      setCSSOverrides(ref.current);
-    }
-  }, [ref.current]);
-
-  useLayoutEffect(() => {
     const elm = ref.current;
     if (elm) {
+      setCSSOverrides(elm);
       // add a timeout so that the DOM has a chance to render. Otherwise clientWidth is 0
       setTimeout(() => {
         setWidth(elm.clientWidth);
       }, 0);
     }
   }, [ref.current]);
+
   // If there are no source for the node, return the image select component
   if (!attrs.contract) {
     if (readOnly) {


### PR DESCRIPTION
The props for Opensea's embed are just confusing. even setting a 'width' triggers 'manual' orientation mode. And you can't actually set 'maxWidth' even though it is a prop on Typescript. I just found that this combination works well enough.

preview:
<img width="809" alt="image" src="https://user-images.githubusercontent.com/305398/208553582-fd24131c-80dc-48a7-a792-5e1feb563b44.png">
