### PR TITLE
show embeds when iframely cannot generate html

### DIFF
--- a/charmClient/apis/iframelyApi.ts
+++ b/charmClient/apis/iframelyApi.ts
@@ -1,8 +1,20 @@
 import * as http from 'adapters/http';
 
+type IframelyResponse = {
+  html?: string;
+  error?: string;
+  url: string;
+  links: { icon: { href: string; type: string; rel: string[] }[] };
+  meta: {
+    canonical: string;
+    description: string;
+    title: string;
+  };
+};
+
 export class IframelyApi {
   get(url: string) {
-    return http.GET<{ html: string; error?: string }>(
+    return http.GET<IframelyResponse>(
       `https://cdn.iframe.ly/api/iframely`,
       {
         url,

--- a/components/common/CharmEditor/components/bookmark/BookmarkNodeView.tsx
+++ b/components/common/CharmEditor/components/bookmark/BookmarkNodeView.tsx
@@ -1,8 +1,9 @@
 import BookmarkIcon from '@mui/icons-material/Bookmark';
-import { Box } from '@mui/material';
+import { Box, Card, CardActionArea, Typography } from '@mui/material';
 import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
+import Link from 'components/common/Link';
 import LoadingComponent from 'components/common/LoadingComponent';
 
 import BlockAligner from '../BlockAligner';
@@ -20,7 +21,7 @@ export function BookmarkNodeView({
   deleteNode
 }: CharmNodeViewProps & { readOnly?: boolean }) {
   const { url } = node.attrs as BookmarkNodeAttrs;
-  const { data, isLoading } = useSWRImmutable(url ? `iframely/${encodeURIComponent(url)}` : null, () =>
+  const { data, error, isLoading } = useSWRImmutable(url ? `iframely/${encodeURIComponent(url)}` : null, () =>
     charmClient.iframely.get(url)
   );
 
@@ -66,6 +67,31 @@ export function BookmarkNodeView({
           <div dangerouslySetInnerHTML={{ __html: data.html }} />
         </BlockAligner>
       </Box>
+    );
+  } else if (data?.meta) {
+    return (
+      <Card variant='outlined'>
+        <CardActionArea
+          component={Link}
+          color='inherit'
+          sx={{ px: 2, py: 1.5 }}
+          href={data.meta.canonical}
+          target='_blank'
+        >
+          <Typography variant='body2' textOverflow='ellipsis' overflow='hidden' whiteSpace='nowrap'>
+            <strong>{data.meta.title}</strong>
+          </Typography>
+          <Typography color='secondary' variant='body2' lineHeight='1.3em !important'>
+            {data.meta.description}
+          </Typography>
+          <Box display='flex' alignItems='center' gap={1} mt={1}>
+            {data.links.icon[0] && <img src={data.links.icon[0].href} />}
+            <Typography component='span' variant='body2' textOverflow='ellipsis' overflow='hidden' whiteSpace='nowrap'>
+              {data.meta.canonical}
+            </Typography>
+          </Box>
+        </CardActionArea>
+      </Card>
     );
   }
 


### PR DESCRIPTION
This example does'nt return HTML and is not supported when you try it on iframely:
https://www.meti.go.jp/english/press/2022/0715_002.html

Iframely link: https://iframely.com/try?url=https://www.meti.go.jp/english/press/2022/0715_002.html

Good news is we still get metadata