### PR TITLE
Fix hydration error when running Next in dev mode

### DIFF
--- a/components/common/RouteGuard.tsx
+++ b/components/common/RouteGuard.tsx
@@ -20,8 +20,7 @@ export default function RouteGuard({ children }: { children: ReactNode }) {
   const [authorized, setAuthorized] = useState(true);
   const { user, setUser, isLoaded } = useUser();
   const { spaces, isLoaded: isSpacesLoaded } = useSpaces();
-  const isRouterLoading = !router.isReady;
-  const isLoading = !isLoaded || isRouterLoading || !isSpacesLoaded;
+  const isLoading = !isLoaded || !isSpacesLoaded;
   const authorizedSpaceDomainRef = useRef('');
 
   if (typeof window !== 'undefined') {
@@ -129,7 +128,7 @@ export default function RouteGuard({ children }: { children: ReactNode }) {
     }
   }
 
-  if (!authorized || !router.isReady) {
+  if (!authorized) {
     return null;
   }
   return <span style={{ display: isLoading ? 'none' : 'inline' }}>{children}</span>;

--- a/components/settings/workspace/ImportNotionWorkspace.tsx
+++ b/components/settings/workspace/ImportNotionWorkspace.tsx
@@ -7,6 +7,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Grid from '@mui/material/Grid';
 import SvgIcon from '@mui/material/SvgIcon';
 import Typography from '@mui/material/Typography';
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useSWRConfig } from 'swr';
 
@@ -34,6 +35,7 @@ interface NotionResponseState {
 export default function ImportNotionWorkspace() {
   const [notionState, setNotionState] = useState<NotionResponseState>({ loading: false });
   const { showMessage } = useSnackbar();
+  const router = useRouter();
   const [modalOpen, setModalOpen] = useState(false);
   const { mutate } = useSWRConfig();
   const space = useCurrentSpace();
@@ -105,7 +107,7 @@ export default function ImportNotionWorkspace() {
             disabled={!isAdmin}
             disabledTooltip='Only admins can import content from Notion'
             loading={notionState.loading}
-            href={`/api/notion/login?redirect=${encodeURIComponent(window.location.href.split('?')[0])}`}
+            href={`/api/notion/login?redirect=${encodeURIComponent(router.asPath.split('?')[0])}`}
             variant='outlined'
             startIcon={
               <SvgIcon sx={{ color: 'text.primary' }}>

--- a/lib/utilities/browser.ts
+++ b/lib/utilities/browser.ts
@@ -1,5 +1,8 @@
 // using deprectead feature, navigator.userAgent doesnt exist yet in FF - https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform
 export function isMac() {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
   return (
     navigator.platform.toUpperCase().indexOf('MAC') >= 0 ||
     navigator.platform.toUpperCase().indexOf('IPHONE') >= 0 ||
@@ -131,7 +134,10 @@ export function setUrlWithoutRerender(pathname: string, params: Record<string, s
   window.history.replaceState(newState, '', displayPath);
 }
 
-export function getCookie(name: string): string {
+export function getCookie(name: string): string | undefined {
+  if (typeof document === 'undefined') {
+    return undefined;
+  }
   const cookieMap = document.cookie.split(';').reduce<{ [key: string]: string }>((cookies, cookie) => {
     const _name = cookie.trim().split('=')[0];
     const value = cookie.trim().split('=')[1];

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -209,11 +209,6 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
       refreshSignupData();
     }
   }, [router.isReady]);
-
-  if (!router.isReady) {
-    return null;
-  }
-
   // DO NOT REMOVE CacheProvider - it protects MUI from Tailwind CSS in settings
   return (
     <CacheProvider value={emotionCache}>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,10 @@
+import createCache from '@emotion/cache';
+import createEmotionServer from '@emotion/server/create-instance';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 
 import { blueColor } from 'theme/colors';
+
+// Source for Emotion SSR: import createEmotionServer from '@emotion/server/create-instance';
 
 class MyDocument extends Document<{ emotionStyleTags: any }> {
   render() {
@@ -28,7 +32,7 @@ class MyDocument extends Document<{ emotionStyleTags: any }> {
             property='twitter:image'
             content='https://app.charmverse.io/images/logo_black_lightgrey_opengraph.png'
           />
-          {/* {this.props.emotionStyleTags} */}
+          {(this.props as any).emotionStyleTags}
         </Head>
         <body>
           <Main />
@@ -38,5 +42,68 @@ class MyDocument extends Document<{ emotionStyleTags: any }> {
     );
   }
 }
+
+function createEmotionCache() {
+  return createCache({ key: 'mui-style' });
+}
+
+// `getInitialProps` belongs to `_document` (instead of `_app`),
+// it's compatible with static-site generation (SSG).
+MyDocument.getInitialProps = async (ctx) => {
+  // Resolution order
+  //
+  // On the server:
+  // 1. app.getInitialProps
+  // 2. page.getInitialProps
+  // 3. document.getInitialProps
+  // 4. app.render
+  // 5. page.render
+  // 6. document.render
+  //
+  // On the server with error:
+  // 1. document.getInitialProps
+  // 2. app.render
+  // 3. page.render
+  // 4. document.render
+  //
+  // On the client
+  // 1. app.getInitialProps
+  // 2. page.getInitialProps
+  // 3. app.render
+  // 4. page.render
+
+  const originalRenderPage = ctx.renderPage;
+
+  // You can consider sharing the same Emotion cache between all the SSR requests to speed up performance.
+  // However, be aware that it can have global side effects.
+  const cache = createEmotionCache();
+  const { extractCriticalToChunks } = createEmotionServer(cache);
+
+  ctx.renderPage = () =>
+    originalRenderPage({
+      enhanceApp: (App: any) =>
+        function EnhanceApp(props) {
+          return <App emotionCache={cache} {...props} />;
+        }
+    });
+
+  const initialProps = await Document.getInitialProps(ctx);
+  // This is important. It prevents Emotion to render invalid HTML.
+  // See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153
+  const emotionStyles = extractCriticalToChunks(initialProps.html);
+  const emotionStyleTags = emotionStyles.styles.map((style) => (
+    <style
+      data-emotion={`${style.key} ${style.ids.join(' ')}`}
+      key={style.key}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: style.css }}
+    />
+  ));
+
+  return {
+    ...initialProps,
+    emotionStyleTags
+  };
+};
 
 export default MyDocument;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,10 +1,6 @@
-import createCache from '@emotion/cache';
-import createEmotionServer from '@emotion/server/create-instance';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 
 import { blueColor } from 'theme/colors';
-
-// Source for Emotion SSR: import createEmotionServer from '@emotion/server/create-instance';
 
 class MyDocument extends Document<{ emotionStyleTags: any }> {
   render() {
@@ -32,7 +28,7 @@ class MyDocument extends Document<{ emotionStyleTags: any }> {
             property='twitter:image'
             content='https://app.charmverse.io/images/logo_black_lightgrey_opengraph.png'
           />
-          {(this.props as any).emotionStyleTags}
+          {/* {this.props.emotionStyleTags} */}
         </Head>
         <body>
           <Main />
@@ -42,68 +38,5 @@ class MyDocument extends Document<{ emotionStyleTags: any }> {
     );
   }
 }
-
-function createEmotionCache() {
-  return createCache({ key: 'mui-style' });
-}
-
-// `getInitialProps` belongs to `_document` (instead of `_app`),
-// it's compatible with static-site generation (SSG).
-MyDocument.getInitialProps = async (ctx) => {
-  // Resolution order
-  //
-  // On the server:
-  // 1. app.getInitialProps
-  // 2. page.getInitialProps
-  // 3. document.getInitialProps
-  // 4. app.render
-  // 5. page.render
-  // 6. document.render
-  //
-  // On the server with error:
-  // 1. document.getInitialProps
-  // 2. app.render
-  // 3. page.render
-  // 4. document.render
-  //
-  // On the client
-  // 1. app.getInitialProps
-  // 2. page.getInitialProps
-  // 3. app.render
-  // 4. page.render
-
-  const originalRenderPage = ctx.renderPage;
-
-  // You can consider sharing the same Emotion cache between all the SSR requests to speed up performance.
-  // However, be aware that it can have global side effects.
-  const cache = createEmotionCache();
-  const { extractCriticalToChunks } = createEmotionServer(cache);
-
-  ctx.renderPage = () =>
-    originalRenderPage({
-      enhanceApp: (App: any) =>
-        function EnhanceApp(props) {
-          return <App emotionCache={cache} {...props} />;
-        }
-    });
-
-  const initialProps = await Document.getInitialProps(ctx);
-  // This is important. It prevents Emotion to render invalid HTML.
-  // See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153
-  const emotionStyles = extractCriticalToChunks(initialProps.html);
-  const emotionStyleTags = emotionStyles.styles.map((style) => (
-    <style
-      data-emotion={`${style.key} ${style.ids.join(' ')}`}
-      key={style.key}
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: style.css }}
-    />
-  ));
-
-  return {
-    ...initialProps,
-    emotionStyleTags
-  };
-};
 
 export default MyDocument;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/305398/213099017-cbb1fb32-fb1d-4bce-ab12-297f22b5b75c.png)


Based on trial-and-error, I think the errors are related to our usage of `router.isReady` to determine how to render components, which Next.js says not to do. I added this logic [12 months](https://github.com/charmverse/app.charmverse.io/commit/85bac433b4121e3fb87c87281e545acf444652f8#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029R67) ago when I was first building the app, but it basically means we don't do any rendering on the server! My comment was about hiding components until the space is known, but all our components seem to handle it gracefully.

https://nextjs.org/docs/api-reference/next/router
> isReady: boolean - Whether the router fields are updated client-side and ready for use. Should only be used inside of useEffect methods and not for conditionally rendering on the server. See related docs for use case with [automatically statically optimized pages](https://nextjs.org/docs/advanced-features/automatic-static-optimization)