### PR TITLE
Don't show the error message since user already has visual feedback

### DIFF
--- a/components/common/TokenGateForm/TokenGateForm.tsx
+++ b/components/common/TokenGateForm/TokenGateForm.tsx
@@ -103,8 +103,6 @@ export default function TokenGateForm({
         setTokenGateResult(verifyResult);
         if (verifyResult.canJoinSpace) {
           showMessage('Verification succeeded.', 'success');
-        } else {
-          showMessage('Verification failed.', 'warning');
         }
       })
       .finally(() => setIsVerifyingGates(false));


### PR DESCRIPTION
Fixes a small issue, where visiting a Token Gate form you can't pass through would give a mysterious "Verification Failed" message, which wasn't great UX