### PR TITLE
CharmEditor Embed improvements

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -13,7 +13,7 @@ import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
 import { useRouter } from 'next/router';
 import type { CSSProperties, ReactNode } from 'react';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { useSWRConfig } from 'swr';
 
 import charmClient from 'charmClient';

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -489,15 +489,6 @@ function CharmEditor({
       color: 'var(--charmeditor-active)'
     }
   });
-
-  const onResizeStop = useCallback(
-    (view: EditorView) => {
-      // Save the current embed size on the backend after we are done resizing
-      debouncedUpdate(view);
-    },
-    [debouncedUpdate]
-  );
-
   useEffect(() => {
     if (editorRef.current) {
       const highlightedMentionId = router.query.mentionId;
@@ -547,7 +538,6 @@ function CharmEditor({
       renderNodeViews={({ children: _children, ...props }) => {
         const allProps: CharmNodeViewProps = {
           ...props,
-          onResizeStop,
           pageId,
           readOnly,
           deleteNode: () => {

--- a/components/common/CharmEditor/components/@bangle.dev/base-components/image.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/base-components/image.ts
@@ -24,6 +24,7 @@ function specFactory(): RawSpecs {
     type: 'node',
     name,
     schema: {
+      atom: true,
       inline: true,
       attrs: {
         caption: {

--- a/components/common/CharmEditor/components/Resizable/HorizontalResizer.tsx
+++ b/components/common/CharmEditor/components/Resizable/HorizontalResizer.tsx
@@ -19,8 +19,9 @@ function Resizer(props: ResizerProps) {
   const width = Math.min(props.width, props.maxWidth || Infinity);
   const height = props.aspectRatio ? width / props.aspectRatio : 0;
 
+  // stop propagation of mousedown event to avoid selection in Prosemirror, which makes drag/drop not work very well
   return (
-    <ResizableContainer>
+    <ResizableContainer onMouseDown={(e) => e.stopPropagation()}>
       <ResizableBox
         onResize={props.onResize}
         width={width}

--- a/components/common/CharmEditor/components/Resizable/Resizable.tsx
+++ b/components/common/CharmEditor/components/Resizable/Resizable.tsx
@@ -2,7 +2,7 @@ import type { NodeViewProps } from '@bangle.dev/core';
 import type { EditorView } from '@bangle.dev/pm';
 import { useEditorViewContext } from '@bangle.dev/react';
 import type { ReactNode } from 'react';
-import { useCallback, useState, memo, useRef } from 'react';
+import { useCallback, useState, memo, useEffect, useRef } from 'react';
 
 import BlockAligner from '../BlockAligner';
 
@@ -34,6 +34,10 @@ function Resizable(props: ResizableProps) {
       setSize(data.size.width);
     }
   }, []);
+
+  useEffect(() => {
+    setSize(initialSize);
+  }, [initialSize]);
 
   return (
     <div ref={containerRef}>

--- a/components/common/CharmEditor/components/Resizable/Resizable.tsx
+++ b/components/common/CharmEditor/components/Resizable/Resizable.tsx
@@ -15,13 +15,11 @@ interface ResizableProps {
   minWidth: number;
   updateAttrs: NodeViewProps['updateAttrs'];
   onDelete: () => void;
-  onResizeStop?: (view: EditorView) => void;
 }
 
 function Resizable(props: ResizableProps) {
-  const { onResizeStop, updateAttrs, onDelete, initialSize = 100, aspectRatio, children, minWidth } = props;
+  const { updateAttrs, onDelete, initialSize = 100, aspectRatio, children, minWidth } = props;
   const [size, setSize] = useState(initialSize || 100);
-  const view = useEditorViewContext();
   const containerRef = useRef<HTMLDivElement>(null);
   const maxWidth = containerRef.current?.clientWidth;
 
@@ -29,9 +27,6 @@ function Resizable(props: ResizableProps) {
     updateAttrs({
       size: data.size.width
     });
-    if (onResizeStop) {
-      onResizeStop(view);
-    }
   }, []);
 
   const onResizeCallback = useCallback((_: any, data: any) => {

--- a/components/common/CharmEditor/components/Resizable/VerticalResizer.tsx
+++ b/components/common/CharmEditor/components/Resizable/VerticalResizer.tsx
@@ -19,7 +19,7 @@ function VerticalResizer(props: ResizerProps) {
   const { width, height, onResizeStop, onResize, minConstraints, maxConstraints, children } = props;
 
   return (
-    <ResizableContainer>
+    <ResizableContainer onMouseDown={(e) => e.stopPropagation()}>
       <ResizableBox
         onResize={onResize}
         width={width}

--- a/components/common/CharmEditor/components/ResizableImage.tsx
+++ b/components/common/CharmEditor/components/ResizableImage.tsx
@@ -128,7 +128,6 @@ function ResizableImage({
   readOnly = false,
   getPos,
   view,
-  onResizeStop,
   deleteNode,
   node,
   updateAttrs,
@@ -215,13 +214,7 @@ function ResizableImage({
     );
   } else {
     return (
-      <Resizable
-        initialSize={node.attrs.size}
-        minWidth={MIN_IMAGE_WIDTH}
-        updateAttrs={updateAttrs}
-        onDelete={onDelete}
-        onResizeStop={onResizeStop}
-      >
+      <Resizable initialSize={node.attrs.size} minWidth={MIN_IMAGE_WIDTH} updateAttrs={updateAttrs} onDelete={onDelete}>
         <StyledImage draggable={false} src={node.attrs.src} alt={node.attrs.alt} />
       </Resizable>
     );

--- a/components/common/CharmEditor/components/ResizablePDF.tsx
+++ b/components/common/CharmEditor/components/ResizablePDF.tsx
@@ -208,13 +208,7 @@ function ResizablePDF({
     return <PDF url={url} width={size} />;
   } else {
     return (
-      <Resizable
-        initialSize={size}
-        minWidth={MIN_PDF_WIDTH}
-        updateAttrs={updateAttrs}
-        onDelete={() => handleDelete()}
-        onResizeStop={onResizeStop}
-      >
+      <Resizable initialSize={size} minWidth={MIN_PDF_WIDTH} updateAttrs={updateAttrs} onDelete={() => handleDelete()}>
         <PDF url={url} width={size} />
       </Resizable>
     );

--- a/components/common/CharmEditor/components/common/MediaUrlInput.tsx
+++ b/components/common/CharmEditor/components/common/MediaUrlInput.tsx
@@ -8,6 +8,7 @@ type InputProps = {
   helperText?: string;
   isValid?: (url: string) => boolean;
   onSubmit: (url: string) => void;
+  multiline?: boolean;
 };
 
 export function MediaUrlInput(props: InputProps) {
@@ -17,7 +18,9 @@ export function MediaUrlInput(props: InputProps) {
     <Box display='flex' flexDirection='column' gap={2} alignItems='center'>
       <TextField
         autoFocus
+        multiline={props.multiline}
         placeholder={props.placeholder}
+        sx={{ width: 400, maxWidth: '100%' }}
         value={embedUrl}
         onChange={(e) => setEmbedUrl(e.target.value)}
       />
@@ -27,7 +30,7 @@ export function MediaUrlInput(props: InputProps) {
           width: 250
         }}
         onClick={() => {
-          props.onSubmit(ensureProtocol(embedUrl));
+          props.onSubmit(ensureProtocol(embedUrl.trim()));
           setEmbedUrl('');
         }}
       >
@@ -44,7 +47,7 @@ export function MediaUrlInput(props: InputProps) {
 
 // automatically add https:// to user input
 function ensureProtocol(userInput: string) {
-  if (userInput.startsWith('http')) {
+  if (userInput.includes('http')) {
     return userInput;
   }
   return `https://${userInput}`;

--- a/components/common/CharmEditor/components/fiduswriter/collab/doc.ts
+++ b/components/common/CharmEditor/components/fiduswriter/collab/doc.ts
@@ -127,6 +127,7 @@ export class ModCollabDoc {
       schema: this.mod.editor.schema,
       doc: stateDoc,
       plugins: this.mod.editor.view.state.plugins.concat(plugins),
+      // if we dont include the selection, the first node gets selected for some reason
       selection: this.mod.editor.view.state.selection
     };
 

--- a/components/common/CharmEditor/components/fiduswriter/collab/doc.ts
+++ b/components/common/CharmEditor/components/fiduswriter/collab/doc.ts
@@ -1,6 +1,7 @@
 import type { Transaction } from '@bangle.dev/pm';
 import { Step, EditorState } from '@bangle.dev/pm';
 import { sendableSteps, receiveTransaction } from 'prosemirror-collab';
+import type { EditorStateConfig } from 'prosemirror-state';
 
 import log from 'lib/log';
 import type {
@@ -122,10 +123,11 @@ export class ModCollabDoc {
       // filter out plugins in case we already loaded the doc once
       .filter((plugin) => !currentPlugins.some((p) => (p as any).key === plugin.key));
 
-    const stateConfig = {
+    const stateConfig: EditorStateConfig = {
       schema: this.mod.editor.schema,
       doc: stateDoc,
-      plugins: this.mod.editor.view.state.plugins.concat(plugins)
+      plugins: this.mod.editor.view.state.plugins.concat(plugins),
+      selection: this.mod.editor.view.state.selection
     };
 
     // Set document in prosemirror
@@ -138,8 +140,9 @@ export class ModCollabDoc {
       // this.mod.editor.scrollIdIntoView(locationHash.slice(1));
     }
 
+    // DISABLED FOR NOW (Matt) - this moves the page around after first load
     // scroll to top in case we had to reset the content due to large payload
-    this.mod.editor.view.dispatch(this.mod.editor.view.state.tr.scrollIntoView());
+    // this.mod.editor.view.dispatch(this.mod.editor.view.state.tr.scrollIntoView());
 
     this.mod.editor.waitingForDocument = false;
   }

--- a/components/common/CharmEditor/components/iframe/IframeComponent.tsx
+++ b/components/common/CharmEditor/components/iframe/IframeComponent.tsx
@@ -136,7 +136,11 @@ function IframeComponent({ readOnly, node, getPos, view, deleteNode, selected, u
             allowFullScreen
             title='iframe'
             src={embeddableSrc}
-            style={{ height: '100%', border: '0 solid transparent', width: '100%' }}
+            style={{
+              width: '100%',
+              height: '100%',
+              border: '0 solid transparent'
+            }}
           />
         </IframeContainer>
       </VerticalResizer>

--- a/components/common/CharmEditor/components/iframe/__tests__/utils.spec.ts
+++ b/components/common/CharmEditor/components/iframe/__tests__/utils.spec.ts
@@ -4,6 +4,12 @@ describe('CharmEditor iframe utils', () => {
   test('extractIframeProps() extracts data from Google forms embed code', () => {
     const src = 'https://docs.google.com/forms/d/e/1FAI...ltEQ/viewform?embedded=true';
     const sample = `<iframe src="${src}" width="640" height="2831" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>`;
-    expect(extractIframeProps(sample)).toEqual({ src, height: 2831 });
+    expect(extractIframeProps(sample)).toEqual({ src, width: 640, height: 2831 });
+  });
+
+  test('extractIframeProps() extracts width and height, even with fancy quotes and pixel units', () => {
+    const src = 'https://docs.google.com/forms';
+    const sample = `<iframe src="${src}" width=“640px“ height="2831" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>`;
+    expect(extractIframeProps(sample)).toEqual({ src, width: 640, height: 2831 });
   });
 });

--- a/components/common/CharmEditor/components/iframe/iframe.ts
+++ b/components/common/CharmEditor/components/iframe/iframe.ts
@@ -30,19 +30,23 @@ export function plugins() {
           const text = event.clipboardData.getData('text/plain');
           const html = event.clipboardData.getData('text/html');
           const isPlainText = text && !html;
-
           if (!isPlainText) {
             return false;
           }
           const props = extractIframeProps(text);
           if (props) {
-            const { src, height } = props;
+            const { src, height, width } = props;
             if (extractYoutubeLinkType(src)) {
               const attrs: Partial<VideoNodeAttrs> = { src };
               insertNode(videoName, view.state, view.dispatch, view, attrs);
             } else {
               const embedType = extractEmbedType(src);
-              const attrs: Partial<IframeNodeAttrs> = { src, height: height ?? MIN_EMBED_HEIGHT, type: embedType };
+              const attrs: Partial<IframeNodeAttrs> = {
+                src,
+                height: height ?? MIN_EMBED_HEIGHT,
+                width: width || undefined,
+                type: embedType
+              };
               insertNode(name, view.state, view.dispatch, view, attrs);
             }
             return true;

--- a/components/common/CharmEditor/components/iframe/iframeSpec.ts
+++ b/components/common/CharmEditor/components/iframe/iframeSpec.ts
@@ -54,13 +54,24 @@ export function spec(): RawSpecs {
           tag: 'iframe',
           getAttrs: (dom: any) => {
             return {
-              src: dom.getAttribute('src')
+              src: dom.getAttribute('src'),
+              width: dom.getAttribute('data-width'),
+              height: dom.getAttribute('data-height'),
+              type: dom.getAttribute('data-type')
             };
           }
         }
       ],
       toDOM: (node: Node) => {
-        return ['iframe', { class: 'ns-embed', style: `height: ${node.attrs.height};`, ...node.attrs }];
+        return [
+          'iframe',
+          {
+            class: 'ns-embed',
+            'data-height': node.attrs.height,
+            'data-width': node.attrs.height,
+            'data-type': node.attrs.height
+          }
+        ];
       }
     }
   });

--- a/components/common/CharmEditor/components/iframe/utils.ts
+++ b/components/common/CharmEditor/components/iframe/utils.ts
@@ -35,6 +35,10 @@ export function extractIframeProps(pastedHtml: string): IframeProps | null {
 
 function getNumberFromString(html: string, param: string): number | null {
   const extracted = getParamFromString(html, param);
+  // ignore percentages
+  if (extracted?.includes('%')) {
+    return null;
+  }
   const parsed = extracted ? parseInt(extracted.replace('px', '').trim(), 10) : null;
   // check if parsed is a number
   if (parsed && !Number.isNaN(parsed)) {

--- a/components/common/CharmEditor/components/inlinePalette/editorItems/database.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/editorItems/database.tsx
@@ -89,7 +89,7 @@ export function items({
     uid: 'database-linked',
     title: 'Linked view of database',
     icon: <DatabaseIcon sx={{ fontSize: iconSize }} />,
-    description: 'Embed a view from an existing board',
+    description: 'Insert a view from an existing board',
     editorExecuteCommand: ({ palettePluginKey }) => {
       return (state, dispatch, view) => {
         // Execute the animation

--- a/components/common/CharmEditor/components/inlinePalette/editorItems/media.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/editorItems/media.tsx
@@ -47,6 +47,7 @@ export function items(): PaletteItemTypeNoGroup[] {
       title: 'Video',
       icon: <VideoLibraryIcon sx={{ fontSize: iconSize }} />,
       description: 'Insert a video block',
+      keywords: ['youtube'],
       editorExecuteCommand: ({ palettePluginKey }) => {
         return (state, dispatch, view) => {
           if (view) {

--- a/components/common/CharmEditor/components/nodeView/nodeView.ts
+++ b/components/common/CharmEditor/components/nodeView/nodeView.ts
@@ -2,7 +2,6 @@ import type { NodeViewProps } from '@bangle.dev/core';
 import type { EditorView } from '@bangle.dev/pm';
 
 export type CharmNodeViewProps = {
-  onResizeStop: (view: EditorView) => void;
   pageId?: string;
   readOnly: boolean;
   deleteNode: () => void;

--- a/components/common/CharmEditor/components/video/VideoNodeView.tsx
+++ b/components/common/CharmEditor/components/video/VideoNodeView.tsx
@@ -26,7 +26,6 @@ export function VideoNodeView({
   pageId,
   readOnly,
   node,
-  onResizeStop,
   selected,
   updateAttrs,
   isPost = false
@@ -128,7 +127,6 @@ export function VideoNodeView({
           updateAttrs({ width: args.size });
         }}
         onDelete={deleteNode}
-        onResizeStop={onResizeStop}
       >
         <IframeContainer>
           <iframe

--- a/components/common/CharmEditor/components/video/video.ts
+++ b/components/common/CharmEditor/components/video/video.ts
@@ -8,7 +8,7 @@ export function plugins() {
   return [
     NodeView.createPlugin({
       name: 'video',
-      containerDOM: ['video-embed']
+      containerDOM: ['div', { class: 'video-container' }]
     })
   ];
 }

--- a/components/common/CharmEditor/specs/embeddedNodeSpec.ts
+++ b/components/common/CharmEditor/specs/embeddedNodeSpec.ts
@@ -10,6 +10,7 @@ export function embeddedNodeSpec(_spec: EmbeddedSpecProps): RawSpecs {
     name: _spec.name,
     markdown: _spec.markdown,
     schema: {
+      atom: true,
       group: 'block',
       inline: false,
       draggable: false,

--- a/hooks/useLocalStorage.tsx
+++ b/hooks/useLocalStorage.tsx
@@ -32,7 +32,8 @@ export function useLocalStorage<T = any>(key: string | null, defaultValue: T, no
   // Any time the key changes we need to get the value from ls again
   useEffect(() => {
     if (key) {
-      setValue(getStorageValue(key, defaultValue, noPrefix));
+      const storedValue = getStorageValue(key, defaultValue, noPrefix);
+      setValue(storedValue || defaultValue);
     }
   }, [key]);
 

--- a/hooks/useLocalStorage.tsx
+++ b/hooks/useLocalStorage.tsx
@@ -33,6 +33,7 @@ export function useLocalStorage<T = any>(key: string | null, defaultValue: T, no
   useEffect(() => {
     if (key) {
       const storedValue = getStorageValue(key, defaultValue, noPrefix);
+      // use defaultValue as a fallback in case storedValue is null
       setValue(storedValue || defaultValue);
     }
   }, [key]);

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -64,6 +64,12 @@
   background-color: var(--background-default);
 }
 
+
+/* Prevent iframes from stealing drag events - https://github.com/react-grid-layout/react-draggable/issues/613 */
+.react-draggable-transparent-selection iframe {
+  pointer-events: none;
+}
+
 .ProseMirror .column-resize-handle {
   position: absolute;
   right: -2px;


### PR DESCRIPTION
- smoother resizing of sizes
- allow users to resize width of iframe
- smarter parsing for width/height attributes from pasted code
- add an "Embed" and "Link" tabs when inputting a iframe src, however we wanted to support embed codes no matter which tab you use - this is just a trick to educate users that they can use embed codes