### PR TITLE
Dont delete user that's logged in

### DIFF
--- a/lib/discord/__tests__/disconnectDiscordAccount.spec.ts
+++ b/lib/discord/__tests__/disconnectDiscordAccount.spec.ts
@@ -35,28 +35,6 @@ describe('disconnectdiscordAccount', () => {
     expect(userAfterDisconnect.username).toEqual(walletAddress);
     expect(userAfterDisconnect.discordUser).toBeNull();
   });
-
-  it('should mark the user as deleted if the discord Account was their only identity', async () => {
-    const user = await prisma.user.create({
-      data: {
-        username: 'Test user',
-        discordUser: {
-          create: {
-            discordId: v4(),
-            account: {}
-          }
-        }
-      },
-      include: sessionUserRelations
-    });
-
-    const userAfterDisconnect = await disconnectDiscordAccount({
-      userId: user.id
-    });
-
-    expect(userAfterDisconnect.deletedAt).toBeInstanceOf(Date);
-  });
-
   it('should update the users username and identity type to another connected identity, after deleting Discord account', async () => {
     const walletAddress = `0x${v4()}`;
 

--- a/lib/discord/disconnectDiscordAccount.ts
+++ b/lib/discord/disconnectDiscordAccount.ts
@@ -1,6 +1,5 @@
 import { prisma } from 'db';
 import { sessionUserRelations } from 'lib/session/config';
-import { softDeleteUserWithoutConnectableIdentities } from 'lib/users/softDeleteUserWithoutConnectableIdentities';
 import { updateUsedIdentity } from 'lib/users/updateUsedIdentity';
 import { InvalidInputError, MissingDataError } from 'lib/utilities/errors';
 import type { LoggedInUser } from 'models';
@@ -37,5 +36,5 @@ export async function disconnectDiscordAccount({ userId }: DisconnectDiscordRequ
     }
   });
 
-  await updateUsedIdentity(user.id);
+  return updateUsedIdentity(user.id);
 }

--- a/lib/discord/disconnectDiscordAccount.ts
+++ b/lib/discord/disconnectDiscordAccount.ts
@@ -38,6 +38,4 @@ export async function disconnectDiscordAccount({ userId }: DisconnectDiscordRequ
   });
 
   await updateUsedIdentity(user.id);
-
-  return softDeleteUserWithoutConnectableIdentities(user.id);
 }

--- a/lib/google/__tests__/disconnectGoogleAccount.spec.ts
+++ b/lib/google/__tests__/disconnectGoogleAccount.spec.ts
@@ -38,29 +38,6 @@ describe('disconnectGoogleAccount', () => {
     expect(userAfterDisconnect.googleAccounts.length).toEqual(0);
   });
 
-  it('should mark the user as deleted if the Google Account was their only identity', async () => {
-    const user = await prisma.user.create({
-      data: {
-        username: 'Test user',
-        googleAccounts: {
-          create: {
-            email: `test-${v4()}@example.com`,
-            name: 'Test User',
-            avatarUrl: 'https://example.com/avatar.png'
-          }
-        }
-      },
-      include: sessionUserRelations
-    });
-
-    const userAfterDisconnect = await disconnectGoogleAccount({
-      googleAccountEmail: user.googleAccounts[0].email,
-      userId: user.id
-    });
-
-    expect(userAfterDisconnect.deletedAt).toBeInstanceOf(Date);
-  });
-
   it('should update the users username and identity type to another connected identity, after deleting Google account', async () => {
     const user = await prisma.user.create({
       data: {

--- a/lib/google/connectGoogleAccount.ts
+++ b/lib/google/connectGoogleAccount.ts
@@ -63,13 +63,7 @@ export async function connectGoogleAccount({
     }
   });
   if (googleAccount && googleAccount.userId !== userId) {
-    const oldUser = await prisma.user.findUnique({
-      where: {
-        id: googleAccount.userId
-      },
-      include: sessionUserRelations
-    });
-    await softDeleteUserWithoutConnectableIdentities(oldUser as LoggedInUser);
+    await softDeleteUserWithoutConnectableIdentities({ userId: googleAccount.userId, newUserId: userId });
   }
   return getUserProfile('id', userId);
 }

--- a/lib/google/disconnectGoogleAccount.ts
+++ b/lib/google/disconnectGoogleAccount.ts
@@ -1,6 +1,5 @@
 import { prisma } from 'db';
 import { sessionUserRelations } from 'lib/session/config';
-import { softDeleteUserWithoutConnectableIdentities } from 'lib/users/softDeleteUserWithoutConnectableIdentities';
 import { updateUsedIdentity } from 'lib/users/updateUsedIdentity';
 import { InvalidInputError, MissingDataError } from 'lib/utilities/errors';
 import type { LoggedInUser } from 'models';
@@ -42,7 +41,5 @@ export async function disconnectGoogleAccount({
     }
   });
 
-  await updateUsedIdentity(user.id);
-
-  return softDeleteUserWithoutConnectableIdentities(user.id);
+  return updateUsedIdentity(user.id);
 }

--- a/lib/users/__tests__/softDeleteUserWithoutConnectableIdentities.spec.ts
+++ b/lib/users/__tests__/softDeleteUserWithoutConnectableIdentities.spec.ts
@@ -31,8 +31,7 @@ describe('softDeleteUserWithoutConnectableIdentities', () => {
             address: `0x${v4()}`
           }
         }
-      },
-      include: sessionUserRelations
+      }
     });
 
     await softDeleteUserWithoutConnectableIdentities({ userId: user.id, newUserId: 'aaa' });

--- a/lib/users/__tests__/softDeleteUserWithoutConnectableIdentities.spec.ts
+++ b/lib/users/__tests__/softDeleteUserWithoutConnectableIdentities.spec.ts
@@ -14,7 +14,10 @@ describe('softDeleteUserWithoutConnectableIdentities', () => {
       include: sessionUserRelations
     });
 
-    const updatedUser = await softDeleteUserWithoutConnectableIdentities(user);
+    await softDeleteUserWithoutConnectableIdentities({ userId: user.id, newUserId: 'aaa' });
+    const updatedUser = await prisma.user.findFirstOrThrow({
+      where: { id: user.id }
+    });
 
     expect(updatedUser.deletedAt).toBeInstanceOf(Date);
   });
@@ -32,8 +35,10 @@ describe('softDeleteUserWithoutConnectableIdentities', () => {
       include: sessionUserRelations
     });
 
-    const updatedUser = await softDeleteUserWithoutConnectableIdentities(user);
-
+    await softDeleteUserWithoutConnectableIdentities({ userId: user.id, newUserId: 'aaa' });
+    const updatedUser = await prisma.user.findFirstOrThrow({
+      where: { id: user.id }
+    });
     expect(updatedUser.deletedAt).toBeNull();
 
     expect(updatedUser).toMatchObject(expect.objectContaining(user));

--- a/lib/users/softDeleteUserWithoutConnectableIdentities.ts
+++ b/lib/users/softDeleteUserWithoutConnectableIdentities.ts
@@ -1,4 +1,5 @@
 import { prisma } from 'db';
+import log from 'lib/log';
 
 import { countConnectableIdentities } from './countConnectableIdentities';
 import { getUserProfile } from './getUser';
@@ -16,6 +17,7 @@ export async function softDeleteUserWithoutConnectableIdentities({
 
   // No identities left, mark user as deleted
   if (connectableIdentities === 0) {
+    log.warn(`Soft deleting user: ${user.id} with no connectable identities`);
     return prisma.user.update({
       where: {
         id: user.id

--- a/lib/users/softDeleteUserWithoutConnectableIdentities.ts
+++ b/lib/users/softDeleteUserWithoutConnectableIdentities.ts
@@ -1,14 +1,16 @@
 import { prisma } from 'db';
-import { sessionUserRelations } from 'lib/session/config';
-import type { LoggedInUser } from 'models';
 
 import { countConnectableIdentities } from './countConnectableIdentities';
 import { getUserProfile } from './getUser';
 
-export async function softDeleteUserWithoutConnectableIdentities(
-  userOrUserId: string | LoggedInUser
-): Promise<LoggedInUser> {
-  const user = typeof userOrUserId === 'string' ? await getUserProfile('id', userOrUserId) : userOrUserId;
+export async function softDeleteUserWithoutConnectableIdentities({
+  userId,
+  newUserId
+}: {
+  userId: string;
+  newUserId: string;
+}) {
+  const user = await getUserProfile('id', userId);
 
   const connectableIdentities = await countConnectableIdentities(user);
 
@@ -19,11 +21,9 @@ export async function softDeleteUserWithoutConnectableIdentities(
         id: user.id
       },
       data: {
-        deletedAt: new Date()
-      },
-      include: sessionUserRelations
+        deletedAt: new Date(),
+        username: `Replaced with user id: ${newUserId}`
+      }
     });
   }
-
-  return user;
 }


### PR DESCRIPTION
Deleting a user for an action they take which isn't 'delete my account' is a dangerous side-effect. It might be the cause of a recent issue we had with a user who could not log in (I think because he was marked 'deleted').

The original purpose of deletedAt is for when we need to delete a user that is not the one logged in. Instead of soft delete, the UI could just either prevent users from disconnecting too many accounts. If they somehow manage to get past that, it's not the end of the world to have no connected accounts, they can still connect another one.

This PR also adds the new 'softDelete' logic for discord auth
