### PR TITLE
try to fix log in thru discord

### DIFF
--- a/hooks/useWeb3AuthSig.tsx
+++ b/hooks/useWeb3AuthSig.tsx
@@ -165,11 +165,13 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
           setStoredAccount(null);
           logoutUser();
         });
-      } else {
-        setSignature(null);
-        setStoredAccount(null);
-        logoutUser();
       }
+      // TODO: Ask Mo hwo to handle this state
+      // } else {
+      //   setSignature(null);
+      //   setStoredAccount(null);
+      //   logoutUser();
+      // }
     }
   }, [account, user, isConnectingIdentity, isLoaded]);
 


### PR DESCRIPTION
I think we've introduced a new Discord login bug:
1) connect a web3 account to CV. (Don't verify wallet).
2) connect to Discord/Google

You will see a flash of content and be logged in automatically. This doesn't seem to happen if you've verified your wallet though - I'm assuming based on the code, however, that we would log you into the other metamask wallet if we have it verified, which is also not what the user wants