### PR TITLE
Improvements to markdown import

### DIFF
--- a/pages/api/pages/import/[spaceId]/zipped.ts
+++ b/pages/api/pages/import/[spaceId]/zipped.ts
@@ -12,7 +12,6 @@ import { getPagePath } from 'lib/pages';
 import { pageMetaSelect } from 'lib/pages/server/getPageMeta';
 import { withSessionRoute } from 'lib/session/withSession';
 import { DataConflictError } from 'lib/utilities/errors';
-import { typedKeys } from 'lib/utilities/objects';
 
 export const config = {
   api: {
@@ -32,65 +31,81 @@ async function importZippedController(req: NextApiRequest, res: NextApiResponse)
   const { spaceId } = req.query;
   const { id: userId } = req.session.user;
 
-  req.on('data', async (chunk) => {
-    try {
-      const content = await unzip.loadAsync(chunk);
+  const chunks: Buffer[] = [];
 
-      const fileNames = typedKeys(content.files);
+  req
+    .on('readable', () => {
+      // read every incoming chunk. Every chunk is 64Kb data of Buffer
+      const chunk = req.read();
+      if (chunk) {
+        chunks.push(chunk);
+      }
+    })
+    .on('end', async () => {
+      try {
+        const buf = Buffer.concat(chunks);
+        const content = await unzip.loadAsync(buf);
 
-      const pagesToCreate: Prisma.PageCreateManyInput[] = [];
+        const fileNames = Object.keys(content.files);
 
-      for (const name of fileNames) {
-        if (name.toString().match('.md')) {
-          const file = content.files[name];
+        const pagesToCreate: Prisma.PageCreateManyInput[] = [];
 
-          const fileMarkdownContent = await file.async('string');
+        for (const name of fileNames) {
+          // include Markdown but exclude MACOSX files
+          const filename = name.split('/').pop() ?? '';
+          if (filename.endsWith('.md') && !filename.startsWith('.')) {
+            const file = content.files[name];
 
-          try {
-            const parsedContent = parseMarkdown(fileMarkdownContent);
-            const pageToCreate: Prisma.PageCreateManyInput = {
-              id: v4(),
-              title: name.toString().replace('.md', ''),
-              content: parsedContent,
-              contentText: fileMarkdownContent,
-              path: getPagePath(),
-              type: 'page',
-              updatedBy: userId,
-              createdBy: userId,
-              spaceId: spaceId as string
-            };
+            const fileMarkdownContent = await file.async('string');
 
-            pagesToCreate.push(pageToCreate);
-          } catch (err) {
-            // Do nothing
+            try {
+              const parsedContent = parseMarkdown(fileMarkdownContent);
+              const pageToCreate: Prisma.PageCreateManyInput = {
+                id: v4(),
+                title: name.replace('.md', ''),
+                content: parsedContent,
+                contentText: fileMarkdownContent,
+                hasContent: fileMarkdownContent.length > 0,
+                path: getPagePath(),
+                type: 'page',
+                updatedBy: userId,
+                createdBy: userId,
+                spaceId: spaceId as string
+              };
+
+              pagesToCreate.push(pageToCreate);
+            } catch (err) {
+              log.error('Unable to parse markdown file', { content: fileMarkdownContent, error: err, userId, spaceId });
+              // Do nothing
+            }
           }
         }
-      }
 
-      const createdPages: PageMeta[] = [];
+        const createdPages: PageMeta[] = [];
 
-      if (pagesToCreate.length > 0) {
-        await prisma.page.createMany({
-          data: pagesToCreate
-        });
-        const _createdPages = await prisma.page.findMany({
-          where: {
-            id: {
-              in: pagesToCreate.map((page) => page.id as string)
-            }
-          },
-          select: pageMetaSelect()
-        });
+        if (pagesToCreate.length > 0) {
+          await prisma.page.createMany({
+            data: pagesToCreate
+          });
+          const _createdPages = await prisma.page.findMany({
+            where: {
+              id: {
+                in: pagesToCreate.map((page) => page.id as string)
+              }
+            },
+            select: pageMetaSelect()
+          });
 
-        createdPages.push(..._createdPages);
+          createdPages.push(..._createdPages);
+        }
+        res.status(201).send(createdPages);
+      } catch (err) {
+        log.error('Unable to import pages', { error: err, userId, spaceId });
+        if (!res.headersSent) {
+          res.status(406).send(new DataConflictError('Unable to import pages'));
+        }
       }
-      res.status(201).send(createdPages);
-    } catch (err) {
-      if (!res.headersSent) {
-        res.status(406).send(new DataConflictError('Unable to import pages'));
-      }
-    }
-  });
+    });
 }
 
 export default withSessionRoute(handler);


### PR DESCRIPTION
I made some updates to make it work for the user zip that was shared with us: https://app.charmverse.io/charmverse/page-21850517986912954
- handles upload of larger zip files. `req.on('end')` was not working but I found a solution here: https://stackoverflow.com/questions/70084915/proxy-pass-multipart-in-nextjsalso-nodejs
- exclude the mirror files that MACOSX creates (these are present in the user's sample zip and were crashing the import, since the content included some weird characters. I found this SO post about the error: https://stackoverflow.com/questions/1347646/postgres-error-on-insert-error-invalid-byte-sequence-for-encoding-utf8-0x0). I wonder if there's a more robust approach than excluding files that start with "." :)