### PR TITLE
set sidebar state before page renders

### DIFF
--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -126,16 +126,20 @@ function PageLayout({ sidebarWidth = 300, children, sidebar: SidebarOverride }: 
             <VotesProvider>
               <PageDialogProvider>
                 <PageActionDisplayProvider>
-                  <AppBar open={open} sidebarWidth={sidebarWidth} position='fixed'>
-                    <Header open={open} openSidebar={handleDrawerOpen} />
-                  </AppBar>
-                  <Drawer sidebarWidth={sidebarWidth} variant='permanent' open={open}>
-                    {SidebarOverride ? (
-                      <SidebarOverride closeSidebar={handleDrawerClose} />
-                    ) : (
-                      <Sidebar closeSidebar={handleDrawerClose} favorites={user?.favorites || []} />
-                    )}
-                  </Drawer>
+                  {open !== null && (
+                    <>
+                      <AppBar open={open} sidebarWidth={sidebarWidth} position='fixed'>
+                        <Header open={open} openSidebar={handleDrawerOpen} />
+                      </AppBar>
+                      <Drawer sidebarWidth={sidebarWidth} variant='permanent' open={open}>
+                        {SidebarOverride ? (
+                          <SidebarOverride closeSidebar={handleDrawerClose} />
+                        ) : (
+                          <Sidebar closeSidebar={handleDrawerClose} favorites={user?.favorites || []} />
+                        )}
+                      </Drawer>
+                    </>
+                  )}
                   <PageContainer>
                     <HeaderSpacer />
                     {children}

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -228,8 +228,8 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
     const currentPage = pages[currentPageId];
     // expand the parent of the active page
     if (currentPage?.parentId && !isFavorites) {
-      if (!expanded.includes(currentPage.parentId) && currentPage.type !== 'card') {
-        setExpanded(expanded.concat(currentPage.parentId));
+      if (!expanded?.includes(currentPage.parentId) && currentPage.type !== 'card') {
+        setExpanded(expanded?.concat(currentPage.parentId) ?? []);
       }
     }
   }, [currentPageId, pages, isFavorites]);
@@ -263,7 +263,7 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
   return (
     <StyledTreeRoot
       mutatePage={mutatePage}
-      expanded={expanded}
+      expanded={expanded ?? []}
       // @ts-ignore - we use null instead of undefined to control the element
       selected={selectedNodeId}
       onNodeToggle={onNodeToggle}

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,5 +1,5 @@
 // Note: NODE_ENV can only be 'development' or 'production' according to Next.js, but we don't want to mix them with test env
-export const isTestEnv = process.env.NEXT_PUBLIC_APP_ENV === 'test';
+export const isTestEnv = process.env.NEXT_PUBLIC_APP_ENV === 'test' || process.env.NODE_ENV === 'test';
 export const isStagingEnv = process.env.NEXT_PUBLIC_APP_ENV === 'staging';
 export const isDevEnv = process.env.NODE_ENV === 'development' && !isTestEnv && !isStagingEnv;
 export const isProdEnv = process.env.NODE_ENV === 'production' && !isTestEnv && !isStagingEnv;

--- a/hooks/useFocalboardViews.tsx
+++ b/hooks/useFocalboardViews.tsx
@@ -7,7 +7,7 @@ type FocalboardViewsRecord = Record<string, null | string>;
 
 interface IContext {
   focalboardViewsRecord: FocalboardViewsRecord;
-  setFocalboardViewsRecord: React.Dispatch<React.SetStateAction<FocalboardViewsRecord>>;
+  setFocalboardViewsRecord: React.Dispatch<React.SetStateAction<FocalboardViewsRecord | null>>;
 }
 
 export const FocalboardViewsContext = createContext<Readonly<IContext>>({
@@ -20,7 +20,7 @@ export function FocalboardViewsProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo(
     () => ({
-      focalboardViewsRecord,
+      focalboardViewsRecord: focalboardViewsRecord ?? {},
       setFocalboardViewsRecord
     }),
     [focalboardViewsRecord]

--- a/hooks/useLocalStorage.tsx
+++ b/hooks/useLocalStorage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 // Add a prefix so if our schema changes, we can invalidate previous content
 export const PREFIX = 'charm.v1';
@@ -29,7 +29,7 @@ export function useLocalStorage<T = any>(key: string | null, defaultValue: T, no
   const [value, setValue] = useState<T>(defaultValue);
 
   // Any time the key changes we need to get the value from ls again
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (key) {
       setValue(getStorageValue(key, defaultValue, noPrefix));
     }

--- a/hooks/useLocalStorage.tsx
+++ b/hooks/useLocalStorage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 // Add a prefix so if our schema changes, we can invalidate previous content
 export const PREFIX = 'charm.v1';
@@ -30,7 +30,7 @@ export function useLocalStorage<T = any>(key: string | null, defaultValue: T, no
   const [value, setValue] = useState<T | null>(null);
 
   // Any time the key changes we need to get the value from ls again
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (key) {
       setValue(getStorageValue(key, defaultValue, noPrefix));
     }

--- a/hooks/useLocalStorage.tsx
+++ b/hooks/useLocalStorage.tsx
@@ -25,8 +25,9 @@ export function setStorageValue<T = any>(key: string, value: T, noPrefix?: boole
   return value;
 }
 
+// value is null until we have a chance to check local storage
 export function useLocalStorage<T = any>(key: string | null, defaultValue: T, noPrefix?: boolean) {
-  const [value, setValue] = useState<T>(defaultValue);
+  const [value, setValue] = useState<T | null>(null);
 
   // Any time the key changes we need to get the value from ls again
   useLayoutEffect(() => {


### PR DESCRIPTION
Turns out, we can't rely on local storage to define UI preferences because it's not available for SSR. I removed a check on 'window', but now the sidebar is always open by default at first, even if it's supposed to be closed.
So this change doesn't render the sidbar/nav at all until the first render, which is unfortunate but we could fix using cookies and getServerSideProps