### PR TITLE
Xps engine - update to create a workspace 

### DIFF
--- a/lib/middleware/onError.ts
+++ b/lib/middleware/onError.ts
@@ -16,6 +16,11 @@ export function onError(err: any, req: NextApiRequest, res: NextApiResponse) {
       url: req.url,
       body: req.body
     });
+  } else {
+    log.warn(`Client Error: ${errorAsSystemError.message}`, {
+      url: req.url,
+      body: req.body
+    });
   }
 
   const { stack, message, ...withoutStack } = errorAsSystemError;

--- a/lib/public-api/createWorkspaceApi.ts
+++ b/lib/public-api/createWorkspaceApi.ts
@@ -5,6 +5,7 @@ import { prisma } from 'db';
 import { upsertUserForDiscordId } from 'lib/discord/upsertUserForDiscordId';
 import { createWorkspace } from 'lib/spaces/createWorkspace';
 import { getAvailableDomainName } from 'lib/spaces/getAvailableDomainName';
+import { createUserFromWallet } from 'lib/users/createUser';
 import { isValidUrl } from 'lib/utilities/isValidUrl';
 
 import type { CreateWorkspaceRequestBody, CreateWorkspaceResponseBody } from './interfaces';
@@ -13,6 +14,7 @@ export async function createWorkspaceApi({
   name,
   discordServerId,
   adminDiscordUserId,
+  adminWalletAddress,
   avatar,
   superApiToken
 }: CreateWorkspaceRequestBody & { superApiToken?: SuperApiToken | null }): Promise<CreateWorkspaceResponseBody> {
@@ -27,7 +29,9 @@ export async function createWorkspaceApi({
       identityType: 'RandomName'
     }
   });
-  const adminUserId = adminDiscordUserId ? await upsertUserForDiscordId(adminDiscordUserId) : null;
+  const adminUserId = adminDiscordUserId
+    ? await upsertUserForDiscordId(adminDiscordUserId)
+    : await createUserFromWallet({ address: adminWalletAddress }).then((user) => user.id);
 
   if (!adminUserId) {
     throw new Error('No admin user ID created. TODO: Implement support for wallet address');

--- a/lib/public-api/createWorkspaceApi.ts
+++ b/lib/public-api/createWorkspaceApi.ts
@@ -7,18 +7,7 @@ import { createWorkspace } from 'lib/spaces/createWorkspace';
 import { getAvailableDomainName } from 'lib/spaces/getAvailableDomainName';
 import { isValidUrl } from 'lib/utilities/isValidUrl';
 
-export type CreatedSpaceResponse = {
-  id: string;
-  spaceUrl: string;
-  joinUrl: string;
-};
-
-export type CreateSpaceApiInputData = {
-  name: string;
-  discordServerId: string;
-  adminDiscordUserId: string;
-  avatar?: string;
-};
+import type { CreateWorkspaceRequestBody, CreateWorkspaceResponseBody } from './interfaces';
 
 export async function createWorkspaceApi({
   name,
@@ -26,7 +15,7 @@ export async function createWorkspaceApi({
   adminDiscordUserId,
   avatar,
   superApiToken
-}: CreateSpaceApiInputData & { superApiToken?: SuperApiToken | null }): Promise<CreatedSpaceResponse> {
+}: CreateWorkspaceRequestBody & { superApiToken?: SuperApiToken | null }): Promise<CreateWorkspaceResponseBody> {
   // generate a domain name based on space
   const spaceDomain = await getAvailableDomainName(name);
 
@@ -38,7 +27,11 @@ export async function createWorkspaceApi({
       identityType: 'RandomName'
     }
   });
-  const adminUserId = await upsertUserForDiscordId(adminDiscordUserId);
+  const adminUserId = adminDiscordUserId ? await upsertUserForDiscordId(adminDiscordUserId) : null;
+
+  if (!adminUserId) {
+    throw new Error('No admin user ID created. TODO: Implement support for wallet address');
+  }
 
   // Create workspace
   const spaceData = {

--- a/lib/public-api/interfaces.ts
+++ b/lib/public-api/interfaces.ts
@@ -293,11 +293,20 @@ export interface Workspace {
  *          type: string
  *          example: Test DAO Space
  *        discordServerId:
+ *          required: false
  *          type: string
  *          example: 260918243123345408
  *        adminDiscordUserId:
+ *          required: false
  *          type: string
  *          example: 260918243123345408
+ *        adminWalletAddress:
+ *          required: false
+ *          type: string
+ *          example: 0x7684F0170a3B37640423b1CD9d8Cb817Edf301aE
+ *        xpsEngineId:
+ *          required: false
+ *          type: string
  *        avatar:
  *          required: false
  *          type: url
@@ -305,8 +314,10 @@ export interface Workspace {
  */
 export interface CreateWorkspaceRequestBody {
   name: string;
-  discordServerId: string;
-  adminDiscordUserId: string;
+  discordServerId?: string;
+  adminDiscordUserId?: string;
+  xpsEngineId?: string;
+  adminWalletAddress?: string;
   avatar?: string;
 }
 

--- a/pages/api-docs.tsx
+++ b/pages/api-docs.tsx
@@ -43,11 +43,11 @@ export default function ApiDoc({ spec }: InferGetStaticPropsType<typeof getStati
   const theme = useTheme();
   const colorMode = useColorMode();
 
-  useEffect(() => {
-    if (theme.palette.mode === 'dark') {
-      colorMode.toggleColorMode();
-    }
-  }, []);
+  // useEffect(() => {
+  //   if (theme.palette.mode === 'dark') {
+  //     colorMode.toggleColorMode();
+  //   }
+  // }, []);
 
   return <SwaggerUI spec={spec}></SwaggerUI>;
   //  ;

--- a/pages/api-docs.tsx
+++ b/pages/api-docs.tsx
@@ -43,12 +43,11 @@ export default function ApiDoc({ spec }: InferGetStaticPropsType<typeof getStati
   const theme = useTheme();
   const colorMode = useColorMode();
 
-  // TODO: optimize swagger docs for dark mode
-  // useEffect(() => {
-  //   if (theme.palette.mode === 'dark') {
-  //     colorMode.toggleColorMode();
-  //   }
-  // }, []);
+  useEffect(() => {
+    if (theme.palette.mode === 'dark') {
+      colorMode.toggleColorMode();
+    }
+  }, [theme.palette.mode]);
 
   return <SwaggerUI spec={spec}></SwaggerUI>;
   //  ;

--- a/pages/api-docs.tsx
+++ b/pages/api-docs.tsx
@@ -43,6 +43,7 @@ export default function ApiDoc({ spec }: InferGetStaticPropsType<typeof getStati
   const theme = useTheme();
   const colorMode = useColorMode();
 
+  // TODO: optimize swagger docs for dark mode
   // useEffect(() => {
   //   if (theme.palette.mode === 'dark') {
   //     colorMode.toggleColorMode();

--- a/pages/api/v1/spaces/index.ts
+++ b/pages/api/v1/spaces/index.ts
@@ -2,8 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
 import { onError, onNoMatch, requireSuperApiKey, requireKeys } from 'lib/middleware';
-import type { CreatedSpaceResponse, CreateSpaceApiInputData } from 'lib/public-api/createWorkspaceApi';
 import { createWorkspaceApi } from 'lib/public-api/createWorkspaceApi';
+import type { CreateWorkspaceResponseBody, CreateWorkspaceRequestBody } from 'lib/public-api/interfaces';
 import { withSessionRoute } from 'lib/session/withSession';
 import { InvalidInputError } from 'lib/utilities/errors';
 
@@ -11,16 +11,7 @@ const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler
   .use(requireSuperApiKey)
-  .use(
-    requireKeys(
-      [
-        { key: 'name', truthy: true },
-        { key: 'discordServerId', truthy: true },
-        { key: 'adminDiscordUserId', truthy: true }
-      ],
-      'body'
-    )
-  )
+  .use(requireKeys([{ key: 'name', truthy: true }], 'body'))
   .post(createSpace);
 
 /**
@@ -42,11 +33,18 @@ handler
  *              schema:
  *                $ref: '#/components/schemas/CreateWorkspaceResponseBody'
  */
-async function createSpace(req: NextApiRequest, res: NextApiResponse<CreatedSpaceResponse>) {
-  const { name, discordServerId, avatar, adminDiscordUserId } = req.body as CreateSpaceApiInputData;
+async function createSpace(req: NextApiRequest, res: NextApiResponse<CreateWorkspaceResponseBody>) {
+  const { name, discordServerId, avatar, adminDiscordUserId, xpsEngineId, adminWalletAddress } =
+    req.body as CreateWorkspaceRequestBody;
 
   if (name.length < 3) {
     throw new InvalidInputError('Workspace name must be at least 3 characters.');
+  }
+
+  if (discordServerId && !adminDiscordUserId) {
+    throw new InvalidInputError('Discord server ID provided but no admin user ID provided.');
+  } else if (xpsEngineId && !adminWalletAddress) {
+    throw new InvalidInputError('XPS engine ID provided but no admin wallet address provided.');
   }
 
   const result = await createWorkspaceApi({

--- a/pages/api/v1/spaces/index.ts
+++ b/pages/api/v1/spaces/index.ts
@@ -37,20 +37,21 @@ async function createSpace(req: NextApiRequest, res: NextApiResponse<CreateWorks
   const { name, discordServerId, avatar, adminDiscordUserId, xpsEngineId, adminWalletAddress } =
     req.body as CreateWorkspaceRequestBody;
 
-  if (name.length < 3) {
-    throw new InvalidInputError('Workspace name must be at least 3 characters.');
+  if (typeof name !== 'string' || name.length < 3) {
+    throw new InvalidInputError('Workspace name must be a string at least 3 characters.');
   }
 
-  if (discordServerId && !adminDiscordUserId) {
-    throw new InvalidInputError('Discord server ID provided but no admin user ID provided.');
-  } else if (xpsEngineId && !adminWalletAddress) {
-    throw new InvalidInputError('XPS engine ID provided but no admin wallet address provided.');
+  // check for an identifier for the admin user
+  const adminIdentifier = adminDiscordUserId || adminWalletAddress;
+  if (!adminIdentifier) {
+    throw new InvalidInputError('At least one admin identifer must be provided.');
   }
 
   const result = await createWorkspaceApi({
     name,
     discordServerId,
     adminDiscordUserId,
+    xpsEngineId,
     avatar,
     superApiToken: req.superApiToken
   });

--- a/prisma/migrations/20230113193547_add_xpsengine_to_space/migration.sql
+++ b/prisma/migrations/20230113193547_add_xpsengine_to_space/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Space" ADD COLUMN     "xpsEngineId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,12 +211,13 @@ model Space {
   defaultVotingDuration       Int?
   snapshotDomain              String?
   spaceImage                  String?
-  defaultPostCategoryId       String?                          @db.Uuid @unique
-  defaultPostCategory         PostCategory?                    @relation(fields: [defaultPostCategoryId], references: [id], name: "defaultPostCategory", onDelete: SetNull)
+  defaultPostCategoryId       String?                           @unique @db.Uuid
+  defaultPostCategory         PostCategory?                     @relation(fields: [defaultPostCategoryId], references: [id], name: "defaultPostCategory", onDelete: SetNull)
   defaultPagePermissionGroup  PagePermissionLevel?              @default(full_access)
   defaultPublicPages          Boolean?                          @default(false)
   permissionConfigurationMode SpacePermissionConfigurationMode? @default(custom)
   publicBountyBoard           Boolean?                          @default(false)
+  xpsEngineId                 String?
   author                      User                              @relation(fields: [createdBy], references: [id], onDelete: Cascade)
   blocks                      Block[]
   bounties                    Bounty[]
@@ -1011,12 +1012,13 @@ model MemberPropertyPermission {
 
 // Begin Forum models
 model PostCategory {
-  id      String @id @default(uuid()) @db.Uuid
-  name    String
+  id              String @id @default(uuid()) @db.Uuid
+  name            String
   defaultForSpace Space? @relation(name: "defaultPostCategory")
-  spaceId String @db.Uuid
-  space   Space  @relation(fields: [spaceId], references: [id], onDelete: Cascade)
-  Post    Post[]
+  spaceId         String @db.Uuid
+  space           Space  @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  Post            Post[]
+
   @@unique([spaceId, name])
 }
 


### PR DESCRIPTION
We need to keep track of the unique id from Game7 (XPS Engine) when they create a workspace. The admin will also have a wallet address instead of a discord user id, which still needs to be supported but my thought was to update the api docs so they could see it