### PR TITLE
focus comment input on mobile

### DIFF
--- a/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
@@ -119,6 +119,7 @@ export function InlineCommentSubMenu({ pluginKey }: { pluginKey: PluginKey }) {
     <Box display='flex' width='400px'>
       <Box flexGrow={1}>
         <InlineCharmEditor
+          focusOnInit={true}
           content={commentContent}
           style={{
             fontSize: '14px'


### PR DESCRIPTION
Also sets max-width so that the comment input doesn't fall off the screen (for some reason, 100% width doesn't work so I used 100vw)