### PR TITLE
add options to hide github and linkedin icons

### DIFF
--- a/components/members/MemberDirectoryPage.tsx
+++ b/components/members/MemberDirectoryPage.tsx
@@ -110,7 +110,7 @@ export default function MemberDirectoryPage() {
         </Stack>
       </Stack>
       <Box position='relative' display='flex' height='100%'>
-        <Box width='100%' overflow='auto' height='fit-content'>
+        <Box width='100%' overflow={currentView === 'table' ? 'auto' : 'visible'} height='fit-content'>
           {currentView === 'table' && <MemberDirectoryTableView members={sortedMembers} />}
           {currentView === 'gallery' && <MemberDirectoryGalleryView members={sortedMembers} />}
         </Box>

--- a/components/members/components/MemberDirectoryGalleryView.tsx
+++ b/components/members/components/MemberDirectoryGalleryView.tsx
@@ -50,6 +50,8 @@ function MemberDirectoryGalleryCard({ member }: { member: Member }) {
   const isNameHidden = !propertiesRecord.name?.enabledViews.includes('gallery');
   const isDiscordHidden = !propertiesRecord.discord?.enabledViews.includes('gallery');
   const isTwitterHidden = !propertiesRecord.twitter?.enabledViews.includes('gallery');
+  const isLinkedInHidden = !propertiesRecord.linked_in?.enabledViews.includes('gallery');
+  const isGithubHidden = !propertiesRecord.github?.enabledViews.includes('gallery');
   const admin = isAdmin();
 
   const updateMemberPropertyValues = async (spaceId: string, values: UpdateMemberPropertyValuePayload[]) => {
@@ -102,7 +104,14 @@ function MemberDirectoryGalleryCard({ member }: { member: Member }) {
                 )?.value as string) ?? member.username}
               </Typography>
             )}
-            <SocialIcons gap={1} social={social} showDiscord={!isDiscordHidden} showTwitter={!isTwitterHidden} />
+            <SocialIcons
+              gap={1}
+              social={social}
+              showLinkedIn={!isLinkedInHidden}
+              showGithub={!isGithubHidden}
+              showDiscord={!isDiscordHidden}
+              showTwitter={!isTwitterHidden}
+            />
             {properties.map((property) => {
               const memberProperty = member.properties.find((mp) => mp.memberPropertyId === property.id);
               const hiddenInGallery = !property.enabledViews.includes('gallery');

--- a/components/members/components/MemberDirectoryProperties/MemberPropertiesSidebar.tsx
+++ b/components/members/components/MemberDirectoryProperties/MemberPropertiesSidebar.tsx
@@ -206,7 +206,7 @@ export function MemberPropertySidebarItem({ property }: { property: MemberProper
               alignItems: 'center'
             }}
           >
-            <Tooltip title={`Edit ${property.name} property.`}>
+            <Tooltip title={`Edit ${property.name} property.`} disableInteractive>
               <EditIcon
                 cursor='pointer'
                 fontSize='small'
@@ -218,7 +218,7 @@ export function MemberPropertySidebarItem({ property }: { property: MemberProper
               />
             </Tooltip>
             {!MEMBER_PROPERTY_CONFIG[property.type]?.default && (
-              <Tooltip title={`Delete ${property.name} property.`}>
+              <Tooltip title={`Delete ${property.name} property.`} disableInteractive>
                 <DeleteOutlinedIcon
                   cursor='pointer'
                   fontSize='small'

--- a/components/members/components/MemberDirectoryProperties/MemberPropertyItem.tsx
+++ b/components/members/components/MemberDirectoryProperties/MemberPropertyItem.tsx
@@ -3,8 +3,10 @@ import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
 import ArrowDropDownCircleIcon from '@mui/icons-material/ArrowDropDownCircle';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline';
+import GithubIcon from '@mui/icons-material/GitHub';
 import InsertPhotoIcon from '@mui/icons-material/InsertPhoto';
 import LinkIcon from '@mui/icons-material/Link';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import ListIcon from '@mui/icons-material/List';
 import MilitaryTechIcon from '@mui/icons-material/MilitaryTech';
 import NumbersIcon from '@mui/icons-material/Numbers';
@@ -34,6 +36,8 @@ export const MemberPropertyIcons: Record<MemberPropertyType, ReactNode> = {
   timezone: <AccessTimeIcon fontSize='small' />,
   discord: <DiscordIcon width={18.5} height={18.5} />,
   twitter: <TwitterIcon fontSize='small' />,
+  linked_in: <LinkedInIcon width={18.5} height={18.5} />,
+  github: <GithubIcon fontSize='small' />,
   name: <DriveFileRenameOutlineIcon fontSize='small' />,
   bio: <PersonIcon fontSize='small' />,
   join_date: <CalendarMonthIcon fontSize='small' />

--- a/components/members/components/MemberDirectoryProperties/MemberPropertySidebarDetails.tsx
+++ b/components/members/components/MemberDirectoryProperties/MemberPropertySidebarDetails.tsx
@@ -99,7 +99,7 @@ export function MemberPropertySidebarDetails({
                 ))}
               </Stack>
             ) : (
-              <Tooltip title={`Everyone in space can see ${property.name} property`}>
+              <Tooltip title={`Everyone in space can see ${property.name} property`} disableInteractive>
                 <Typography pl={4} variant='overline' alignItems='center' display='flex'>
                   Everyone in space
                   <VisibilityOutlinedIcon fontSize='small' color='secondary' sx={{ ml: 1 }} />

--- a/components/profile/components/UserDetails/SocialIcons.tsx
+++ b/components/profile/components/UserDetails/SocialIcons.tsx
@@ -20,10 +20,14 @@ export function SocialIcons({
   },
   showDiscord = true,
   showTwitter = true,
+  showGithub = true,
+  showLinkedIn = true,
   ...props
 }: {
   showDiscord?: boolean;
   showTwitter?: boolean;
+  showGithub?: boolean;
+  showLinkedIn?: boolean;
   children?: ReactNode;
   social?: {
     twitterURL?: string;
@@ -36,6 +40,14 @@ export function SocialIcons({
 
   return (
     <Stack direction='row' alignItems='center' gap={2} {...props}>
+      {showDiscord &&
+        (social?.discordUsername && showDiscord ? (
+          <DiscordSocialIcon username={social.discordUsername} />
+        ) : (
+          <SvgIcon color='disabled' sx={{ height: '22px' }}>
+            <DiscordIcon />
+          </SvgIcon>
+        ))}
       {showTwitter &&
         (social.twitterURL ? (
           <Link href={social.twitterURL} target='_blank' display='flex'>
@@ -44,28 +56,22 @@ export function SocialIcons({
         ) : (
           <TwitterIcon color='disabled' style={{ height: '22px' }} />
         ))}
-      {social.githubURL ? (
-        <Link href={social.githubURL} target='_blank' display='flex'>
-          <GitHubIcon style={{ color: '#888', height: '22px' }} />
-        </Link>
-      ) : (
-        <GitHubIcon color='disabled' style={{ height: '22px' }} />
-      )}
-      {showDiscord &&
-        (social?.discordUsername && showDiscord ? (
-          <DiscordSocialIcon username={social.discordUsername} />
+      {showLinkedIn &&
+        (social?.linkedinURL ? (
+          <Link href={social.linkedinURL} target='_blank' display='flex'>
+            <LinkedInIcon style={{ color: '#0072B1', height: '22px' }} />
+          </Link>
         ) : (
-          <SvgIcon viewBox='0 -10 70 70' sx={{ color: theme.palette.text.disabled, height: '22px' }}>
-            <DiscordIcon />
-          </SvgIcon>
+          <LinkedInIcon color='disabled' style={{ height: '22px' }} />
         ))}
-      {social?.linkedinURL ? (
-        <Link href={social.linkedinURL} target='_blank' display='flex'>
-          <LinkedInIcon style={{ color: '#0072B1', height: '22px' }} />
-        </Link>
-      ) : (
-        <LinkedInIcon color='disabled' style={{ height: '22px' }} />
-      )}
+      {showGithub &&
+        (social.githubURL ? (
+          <Link href={social.githubURL} target='_blank' display='flex'>
+            <GitHubIcon style={{ color: '#888', height: '22px' }} />
+          </Link>
+        ) : (
+          <GitHubIcon color='disabled' style={{ height: '22px' }} />
+        ))}
       {children}
     </Stack>
   );

--- a/components/profile/components/UserDetails/SocialIcons.tsx
+++ b/components/profile/components/UserDetails/SocialIcons.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@emotion/react';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import TwitterIcon from '@mui/icons-material/Twitter';
@@ -9,6 +8,8 @@ import type { ReactNode } from 'react';
 import DiscordIcon from 'public/images/discord_logo.svg';
 
 import { DiscordSocialIcon } from './DiscordSocialIcon';
+
+const iconHeight = '22px';
 
 export function SocialIcons({
   children,
@@ -36,41 +37,39 @@ export function SocialIcons({
     linkedinURL?: string;
   };
 } & StackProps) {
-  const theme = useTheme();
-
   return (
     <Stack direction='row' alignItems='center' gap={2} {...props}>
       {showDiscord &&
-        (social?.discordUsername && showDiscord ? (
+        (social?.discordUsername ? (
           <DiscordSocialIcon username={social.discordUsername} />
         ) : (
-          <SvgIcon color='disabled' sx={{ height: '22px' }}>
+          <SvgIcon color='disabled' sx={{ height: iconHeight }}>
             <DiscordIcon />
           </SvgIcon>
         ))}
       {showTwitter &&
         (social.twitterURL ? (
           <Link href={social.twitterURL} target='_blank' display='flex'>
-            <TwitterIcon style={{ color: '#00ACEE', height: '22px' }} />
+            <TwitterIcon style={{ color: '#00ACEE', height: iconHeight }} />
           </Link>
         ) : (
-          <TwitterIcon color='disabled' style={{ height: '22px' }} />
+          <TwitterIcon color='disabled' style={{ height: iconHeight }} />
         ))}
       {showLinkedIn &&
         (social?.linkedinURL ? (
           <Link href={social.linkedinURL} target='_blank' display='flex'>
-            <LinkedInIcon style={{ color: '#0072B1', height: '22px' }} />
+            <LinkedInIcon style={{ color: '#0072B1', height: iconHeight }} />
           </Link>
         ) : (
-          <LinkedInIcon color='disabled' style={{ height: '22px' }} />
+          <LinkedInIcon color='disabled' style={{ height: iconHeight }} />
         ))}
       {showGithub &&
         (social.githubURL ? (
           <Link href={social.githubURL} target='_blank' display='flex'>
-            <GitHubIcon style={{ color: '#888', height: '22px' }} />
+            <GitHubIcon style={{ color: '#888', height: iconHeight }} />
           </Link>
         ) : (
-          <GitHubIcon color='disabled' style={{ height: '22px' }} />
+          <GitHubIcon color='disabled' style={{ height: iconHeight }} />
         ))}
       {children}
     </Stack>

--- a/lib/members/constants.ts
+++ b/lib/members/constants.ts
@@ -47,7 +47,7 @@ export const MEMBER_PROPERTY_CONFIG: Record<MemberPropertyType, MemberPropertyCo
     readonly: true
   },
   github: {
-    label: 'Github',
+    label: 'GitHub',
     default: true,
     readonly: true
   },

--- a/lib/members/constants.ts
+++ b/lib/members/constants.ts
@@ -41,6 +41,16 @@ export const MEMBER_PROPERTY_CONFIG: Record<MemberPropertyType, MemberPropertyCo
     default: true,
     readonly: true
   },
+  linked_in: {
+    label: 'LinkedIn',
+    default: true,
+    readonly: true
+  },
+  github: {
+    label: 'Github',
+    default: true,
+    readonly: true
+  },
   timezone: {
     label: 'Timezone',
     default: true,

--- a/prisma/migrations/20230124032856_add_social_member_type/migration.sql
+++ b/prisma/migrations/20230124032856_add_social_member_type/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "MemberPropertyType" ADD VALUE 'linked_in';
+ALTER TYPE "MemberPropertyType" ADD VALUE 'github';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -186,6 +186,8 @@ enum MemberPropertyType {
   twitter
   bio
   join_date
+  linked_in
+  github
 }
 
 enum MemberPropertyPermissionLevel {

--- a/scripts/migrations/2023_01_23_addMemberProperties.ts
+++ b/scripts/migrations/2023_01_23_addMemberProperties.ts
@@ -1,0 +1,58 @@
+import { prisma } from 'db'
+
+async function init () {
+
+  const spaces = await prisma.space.findMany({
+    include: {
+      memberProperties: true
+    }
+  });
+
+  let count = 0;
+  for (let space of spaces) {
+    if (count++ % 100 === 0) {
+      console.log('updated', count, 'spaces')
+    }
+    if (!space.memberProperties.some(prop => prop.type === 'linked_in')) {
+      const admin = await prisma.user.findFirst({
+        where: {
+          spaceRoles: {
+            some: {
+              isAdmin: true,
+              spaceId: space.id
+            }
+          }
+        }
+      });
+      if (admin) {
+        const lastIndex = Math.max(...space.memberProperties.map(prop => prop.index));
+        console.log('lastIndex', lastIndex)
+        const createdBy = admin.id;
+        await prisma.memberProperty.createMany({
+          data: [{
+            createdBy,
+            updatedBy: createdBy,
+            index: lastIndex + 1,
+            name: 'LinkedIn',
+            type: 'linked_in',
+            spaceId: space.id
+          },{
+            createdBy,
+            updatedBy: createdBy,
+            index: lastIndex + 2,
+            name: 'GitHub',
+            type: 'github',
+            spaceId: space.id
+          }],
+        })
+      }
+      else {
+        console.warn('No admin for space', { spaceId: space.id, spaceName: space.name })
+      }
+    }
+  }
+
+
+}
+
+init()

--- a/scripts/migrations/2023_01_23_addMemberProperties.ts
+++ b/scripts/migrations/2023_01_23_addMemberProperties.ts
@@ -25,26 +25,43 @@ async function init () {
         }
       });
       if (admin) {
-        const lastIndex = Math.max(...space.memberProperties.map(prop => prop.index));
-        console.log('lastIndex', lastIndex)
+        // we want to inject these after the last social property
+        const lastSocialIndex = Math.max(...space.memberProperties.filter(prop => prop.type === 'twitter' || prop.type === 'discord').map(prop => prop.index));
+
         const createdBy = admin.id;
-        await prisma.memberProperty.createMany({
-          data: [{
-            createdBy,
-            updatedBy: createdBy,
-            index: lastIndex + 1,
-            name: 'LinkedIn',
-            type: 'linked_in',
-            spaceId: space.id
-          },{
-            createdBy,
-            updatedBy: createdBy,
-            index: lastIndex + 2,
-            name: 'GitHub',
-            type: 'github',
-            spaceId: space.id
-          }],
-        })
+        await prisma.$transaction([
+          // update all indexes after the last social index
+          prisma.memberProperty.updateMany({
+            where: {
+              spaceId: space.id,
+              index: {
+                gt: lastSocialIndex
+              }
+            },
+            data: {
+              index:{
+                increment: 2
+              }
+            }
+          }),
+          prisma.memberProperty.createMany({
+              data: [{
+                createdBy,
+                updatedBy: createdBy,
+                index: lastSocialIndex + 1,
+                name: 'LinkedIn',
+                type: 'linked_in',
+                spaceId: space.id
+              },{
+                createdBy,
+                updatedBy: createdBy,
+                index: lastSocialIndex + 2,
+                name: 'GitHub',
+                type: 'github',
+                spaceId: space.id
+              }],
+          })
+        ])
       }
       else {
         console.warn('No admin for space', { spaceId: space.id, spaceName: space.name })


### PR DESCRIPTION
This change requires a db migration, which was tested locally. Until it is run on a space, the two icons will not be visible