### PR TITLE
add missing indices

### DIFF
--- a/prisma/migrations/20230119234413_add_missing_indices/migration.sql
+++ b/prisma/migrations/20230119234413_add_missing_indices/migration.sql
@@ -1,0 +1,26 @@
+-- CreateIndex
+CREATE INDEX "GoogleAccount_email_idx" ON "GoogleAccount"("email");
+
+-- CreateIndex
+CREATE INDEX "GoogleAccount_userId_idx" ON "GoogleAccount"("userId");
+
+-- CreateIndex
+CREATE INDEX "Post_categoryId_idx" ON "Post"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "Post_path_idx" ON "Post"("path");
+
+-- CreateIndex
+CREATE INDEX "Post_spaceId_deletedAt_idx" ON "Post"("spaceId", "deletedAt");
+
+-- CreateIndex
+CREATE INDEX "Post_spaceId_deletedAt_categoryId_idx" ON "Post"("spaceId", "deletedAt", "categoryId");
+
+-- CreateIndex
+CREATE INDEX "Post_spaceId_deletedAt_categoryId_title_contentText_idx" ON "Post"("spaceId", "deletedAt", "categoryId", "title", "contentText");
+
+-- CreateIndex
+CREATE INDEX "UnstoppableDomain_domain_idx" ON "UnstoppableDomain"("domain");
+
+-- CreateIndex
+CREATE INDEX "UnstoppableDomain_userId_idx" ON "UnstoppableDomain"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1012,12 +1012,12 @@ model MemberPropertyPermission {
 
 // Begin Forum models
 model PostCategory {
-  id      String @id @default(uuid()) @db.Uuid
-  name    String
-  path    String?
-  defaultForSpace Space? @relation(name: "defaultPostCategory")
-  spaceId         String @db.Uuid
-  space           Space  @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  id              String  @id @default(uuid()) @db.Uuid
+  name            String
+  path            String?
+  defaultForSpace Space?  @relation(name: "defaultPostCategory")
+  spaceId         String  @db.Uuid
+  space           Space   @relation(fields: [spaceId], references: [id], onDelete: Cascade)
   Post            Post[]
 
   @@unique([spaceId, name])
@@ -1044,6 +1044,12 @@ model Post {
   comments           PostComment[]
   upDownVotes        PostUpDownVote[]
   commentUpDownVotes PostCommentUpDownVote[]
+
+  @@index([categoryId])
+  @@index([path])
+  @@index([spaceId, deletedAt]) // space feed
+  @@index([spaceId, deletedAt, categoryId]) // category feed
+  @@index([spaceId, deletedAt, categoryId, title, contentText]) // search results
 }
 
 model PostUpDownVote {
@@ -1095,6 +1101,9 @@ model UnstoppableDomain {
   domain String @unique
   userId String @db.Uuid
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([domain])
+  @@index([userId])
 }
 
 model GoogleAccount {
@@ -1104,6 +1113,9 @@ model GoogleAccount {
   avatarUrl String
   userId    String @db.Uuid
   user      User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([email])
+  @@index([userId])
 }
 
 model GoogleCredential {


### PR DESCRIPTION
just db cleanup. Ideally, every query we make is hitting an index. And indices on things like posts are an easy trade-off since they spend most of their time being read not written (which is more expensive with indices).