### PR TITLE
Remove proposal editor as an option in default page permission presets

### DIFF
--- a/components/settings/roles/components/SpacePermissions/components/DefaultPagePermissions.tsx
+++ b/components/settings/roles/components/SpacePermissions/components/DefaultPagePermissions.tsx
@@ -4,6 +4,7 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
 import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
+import type { PagePermissionLevel } from '@prisma/client';
 import { bindMenu, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
 import { useState } from 'react';
 
@@ -14,12 +15,12 @@ import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import useIsAdmin from 'hooks/useIsAdmin';
 import { usePreventReload } from 'hooks/usePreventReload';
 import { useSpaces } from 'hooks/useSpaces';
-import type { PagePermissionLevelWithoutCustom } from 'lib/permissions/pages/page-permission-interfaces';
 import { permissionLevels } from 'lib/permissions/pages/page-permission-mapping';
+import { typedKeys } from 'lib/utilities/objects';
 
-const pagePermissionDescriptions: Record<PagePermissionLevelWithoutCustom, string> = {
+type PagePermissionLevelWithoutCustomAndProposalEditor = Exclude<PagePermissionLevel, 'custom' | 'proposal_editor'>;
+const pagePermissionDescriptions: Record<PagePermissionLevelWithoutCustomAndProposalEditor, string> = {
   full_access: 'Workspace members can edit pages, share them with the public and manage permissions.',
-  proposal_editor: 'Proposal editors can edit proposals and share them with the public.',
   editor: 'Workspace members can edit but not share pages.',
   view_comment: 'Workspace members can view and comment on pages.',
   view: 'Workspace members can only view pages.'
@@ -36,9 +37,10 @@ export default function DefaultSpacePagePermissions() {
   const popupState = usePopupState({ variant: 'popover', popupId: 'workspace-default-page-permission' });
 
   // Permission states
-  const [selectedPagePermission, setSelectedPagePermission] = useState<PagePermissionLevelWithoutCustom>(
-    (space?.defaultPagePermissionGroup as PagePermissionLevelWithoutCustom) ?? 'full_access'
-  );
+  const [selectedPagePermission, setSelectedPagePermission] =
+    useState<PagePermissionLevelWithoutCustomAndProposalEditor>(
+      (space?.defaultPagePermissionGroup as PagePermissionLevelWithoutCustomAndProposalEditor) ?? 'full_access'
+    );
   const [defaultPublicPages, setDefaultPublicPages] = useState<boolean>(space?.defaultPublicPages ?? false);
 
   const settingsChanged =
@@ -108,7 +110,7 @@ export default function DefaultSpacePagePermissions() {
               sx: { width: 300 }
             }}
           >
-            {(Object.keys(pagePermissionDescriptions) as PagePermissionLevelWithoutCustom[]).map((permissionLevel) => {
+            {typedKeys(pagePermissionDescriptions).map((permissionLevel) => {
               const permissionLevelLabel = permissionLevels[permissionLevel];
               const isSelected = selectedPagePermission === permissionLevel;
               const description = pagePermissionDescriptions[permissionLevel];

--- a/lib/permissions/pages/page-permission-interfaces.ts
+++ b/lib/permissions/pages/page-permission-interfaces.ts
@@ -15,8 +15,6 @@ export type PageOperationType = keyof typeof PageOperationEnum;
 
 export type PagePermissionLevelType = keyof typeof PagePermissionLevel;
 
-export type PagePermissionLevelWithoutCustom = Exclude<PagePermissionLevelType, 'custom'>;
-
 export type IPagePermissionFlags = UserPermissionFlags<PageOperationType>;
 
 /**

--- a/lib/spaces/__tests__/setSpaceDefaultPagePermission.spec.ts
+++ b/lib/spaces/__tests__/setSpaceDefaultPagePermission.spec.ts
@@ -2,6 +2,7 @@ import type { Space } from '@prisma/client';
 import { v4 } from 'uuid';
 
 import { SpaceNotFoundError } from 'lib/public-api';
+import { InvalidInputError } from 'lib/utilities/errors';
 import { ExpectedAnError } from 'testing/errors';
 import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
 
@@ -33,5 +34,25 @@ describe('setSpaceDefaultPagePermission', () => {
       spaceId: space.id
     });
     expect(spaceWithPermission.defaultPagePermissionGroup).toBe('view');
+  });
+
+  // We don't yet use the custom option
+  it('Should fail to set the default page permission level to custom', async () => {
+    await expect(
+      setSpaceDefaultPagePermission({
+        defaultPagePermissionGroup: 'custom',
+        spaceId: space.id
+      })
+    ).rejects.toBeInstanceOf(InvalidInputError);
+  });
+
+  // Proposal editor preset is only used for proposals
+  it('Should fail to set the default page permission level to proposal_editor', async () => {
+    await expect(
+      setSpaceDefaultPagePermission({
+        defaultPagePermissionGroup: 'proposal_editor',
+        spaceId: space.id
+      })
+    ).rejects.toBeInstanceOf(InvalidInputError);
   });
 });

--- a/lib/spaces/setSpaceDefaultPagePermission.ts
+++ b/lib/spaces/setSpaceDefaultPagePermission.ts
@@ -2,6 +2,7 @@ import type { PagePermissionLevel, Space } from '@prisma/client';
 
 import { prisma } from 'db';
 import { SpaceNotFoundError } from 'lib/public-api';
+import { InvalidInputError } from 'lib/utilities/errors';
 
 export async function setSpaceDefaultPagePermission({
   spaceId,
@@ -10,6 +11,10 @@ export async function setSpaceDefaultPagePermission({
   spaceId: string;
   defaultPagePermissionGroup: PagePermissionLevel;
 }): Promise<Space> {
+  if (defaultPagePermissionGroup === 'custom' || defaultPagePermissionGroup === 'proposal_editor') {
+    throw new InvalidInputError(`Invalid default page permission group: ${defaultPagePermissionGroup}`);
+  }
+
   const space = await prisma.space.findUnique({
     where: {
       id: spaceId


### PR DESCRIPTION
Prevents space page permissions preset from being proposal editor or custom

Also filters out proposal editor option in the page permissions UI