### PR TITLE
Remove some block options from floating menu

### DIFF
--- a/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
@@ -11,7 +11,6 @@ import { useState } from 'react';
 import reactDOM from 'react-dom';
 
 import Button from 'components/common/Button';
-import { useSnackbar } from 'hooks/useSnackbar';
 import type { IPagePermissionFlags } from 'lib/permissions/pages';
 
 import { InlineCommentSubMenu } from '../inlineComment/inlineComment.components';
@@ -109,7 +108,8 @@ function MenuByType(props: MenuProps) {
               nestedPagePluginKey={nestedPagePluginKey}
               disableNestedPage={disableNestedPage}
               externalPopupState={popupState}
-              size='small'
+              filterItem={(item) => !!item.showInFloatingMenu}
+              isFloatingMenuList={true}
               handleActiveItem={handleActiveItem}
             />
           </MenuGroup>

--- a/components/common/CharmEditor/components/inlinePalette/editorItems/advancedBlocks.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/editorItems/advancedBlocks.tsx
@@ -19,6 +19,7 @@ function createColumnPaletteItem(colCount: number): PaletteItemTypeNoGroup {
     title: `${colCount} Columns`,
     icon: <ViewColumnIcon sx={{ fontSize: iconSize }} />,
     description: `${colCount} Column Layout`,
+    showInFloatingMenu: true,
     editorExecuteCommand: ({ palettePluginKey }) => {
       return (state, dispatch, view) => {
         if (view) {

--- a/components/common/CharmEditor/components/inlinePalette/editorItems/advancedBlocks.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/editorItems/advancedBlocks.tsx
@@ -19,7 +19,6 @@ function createColumnPaletteItem(colCount: number): PaletteItemTypeNoGroup {
     title: `${colCount} Columns`,
     icon: <ViewColumnIcon sx={{ fontSize: iconSize }} />,
     description: `${colCount} Column Layout`,
-    showInFloatingMenu: true,
     editorExecuteCommand: ({ palettePluginKey }) => {
       return (state, dispatch, view) => {
         if (view) {

--- a/components/common/CharmEditor/components/inlinePalette/editorItems/text.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/editorItems/text.tsx
@@ -103,6 +103,7 @@ export function items(props: ItemsProps): PaletteItemTypeNoGroup[] {
         />
       ),
       description: 'Create a plain text block',
+      showInFloatingMenu: true,
       editorExecuteCommand: ({ palettePluginKey }) => {
         return (state, dispatch, view) => {
           rafCommandExec(view!, (_state, _dispatch, _view) => {
@@ -135,6 +136,7 @@ export function items(props: ItemsProps): PaletteItemTypeNoGroup[] {
       ),
       keywords: ['todo', 'lists', 'checkbox', 'checked'],
       description: 'Create a todo list',
+      showInFloatingMenu: true,
       editorExecuteCommand: ({ palettePluginKey }) => {
         return (state, dispatch, view) => {
           rafCommandExec(view!, (_state, _dispatch, _view) => {
@@ -164,6 +166,7 @@ export function items(props: ItemsProps): PaletteItemTypeNoGroup[] {
         ),
         title: `Heading ${level}`,
         description: `Create a heading level ${level}`,
+        showInFloatingMenu: true,
         disabled: (state) => {
           const result = isList()(state);
           return result;
@@ -233,6 +236,7 @@ export function items(props: ItemsProps): PaletteItemTypeNoGroup[] {
       ),
       keywords: ['unordered', 'lists'],
       description: 'Create a simple bulleted list',
+      showInFloatingMenu: true,
       editorExecuteCommand: ({ palettePluginKey }) => {
         return (state, dispatch, view) => {
           rafCommandExec(view!, (_state, _dispatch, _view) => {
@@ -255,6 +259,7 @@ export function items(props: ItemsProps): PaletteItemTypeNoGroup[] {
       title: 'Ordered List',
       keywords: ['numbered', 'lists'],
       description: 'Create an ordered list',
+      showInFloatingMenu: true,
       editorExecuteCommand: ({ palettePluginKey }) => {
         return (state, dispatch, view) => {
           rafCommandExec(view!, (_state, _dispatch, _view) => {
@@ -271,6 +276,7 @@ export function items(props: ItemsProps): PaletteItemTypeNoGroup[] {
       title: 'Toggle List/Heading',
       keywords: ['summary', 'disclosure', 'toggle', 'collapse'],
       description: 'Insert a summary and content',
+      showInFloatingMenu: true,
       editorExecuteCommand: ({ palettePluginKey }) => {
         return (state, dispatch, view) => {
           rafCommandExec(view!, (_state, _dispatch) => {
@@ -318,6 +324,7 @@ export function items(props: ItemsProps): PaletteItemTypeNoGroup[] {
         />
       ),
       description: 'Insert a quote in the line below',
+      showInFloatingMenu: true,
       editorExecuteCommand: ({ palettePluginKey }) => {
         return (state, dispatch, view) => {
           rafCommandExec(view!, (_state, _dispatch) => {
@@ -403,6 +410,7 @@ export function items(props: ItemsProps): PaletteItemTypeNoGroup[] {
         />
       ),
       description: 'Insert a callout block in the line below',
+      showInFloatingMenu: true,
       editorExecuteCommand: ({ palettePluginKey }) => {
         return (state, dispatch, view) => {
           rafCommandExec(view!, (_state, _dispatch) => {

--- a/components/common/CharmEditor/components/inlinePalette/paletteItem.ts
+++ b/components/common/CharmEditor/components/inlinePalette/paletteItem.ts
@@ -95,6 +95,7 @@ export class PaletteItem implements PaletteItemType {
       editorExecuteCommand,
       group,
       skipFiltering,
+      showInFloatingMenu,
       icon,
       ...otherKeys
     } = obj;
@@ -121,5 +122,6 @@ export class PaletteItem implements PaletteItemType {
     this.skipFiltering = skipFiltering ?? false;
     this._isItemDisabled = false;
     this.icon = icon;
+    this.showInFloatingMenu = showInFloatingMenu;
   }
 }

--- a/components/common/CharmEditor/components/inlinePalette/paletteItem.ts
+++ b/components/common/CharmEditor/components/inlinePalette/paletteItem.ts
@@ -39,6 +39,7 @@ export interface PaletteItemTypeNoGroup {
   editorExecuteCommand: EditorExecuteCommand;
   skipFiltering?: boolean;
   _isItemDisabled?: boolean;
+  showInFloatingMenu?: boolean; // make it appear in the floating menu to convert highlighted text
   icon?: JSX.Element | null | undefined;
 }
 
@@ -72,6 +73,8 @@ export class PaletteItem implements PaletteItemType {
   group: string;
 
   skipFiltering: boolean;
+
+  showInFloatingMenu?: boolean; // make it appear in the floating menu to convert highlighted text
 
   icon?: JSX.Element | null | undefined;
 


### PR DESCRIPTION
User was trying to highlight text and select "Link to Page" but it doesn't do anything in this context:
![image](https://user-images.githubusercontent.com/305398/214205208-36ed476b-800a-48f7-90b2-51e3a3667ea1.png)



We currently have "Link to Page", "Divider", "Table" etc which make no sense when you are trying to change the type of a highlighted piece of text. The Link to page in particular was confusing for one user who just wanted to use the normal link