### PR TITLE
dont call connect() when connecting to space sockets

### DIFF
--- a/hooks/useWebSocketClient.tsx
+++ b/hooks/useWebSocketClient.tsx
@@ -76,7 +76,7 @@ export function WebSocketClientProvider({ children }: { children: ReactNode }) {
     socket = io(socketHost, {
       withCredentials: true
       // path: '/api/socket'
-    }).connect();
+    });
 
     socket.on('connect', () => {
       log.info('[ws] Client connected');


### PR DESCRIPTION
It doesn't appear that we were getting two connections w/the space-wide socket server (I would expect the 'connect' event to trigger twice) the way we were with the namespaced one for "/ceditor", but the call to .connect() is also unnecessary. 

In VS Code, when I hover over connect(), this is the example they give for its usage (where you set autoConnect: false):
![image](https://user-images.githubusercontent.com/305398/213013249-a528507f-fad4-48f9-b4a8-8d450584d434.png)
