### PR TITLE
improve database search + CSS tweaks

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/dialog.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.tsx
@@ -18,12 +18,6 @@ type Props = {
 
 function FBDialog(props: Props) {
   const { toolbar, toolsMenu, fullWidth = false } = props;
-  const intl = useIntl();
-
-  const closeDialogText = intl.formatMessage({
-    id: 'Dialog.closeDialog',
-    defaultMessage: 'Close dialog'
-  });
 
   useHotkeys('esc', () => props.onClose());
 
@@ -43,8 +37,8 @@ function FBDialog(props: Props) {
               {toolbar && <div className='cardToolbar'>{toolbar}</div>}
               {toolsMenu}
               {!props.hideCloseButton && (
-                <IconButton onClick={props.onClose}>
-                  <CloseIcon />
+                <IconButton size='small' onClick={props.onClose}>
+                  <CloseIcon color='secondary' fontSize='small' />
                 </IconButton>
               )}
             </div>

--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions.tsx
@@ -160,6 +160,7 @@ function CharmVerseDatabases(props: DatabaseSourceProps & { activePageId?: strin
     <>
       <SidebarContent>
         <TextField
+          autoFocus
           placeholder='Search pages'
           value={searchTerm}
           onChange={(e) => {
@@ -170,7 +171,12 @@ function CharmVerseDatabases(props: DatabaseSourceProps & { activePageId?: strin
           }}
           fullWidth
         />
-        <PagesList isDatabase pages={sortedPages} activePageId={props.activePageId} onSelectPage={onSelect} />
+        <PagesList
+          emptyText='No databases found'
+          pages={sortedPages}
+          activePageId={props.activePageId}
+          onSelectPage={onSelect}
+        />
       </SidebarContent>
       {props.onCreate && (
         <MenuItem onClick={props.onCreate}>

--- a/components/common/CharmEditor/components/PageList.tsx
+++ b/components/common/CharmEditor/components/PageList.tsx
@@ -10,11 +10,11 @@ interface Props {
   activePageId?: string;
   pages: PageMeta[];
   onSelectPage: (page: PageMeta) => void;
-  isDatabase?: boolean;
+  emptyText?: string;
 }
 
 export default function PagesList({
-  isDatabase = false,
+  emptyText = 'No pages found',
   activeItemIndex = -1,
   activePageId,
   pages,
@@ -33,7 +33,7 @@ export default function PagesList({
       variant='subtitle2'
       color='secondary'
     >
-      No {isDatabase ? 'databases' : 'pages'} found
+      {emptyText}
     </Typography>
   ) : (
     <div

--- a/components/common/PageActions.tsx
+++ b/components/common/PageActions.tsx
@@ -80,7 +80,7 @@ export function PageActions({
   }
   return (
     <>
-      <IconButton size='small' sx={{ minWidth: '40px' }} className='icons' onClick={handleClick}>
+      <IconButton size='small' className='icons' onClick={handleClick}>
         <MoreHorizIcon color='secondary' fontSize='small' />
       </IconButton>
       <Menu


### PR DESCRIPTION
When the sideview opens now, I get a cursor floating out in the middle of nowhere - if I start typing, it appears to be focused on the CharmEditor! This fixes what I'm seeing in Firefox:

<img width="333" alt="image" src="https://user-images.githubusercontent.com/305398/213574219-9a22e1d7-b4b9-4dbf-ab3e-d7b54ec19491.png">
