### PR TITLE
fix drag and drop of rows

### DIFF
--- a/components/members/components/MemberDirectoryProperties/MemberPropertySidebarDetails.tsx
+++ b/components/members/components/MemberDirectoryProperties/MemberPropertySidebarDetails.tsx
@@ -55,7 +55,7 @@ export function MemberPropertySidebarDetails({
 
   return (
     <>
-      <Collapse in={isExpanded}>
+      <Collapse in={isExpanded} mountOnEnter={true} unmountOnExit={true}>
         <Stack mb={1}>
           <Stack>
             <Box pl={4}>


### PR DESCRIPTION
https://github.com/react-dnd/react-dnd/issues/1608

In Webkit, if the draggable element has a child of larger width/height, the 'drag preview' will expand to the max width/height. In Member Properties, this makes it appear you are dragging multiple rows, but really the fix was to just have the collapsed section unmounted until it needs to be expanded.