### PR TITLE
reset view settings state when navigating between databases

### DIFF
--- a/components/[pageId]/DatabasePage/DatabasePage.tsx
+++ b/components/[pageId]/DatabasePage/DatabasePage.tsx
@@ -142,6 +142,8 @@ export function DatabasePage({ page, setPage, readOnly = false, pagePermissions 
             viewId: viewId || ''
           }
         });
+        // call setCurrentViewId in case user clicked "add view", because we didnt update the URL so it wouldnt affect the activeView
+        setCurrentViewId(viewId);
       }
     },
     [router.query]

--- a/components/[pageId]/DatabasePage/DatabasePage.tsx
+++ b/components/[pageId]/DatabasePage/DatabasePage.tsx
@@ -12,7 +12,7 @@ import {
   setCurrent as setCurrentBoard
 } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import { useAppDispatch, useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
-import { initialReadOnlyLoad } from 'components/common/BoardEditor/focalboard/src/store/initialLoad';
+import { initialLoad, initialReadOnlyLoad } from 'components/common/BoardEditor/focalboard/src/store/initialLoad';
 import {
   getCurrentBoardViews,
   getView,
@@ -40,9 +40,11 @@ interface Props {
 export function DatabasePage({ page, setPage, readOnly = false, pagePermissions }: Props) {
   const router = useRouter();
   const board = useAppSelector(getCurrentBoard);
-  const [currentViewId, setCurrentViewId] = useState<string>(router.query.viewId as string);
-  const activeView = useAppSelector(getView(currentViewId));
+  const [currentViewId, setCurrentViewId] = useState<string | undefined>(router.query.viewId as string | undefined);
   const boardViews = useAppSelector(getCurrentBoardViews);
+  // grab the first board view if current view is not specified
+  const activeView =
+    typeof currentViewId === 'string' ? boardViews.find((view) => view.id === currentViewId) : boardViews[0];
   const dispatch = useAppDispatch();
   const [shownCardId, setShownCardId] = useState<string | null>((router.query.cardId as string) ?? null);
 

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -106,8 +106,10 @@ function CenterPanel(props: Props) {
   useEffect(() => {
     if (views.length === 0 && !activeView) {
       setState((s) => ({ ...s, showSettings: 'create-linked-view' }));
+    } else if (activeView) {
+      setState((s) => ({ ...s, showSettings: null }));
     }
-  }, [!!activeView, views.length]);
+  }, [activeView?.id, views.length]);
 
   const isEmbedded = !!props.embeddedBoardPath;
   const boardPage = pages[board.id];

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -93,7 +93,7 @@ function CenterPanel(props: Props) {
     cardIdToFocusOnRender: '',
     selectedCardIds: [],
     // assume this is a page type 'inline_linked_board' or 'linked_board' if no view exists
-    showSettings: !props.activeView ? 'create-linked-view' : null
+    showSettings: null
   });
 
   const [loadingFormResponses, setLoadingFormResponses] = useState(false);
@@ -122,7 +122,6 @@ function CenterPanel(props: Props) {
   }
 
   const activeBoard = useAppSelector(getBoard(activeBoardId ?? ''));
-  const loadingState = useAppSelector(getLoadingState());
   const activePage = pages[activeBoardId ?? ''];
   const _groupByProperty = activeBoard?.fields.cardProperties.find((o) => o.id === activeView?.fields.groupById);
   const _dateDisplayProperty = activeBoard?.fields.cardProperties.find(

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -436,6 +436,7 @@ function CenterPanel(props: Props) {
 
   return (
     <div
+      // remount components between pages
       className={`BoardComponent ${isEmbedded ? 'embedded-board' : ''}`}
       ref={backgroundRef}
       onClick={(e) => {
@@ -465,6 +466,7 @@ function CenterPanel(props: Props) {
           />
         )}
         <ViewHeader
+          key={board.id}
           onDeleteView={props.onDeleteView}
           maxTabsShown={props.maxTabsShown}
           disableUpdatingUrl={props.disableUpdatingUrl}

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -431,7 +431,7 @@ function CenterPanel(props: Props) {
     }
   }, [`${activeView?.fields.sourceData?.formId}${activeView?.fields.sourceData?.boardId}`]);
 
-  const isLoadingSourceData = !loadingState.loaded || (!activeBoard && state.showSettings !== 'create-linked-view');
+  const isLoadingSourceData = !activeBoard && state.showSettings !== 'create-linked-view';
 
   return (
     <div

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -28,6 +28,7 @@ import {
   sortCards
 } from 'components/common/BoardEditor/focalboard/src/store/cards';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
+import { getLoadingState } from 'components/common/BoardEditor/focalboard/src/store/loadingState';
 import Button from 'components/common/Button';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
@@ -102,6 +103,12 @@ function CenterPanel(props: Props) {
   const { pages, updatePage } = usePages();
   const { members } = useMembers();
 
+  useEffect(() => {
+    if (views.length === 0 && !activeView) {
+      setState((s) => ({ ...s, showSettings: 'create-linked-view' }));
+    }
+  }, [!!activeView, views.length]);
+
   const isEmbedded = !!props.embeddedBoardPath;
   const boardPage = pages[board.id];
   const boardPageType = boardPage?.type;
@@ -115,6 +122,7 @@ function CenterPanel(props: Props) {
   }
 
   const activeBoard = useAppSelector(getBoard(activeBoardId ?? ''));
+  const loadingState = useAppSelector(getLoadingState());
   const activePage = pages[activeBoardId ?? ''];
   const _groupByProperty = activeBoard?.fields.cardProperties.find((o) => o.id === activeView?.fields.groupById);
   const _dateDisplayProperty = activeBoard?.fields.cardProperties.find(
@@ -423,7 +431,7 @@ function CenterPanel(props: Props) {
     }
   }, [`${activeView?.fields.sourceData?.formId}${activeView?.fields.sourceData?.boardId}`]);
 
-  const isLoadingSourceData = !activeBoard && state.showSettings !== 'create-linked-view';
+  const isLoadingSourceData = !loadingState.loaded || (!activeBoard && state.showSettings !== 'create-linked-view');
 
   return (
     <div

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -466,7 +466,6 @@ function CenterPanel(props: Props) {
           />
         )}
         <ViewHeader
-          key={board.id}
           onDeleteView={props.onDeleteView}
           maxTabsShown={props.maxTabsShown}
           disableUpdatingUrl={props.disableUpdatingUrl}

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
@@ -94,7 +94,7 @@ function ViewHeader(props: Props) {
   }
 
   return (
-    <div className={`ViewHeader ${props.showActionsOnHover ? 'hide-actions' : ''}`}>
+    <div key={viewsBoardId} className={`ViewHeader ${props.showActionsOnHover ? 'hide-actions' : ''}`}>
       <ViewTabs
         onDeleteView={props.onDeleteView}
         addViewButton={props.addViewButton}

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
@@ -238,7 +238,6 @@ function ViewTabs(props: ViewTabsProps) {
                 fontWeight={500}
                 gap={1}
               >
-                {iconForViewType(view.fields.viewType)}
                 {view.title || formatViewTitle(view)}
               </StyledTabContent>
             }

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
@@ -24,7 +24,6 @@ import { useForm } from 'react-hook-form';
 import type { IntlShape } from 'react-intl';
 import { injectIntl } from 'react-intl';
 
-import charmClient from 'charmClient';
 import Button from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import type { BoardView } from 'lib/focalboard/boardView';
@@ -84,7 +83,13 @@ function ViewTabs(props: ViewTabsProps) {
   let restViews = views.slice(maxTabsShown);
 
   // make sure active view id is visible
-  const activeShowViewId = shownViews.find((view) => view.id === activeView?.id)?.id ?? false;
+  // during transition between boards, there is a period where activeView has not caught up with the new views
+  const activeShowViewId =
+    shownViews.find((view) => view.id === activeView?.id)?.id ??
+    // check viewId by the query, there is a period where activeView has not caught up
+    shownViews.find((view) => view.id === router.query.viewId)?.id ??
+    shownViews[0]?.id ??
+    false;
 
   // If the current view index is more than what we can show in the screen
   if (currentViewIndex >= maxTabsShown) {
@@ -206,10 +211,16 @@ function ViewTabs(props: ViewTabsProps) {
 
   return (
     <>
-      <Tabs textColor='primary' indicatorColor='secondary' value={activeShowViewId} sx={{ minHeight: 0, mb: '-4px' }}>
+      <Tabs
+        // assign a key so that the tabs are remounted when the page change, otherwise the indicator will animate to the new tab
+        key={viewsProp[0]?.id}
+        textColor='primary'
+        indicatorColor='secondary'
+        value={activeShowViewId}
+        sx={{ minHeight: 0, mb: '-4px' }}
+      >
         {shownViews.map((view) => (
           <Tab
-            component='div'
             disableRipple
             key={view.id}
             label={
@@ -231,7 +242,6 @@ function ViewTabs(props: ViewTabsProps) {
         ))}
         {restViews.length !== 0 && (
           <Tab
-            component='div'
             disableRipple
             sx={{ p: 0, mb: 0.5 }}
             label={

--- a/components/common/BoardEditor/focalboard/src/store/index.ts
+++ b/components/common/BoardEditor/focalboard/src/store/index.ts
@@ -7,6 +7,7 @@ import { reducer as commentsReducer } from './comments';
 import { reducer as globalErrorReducer } from './globalError';
 import { reducer as globalTemplatesReducer } from './globalTemplates';
 import { reducer as languageReducer } from './language';
+import { reducer as loadingStateReducer } from './loadingState';
 import { reducer as searchTextReducer } from './searchText';
 import { reducer as usersReducer } from './users';
 import { reducer as viewsReducer } from './views';
@@ -22,7 +23,8 @@ const store = configureStore({
     comments: commentsReducer,
     searchText: searchTextReducer,
     globalError: globalErrorReducer,
-    clientConfig: clientConfigReducer
+    clientConfig: clientConfigReducer,
+    loadingState: loadingStateReducer
   }
 });
 

--- a/components/common/BoardEditor/focalboard/src/store/initialLoad.ts
+++ b/components/common/BoardEditor/focalboard/src/store/initialLoad.ts
@@ -10,6 +10,7 @@ export const initialLoad = createAsyncThunk('initialLoad', async ({ spaceId }: {
 
   return {
     workspaceUsers,
+    loaded: true,
     blocks
   };
 });

--- a/components/common/BoardEditor/focalboard/src/store/initialLoad.ts
+++ b/components/common/BoardEditor/focalboard/src/store/initialLoad.ts
@@ -10,7 +10,6 @@ export const initialLoad = createAsyncThunk('initialLoad', async ({ spaceId }: {
 
   return {
     workspaceUsers,
-    loaded: true,
     blocks
   };
 });

--- a/components/common/BoardEditor/focalboard/src/store/loadingState.ts
+++ b/components/common/BoardEditor/focalboard/src/store/loadingState.ts
@@ -1,0 +1,29 @@
+import { createSelector, createSlice } from '@reduxjs/toolkit';
+
+import { initialLoad, initialReadOnlyLoad } from './initialLoad';
+
+import type { RootState } from './index';
+
+type LoadingState = {
+  loaded: boolean;
+};
+
+const viewsSlice = createSlice({
+  name: 'loadingState',
+  initialState: { loaded: false } as LoadingState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(initialReadOnlyLoad.fulfilled, (state, action) => {
+      state.loaded = true;
+    });
+    builder.addCase(initialLoad.fulfilled, (state, action) => {
+      state.loaded = true;
+    });
+  }
+});
+export const { reducer } = viewsSlice;
+export const getLoadingState = () =>
+  createSelector(
+    (state: RootState) => state.loadingState,
+    (state: LoadingState) => state
+  );

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -16,7 +16,7 @@ export const StyledSpinner = styled(CircularProgress)`
 `;
 
 type ButtonProps = ComponentProps<typeof Button>;
-export type InputProps<C extends ElementType> = ButtonProps &
+export type InputProps<C extends ElementType = ElementType> = ButtonProps &
   // Omit 'variant' because it gets overridden sometimes by component
   Omit<ComponentProps<C>, 'variant'> & {
     component?: C;

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -100,7 +100,6 @@ export default function DatabaseView({ containerWidth, readOnly: readOnlyOverrid
   const views = useMemo(() => allViews.filter((view) => view.parentId === pageId), [pageId, allViews]);
   const [currentViewId, setCurrentViewId] = useState<string | null>(views[0]?.id || null);
   const currentView = useAppSelector(getView(currentViewId || '')) ?? undefined;
-
   const { pages, updatePage, getPagePermissions } = usePages();
 
   const [shownCardId, setShownCardId] = useState<string | null>(null);
@@ -127,12 +126,6 @@ export default function DatabaseView({ containerWidth, readOnly: readOnlyOverrid
     typeof readOnlyOverride === 'undefined' ? currentPagePermissions.edit_content !== true : readOnlyOverride;
 
   const readOnlySourceData = currentView?.fields?.sourceType === 'google_form'; // blocks that are synced cannot be edited
-
-  useEffect(() => {
-    if (views.length > 0 && !currentViewId) {
-      setCurrentViewId(views[0].id);
-    }
-  }, [currentViewId, views]);
 
   if (!board) {
     return null;

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -112,7 +112,7 @@ type PageNavigationProps = {
 
 function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageNavigationProps) {
   const router = useRouter();
-  const { pages, currentPageId, setPages, mutatePage } = usePages();
+  const { pages, setPages, mutatePage } = usePages();
   const space = useCurrentSpace();
   const { user } = useUser();
   const [expanded, setExpanded] = useLocalStorage<string[]>(`${space?.id}.expanded-pages`, []);
@@ -132,6 +132,9 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
       spaceId: page.spaceId
     })
   );
+
+  const currentPage = pagesArray.find((page) => page.path === router.query.pageId);
+  const currentPageId = currentPage?.id ?? '';
 
   const pageHash = JSON.stringify(pagesArray);
 
@@ -168,10 +171,10 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
         });
       });
       siblings.forEach((page) => {
-        const currentPage = _pages[page.id];
-        if (currentPage) {
+        const _currentPage = _pages[page.id];
+        if (_currentPage) {
           _pages[page.id] = {
-            ...currentPage,
+            ..._currentPage,
             index: page.index,
             parentId: page.parentId
           };
@@ -225,11 +228,11 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
   );
 
   useEffect(() => {
-    const currentPage = pages[currentPageId];
+    const _currentPage = pages[currentPageId];
     // expand the parent of the active page
-    if (currentPage?.parentId && !isFavorites) {
-      if (!expanded?.includes(currentPage.parentId) && currentPage.type !== 'card') {
-        setExpanded(expanded?.concat(currentPage.parentId) ?? []);
+    if (_currentPage?.parentId && !isFavorites) {
+      if (!expanded?.includes(_currentPage.parentId) && _currentPage.type !== 'card') {
+        setExpanded(expanded?.concat(_currentPage.parentId) ?? []);
       }
     }
   }, [currentPageId, pages, isFavorites]);
@@ -238,12 +241,10 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
     setExpanded(nodeIds);
   }
 
-  let selectedNodeId: string | null = null;
-  if (currentPageId) {
-    selectedNodeId = currentPageId;
-    if (typeof router.query.viewId === 'string') {
-      selectedNodeId = router.query.viewId;
-    }
+  let selectedNodeId: string | null = currentPageId ?? null;
+
+  if (typeof router.query.viewId === 'string') {
+    selectedNodeId = router.query.viewId;
   }
 
   const addPage = useCallback(


### PR DESCRIPTION
This fixes a few bugs related to state not getting updated properly when navigating between boards.

Fixes:
- when navigating from a databsae that had a source to one that doesn't, we wouldn't show the 'select a source' menu
- when navigating from a db with no source to one that has a source, we would briefly show the 'select a source' menu, because activeView was not set until a useEffect got triggered. Instead, I try to grab the first one from the board views if there are any
- it was not possible to create a new view on a linked inline db. (we'd constantly reset the current view to the first available - removing this logic doesnt seem to break anything, tested w/google forms too)
- in the views tabs, fixed the underline / tab indicator that animates into the first position when loading a new board. It now just appears instant.
- fixed flicker of bold font weight when clicking a Database page or one of its views in the sidebar
- added a loadingState to our Redux data. I thought I'd need this, but I don't. I am leaving it in cuz it could be useful, but open to just deleting it. It was a little hard to figure out, not having used Redux before
