### PR TITLE
hot fix for icons in all safari os

### DIFF
--- a/components/common/Emoji.tsx
+++ b/components/common/Emoji.tsx
@@ -58,6 +58,8 @@ export function getTwitterEmoji(emoji: string): string | null {
 
   // @ts-ignore - library type is incorrect
   const html = twemoji.parse(emoji, {
+    // the original maxCDN went down Jan 11, 2023
+    base: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/',
     folder: 'svg',
     ext: '.svg'
   }) as string;

--- a/lib/utilities/browser.ts
+++ b/lib/utilities/browser.ts
@@ -1,6 +1,10 @@
 // using deprectead feature, navigator.userAgent doesnt exist yet in FF - https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform
 export function isMac() {
-  return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  return (
+    navigator.platform.toUpperCase().indexOf('MAC') >= 0 ||
+    navigator.platform.toUpperCase().indexOf('IPHONE') >= 0 ||
+    navigator.platform.toUpperCase().indexOf('IPAD') >= 0
+  );
 }
 
 export function isTouchScreen(): boolean {


### PR DESCRIPTION
Use system font for iOS/iPhone but also change the CDN since Twitter dropped support: https://github.com/twitter/twemoji/issues/580 