### PR TITLE
Persist ens

### DIFF
--- a/charmClient/apis/blockchainApi.ts
+++ b/charmClient/apis/blockchainApi.ts
@@ -1,8 +1,13 @@
 import * as http from 'adapters/http';
 import type { NftData } from 'lib/blockchain/interfaces';
+import type { LoggedInUser } from 'models';
 
 export class BlockchainApi {
   listNFTs(userId: string) {
     return http.GET<NftData[]>(`/api/nft/list/${userId}`);
+  }
+
+  refreshENSName(address: string) {
+    return http.POST<LoggedInUser>(`/api/nft/refresh-ensname`, { address });
   }
 }

--- a/components/profile/components/IdentityModal.tsx
+++ b/components/profile/components/IdentityModal.tsx
@@ -5,7 +5,7 @@ import TelegramIcon from '@mui/icons-material/Telegram';
 import { Box, SvgIcon, Tooltip, Typography } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import type { IdentityType } from '@prisma/client';
-import { isAddress } from 'ethers/lib/utils';
+import { utils } from 'ethers';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
@@ -16,7 +16,7 @@ import LoadingComponent from 'components/common/LoadingComponent';
 import { DialogTitle, Modal } from 'components/common/Modal';
 import { useUser } from 'hooks/useUser';
 import randomName from 'lib/utilities/randomName';
-import { shortenHex } from 'lib/utilities/strings';
+import { shortWalletAddress } from 'lib/utilities/strings';
 import DiscordIcon from 'public/images/discord_logo.svg';
 import MetamaskIcon from 'public/images/metamask.svg';
 
@@ -116,14 +116,13 @@ function IdentityModal(props: IdentityModalProps) {
       <Box mb={2}>
         {identityTypes.map((item: IntegrationModel) => {
           const usernameToDisplay = item.type === 'RandomName' ? generatedName : item.username;
-          const isValidAddress = item.type === 'Wallet' && isAddress(item.username);
           return (
             <Integration
               isInUse={item.type === 'RandomName' && generatedName !== item.username ? false : item.isInUse}
               icon={item.icon}
               identityType={item.type}
               name={item.type === 'RandomName' ? 'Anonymous' : item.type}
-              username={isValidAddress ? shortenHex(item.username) : usernameToDisplay}
+              username={shortWalletAddress(usernameToDisplay)}
               secondaryUserName={item.secondaryUserName}
               useIntegration={() => save(usernameToDisplay, item.type)}
               action={
@@ -133,7 +132,7 @@ function IdentityModal(props: IdentityModalProps) {
                       <RefreshIcon fontSize='small' />
                     </IconButton>
                   </Tooltip>
-                ) : isValidAddress ? (
+                ) : utils.isAddress(usernameToDisplay) ? (
                   <Tooltip
                     //                    disableHoverListener
                     onMouseEnter={(e) => e.stopPropagation()}

--- a/components/profile/components/Integration.tsx
+++ b/components/profile/components/Integration.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import CheckIcon from '@mui/icons-material/Check';
-import { Box, Divider, Grid, Typography } from '@mui/material';
+import { Box, Divider, Grid, Tooltip, Typography } from '@mui/material';
 import type { IdentityType } from '@prisma/client';
 import type { ReactNode } from 'react';
 
@@ -20,27 +20,34 @@ type IntegrationProps = {
   identityType: IdentityType;
   name: string;
   username: string;
+  // Used for showing email for Google accounts, and wallet address for shortened wallet names or ens names
+  secondaryUserName?: string;
   useIntegration: (id: string, type: IdentityType) => void;
 };
 
 function Integration(props: IntegrationProps) {
-  const { isInUse, icon, action, username, name, identityType, useIntegration } = props;
+  const { isInUse, icon, action, username, name, identityType, useIntegration, secondaryUserName } = props;
 
   return (
     <Grid container>
-      <Grid item xs={10}>
+      <Grid container item xs={10}>
         <Box py={2} px={1}>
           <Box display='flex' gap={1} alignItems='flex-end' mb={1}>
             {icon}
             {/* use smaller font size fofr wallet addresses and larger strings */}
-            <Typography component='span' fontSize={username.length < 40 ? '1.4em' : '.9em'} fontWeight={700}>
-              {username}
-              {action}
-            </Typography>
+            <Tooltip title={secondaryUserName ?? ''}>
+              <Typography component='span' fontSize={username.length < 40 ? '1.4em' : '.9em'} fontWeight={700}>
+                {username}
+                {action}
+              </Typography>
+            </Tooltip>
           </Box>
           <IntegrationName variant='caption'>{name}</IntegrationName>
         </Box>
+
+        <Grid item></Grid>
       </Grid>
+
       <Grid item container direction='column' xs={2}>
         <Box display='flex' alignItems='center' justifyContent='flex-end' height='100%'>
           {isInUse ? (

--- a/components/profile/components/UserDetails/UserDetails.tsx
+++ b/components/profile/components/UserDetails/UserDetails.tsx
@@ -74,13 +74,11 @@ function EditIconContainer({
 }
 
 function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) {
-  const { account } = useWeb3AuthSig();
   const isPublic = isPublicUser(user);
   const { data: userDetails, mutate } = useSWRImmutable(`/userDetails/${user.id}/${isPublic}`, () => {
     return isPublic ? user.profile : charmClient.getUserDetails();
   });
 
-  const ENSName = useENSName(account);
   const [isPersonalLinkCopied, setIsPersonalLinkCopied] = useState(false);
 
   const descriptionModalState = usePopupState({ variant: 'popover', popupId: 'description-modal' });
@@ -110,15 +108,14 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
     }
 
     const types: IntegrationModel[] = [];
-    if (user?.wallets.length !== 0) {
+    user.wallets.forEach((wallet) => {
       types.push({
         type: 'Wallet',
-        username: ENSName || user.wallets[0].address,
+        username: wallet.ensname ?? wallet.address,
         isInUse: user.identityType === 'Wallet',
         icon: getIdentityIcon('Wallet')
       });
-    }
-
+    });
     if (user?.discordUser && user.discordUser.account) {
       const discordAccount = user.discordUser.account as Partial<DiscordAccount>;
       types.push({
@@ -242,8 +239,7 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
             isOpen={identityModalState.isOpen}
             close={identityModalState.close}
             save={(id: string, identityType: IdentityType) => {
-              const username: string = identityType === 'Wallet' ? ENSName || shortenHex(id) : id;
-              handleUserUpdate({ username, identityType });
+              handleUserUpdate({ id, identityType });
             }}
             identityTypes={identityTypes}
             identityType={(user?.identityType || 'Wallet') as IdentityType}

--- a/components/profile/components/UserDetails/UserDetails.tsx
+++ b/components/profile/components/UserDetails/UserDetails.tsx
@@ -23,6 +23,7 @@ import useENSName from 'hooks/useENSName';
 import { useWeb3AuthSig } from 'hooks/useWeb3AuthSig';
 import type { DiscordAccount } from 'lib/discord/getDiscordAccount';
 import { hasNftAvatar } from 'lib/users/hasNftAvatar';
+import randomName from 'lib/utilities/randomName';
 import { shortenHex } from 'lib/utilities/strings';
 import type { LoggedInUser } from 'models';
 import type { PublicUser } from 'pages/api/public/profile/[userId]';
@@ -112,7 +113,9 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
       types.push({
         type: 'Wallet',
         username: wallet.ensname ?? wallet.address,
-        isInUse: user.identityType === 'Wallet',
+        secondaryUserName: wallet.address,
+        isInUse:
+          user.identityType === 'Wallet' && (user.username === wallet.ensname || user.username === wallet.address),
         icon: getIdentityIcon('Wallet')
       });
     });
@@ -121,6 +124,7 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
       types.push({
         type: 'Discord',
         username: discordAccount.username || '',
+        secondaryUserName: `${discordAccount.username} #${discordAccount.discriminator}`,
         isInUse: user.identityType === 'Discord',
         icon: getIdentityIcon('Discord')
       });
@@ -139,7 +143,7 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
     if (user) {
       types.push({
         type: 'RandomName',
-        username: user.identityType === 'RandomName' && user.username ? user.username : '',
+        username: user.identityType === 'RandomName' && user.username ? user.username : randomName(),
         isInUse: user.identityType === 'RandomName',
         icon: getIdentityIcon('RandomName')
       });
@@ -149,6 +153,7 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
       types.push({
         type: 'Google',
         username: acc.name,
+        secondaryUserName: acc.email,
         icon: getIdentityIcon('Google'),
         isInUse: user.identityType === 'Google' && user.username === acc.name
       });
@@ -238,12 +243,11 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
           <IdentityModal
             isOpen={identityModalState.isOpen}
             close={identityModalState.close}
-            save={(id: string, identityType: IdentityType) => {
-              handleUserUpdate({ id, identityType });
+            save={(username: string, identityType: IdentityType) => {
+              handleUserUpdate({ username, identityType });
             }}
             identityTypes={identityTypes}
             identityType={(user?.identityType || 'Wallet') as IdentityType}
-            username={user?.username || ''}
           />
           <DescriptionModal
             isOpen={descriptionModalState.isOpen}

--- a/components/profile/components/UserDetails/UserDetails.tsx
+++ b/components/profile/components/UserDetails/UserDetails.tsx
@@ -6,6 +6,7 @@ import { Box, Divider, Grid, Stack, Tooltip, Typography } from '@mui/material';
 import type { IconButtonProps } from '@mui/material/IconButton';
 import IconButton from '@mui/material/IconButton';
 import type { IdentityType } from '@prisma/client';
+import { utils } from 'ethers';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import { useMemo, useState } from 'react';
@@ -19,8 +20,6 @@ import { TimezoneDisplay } from 'components/members/components/TimezoneDisplay';
 import { useUpdateProfileAvatar } from 'components/profile/components/UserDetails/hooks/useUpdateProfileAvatar';
 import { useUserDetails } from 'components/profile/components/UserDetails/hooks/useUserDetails';
 import Avatar from 'components/settings/workspace/LargeAvatar';
-import useENSName from 'hooks/useENSName';
-import { useWeb3AuthSig } from 'hooks/useWeb3AuthSig';
 import type { DiscordAccount } from 'lib/discord/getDiscordAccount';
 import { hasNftAvatar } from 'lib/users/hasNftAvatar';
 import randomName from 'lib/utilities/randomName';
@@ -191,7 +190,9 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
           <Grid item>
             <EditIconContainer data-testid='edit-identity' readOnly={readOnly} onClick={identityModalState.open}>
               {user && !isPublicUser(user) && getIdentityIcon(user.identityType as IdentityType)}
-              <Typography variant='h1'>{user?.username}</Typography>
+              <Typography variant='h1'>
+                {utils.isAddress(user?.username) ? shortenHex(user.username) : user.username}
+              </Typography>
             </EditIconContainer>
           </Grid>
           {!readOnly && (

--- a/components/profile/components/UserDetails/UserDetails.tsx
+++ b/components/profile/components/UserDetails/UserDetails.tsx
@@ -6,7 +6,6 @@ import { Box, Divider, Grid, Stack, Tooltip, Typography } from '@mui/material';
 import type { IconButtonProps } from '@mui/material/IconButton';
 import IconButton from '@mui/material/IconButton';
 import type { IdentityType } from '@prisma/client';
-import { utils } from 'ethers';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import { useMemo, useState } from 'react';
@@ -23,7 +22,7 @@ import Avatar from 'components/settings/workspace/LargeAvatar';
 import type { DiscordAccount } from 'lib/discord/getDiscordAccount';
 import { hasNftAvatar } from 'lib/users/hasNftAvatar';
 import randomName from 'lib/utilities/randomName';
-import { shortenHex } from 'lib/utilities/strings';
+import { matchWalletAddress, shortWalletAddress } from 'lib/utilities/strings';
 import type { LoggedInUser } from 'models';
 import type { PublicUser } from 'pages/api/public/profile/[userId]';
 import type { TelegramAccount } from 'pages/api/telegram/connect';
@@ -109,12 +108,13 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
 
     const types: IntegrationModel[] = [];
     user.wallets.forEach((wallet) => {
+      const address = wallet.address;
+
       types.push({
         type: 'Wallet',
         username: wallet.ensname ?? wallet.address,
-        secondaryUserName: wallet.address,
-        isInUse:
-          user.identityType === 'Wallet' && (user.username === wallet.ensname || user.username === wallet.address),
+        secondaryUserName: address,
+        isInUse: user.identityType === 'Wallet' && matchWalletAddress(user.username, wallet),
         icon: getIdentityIcon('Wallet')
       });
     });
@@ -190,9 +190,7 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
           <Grid item>
             <EditIconContainer data-testid='edit-identity' readOnly={readOnly} onClick={identityModalState.open}>
               {user && !isPublicUser(user) && getIdentityIcon(user.identityType as IdentityType)}
-              <Typography variant='h1'>
-                {utils.isAddress(user?.username) ? shortenHex(user.username) : user.username}
-              </Typography>
+              <Typography variant='h1'>{shortWalletAddress(user.username)}</Typography>
             </EditIconContainer>
           </Grid>
           {!readOnly && (

--- a/hooks/useMembers.tsx
+++ b/hooks/useMembers.tsx
@@ -1,4 +1,3 @@
-import { utils } from 'ethers';
 import type { ReactNode } from 'react';
 import { createContext, useContext, useMemo } from 'react';
 import type { KeyedMutator } from 'swr';
@@ -6,7 +5,7 @@ import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import type { Member } from 'lib/members/interfaces';
-import { shortenHex } from 'lib/utilities/strings';
+import { shortWalletAddress } from 'lib/utilities/strings';
 
 import { useCurrentSpace } from './useCurrentSpace';
 
@@ -28,12 +27,9 @@ export function MembersProvider({ children }: { children: ReactNode }) {
     () => {
       return charmClient.members.getMembers(space!.id).then((_members) =>
         _members.map((m) => {
-          const { username } = m;
-
-          if (m.identityType === 'Wallet' && utils.isAddress(username)) {
-            m.username = shortenHex(username);
+          if (m.identityType === 'Wallet') {
+            m.username = shortWalletAddress(m.username);
           }
-
           return m;
         })
       );

--- a/hooks/useMembers.tsx
+++ b/hooks/useMembers.tsx
@@ -1,3 +1,4 @@
+import { utils } from 'ethers';
 import type { ReactNode } from 'react';
 import { createContext, useContext, useMemo } from 'react';
 import type { KeyedMutator } from 'swr';
@@ -5,6 +6,7 @@ import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import type { Member } from 'lib/members/interfaces';
+import { shortenHex } from 'lib/utilities/strings';
 
 import { useCurrentSpace } from './useCurrentSpace';
 
@@ -24,7 +26,17 @@ export function MembersProvider({ children }: { children: ReactNode }) {
   const { data: members, mutate: mutateMembers } = useSWR(
     () => (space ? `members/${space?.id}` : null),
     () => {
-      return charmClient.members.getMembers(space!.id);
+      return charmClient.members.getMembers(space!.id).then((_members) =>
+        _members.map((m) => {
+          const { username } = m;
+
+          if (m.identityType === 'Wallet' && utils.isAddress(username)) {
+            m.username = shortenHex(username);
+          }
+
+          return m;
+        })
+      );
     }
   );
 

--- a/lib/blockchain/__tests__/refreshENSName.spec.ts
+++ b/lib/blockchain/__tests__/refreshENSName.spec.ts
@@ -1,9 +1,9 @@
-import { Wallet } from 'ethers';
 import { v4 } from 'uuid';
 
 import { prisma } from 'db';
 import { sessionUserRelations } from 'lib/session/config';
 import { InvalidInputError, MissingDataError } from 'lib/utilities/errors';
+import { randomETHWalletAddress } from 'testing/generate-stubs';
 
 import { refreshENSName } from '../refreshENSName';
 
@@ -27,13 +27,15 @@ function checkEnsName(address: string, ensName: string) {
 
 describe('refreshENSName', () => {
   it('should retrieve the ENS Name and assign it to the user wallet', async () => {
-    const address = Wallet.createRandom().address.toLowerCase();
+    const address = randomETHWalletAddress();
     const user = await prisma.user.create({
       data: {
         username: address,
         wallets: {
           create: {
-            address
+            address,
+            // We want to ensure this old value is overwritten
+            ensname: `testname-${v4()}.eth`
           }
         }
       }
@@ -47,8 +49,8 @@ describe('refreshENSName', () => {
     expect(checkEnsName(address, userAfterRefresh.wallets[0].ensname as string)).toBe(true);
   });
 
-  it('should update the main current user displayname if identity type is "Wallet" it does not match the ENS Name', async () => {
-    const address = Wallet.createRandom().address.toLowerCase();
+  it('should update the current users used displayname to the ENS name if identity type is "Wallet" and current address matches the ENS Name', async () => {
+    const address = randomETHWalletAddress();
     const user = await prisma.user.create({
       data: {
         username: address,
@@ -65,17 +67,18 @@ describe('refreshENSName', () => {
       address
     });
 
-    expect(checkEnsName(address, userAfterRefresh.wallets[0].ensname as string)).toBe(true);
+    expect(checkEnsName(address, userAfterRefresh.username)).toBe(true);
   });
 
   it('should perform a no-op if no ENS name is found', async () => {
-    const address = `ignore-${Wallet.createRandom().address.toLowerCase()}`;
+    const address = `ignore-${randomETHWalletAddress()}`;
     const user = await prisma.user.create({
       data: {
         username: address,
         wallets: {
           create: {
-            address
+            address,
+            ensname: `testname-${v4()}.eth`
           }
         }
       },
@@ -87,20 +90,24 @@ describe('refreshENSName', () => {
       address
     });
 
-    expect(userAfterRefresh.wallets[0].ensname).toBeNull();
+    expect(userAfterRefresh).toMatchObject(expect.objectContaining(user));
   });
 
   it('should throw an error if userID or wallet address is not provided', async () => {
     await expect(refreshENSName({ userId: '123', address: null as any })).rejects.toBeInstanceOf(InvalidInputError);
 
-    await expect(refreshENSName({ userId: null as any, address: v4() })).rejects.toBeInstanceOf(InvalidInputError);
+    await expect(refreshENSName({ userId: null as any, address: randomETHWalletAddress() })).rejects.toBeInstanceOf(
+      InvalidInputError
+    );
   });
 
   it('should throw an error if the user does not exist', async () => {
-    await expect(refreshENSName({ userId: v4(), address: v4() })).rejects.toBeInstanceOf(MissingDataError);
+    await expect(refreshENSName({ userId: v4(), address: randomETHWalletAddress() })).rejects.toBeInstanceOf(
+      MissingDataError
+    );
   });
   it('should throw an error if this user does not have a matching wallet address or ENSname', async () => {
-    const address = `${Wallet.createRandom().address}`;
+    const address = `${randomETHWalletAddress()}`;
     const user = await prisma.user.create({
       data: {
         username: 'Example User',
@@ -109,7 +116,7 @@ describe('refreshENSName', () => {
     });
 
     await expect(refreshENSName({ userId: user.id, address })).rejects.toBeInstanceOf(MissingDataError);
-    await expect(refreshENSName({ userId: user.id, address: `test-${v4()}.ft` })).rejects.toBeInstanceOf(
+    await expect(refreshENSName({ userId: user.id, address: randomETHWalletAddress() })).rejects.toBeInstanceOf(
       MissingDataError
     );
   });

--- a/lib/blockchain/__tests__/refreshENSName.spec.ts
+++ b/lib/blockchain/__tests__/refreshENSName.spec.ts
@@ -3,6 +3,7 @@ import { v4 } from 'uuid';
 import { prisma } from 'db';
 import { sessionUserRelations } from 'lib/session/config';
 import { InvalidInputError, MissingDataError } from 'lib/utilities/errors';
+import { shortWalletAddress } from 'lib/utilities/strings';
 import { randomETHWalletAddress } from 'testing/generate-stubs';
 
 import { refreshENSName } from '../refreshENSName';
@@ -65,6 +66,26 @@ describe('refreshENSName', () => {
     const userAfterRefresh = await refreshENSName({
       userId: user.id,
       address
+    });
+
+    expect(checkEnsName(address, userAfterRefresh.username)).toBe(true);
+  });
+  it('should support the shortened address as a lookup for the users ENS Name', async () => {
+    const address = randomETHWalletAddress();
+    const user = await prisma.user.create({
+      data: {
+        username: address,
+        wallets: {
+          create: {
+            address
+          }
+        }
+      }
+    });
+
+    const userAfterRefresh = await refreshENSName({
+      userId: user.id,
+      address: shortWalletAddress(address)
     });
 
     expect(checkEnsName(address, userAfterRefresh.username)).toBe(true);

--- a/lib/blockchain/__tests__/refreshENSName.spec.ts
+++ b/lib/blockchain/__tests__/refreshENSName.spec.ts
@@ -1,0 +1,92 @@
+import { Wallet } from 'ethers';
+import { v4 } from 'uuid';
+
+import { prisma } from 'db';
+import { sessionUserRelations } from 'lib/session/config';
+import { InvalidInputError, MissingDataError } from 'lib/utilities/errors';
+
+import { refreshENSName } from '../refreshENSName';
+
+jest.mock('../getENSName', () => {
+  return {
+    getENSName: (address: string) => {
+      if (address.match('ignore')) {
+        return null;
+      }
+      return `testname-${address}.eth`;
+    }
+  };
+});
+afterAll(async () => {
+  jest.resetModules();
+});
+
+function checkEnsName(address: string, ensName: string) {
+  return ensName === `testname-${address}.eth`;
+}
+
+describe('refreshENSName', () => {
+  it('should retrieve the ENS Name and assign it to the user wallet', async () => {
+    const address = Wallet.createRandom().address.toLowerCase();
+    const user = await prisma.user.create({
+      data: {
+        username: address,
+        wallets: {
+          create: {
+            address
+          }
+        }
+      }
+    });
+
+    const userAfterRefresh = await refreshENSName({
+      userId: user.id,
+      address
+    });
+
+    expect(checkEnsName(address, userAfterRefresh.wallets[0].ensname as string)).toBe(true);
+  });
+
+  it('should perform a no-op if no ENS name is found', async () => {
+    const address = `ignore-${Wallet.createRandom().address.toLowerCase()}`;
+    const user = await prisma.user.create({
+      data: {
+        username: address,
+        wallets: {
+          create: {
+            address
+          }
+        }
+      },
+      include: sessionUserRelations
+    });
+
+    const userAfterRefresh = await refreshENSName({
+      userId: user.id,
+      address
+    });
+
+    expect(userAfterRefresh.wallets[0].ensname).toBeNull();
+  });
+
+  it('should throw an error if userID or wallet address is not provided', async () => {
+    await expect(refreshENSName({ userId: '123', address: null as any })).rejects.toBeInstanceOf(InvalidInputError);
+
+    await expect(refreshENSName({ userId: null as any, address: v4() })).rejects.toBeInstanceOf(InvalidInputError);
+  });
+
+  it('should throw an error if the user does not exist', async () => {
+    await expect(refreshENSName({ userId: v4(), address: v4() })).rejects.toBeInstanceOf(MissingDataError);
+  });
+  it('should throw an error if this user does not have a matching wallet address', async () => {
+    const address = `${Wallet.createRandom().address}`;
+    const user = await prisma.user.create({
+      data: {
+        username: 'Example User',
+        identityType: 'RandomName'
+      }
+    });
+
+    await expect(refreshENSName({ userId: user.id, address })).rejects.toBeInstanceOf(MissingDataError);
+  });
+});

--- a/lib/blockchain/getENSName.ts
+++ b/lib/blockchain/getENSName.ts
@@ -6,7 +6,7 @@ const providerKey = process.env.ALCHEMY_API_KEY;
 const providerUrl = `https://eth-mainnet.alchemyapi.io/v2/${providerKey}`;
 const provider = providerKey ? new ethers.providers.JsonRpcProvider(providerUrl) : null;
 
-export default function getENSName(address: string) {
+export function getENSName(address: string) {
   if (!provider) {
     log.warn('No api key provided for Alchemy');
     return null;

--- a/lib/blockchain/refreshENSName.ts
+++ b/lib/blockchain/refreshENSName.ts
@@ -1,0 +1,49 @@
+import { prisma } from 'db';
+import { getUserProfile } from 'lib/users/getUser';
+import { InvalidInputError, MissingDataError } from 'lib/utilities/errors';
+import type { LoggedInUser } from 'models';
+
+import { getENSName } from './getENSName';
+
+export type ENSUserNameRefresh = {
+  userId: string;
+  address: string;
+};
+
+export async function refreshENSName({ userId, address }: ENSUserNameRefresh): Promise<LoggedInUser> {
+  if (!userId || !address) {
+    throw new InvalidInputError('userId and walletAddress are required');
+  }
+
+  const lowerCaseAddress = address.toLowerCase();
+
+  const user = await prisma.user.findUnique({
+    where: {
+      id: userId
+    },
+    select: {
+      wallets: true
+    }
+  });
+
+  if (!user) {
+    throw new MissingDataError('User not found');
+  } else if (!user.wallets.some((w) => w.address === lowerCaseAddress)) {
+    throw new MissingDataError('No user wallet found with this address');
+  }
+
+  const ensName = await getENSName(address);
+
+  if (ensName) {
+    await prisma.userWallet.update({
+      where: {
+        address: lowerCaseAddress
+      },
+      data: {
+        ensname: ensName
+      }
+    });
+  }
+
+  return getUserProfile('id', userId);
+}

--- a/lib/session/config.ts
+++ b/lib/session/config.ts
@@ -50,7 +50,12 @@ export const sessionUserRelations = {
   discordUser: true,
   telegramUser: true,
   notificationState: true,
-  wallets: true,
+  wallets: {
+    select: {
+      address: true,
+      ensname: true
+    }
+  },
   unstoppableDomains: {
     select: {
       domain: true

--- a/lib/users/__tests__/createUser.spec.ts
+++ b/lib/users/__tests__/createUser.spec.ts
@@ -1,12 +1,40 @@
+import { Wallet } from 'ethers';
+import { v4 } from 'uuid';
+
+import { randomETHWalletAddress } from 'testing/generate-stubs';
+
 import { createUserFromWallet } from '../createUser';
 
+jest.mock('lib/blockchain/getENSName', () => {
+  return {
+    getENSName: (address: string) => {
+      if (address.match('ignore')) {
+        return null;
+      }
+      return `testname-${address}.eth`;
+    }
+  };
+});
+afterAll(async () => {
+  jest.resetModules();
+});
+
 describe('createUserFromWallet', () => {
-  it('should create the user with the lowercase version of their web3 address', async () => {
-    const address = '0x7240CD336aD076dFF51383b155F8bb38bdB3c98a';
+  it('should create the user with their web3 address as their username', async () => {
+    const address = `ignore-${Wallet.createRandom().address}`;
 
     const user = await createUserFromWallet({ address });
 
     expect(user.wallets.length).toBe(1);
     expect(user.wallets[0].address).toBe(address.toLowerCase());
+    expect(user.username).toBe(address.toLowerCase());
+  });
+  it('should assign the user ens name as their username automatically if this exists', async () => {
+    const address = randomETHWalletAddress();
+
+    const user = await createUserFromWallet({ address });
+
+    expect(user.wallets[0].ensname).toBe(`testname-${address}.eth`);
+    expect(user.username).toBe(`testname-${address}.eth`);
   });
 });

--- a/lib/users/__tests__/updateUsedIdentity.spec.ts
+++ b/lib/users/__tests__/updateUsedIdentity.spec.ts
@@ -138,6 +138,32 @@ describe('updateUsedIdentity', () => {
     expect(userAfterUpdate.identityType).toBe(`Wallet`);
   });
 
+  it('should update a user identity to their connected ENS name', async () => {
+    const ensname = `example-${v4()}.nft`;
+
+    const user = await prisma.user.create({
+      data: {
+        username: 'random-name',
+        identityType: 'RandomName',
+        wallets: {
+          create: {
+            address: v4(),
+            ensname
+          }
+        }
+      },
+      include: sessionUserRelations
+    });
+
+    const userAfterUpdate = await updateUsedIdentity(user.id, {
+      identityType: 'Wallet',
+      displayName: ensname
+    });
+
+    expect(userAfterUpdate.username).toBe(ensname);
+    expect(userAfterUpdate.identityType).toBe(`Wallet`);
+  });
+
   it('should update a user identity to their connected Unstoppable Domain', async () => {
     const user = await prisma.user.create({
       data: {

--- a/lib/users/__tests__/updateUsedIdentity.spec.ts
+++ b/lib/users/__tests__/updateUsedIdentity.spec.ts
@@ -3,6 +3,8 @@ import { v4 } from 'uuid';
 import { prisma } from 'db';
 import { sessionUserRelations } from 'lib/session/config';
 import { InsecureOperationError, InvalidInputError, MissingDataError } from 'lib/utilities/errors';
+import { shortWalletAddress } from 'lib/utilities/strings';
+import { randomETHWalletAddress } from 'testing/generate-stubs';
 
 import { updateUsedIdentity } from '../updateUsedIdentity';
 
@@ -115,14 +117,16 @@ describe('updateUsedIdentity', () => {
     expect(userWithGoogleAfterUpdate.identityType).toBe(`Google`);
   });
 
-  it('should update a user identity to their connected Wallet address', async () => {
+  it('should update a user identity to the short version of the specified Wallet address', async () => {
+    const address = randomETHWalletAddress();
+
     const user = await prisma.user.create({
       data: {
         username: 'random-name',
         identityType: 'RandomName',
         wallets: {
           create: {
-            address: `0x${v4()}`
+            address
           }
         }
       },
@@ -134,8 +138,23 @@ describe('updateUsedIdentity', () => {
       displayName: user.wallets[0].address
     });
 
-    expect(userAfterUpdate.username).toBe(user.wallets[0].address);
+    expect(userAfterUpdate.username).toBe(shortWalletAddress(user.wallets[0].address));
     expect(userAfterUpdate.identityType).toBe(`Wallet`);
+
+    // Reset identity
+    await updateUsedIdentity(user.id, {
+      identityType: 'RandomName',
+      displayName: 'random name'
+    });
+
+    // Make sure we support update using shortform version of address
+    const userAfterSecondUpdate = await updateUsedIdentity(user.id, {
+      identityType: 'Wallet',
+      displayName: shortWalletAddress(user.wallets[0].address)
+    });
+
+    expect(userAfterSecondUpdate.username).toBe(shortWalletAddress(user.wallets[0].address));
+    expect(userAfterSecondUpdate.identityType).toBe(`Wallet`);
   });
 
   it('should update a user identity to their connected ENS name', async () => {

--- a/lib/users/createUser.ts
+++ b/lib/users/createUser.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'ethers';
 import { v4 } from 'uuid';
 
 import { prisma } from 'db';
-import getENSName from 'lib/blockchain/getENSName';
+import { getENSName } from 'lib/blockchain/getENSName';
 import type { SignupAnalytics } from 'lib/metrics/mixpanel/interfaces/UserEvent';
 import { trackUserAction } from 'lib/metrics/mixpanel/trackUserAction';
 import { updateTrackUserProfile } from 'lib/metrics/mixpanel/updateTrackUserProfile';

--- a/lib/users/createUser.ts
+++ b/lib/users/createUser.ts
@@ -8,7 +8,7 @@ import { trackUserAction } from 'lib/metrics/mixpanel/trackUserAction';
 import { updateTrackUserProfile } from 'lib/metrics/mixpanel/updateTrackUserProfile';
 import { isProfilePathAvailable } from 'lib/profile/isProfilePathAvailable';
 import { sessionUserRelations } from 'lib/session/config';
-import { shortenHex } from 'lib/utilities/strings';
+import { shortenHex, shortWalletAddress } from 'lib/utilities/strings';
 import type { LoggedInUser } from 'models';
 
 import { getUserProfile } from './getUser';
@@ -24,7 +24,7 @@ export async function createUserFromWallet(
     return user;
   } catch (error) {
     const ens: string | null = await getENSName(address);
-    const userPath = shortenHex(address).replace('…', '-');
+    const userPath = shortWalletAddress(address).replace('…', '-');
     const isUserPathAvailable = await isProfilePathAvailable(userPath);
 
     const newUser = await prisma.user.create({

--- a/lib/users/updateUsedIdentity.ts
+++ b/lib/users/updateUsedIdentity.ts
@@ -33,7 +33,7 @@ export async function updateUsedIdentity(userId: string, identityUpdate?: Identi
 
     if (identityType === 'Google' && !user.googleAccounts.some((acc) => acc.name === displayName)) {
       throw new InsecureOperationError(`User ${userId} does not have a Google account with name ${displayName}`);
-    } else if (identityType === 'Discord' && (!user.discordUser?.account as any)?.username !== displayName) {
+    } else if (identityType === 'Discord' && (user.discordUser?.account as any)?.username !== displayName) {
       throw new InsecureOperationError(`User ${userId} does not have a Discord account with name ${displayName}`);
     } else if (
       identityType === 'UnstoppableDomain' &&

--- a/lib/users/updateUsedIdentity.ts
+++ b/lib/users/updateUsedIdentity.ts
@@ -41,12 +41,8 @@ export async function updateUsedIdentity(userId: string, identityUpdate?: Identi
     ) {
       throw new InsecureOperationError(`User ${userId} does not have an Unstoppable Domain with name ${displayName}`);
     } else if (identityType === 'Wallet') {
-      if (!user.wallets.some((wallet) => wallet.address === displayName)) {
-        const ensNames = await Promise.all(user.wallets.map((wallet) => getENSName(wallet.address)));
-        const matchingENSNameFound = ensNames.some((ensName) => ensName === displayName);
-        if (!matchingENSNameFound) {
-          throw new InsecureOperationError(`User ${userId} does not have a wallet with address ${displayName}`);
-        }
+      if (!user.wallets.some((wallet) => wallet.address === displayName || wallet.ensname === displayName)) {
+        throw new InsecureOperationError(`User ${userId} does not have wallet with address or ensname ${displayName}`);
       }
     } else if (identityType === 'Telegram' && (user.telegramUser?.account as any)?.username !== displayName) {
       throw new InsecureOperationError(`User ${userId} does not have a Telegram account with name ${displayName}`);

--- a/lib/users/updateUsedIdentity.ts
+++ b/lib/users/updateUsedIdentity.ts
@@ -5,6 +5,7 @@ import { prisma } from 'db';
 import { getENSName } from 'lib/blockchain/getENSName';
 import { sessionUserRelations } from 'lib/session/config';
 import { InsecureOperationError, InvalidInputError } from 'lib/utilities/errors';
+import { matchWalletAddress, shortWalletAddress } from 'lib/utilities/strings';
 import type { LoggedInUser } from 'models';
 
 import { getUserProfile } from './getUser';
@@ -41,7 +42,7 @@ export async function updateUsedIdentity(userId: string, identityUpdate?: Identi
     ) {
       throw new InsecureOperationError(`User ${userId} does not have an Unstoppable Domain with name ${displayName}`);
     } else if (identityType === 'Wallet') {
-      if (!user.wallets.some((wallet) => wallet.address === displayName || wallet.ensname === displayName)) {
+      if (!user.wallets.some((wallet) => matchWalletAddress(displayName, wallet))) {
         throw new InsecureOperationError(`User ${userId} does not have wallet with address or ensname ${displayName}`);
       }
     } else if (identityType === 'Telegram' && (user.telegramUser?.account as any)?.username !== displayName) {
@@ -53,7 +54,7 @@ export async function updateUsedIdentity(userId: string, identityUpdate?: Identi
         id: userId
       },
       data: {
-        username: displayName,
+        username: shortWalletAddress(displayName),
         identityType
       },
       include: sessionUserRelations

--- a/lib/users/updateUsedIdentity.ts
+++ b/lib/users/updateUsedIdentity.ts
@@ -2,7 +2,7 @@ import type { Prisma } from '@prisma/client';
 import { IdentityType } from '@prisma/client';
 
 import { prisma } from 'db';
-import getENSName from 'lib/blockchain/getENSName';
+import { getENSName } from 'lib/blockchain/getENSName';
 import { sessionUserRelations } from 'lib/session/config';
 import { InsecureOperationError, InvalidInputError } from 'lib/utilities/errors';
 import type { LoggedInUser } from 'models';

--- a/lib/utilities/__tests__/strings.spec.ts
+++ b/lib/utilities/__tests__/strings.spec.ts
@@ -1,6 +1,9 @@
+import type { UserWallet } from '@prisma/client';
+import { utils, Wallet } from 'ethers';
+
 import { randomETHWalletAddress } from 'testing/generate-stubs';
 
-import { conditionalPlural, sanitizeForRegex, shortenHex, shortWalletAddress } from '../strings';
+import { conditionalPlural, matchWalletAddress, sanitizeForRegex, shortenHex, shortWalletAddress } from '../strings';
 
 describe('strings', () => {
   it('should sanitize parenthesis in a regex', () => {
@@ -31,11 +34,80 @@ describe('shortWalletAddress', () => {
     expect(shortAddress.length).toBe(11);
   });
 
+  it('should return a lowercase string', () => {
+    const addressWithMixedCase = Wallet.createRandom().address;
+
+    const shortAddress = shortWalletAddress(addressWithMixedCase);
+    expect(!!shortAddress.match(/[A-Z]/)).toBe(false);
+  });
+
   it('should leave other strings unchanged', () => {
     const ignoredString = 'test';
     const invalidWallet = '0x123abc';
 
     expect(shortWalletAddress(ignoredString)).toBe(ignoredString);
     expect(shortWalletAddress(invalidWallet)).toBe(invalidWallet);
+  });
+});
+describe('matchShortAddress', () => {
+  it('should return true if the first argument is a valid short version of the wallet address', () => {
+    const address = randomETHWalletAddress();
+    const shortAddress = shortWalletAddress(address);
+
+    expect(shortAddress.length).toBeLessThan(address.length);
+
+    expect(matchWalletAddress(shortAddress, address)).toBe(true);
+  });
+
+  it('should support a wallet as input, allowing comparison with ensname', () => {
+    const address = randomETHWalletAddress();
+    const ensname = 'test-name.eth';
+
+    const wallet: Pick<UserWallet, 'address' | 'ensname'> = {
+      address,
+      ensname
+    };
+
+    const shortAddress = shortWalletAddress(address);
+
+    expect(matchWalletAddress(shortAddress, wallet)).toBe(true);
+    expect(matchWalletAddress(ensname, wallet)).toBe(true);
+    expect(matchWalletAddress(address, wallet)).toBe(true);
+
+    // Quick test to ensure that wallet doesn't give bad results
+    expect(matchWalletAddress(randomETHWalletAddress(), wallet)).toBe(false);
+  });
+
+  it('should return true if the first argument is a short, or full lower / mixed case version of the wallet address', () => {
+    const address = randomETHWalletAddress();
+
+    const withMixedCase = utils.getAddress(address);
+
+    const shortAddress = shortWalletAddress(address);
+
+    expect(address !== withMixedCase).toBe(true);
+
+    expect(matchWalletAddress(shortAddress, address)).toBe(true);
+    expect(matchWalletAddress(shortAddress, withMixedCase)).toBe(true);
+    expect(matchWalletAddress(withMixedCase, address)).toBe(true);
+    expect(matchWalletAddress(address, address)).toBe(true);
+  });
+
+  it('should return false if these do not match', () => {
+    const address = randomETHWalletAddress();
+    const shortAddress = shortWalletAddress(address).slice(0, 5);
+    expect(matchWalletAddress(shortAddress, address)).toBe(false);
+  });
+
+  it('should return false if the second argument is not a valid wallet address', () => {
+    const address = randomETHWalletAddress();
+
+    const alteredAddress = address.slice(0, 20);
+
+    expect(matchWalletAddress(address, alteredAddress)).toBe(false);
+  });
+  it('should return false if the input is undefined', () => {
+    expect(matchWalletAddress('123', undefined as any)).toBe(false);
+    expect(matchWalletAddress(null as any, null as any)).toBe(false);
   });
 });

--- a/lib/utilities/__tests__/strings.spec.ts
+++ b/lib/utilities/__tests__/strings.spec.ts
@@ -1,4 +1,6 @@
-import { conditionalPlural, sanitizeForRegex } from '../strings';
+import { randomETHWalletAddress } from 'testing/generate-stubs';
+
+import { conditionalPlural, sanitizeForRegex, shortenHex, shortWalletAddress } from '../strings';
 
 describe('strings', () => {
   it('should sanitize parenthesis in a regex', () => {
@@ -18,5 +20,22 @@ describe('conditionalPlural', () => {
 
   it('should return plural if provided and the number is not 1', () => {
     expect(conditionalPlural({ word: 'Identity', count: 2, plural: 'Identities' })).toBe('Identities');
+  });
+});
+
+describe('shortWalletAddress', () => {
+  it('should shorten valid wallet addresses', () => {
+    const address = randomETHWalletAddress();
+    const shortAddress = shortWalletAddress(address);
+    expect(shortAddress).toBe(shortenHex(address));
+    expect(shortAddress.length).toBe(11);
+  });
+
+  it('should leave other strings unchanged', () => {
+    const ignoredString = 'test';
+    const invalidWallet = '0x123abc';
+
+    expect(shortWalletAddress(ignoredString)).toBe(ignoredString);
+    expect(shortWalletAddress(invalidWallet)).toBe(invalidWallet);
   });
 });

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -1,3 +1,4 @@
+import { utils } from 'ethers';
 import { validate } from 'uuid';
 
 export function fancyTrim(_text: string = '', maxLength: number = 40) {
@@ -137,4 +138,14 @@ export function lowerCaseEqual(firstString?: string | null, secondString?: strin
 // ref: https://stackoverflow.com/questions/6300183/sanitize-string-of-regex-characters-before-regexp-build
 export function sanitizeForRegex(string: string) {
   return string.replace(/[#-.]|[[-^]|[?|{}]/g, '\\$&');
+}
+
+/**
+ * Shortens valid wallet addresses, leaves other strings unchanged
+ */
+export function shortWalletAddress(string: string): string {
+  if (utils.isAddress(string)) {
+    return shortenHex(string);
+  }
+  return string;
 }

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -1,3 +1,4 @@
+import type { UserWallet } from '@prisma/client';
 import { utils } from 'ethers';
 import { validate } from 'uuid';
 
@@ -145,7 +146,28 @@ export function sanitizeForRegex(string: string) {
  */
 export function shortWalletAddress(string: string): string {
   if (utils.isAddress(string)) {
-    return shortenHex(string);
+    return shortenHex(string).toLowerCase();
   }
   return string;
+}
+
+/**
+ * Tie a wallet address to a short address, or its mixed case format
+ */
+export function matchWalletAddress(
+  address1: string,
+  address2: string | Pick<UserWallet, 'address' | 'ensname'>
+): boolean {
+  if (!address1 || !address2) {
+    return false;
+  }
+  const ensname = typeof address2 === 'string' ? null : address2.ensname;
+
+  if (ensname === address1) {
+    return true;
+  }
+
+  const baseAddress = typeof address2 === 'string' ? address2 : address2.address;
+
+  return shortWalletAddress(address1) === shortWalletAddress(baseAddress);
 }

--- a/models/User.ts
+++ b/models/User.ts
@@ -7,7 +7,8 @@ import type {
   TelegramUser,
   UnstoppableDomain,
   User,
-  UserNotificationState
+  UserNotificationState,
+  UserWallet
 } from '@prisma/client';
 
 interface NestedMemberships {
@@ -17,7 +18,7 @@ interface NestedMemberships {
 export interface LoggedInUser extends User {
   favorites: { pageId: string }[];
   spaceRoles: (SpaceRole & NestedMemberships)[];
-  wallets: { address: string }[];
+  wallets: Pick<UserWallet, 'address' | 'ensname'>[];
   unstoppableDomains: Pick<UnstoppableDomain, 'domain'>[];
   googleAccounts: Pick<GoogleAccount, 'email' | 'name'>[];
   ensName?: string;

--- a/pages/api/google/disconnect-account.ts
+++ b/pages/api/google/disconnect-account.ts
@@ -4,7 +4,6 @@ import nc from 'next-connect';
 import type { DisconnectGoogleAccountRequest } from 'lib/google/disconnectGoogleAccount';
 import { disconnectGoogleAccount } from 'lib/google/disconnectGoogleAccount';
 import { onError, onNoMatch, requireKeys } from 'lib/middleware';
-import { saveSession } from 'lib/middleware/saveSession';
 import { withSessionRoute } from 'lib/session/withSession';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
@@ -17,8 +16,6 @@ async function disconnectGoogleAccountController(req: NextApiRequest, res: NextA
   const disconnectRequest = { ...req.body, userId: req.session.user.id } as DisconnectGoogleAccountRequest;
 
   const loggedInUser = await disconnectGoogleAccount(disconnectRequest);
-
-  await saveSession({ req, userId: loggedInUser.id });
 
   res.status(200).send(loggedInUser);
 }

--- a/pages/api/nft/refresh-ensname.ts
+++ b/pages/api/nft/refresh-ensname.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
+
+import type { ENSUserNameRefresh } from 'lib/blockchain/refreshENSName';
+import { refreshENSName } from 'lib/blockchain/refreshENSName';
+import { onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
+import { withSessionRoute } from 'lib/session/withSession';
+
+const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+
+handler
+  .use(requireUser)
+  .use(requireKeys<ENSUserNameRefresh>(['address'], 'body'))
+  .post(refreshENSNameController);
+
+async function refreshENSNameController(req: NextApiRequest, res: NextApiResponse) {
+  const { address } = req.body as ENSUserNameRefresh;
+
+  const updatedUser = await refreshENSName({ userId: req.session.user.id, address });
+
+  res.status(200).json(updatedUser);
+}
+
+export default withSessionRoute(handler);

--- a/pages/api/profile/index.ts
+++ b/pages/api/profile/index.ts
@@ -78,10 +78,6 @@ async function getUser(req: NextApiRequest, res: NextApiResponse<LoggedInUser | 
 
   const profile = await getUserProfile('id', req.session.user.id);
 
-  if (!profile) {
-    return handleNoProfile(req, res);
-  }
-
   // Clean up the anonymous id if the user has a profile
   if (req.session.anonymousUserId) {
     req.session.anonymousUserId = undefined;

--- a/pages/api/profile/index.ts
+++ b/pages/api/profile/index.ts
@@ -1,10 +1,8 @@
-import type { User } from '@prisma/client';
 import Cookies from 'cookies';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 import { v4 } from 'uuid';
 
-import { prisma } from 'db';
 import { updateGuildRolesForUser } from 'lib/guild-xyz/server/updateGuildRolesForUser';
 import { updateTrackUserProfile } from 'lib/metrics/mixpanel/updateTrackUserProfile';
 import { extractSignupAnalytics } from 'lib/metrics/mixpanel/utilsSignup';
@@ -13,12 +11,10 @@ import type { SignupCookieType } from 'lib/metrics/userAcquisition/interfaces';
 import { signupCookieNames } from 'lib/metrics/userAcquisition/interfaces';
 import { onError, onNoMatch, requireUser } from 'lib/middleware';
 import { requireWalletSignature } from 'lib/middleware/requireWalletSignature';
-import { sessionUserRelations } from 'lib/session/config';
 import { withSessionRoute } from 'lib/session/withSession';
 import { createUserFromWallet } from 'lib/users/createUser';
 import { getUserProfile } from 'lib/users/getUser';
 import { updateUserProfile } from 'lib/users/updateUserProfile';
-import { DataNotFoundError, InsecureOperationError, MissingDataError } from 'lib/utilities/errors';
 import type { LoggedInUser } from 'models';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });

--- a/pages/api/telegram/disconnect.ts
+++ b/pages/api/telegram/disconnect.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
 import { prisma } from 'db';
-import getENSName from 'lib/blockchain/getENSName';
+import { getENSName } from 'lib/blockchain/getENSName';
 import type { DiscordAccount } from 'lib/discord/getDiscordAccount';
 import { InvalidStateError, onError, onNoMatch, requireUser } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';

--- a/prisma/migrations/20221226132047_add_wallet_ensname/migration.sql
+++ b/prisma/migrations/20221226132047_add_wallet_ensname/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[ensname]` on the table `UserWallet` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "UserWallet" ADD COLUMN     "ensname" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserWallet_ensname_key" ON "UserWallet"("ensname");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -455,6 +455,7 @@ model User {
 model UserWallet {
   address String @unique
   userId  String @db.Uuid
+  ensname String? @unique
   user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])

--- a/scripts/updateUserIdentity.ts
+++ b/scripts/updateUserIdentity.ts
@@ -1,5 +1,5 @@
 import { IdentityType } from '@prisma/client';
-import getENSName from 'lib/blockchain/getENSName';
+import {getENSName} from 'lib/blockchain/getENSName';
 import { DiscordAccount } from 'lib/discord/getDiscordAccount';
 import log from 'lib/log';
 import { shortenHex } from 'lib/utilities/strings';

--- a/testing/__tests__/generateStubs.spec.ts
+++ b/testing/__tests__/generateStubs.spec.ts
@@ -1,0 +1,14 @@
+import { utils } from 'ethers';
+
+import { randomETHWalletAddress } from 'testing/generate-stubs';
+
+describe('randomETHWalletAddress', () => {
+  it('should return a random lowercase ETH wallet address', () => {
+    const address = randomETHWalletAddress();
+    // Lowercase check
+    expect(address).toBe(address.toLowerCase());
+
+    // Address validity check
+    expect(utils.isAddress(address)).toBe(true);
+  });
+});

--- a/testing/generate-stubs.ts
+++ b/testing/generate-stubs.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@prisma/client';
+import { Wallet } from 'ethers';
 import { v4 } from 'uuid';
 
 import type { SubmissionContent } from 'lib/applications/interfaces';
@@ -60,4 +61,7 @@ export function generateSubmissionContent(): SubmissionContent {
       '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"My submission and all of its content"}]}]}',
     walletAddress: '0x123456789'
   };
+}
+export function randomETHWalletAddress() {
+  return Wallet.createRandom().address.toLowerCase();
 }


### PR DESCRIPTION
This PR adds some cleanup for ENS and identity selection

- User can trigger manual refresh of their wallet address, to fetch the ENS Name.

- We don't lookup ENS anymore when you switch identities, this removes the long delay when switching to wallet identity

- When adding a user wallet to an existing account, or creating a new account, we refresh their ENS

- We now always save the exact wallet address as username to the back-end. Responsibility for shortening the address is done in presentation layer (so we can always match the username to a wallet address they are allowed to have)

- Also added "secondary" username concept, so the selector modal shows more details as tooltip for each ID ( address for ENS name, email for Google, and username + discriminator number for Discord)