### PR TITLE
make sure to load space data in settings page

### DIFF
--- a/pages/[domain]/settings/workspace.tsx
+++ b/pages/[domain]/settings/workspace.tsx
@@ -56,6 +56,13 @@ export default function WorkspaceSettings() {
     charmClient.track.trackAction('page_view', { spaceId: space?.id, type: 'settings' });
   }, []);
 
+  // set default values when space is set
+  useEffect(() => {
+    if (space) {
+      reset(space);
+    }
+  }, [space?.id]);
+
   const watchName = watch('name');
   const watchSpaceImage = watch('spaceImage');
 


### PR DESCRIPTION
When visitng the space settings directly, the `space` data is not available right away, resulting in a blank form at first:



![image](https://user-images.githubusercontent.com/305398/212812129-81302700-a849-4bda-b68f-7cfdb8c4b4e9.png)

