### PR TITLE
extend Error class to include stack traces

### DIFF
--- a/lib/middleware/onError.ts
+++ b/lib/middleware/onError.ts
@@ -18,7 +18,9 @@ export function onError(err: any, req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  res.status(errorAsSystemError.code).json({ ...errorAsSystemError, message: errorAsSystemError.message });
+  const { stack, message, ...withoutStack } = errorAsSystemError;
+
+  res.status(errorAsSystemError.code).json({ ...withoutStack, message });
 }
 
 export default onError;

--- a/lib/middleware/onError.ts
+++ b/lib/middleware/onError.ts
@@ -18,7 +18,7 @@ export function onError(err: any, req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  res.status(errorAsSystemError.code).json(errorAsSystemError);
+  res.status(errorAsSystemError.code).json({ ...errorAsSystemError, message: errorAsSystemError.message });
 }
 
 export default onError;

--- a/lib/utilities/errors/errors.ts
+++ b/lib/utilities/errors/errors.ts
@@ -34,7 +34,7 @@ export interface ISystemError<E = any> {
 export type ISystemErrorInput<E = any> = Pick<ISystemError<E>, 'message' | 'errorType'> &
   Partial<Pick<ISystemError<E>, 'severity' | 'error'>>;
 
-export class SystemError<E = any> implements ISystemError<E> {
+export class SystemError<E = any> extends Error implements ISystemError<E> {
   code: number;
 
   errorType: ErrorType;
@@ -48,6 +48,7 @@ export class SystemError<E = any> implements ISystemError<E> {
   error: E;
 
   constructor(errorInfo: ISystemErrorInput<E>) {
+    super(errorInfo.message);
     this.errorType = errorInfo.errorType;
     this.code = ErrorCodes[this.errorType];
     this.message = errorInfo.message;


### PR DESCRIPTION
now you can log (err.stack) in the `onError` middleware, for example, and see where in the code the error was thrown