### PR TITLE
Simplify useUser and implement logout on wallet switch

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountySignupButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountySignupButton.tsx
@@ -9,6 +9,7 @@ import Button from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import PrimaryButton from 'components/common/PrimaryButton';
 import TokenGateForm from 'components/common/TokenGateForm';
+import { WalletSign } from 'components/login/WalletSign';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useMembers } from 'hooks/useMembers';
 import { useUser } from 'hooks/useUser';
@@ -21,13 +22,12 @@ interface Props {
 }
 
 export function BountySignupButton({ bountyPage }: Props) {
-  const { account, walletAuthSignature } = useWeb3AuthSig();
+  const { account, walletAuthSignature, loginFromWeb3Account } = useWeb3AuthSig();
   const { user, setUser, isLoaded: isUserLoaded } = useUser();
   const router = useRouter();
   const { members } = useMembers();
   const space = useCurrentSpace();
   const loginViaTokenGateModal = usePopupState({ variant: 'popover', popupId: 'login-via-token-gate' });
-  const { openWalletSelectorModal } = useContext(Web3Connection);
   const [loggingIn, setLoggingIn] = useState(false);
 
   const isSpaceMember = Boolean(user && members.some((c) => c.id === user.id));
@@ -86,9 +86,7 @@ export function BountySignupButton({ bountyPage }: Props) {
       >
         {!account ? (
           <Box display='flex' justifyContent='center' sx={{ mt: 3 }}>
-            <PrimaryButton onClick={openWalletSelectorModal} loading={loggingIn}>
-              Connect wallet
-            </PrimaryButton>
+            <WalletSign signSuccess={loginFromWeb3Account} />
           </Box>
         ) : (
           <TokenGateForm

--- a/components/common/DiscordGate/hooks/useDiscordGate.ts
+++ b/components/common/DiscordGate/hooks/useDiscordGate.ts
@@ -13,7 +13,7 @@ type Props = {
 };
 
 export function useDiscordGate({ spaceDomain, onSuccess }: Props) {
-  const { user, refreshUserWithWeb3Account } = useUser();
+  const { user, refreshUser } = useUser();
   const { showMessage } = useSnackbar();
   const discordUserId = user?.discordUser?.discordId;
   const [joiningSpace, setJoiningSpace] = useState(false);
@@ -36,7 +36,7 @@ export function useDiscordGate({ spaceDomain, onSuccess }: Props) {
 
       showMessage(`You have joined the ${space.name} workspace.`, 'success');
 
-      await refreshUserWithWeb3Account();
+      await refreshUser();
 
       const spaceExists = spaces.some((s) => s.id === space.id);
       if (!spaceExists) {

--- a/components/common/TokenGateForm/TokenGateForm.tsx
+++ b/components/common/TokenGateForm/TokenGateForm.tsx
@@ -37,8 +37,8 @@ export default function TokenGateForm({
   //  console.log('Renders', renders.current);
   const { showMessage } = useSnackbar();
   const { spaces, setSpaces } = useSpaces();
-  const { getStoredSignature } = useWeb3AuthSig();
-  const { refreshUserWithWeb3Account, loginFromWeb3Account, user } = useUser();
+  const { getStoredSignature, loginFromWeb3Account } = useWeb3AuthSig();
+  const { refreshUser, user } = useUser();
 
   const [tokenGates, setTokenGates] = useState<TokenGateWithRoles[] | null>(null);
 
@@ -127,7 +127,7 @@ export default function TokenGateForm({
 
       showMessage(`You have joined the ${tokenGateResult?.space.name} workspace.`, 'success');
 
-      await refreshUserWithWeb3Account();
+      await refreshUser();
 
       const spaceExists = spaces.some((s) => s.id === tokenGateResult?.space.id);
 

--- a/components/invite/InviteLinkPage.tsx
+++ b/components/invite/InviteLinkPage.tsx
@@ -15,8 +15,7 @@ import { CenteredBox } from './components/CenteredBox';
 
 export default function InvitationPage({ invite }: { invite: InviteLinkPopulated }) {
   const { user } = useUser();
-  const { walletAuthSignature, verifiableWalletDetected } = useWeb3AuthSig();
-  const { loginFromWeb3Account } = useUser();
+  const { walletAuthSignature, verifiableWalletDetected, loginFromWeb3Account } = useWeb3AuthSig();
   const router = useRouter();
 
   async function joinSpace() {

--- a/components/login/Login.tsx
+++ b/components/login/Login.tsx
@@ -9,7 +9,6 @@ import { WalletSelector } from 'components/_app/Web3ConnectionManager/components
 import { ConnectorButton } from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/ConnectorButton';
 import Button from 'components/common/Button';
 import { useSnackbar } from 'hooks/useSnackbar';
-import { useUser } from 'hooks/useUser';
 import { useWeb3AuthSig } from 'hooks/useWeb3AuthSig';
 import type { AuthSig } from 'lib/blockchain/interfaces';
 import type { LoggedInUser } from 'models/User';
@@ -33,7 +32,7 @@ export interface DialogProps {
 
 function LoginHandler(props: DialogProps) {
   const { onClose, selectedValue, open } = props;
-  const { loginFromWeb3Account } = useUser();
+  const { loginFromWeb3Account } = useWeb3AuthSig();
 
   const { showMessage } = useSnackbar();
 

--- a/components/nexus/components/NexusPageTitle.tsx
+++ b/components/nexus/components/NexusPageTitle.tsx
@@ -1,8 +1,7 @@
-import { Box, Tooltip, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
-import charmClient from 'charmClient';
 import Button from 'components/common/Button';
 import { useUser } from 'hooks/useUser';
 import { useWeb3AuthSig } from 'hooks/useWeb3AuthSig';
@@ -11,14 +10,13 @@ export default function PageTitle({ subPage }: { subPage?: string }) {
   const MyNexus = 'My Nexus';
   const { account, disconnectWallet } = useWeb3AuthSig();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
-  const { setUser } = useUser();
+  const { setUser, logoutUser } = useUser();
   const router = useRouter();
 
-  async function logoutUser() {
+  async function logoutCurrentUser() {
     disconnectWallet();
     setIsLoggingOut(true);
-    await charmClient.logout();
-    setUser(null);
+    await logoutUser();
     router.push('/');
   }
 
@@ -49,7 +47,7 @@ export default function PageTitle({ subPage }: { subPage?: string }) {
               variant='outlined'
               color='secondary'
               loading={isLoggingOut}
-              onClick={logoutUser}
+              onClick={logoutCurrentUser}
             >
               Logout
             </Button>

--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -14,8 +14,8 @@ type IContext = {
   updateUser: (user: Partial<LoggedInUser>) => void;
   isLoaded: boolean;
   setIsLoaded: (isLoaded: boolean) => void;
-  loginFromWeb3Account: (authSig?: AuthSig) => Promise<LoggedInUser>;
-  refreshUserWithWeb3Account: () => Promise<void>;
+  refreshUser: () => Promise<void>;
+  logoutUser: () => Promise<void>;
 };
 
 export const UserContext = createContext<Readonly<IContext>>({
@@ -24,45 +24,13 @@ export const UserContext = createContext<Readonly<IContext>>({
   updateUser: () => undefined,
   isLoaded: false,
   setIsLoaded: () => undefined,
-  loginFromWeb3Account: () => Promise.resolve() as any,
-  refreshUserWithWeb3Account: () => Promise.resolve()
+  refreshUser: () => Promise.resolve(),
+  logoutUser: () => Promise.resolve()
 });
 
 export function UserProvider({ children }: { children: ReactNode }) {
-  const {
-    account,
-    sign,
-    getStoredSignature,
-    setLoggedInUser: setLoggedInUserForWeb3Hook,
-    verifiableWalletDetected
-  } = useWeb3AuthSig();
   const [user, setUser] = useState<LoggedInUser | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
-
-  async function loginFromWeb3Account(authSig?: AuthSig) {
-    if (!verifiableWalletDetected && !authSig) {
-      throw new MissingWeb3AccountError();
-    }
-
-    let signature = authSig ?? (getStoredSignature() as AuthSig);
-
-    if (!signature) {
-      signature = await sign();
-    }
-
-    try {
-      // Refresh the user account. This was required as otherwise the user would not be able to see the first page upon joining the space
-      const refreshedProfile = await charmClient.login({ address: signature.address, walletSignature: signature });
-
-      setUser(refreshedProfile);
-
-      return refreshedProfile;
-    } catch (err) {
-      const newProfile = await charmClient.createUser({ address: signature.address, walletSignature: signature });
-      setUser(newProfile);
-      return newProfile;
-    }
-  }
 
   async function logoutUser() {
     await charmClient.logout();
@@ -74,48 +42,26 @@ export function UserProvider({ children }: { children: ReactNode }) {
    *
    * Logs out current user if the web 3 account is not the same as the current user, otherwise refreshes them
    */
-  async function refreshUserWithWeb3Account() {
-    const signature = getStoredSignature();
-
-    // Support the initial load
-    if (
-      !isLoaded ||
-      // Account is only ever visible if it belongs to the current user
-      account ||
-      // If the user is connected with a Discord account, we can ignore changes
-      user?.discordUser ||
-      // If the web3 wallet is locked, don't log out the user
-      (!verifiableWalletDetected && user)
-    ) {
-      charmClient
-        .getUser()
-        .then((_user) => {
-          setUser(_user);
-        })
-        .finally(() => {
-          setIsLoaded(true);
-        });
-      // a hack for now to support users that are trying to log in thru discord
-    } else if (verifiableWalletDetected && signature) {
-      loginFromWeb3Account(signature)
-        .then((loggedInUser) => setUser(loggedInUser))
-        .catch(logoutUser);
-    } else {
-      logoutUser();
-    }
+  async function refreshUser() {
+    charmClient
+      .getUser()
+      .then((_user) => {
+        setUser(_user);
+      })
+      .finally(() => {
+        setIsLoaded(true);
+      });
   }
 
   useEffect(() => {
-    refreshUserWithWeb3Account();
-  }, [account]);
+    refreshUser();
+  }, []);
 
   const updateUser = useCallback((updatedUser: Partial<LoggedInUser>) => {
     setUser((u) => (u ? { ...u, ...updatedUser } : null));
   }, []);
 
   useEffect(() => {
-    setLoggedInUserForWeb3Hook(user);
-
     if (user?.deletedAt) {
       charmClient.logout().then(() => {
         window.location.href = window.location.origin;
@@ -130,8 +76,8 @@ export function UserProvider({ children }: { children: ReactNode }) {
       isLoaded,
       setIsLoaded,
       updateUser,
-      loginFromWeb3Account,
-      refreshUserWithWeb3Account
+      refreshUser,
+      logoutUser
     };
   }, [user, isLoaded]);
 

--- a/hooks/useWeb3AuthSig.tsx
+++ b/hooks/useWeb3AuthSig.tsx
@@ -120,11 +120,13 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
       // Refresh the user account. This was required as otherwise the user would not be able to see the first page upon joining the space
       const refreshedProfile = await charmClient.login({ address: signature.address, walletSignature: signature });
 
+      setSignature(signature, true);
       setUser(refreshedProfile);
 
       return refreshedProfile;
     } catch (err) {
       const newProfile = await charmClient.createUser({ address: signature.address, walletSignature: signature });
+      setSignature(signature, true);
       setUser(newProfile);
       return newProfile;
     }
@@ -150,9 +152,19 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
       const storedWalletSignature = getStoredSignature();
       setSignature(storedWalletSignature);
     } else if (isLoaded && account && !user?.wallets.some((w) => lowerCaseEqual(w.address, account))) {
-      setSignature(null);
-      setStoredAccount(null);
-      logoutUser();
+      const storedSignature = getStoredSignature();
+
+      if (storedSignature) {
+        loginFromWeb3Account(storedSignature).catch((e) => {
+          setSignature(null);
+          setStoredAccount(null);
+          logoutUser();
+        });
+      } else {
+        setSignature(null);
+        setStoredAccount(null);
+        logoutUser();
+      }
     }
   }, [account, user, isConnectingIdentity, isLoaded]);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -219,43 +219,37 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
         <ThemeProvider theme={theme}>
           <LocalizationProvider dateAdapter={AdapterLuxon as any}>
             <SnackbarProvider>
-              <Web3ReactProvider getLibrary={getLibrary}>
-                <Web3ConnectionManager>
-                  <Web3AccountProvider>
-                    <ReactDndProvider>
-                      <DataProviders>
-                        <OnboardingProvider>
-                          <FocalBoardProvider>
-                            <IntlProvider>
-                              <PageMetaTags />
-                              <CssBaseline enableColorScheme={true} />
-                              <Global styles={cssVariables} />
-                              <RouteGuard>
-                                <ErrorBoundary>
-                                  <Snackbar
-                                    isOpen={isOldBuild}
-                                    message='New CharmVerse platform update available. Please refresh.'
-                                    actions={[
-                                      <IconButton key='reload' onClick={() => window.location.reload()} color='inherit'>
-                                        <RefreshIcon fontSize='small' />
-                                      </IconButton>
-                                    ]}
-                                    origin={{ vertical: 'top', horizontal: 'center' }}
-                                    severity='warning'
-                                    handleClose={() => setIsOldBuild(false)}
-                                  />
-                                  {getLayout(<Component {...pageProps} />)}
-                                  <GlobalComponents />
-                                </ErrorBoundary>
-                              </RouteGuard>
-                            </IntlProvider>
-                          </FocalBoardProvider>
-                        </OnboardingProvider>
-                      </DataProviders>
-                    </ReactDndProvider>
-                  </Web3AccountProvider>
-                </Web3ConnectionManager>
-              </Web3ReactProvider>
+              <ReactDndProvider>
+                <DataProviders>
+                  <OnboardingProvider>
+                    <FocalBoardProvider>
+                      <IntlProvider>
+                        <PageMetaTags />
+                        <CssBaseline enableColorScheme={true} />
+                        <Global styles={cssVariables} />
+                        <RouteGuard>
+                          <ErrorBoundary>
+                            <Snackbar
+                              isOpen={isOldBuild}
+                              message='New CharmVerse platform update available. Please refresh.'
+                              actions={[
+                                <IconButton key='reload' onClick={() => window.location.reload()} color='inherit'>
+                                  <RefreshIcon fontSize='small' />
+                                </IconButton>
+                              ]}
+                              origin={{ vertical: 'top', horizontal: 'center' }}
+                              severity='warning'
+                              handleClose={() => setIsOldBuild(false)}
+                            />
+                            {getLayout(<Component {...pageProps} />)}
+                            <GlobalComponents />
+                          </ErrorBoundary>
+                        </RouteGuard>
+                      </IntlProvider>
+                    </FocalBoardProvider>
+                  </OnboardingProvider>
+                </DataProviders>
+              </ReactDndProvider>
             </SnackbarProvider>
           </LocalizationProvider>
         </ThemeProvider>
@@ -267,21 +261,27 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
 function DataProviders({ children }: { children: ReactNode }) {
   return (
     <UserProvider>
-      <SpacesProvider>
-        <WebSocketClientProvider>
-          <MembersProvider>
-            <BountiesProvider>
-              <PaymentMethodsProvider>
-                <PagesProvider>
-                  <PrimaryCharmEditorProvider>
-                    <PageTitleProvider>{children}</PageTitleProvider>
-                  </PrimaryCharmEditorProvider>
-                </PagesProvider>
-              </PaymentMethodsProvider>
-            </BountiesProvider>
-          </MembersProvider>
-        </WebSocketClientProvider>
-      </SpacesProvider>
+      <Web3ReactProvider getLibrary={getLibrary}>
+        <Web3ConnectionManager>
+          <Web3AccountProvider>
+            <SpacesProvider>
+              <WebSocketClientProvider>
+                <MembersProvider>
+                  <BountiesProvider>
+                    <PaymentMethodsProvider>
+                      <PagesProvider>
+                        <PrimaryCharmEditorProvider>
+                          <PageTitleProvider>{children}</PageTitleProvider>
+                        </PrimaryCharmEditorProvider>
+                      </PagesProvider>
+                    </PaymentMethodsProvider>
+                  </BountiesProvider>
+                </MembersProvider>
+              </WebSocketClientProvider>
+            </SpacesProvider>
+          </Web3AccountProvider>
+        </Web3ConnectionManager>
+      </Web3ReactProvider>
     </UserProvider>
   );
 }


### PR DESCRIPTION
Key change: Put useUser above instead of below the useWeb3AuthSig hook in the dependency hierarchy

If user switches to a wallet that has signed with CharmVerse before, switch accounts

If new wallet, logout user entirely