### PR TITLE
remove sort options on comments sidebar

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -17,7 +17,7 @@ import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useSWRConfig } from 'swr';
 
 import charmClient from 'charmClient';
-import CommentsSidebar from 'components/[pageId]/DocumentPage/components/CommentsSidebar';
+import { CommentsSidebar } from 'components/[pageId]/DocumentPage/components/CommentsSidebar';
 import { SuggestionsSidebar } from 'components/[pageId]/DocumentPage/components/SuggestionsSidebar';
 import * as codeBlock from 'components/common/CharmEditor/components/@bangle.dev/base-components/code-block';
 import { plugins as imagePlugins } from 'components/common/CharmEditor/components/@bangle.dev/base-components/image';


### PR DESCRIPTION
Users have been trained that comments are always sorted by position. Discord discussion: https://discord.com/channels/894960387743698944/1016422398964269076/1059582305770950756

Anyway, it's good to have less options + simpler UI and if people really want more features, they can ask for it :)