### PR TITLE
Highlighting text with keyboard doesn't show floating menu v2

### DIFF
--- a/components/common/CharmEditor/components/fiduswriter/state_plugins/collab_carets.ts
+++ b/components/common/CharmEditor/components/fiduswriter/state_plugins/collab_carets.ts
@@ -140,7 +140,7 @@ export const collabCaretsPlugin = function (options: { editor: { docInfo: { acce
         if (
           tr.selectionSet &&
           !sendableSteps(state) &&
-          !tr.getMeta('row-handle-drag') &&
+          !tr.getMeta('row-handle-is-dragging') &&
           !['review', 'review-tracked'].includes(options.editor.docInfo.access_rights)
         ) {
           caretUpdate = { anchor: tr.selection.anchor, head: tr.selection.head };

--- a/components/common/CharmEditor/components/floatingMenu/floatingMenu.plugins.ts
+++ b/components/common/CharmEditor/components/floatingMenu/floatingMenu.plugins.ts
@@ -1,15 +1,6 @@
 import { link } from '@bangle.dev/base-components';
 import type { PluginKey } from '@bangle.dev/core';
-import type {
-  EditorState,
-  EditorView,
-  Transaction,
-  Node,
-  ResolvedPos,
-  DirectEditorProps,
-  Plugin
-} from '@bangle.dev/pm';
-import { selectionTooltip } from '@bangle.dev/tooltip';
+import type { EditorState, EditorView, Transaction, Node, ResolvedPos, Plugin } from '@bangle.dev/pm';
 import type { NodeSelection } from 'prosemirror-state';
 
 import { hasComponentInSchema } from 'lib/prosemirror/hasComponentInSchema';

--- a/components/common/CharmEditor/components/floatingMenu/floatingMenu.plugins.ts
+++ b/components/common/CharmEditor/components/floatingMenu/floatingMenu.plugins.ts
@@ -86,7 +86,7 @@ export function plugins({
           return false;
         },
         apply(tr: Transaction) {
-          return tr.getMeta('row-handle-drag');
+          return tr.getMeta('row-handle-is-dragging');
         }
       },
       view: (_view: EditorView) => {

--- a/components/common/CharmEditor/components/floatingMenu/floatingMenu.plugins.ts
+++ b/components/common/CharmEditor/components/floatingMenu/floatingMenu.plugins.ts
@@ -1,6 +1,15 @@
 import { link } from '@bangle.dev/base-components';
 import type { PluginKey } from '@bangle.dev/core';
-import type { Node, Plugin, ResolvedPos } from '@bangle.dev/pm';
+import type {
+  EditorState,
+  EditorView,
+  Transaction,
+  Node,
+  ResolvedPos,
+  DirectEditorProps,
+  Plugin
+} from '@bangle.dev/pm';
+import { selectionTooltip } from '@bangle.dev/tooltip';
 import type { NodeSelection } from 'prosemirror-state';
 
 import { hasComponentInSchema } from 'lib/prosemirror/hasComponentInSchema';
@@ -73,17 +82,33 @@ export function plugins({
   const selectionTooltipPluginFn = menuPlugins[0] as () => Plugin<any>[];
   menuPlugins[0] = () => {
     const selectionTooltipPlugins = selectionTooltipPluginFn();
-    const selectionTooltipController = selectionTooltipPlugins[1] as Plugin<any>;
-    if (!selectionTooltipController.spec.view) {
+    const controller = selectionTooltipPlugins[1] as Plugin<any>;
+    if (!controller.spec.view) {
       throw new Error('View not found for the selection toolip plugin');
     }
-    // Remove the watcher in `view.update` to avoid triggering the tooltip when a selection changes
     // @ts-ignore
-    const view = selectionTooltipController.spec.view();
-    selectionTooltipController.spec.view = () => {
-      view.update = () => {};
-      return view;
-    };
+    const viewUpdate = controller.spec.view().update;
+
+    Object.assign(controller.spec, {
+      state: {
+        init() {
+          return false;
+        },
+        apply(tr: Transaction) {
+          return tr.getMeta('row-handle-drag');
+        }
+      },
+      view: (_view: EditorView) => {
+        return {
+          update: (view: EditorView, lastState: EditorState) => {
+            const isDragging = controller.getState(view.state) || controller.getState(lastState);
+            if (viewUpdate && !isDragging) {
+              return viewUpdate(view, lastState);
+            }
+          }
+        };
+      }
+    });
     return selectionTooltipPlugins;
   };
 

--- a/components/common/CharmEditor/components/rowActions/rowActions.ts
+++ b/components/common/CharmEditor/components/rowActions/rowActions.ts
@@ -10,7 +10,6 @@ import { __serializeForClipboard as serializeForClipboard } from 'prosemirror-vi
 
 export interface PluginState {
   tooltipDOM: HTMLElement;
-  isDragging: boolean;
   open: boolean;
   rowDOM?: HTMLElement;
   rowPos?: number;
@@ -84,7 +83,6 @@ export function plugins({ key }: { key: PluginKey }) {
         init: (): PluginState => {
           return {
             tooltipDOM,
-            isDragging: false,
             // For tooltipPlacement plugin
             open: false
           };

--- a/components/common/CharmEditor/components/rowActions/rowActions.ts
+++ b/components/common/CharmEditor/components/rowActions/rowActions.ts
@@ -10,6 +10,7 @@ import { __serializeForClipboard as serializeForClipboard } from 'prosemirror-vi
 
 export interface PluginState {
   tooltipDOM: HTMLElement;
+  isDragging: boolean;
   open: boolean;
   rowDOM?: HTMLElement;
   rowPos?: number;
@@ -83,6 +84,7 @@ export function plugins({ key }: { key: PluginKey }) {
         init: (): PluginState => {
           return {
             tooltipDOM,
+            isDragging: false,
             // For tooltipPlacement plugin
             open: false
           };
@@ -92,12 +94,15 @@ export function plugins({ key }: { key: PluginKey }) {
           if (newPluginState) {
             return { ...pluginState, ...newPluginState };
           }
-
           return pluginState;
         }
       },
       props: {
         handleDOMEvents: {
+          // set meta on drop so that floating menu (selection-tooltip) can ignore the event
+          drop: (view) => {
+            view.dispatch(view.state.tr.setMeta('row-handle-drag', true));
+          },
           mousemove: (view: EditorView, event: MouseEvent) => {
             throttledMouseOver(view, event);
             return false;

--- a/components/common/CharmEditor/components/rowActions/rowActions.ts
+++ b/components/common/CharmEditor/components/rowActions/rowActions.ts
@@ -62,7 +62,7 @@ export function plugins({ key }: { key: PluginKey }) {
     const pos = blockPosAtCoords(view, coords);
     if (pos != null) {
       view.dispatch(
-        view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)).setMeta('row-handle-drag', true)
+        view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)).setMeta('row-handle-is-dragging', true)
       );
 
       const slice = view.state.selection.content();
@@ -99,7 +99,7 @@ export function plugins({ key }: { key: PluginKey }) {
         handleDOMEvents: {
           // set meta on drop so that floating menu (selection-tooltip) can ignore the event
           drop: (view) => {
-            view.dispatch(view.state.tr.setMeta('row-handle-drag', true));
+            view.dispatch(view.state.tr.setMeta('row-handle-is-dragging', true));
           },
           mousemove: (view: EditorView, event: MouseEvent) => {
             throttledMouseOver(view, event);


### PR DESCRIPTION
This brings back the call to the selection tooltip update, but checks the state from row-action before calling it...

Some inspiration came from https://github.com/ProseMirror/prosemirror/issues/587