### PR TITLE
Standardise the close button UI to the right on dialogs

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/dialog.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.tsx
@@ -1,11 +1,10 @@
 import CloseIcon from '@mui/icons-material/Close';
+import IconButton from '@mui/material/IconButton';
 import Modal from '@mui/material/Modal';
 import clsx from 'clsx';
 import React from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useIntl } from 'react-intl';
-
-import IconButton from '../widgets/buttons/iconButton';
 
 type Props = {
   children: React.ReactNode;
@@ -44,15 +43,9 @@ function FBDialog(props: Props) {
               {toolbar && <div className='cardToolbar'>{toolbar}</div>}
               {toolsMenu}
               {!props.hideCloseButton && (
-                <IconButton
-                  onClick={props.onClose}
-                  icon={<CloseIcon />}
-                  style={{
-                    paddingLeft: '20px'
-                  }}
-                  title={closeDialogText}
-                  className='IconButton'
-                />
+                <IconButton onClick={props.onClose}>
+                  <CloseIcon />
+                </IconButton>
               )}
             </div>
             {props.children}

--- a/components/common/BoardEditor/focalboard/src/components/dialog.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.tsx
@@ -41,16 +41,19 @@ function FBDialog(props: Props) {
         >
           <div role='dialog' className={clsx('dialog', { fullWidth })}>
             <div className='toolbar'>
+              {toolbar && <div className='cardToolbar'>{toolbar}</div>}
+              {toolsMenu}
               {!props.hideCloseButton && (
                 <IconButton
                   onClick={props.onClose}
                   icon={<CloseIcon />}
+                  style={{
+                    paddingLeft: '20px'
+                  }}
                   title={closeDialogText}
-                  className='IconButton--large'
+                  className='IconButton'
                 />
               )}
-              {toolbar && <div className='cardToolbar'>{toolbar}</div>}
-              {toolsMenu}
             </div>
             {props.children}
           </div>

--- a/components/common/PageActions.tsx
+++ b/components/common/PageActions.tsx
@@ -80,7 +80,7 @@ export function PageActions({
   }
   return (
     <>
-      <IconButton size='small' className='icons' onClick={handleClick}>
+      <IconButton size='small' sx={{ minWidth: '40px' }} className='icons' onClick={handleClick}>
         <MoreHorizIcon color='secondary' fontSize='small' />
       </IconButton>
       <Menu

--- a/components/common/PageDialog/PageDialog.tsx
+++ b/components/common/PageDialog/PageDialog.tsx
@@ -124,7 +124,6 @@ export default function PageDialog(props: Props) {
 
   return (
     <Dialog
-      hideCloseButton
       toolsMenu={
         !hideToolsMenu &&
         !readOnly &&


### PR DESCRIPTION
This PR relocates the close button to the right of the dialog, and actually shows it

<img width="1263" alt="Screenshot 2023-01-13 at 13 45 31" src="https://user-images.githubusercontent.com/18669748/212313164-959ba30a-843b-4386-994f-91a658698183.png">
