### PR TITLE
dont pull in defaults for local storage until after the first render

### DIFF
--- a/components/common/UserDisplay.tsx
+++ b/components/common/UserDisplay.tsx
@@ -66,8 +66,11 @@ interface UserDisplayProps extends StyleProps {
 
 function UserDisplay({ user, linkToProfile = false, ...props }: UserDisplayProps) {
   if (!user) {
+    // strip out invalid names
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { hideName, avatarSize, ...boxProps } = props;
     return (
-      <Box display='flex' alignItems='center' gap={1} {...props}>
+      <Box display='flex' alignItems='center' gap={1} {...boxProps}>
         <Avatar avatar={null} size='small' />
       </Box>
     );

--- a/hooks/useLocalStorage.tsx
+++ b/hooks/useLocalStorage.tsx
@@ -26,9 +26,7 @@ export function setStorageValue<T = any>(key: string, value: T, noPrefix?: boole
 }
 
 export function useLocalStorage<T = any>(key: string | null, defaultValue: T, noPrefix?: boolean) {
-  const [value, setValue] = useState<T>(() => {
-    return key ? getStorageValue(key, defaultValue, noPrefix) : defaultValue;
-  });
+  const [value, setValue] = useState<T>(defaultValue);
 
   // Any time the key changes we need to get the value from ls again
   useEffect(() => {


### PR DESCRIPTION
We aren't supposed to use the `window` object except inside a useEffect(), the useLocalStorage hook violates that rule, and it seems to be causing havoc in the sidebar right now: the default is set to "open", and the user can't change the state/close the sidebar

The good news is we don't really use this hook (!) so i'm not worried about other regressions

Bug report:  https://discord.com/channels/894960387743698944/1065339867971731537/1065339867971731537