### PR TITLE
fix auto adjustment of height for embeds

### DIFF
--- a/components/common/CharmEditor/components/Resizable/HorizontalResizer.tsx
+++ b/components/common/CharmEditor/components/Resizable/HorizontalResizer.tsx
@@ -16,17 +16,19 @@ interface ResizerProps {
 }
 
 function Resizer(props: ResizerProps) {
-  const height = props.aspectRatio ? props.width / props.aspectRatio : 0;
+  const width = Math.min(props.width, props.maxWidth || Infinity);
+  const height = props.aspectRatio ? width / props.aspectRatio : 0;
+
   return (
     <ResizableContainer>
       <ResizableBox
         onResize={props.onResize}
-        width={props.width}
+        width={width}
         // @ts-ignore - HACK: give a garbage value to height so react-resizable will not try to calculate it
         height={height || ''}
         resizeHandles={['w', 'e']}
         onResizeStop={props.onResizeStop}
-        minConstraints={[props.minWidth, Infinity]}
+        minConstraints={[props.minWidth, 10]}
         maxConstraints={
           props.maxWidth
             ? [props.maxWidth, props.aspectRatio ? props.maxWidth / props.aspectRatio : Infinity]


### PR DESCRIPTION
According to Andy, videos used to auto-adjust their height when added to columns. I did change the component that handles youtube embeds when we added Mux from 'iframe' to 'video', but I checked that PR and it looks like I kept all the same logic... 
anyways, I tested this with image embeds as well which also uses Resizable component.