### PR TITLE
simplify logic to show menu item in sidebar

### DIFF
--- a/components/common/BoardEditor/FocalBoardProvider.tsx
+++ b/components/common/BoardEditor/FocalBoardProvider.tsx
@@ -20,7 +20,6 @@ function FocalBoardWatcher({ children }: { children: JSX.Element }) {
 
   useEffect(() => {
     if (space) {
-      log.debug('Load focalboard blocks');
       dispatch(initialLoad({ spaceId: space.id }));
     }
   }, [space?.id]);

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -75,9 +75,8 @@ function TreeRoot({ children, mutatePage, isFavorites, ...rest }: TreeRootProps)
   const hasChildrenLoaded = !!(children as any[]).length;
 
   useEffect(() => {
-    // if (menuItemCount > 0) {
     const { pageId } = router.query;
-    if (pageId) {
+    if (hasChildrenLoaded && pageId) {
       const anchor = document.querySelector(`a[href^="/${router.query.domain}/${pageId}"]`);
       if (anchor) {
         setTimeout(() => {

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -6,12 +6,12 @@ import TreeView from '@mui/lab/TreeView';
 import type { Page } from '@prisma/client';
 import { useRouter } from 'next/router';
 import type { ComponentProps, ReactNode, SyntheticEvent } from 'react';
-import { memo, useCallback, useEffect, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDrop } from 'react-dnd';
 
 import charmClient from 'charmClient';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import { getKey, useLocalStorage } from 'hooks/useLocalStorage';
+import { useLocalStorage } from 'hooks/useLocalStorage';
 import { usePages } from 'hooks/usePages';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { useUser } from 'hooks/useUser';
@@ -65,9 +65,30 @@ function TreeRoot({ children, mutatePage, isFavorites, ...rest }: TreeRootProps)
       })
     })
   );
+  const ref = useRef<HTMLDivElement>(null);
+  const router = useRouter();
 
   const theme = useTheme();
   const isActive = canDrop && isOverCurrent;
+
+  // Need to wait for the child nodes to appear before we can start scrolling
+  const hasChildrenLoaded = !!(children as any[]).length;
+
+  useEffect(() => {
+    // if (menuItemCount > 0) {
+    const { pageId } = router.query;
+    if (pageId) {
+      const anchor = document.querySelector(`a[href^="/${router.query.domain}/${pageId}"]`);
+      if (anchor) {
+        setTimeout(() => {
+          anchor.scrollIntoView({
+            behavior: 'smooth'
+          });
+        });
+      }
+    }
+  }, [hasChildrenLoaded]);
+
   return (
     <div
       ref={drop}
@@ -76,7 +97,9 @@ function TreeRoot({ children, mutatePage, isFavorites, ...rest }: TreeRootProps)
         flexGrow: isFavorites ? 0 : 1
       }}
     >
-      <TreeView {...rest}>{children}</TreeView>
+      <TreeView {...rest} ref={ref}>
+        {children}
+      </TreeView>
     </div>
   );
 }
@@ -93,7 +116,7 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
   const { pages, currentPageId, setPages, mutatePage } = usePages();
   const space = useCurrentSpace();
   const { user } = useUser();
-  const [expanded, setExpanded] = useLocalStorage<string[]>(`${space!.id}.expanded-pages`, []);
+  const [expanded, setExpanded] = useLocalStorage<string[]>(`${space?.id}.expanded-pages`, []);
   const { showMessage } = useSnackbar();
   const pagesArray: MenuNode[] = filterVisiblePages(Object.values(pages)).map(
     (page): MenuNode => ({
@@ -201,37 +224,6 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
     },
     [pages]
   );
-
-  const pageNavigationElement = document.querySelector('.page-navigation');
-  const treeViewElement = pageNavigationElement?.querySelector('.MuiTreeView-root');
-  const pageSidebarChildrenCount = treeViewElement?.children.length;
-
-  useEffect(() => {
-    // Need to wait for the child nodes to appear before we can start scrolling
-    if (pageNavigationElement && pageSidebarChildrenCount !== 0) {
-      const sidebarScrollTop = localStorage.getItem(getKey('sidebar-scroll-top'));
-      if (sidebarScrollTop) {
-        pageNavigationElement.scrollBy({
-          top: Number(sidebarScrollTop)
-        });
-      }
-      // If there are no scroll value stored on ls
-      // We use the router's pageId to scroll to the correct place
-      else {
-        const { pageId } = router.query;
-        if (pageId) {
-          const anchor = document.querySelector(`a[href^="/${space?.domain}/${pageId}"]`);
-          if (anchor) {
-            setTimeout(() => {
-              anchor.scrollIntoView({
-                behavior: 'smooth'
-              });
-            });
-          }
-        }
-      }
-    }
-  }, [pageSidebarChildrenCount]);
 
   useEffect(() => {
     const currentPage = pages[currentPageId];

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -16,16 +16,14 @@ import { bindMenu, bindTrigger, usePopupState } from 'material-ui-popup-state/ho
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import type { ReactNode, SyntheticEvent } from 'react';
-import React, { forwardRef, memo, useCallback, useMemo } from 'react';
+import React, { useRef, forwardRef, memo, useEffect, useCallback, useMemo } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
-import mutator from 'components/common/BoardEditor/focalboard/src/mutator';
 import { getSortedBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import EmojiPicker from 'components/common/BoardEditor/focalboard/src/widgets/emojiPicker';
 import TreeItemContent from 'components/common/TreeItemContent';
 import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
-import { getKey } from 'hooks/useLocalStorage';
 import { usePages } from 'hooks/usePages';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { isTouchScreen } from 'lib/utilities/browser';
@@ -199,10 +197,6 @@ export function PageLink({
   const isempty = !label;
 
   const stopPropagation = useCallback((event: SyntheticEvent) => {
-    const pageNavigationElement = document.querySelector('.page-navigation');
-    if (pageNavigationElement) {
-      localStorage.setItem(getKey('sidebar-scroll-top'), pageNavigationElement.scrollTop.toString());
-    }
     event.stopPropagation();
   }, []);
 
@@ -305,6 +299,7 @@ const PageTreeItem = forwardRef<any, PageTreeItemProps>((props, ref) => {
     () => ({ isAdjacent, className: hasSelectedChildView ? 'Mui-selected' : undefined }),
     [isAdjacent, hasSelectedChildView]
   );
+
   const TransitionProps = useMemo(() => ({ timeout: 50 }), []);
   const anchorOrigin = useMemo(() => ({ vertical: 'bottom', horizontal: 'left' } as const), []);
   const transformOrigin = useMemo(() => ({ vertical: 'top', horizontal: 'left' } as const), []);

--- a/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
@@ -165,7 +165,7 @@ function DraggableTreeNode({
       ref={mergeRefs([ref, drag, drop, dragPreview, focusListener])}
       label={item.title}
       href={`${pathPrefix}/${item.path}${
-        item.type.match(/board/) && focalboardViewsRecord[item.id] ? `?viewId=${focalboardViewsRecord[item.id]}` : ''
+        item.type.includes('board') && focalboardViewsRecord[item.id] ? `?viewId=${focalboardViewsRecord[item.id]}` : ''
       }`}
       isActive={isActive}
       isAdjacent={isAdjacentActive}

--- a/components/common/TreeItemContent.tsx
+++ b/components/common/TreeItemContent.tsx
@@ -3,9 +3,9 @@
 import type { TreeItemContentProps } from '@mui/lab/TreeItem';
 import { useTreeItem } from '@mui/lab/TreeItem';
 import clsx from 'clsx';
-import * as React from 'react';
+import { forwardRef, useCallback, memo, useEffect, useMemo } from 'react';
 
-const TreeItemContent = React.forwardRef<HTMLDivElement, TreeItemContentProps>((props, ref) => {
+const TreeItemContent = forwardRef<HTMLDivElement, TreeItemContentProps>((props, ref) => {
   const {
     classes,
     className,
@@ -24,7 +24,7 @@ const TreeItemContent = React.forwardRef<HTMLDivElement, TreeItemContentProps>((
 
   const icon = iconProp || expansionIcon || displayIcon;
 
-  const handleMouseDown = React.useCallback(
+  const handleMouseDown = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       preventSelection(event);
 
@@ -35,7 +35,7 @@ const TreeItemContent = React.forwardRef<HTMLDivElement, TreeItemContentProps>((
     [onMouseDown]
   );
 
-  const handleClick = React.useCallback(
+  const handleClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       handleExpansion(event);
       handleSelection(event);
@@ -47,7 +47,7 @@ const TreeItemContent = React.forwardRef<HTMLDivElement, TreeItemContentProps>((
     [handleExpansion, handleSelection, onClick]
   );
 
-  const newClassName = React.useMemo(
+  const newClassName = useMemo(
     () =>
       clsx(className, classes.root, {
         [classes.expanded]: expanded,
@@ -67,4 +67,4 @@ const TreeItemContent = React.forwardRef<HTMLDivElement, TreeItemContentProps>((
   );
 });
 
-export default React.memo(TreeItemContent);
+export default memo(TreeItemContent);


### PR DESCRIPTION
This is a cleanup of how we scroll to the correct page on first load. Will result in more accurate sidebar :)
- I think we can get rid of the local storage solution to remember the scroll position of sidebar - this was probably due to the page remounting all the time?
- I moved the scroll logic down and removed some DOM queries (these are really expensive compared to regular JS, and were running on every render!)