### PR TITLE
Fix CSV export encoding

### DIFF
--- a/components/common/BoardEditor/focalboard/src/csvExporter.ts
+++ b/components/common/BoardEditor/focalboard/src/csvExporter.ts
@@ -22,15 +22,14 @@ class CsvExporter {
     let csvContent = 'data:text/csv;charset=utf-8,';
 
     rows.forEach((row) => {
-      const encodedRow = row.join(',');
+      const encodedRow = row.map((str) => encodeURIComponent(str)).join(',');
       csvContent += `${encodedRow}\r\n`;
     });
 
     const filename = `${Utils.sanitizeFilename(viewToExport.title || 'Untitled')}.csv`;
-    const encodedUri = encodeURI(csvContent);
     const link = document.createElement('a');
     link.style.display = 'none';
-    link.setAttribute('href', encodedUri);
+    link.setAttribute('href', csvContent);
     link.setAttribute('download', filename);
     document.body.appendChild(link); // FireFox support
 
@@ -38,7 +37,7 @@ class CsvExporter {
 
     // TODO: Review if this is needed in the future, this is to fix the problem with linux webview links
     if (window.openInNewBrowser) {
-      window.openInNewBrowser(encodedUri);
+      window.openInNewBrowser(csvContent);
     }
 
     // TODO: Remove or reuse link


### PR DESCRIPTION
If you have a # symbol in the title of a card, the csv file will show everything until that point but not continue to export after that character.

That means:
If I have 3 cards in a database and the 2nd one has the title "My name is #elon", the result of the exported csv will be:

Name,Priority,Category,Assignee,System,Status
"Conduct first community call","Low",Development,"a65810e1-d20e-4c93-aa6c-50c479d9c1cf","","Completed"
"My name is

As you can see, the csv file looks broken and you can't import it anywhere.

Task:
https://app.charmverse.io/charmverse/page-16845167973892972