### PR TITLE
Fix text as a uuid import from csv

### DIFF
--- a/components/common/PageLayout/components/Header/components/utils/databasePageOptions.ts
+++ b/components/common/PageLayout/components/Header/components/utils/databasePageOptions.ts
@@ -106,9 +106,6 @@ export function createNewPropertiesForBoard(
 
     return { ...defaultProps, options, type: 'multiSelect' };
   }
-  if (propValues.every((p) => uuidValidate(p))) {
-    return { ...defaultProps, type: 'person' };
-  }
   if (propValues.every(validateAllBlockDates)) {
     return { ...defaultProps, type: 'date' };
   }


### PR DESCRIPTION
In a csv, if a column had uuid's, I was assuming that the filed was type person.
We need to import any uuid as type text, not person.