### PR TITLE
encode url for redirect

### DIFF
--- a/components/common/RouteGuard.tsx
+++ b/components/common/RouteGuard.tsx
@@ -92,7 +92,7 @@ export default function RouteGuard({ children }: { children: ReactNode }) {
         authorized: true,
         redirect: {
           pathname: '/',
-          query: { returnUrl: router.asPath }
+          query: { returnUrl: encodeURIComponent(router.asPath) }
         }
       };
     }
@@ -117,7 +117,7 @@ export default function RouteGuard({ children }: { children: ReactNode }) {
         authorized: false,
         redirect: {
           pathname: '/join',
-          query: { domain: spaceDomain, returnUrl: router.asPath }
+          query: { domain: spaceDomain, returnUrl: encodeURIComponent(router.asPath) }
         }
       };
     } else {

--- a/components/common/RouteGuard.tsx
+++ b/components/common/RouteGuard.tsx
@@ -92,7 +92,7 @@ export default function RouteGuard({ children }: { children: ReactNode }) {
         authorized: true,
         redirect: {
           pathname: '/',
-          query: { returnUrl: encodeURIComponent(router.asPath) }
+          query: { returnUrl: router.asPath }
         }
       };
     }
@@ -117,7 +117,7 @@ export default function RouteGuard({ children }: { children: ReactNode }) {
         authorized: false,
         redirect: {
           pathname: '/join',
-          query: { domain: spaceDomain, returnUrl: encodeURIComponent(router.asPath) }
+          query: { domain: spaceDomain, returnUrl: router.asPath }
         }
       };
     } else {

--- a/pages/api/discord/callback.ts
+++ b/pages/api/discord/callback.ts
@@ -17,11 +17,14 @@ const handler = nc({
 });
 
 handler.get(async (req, res) => {
+  const cookies = new Cookies(req, res);
   const state = JSON.parse(decodeURIComponent(req.query.state as string));
-  const redirect = (state?.redirect as string) || '/';
   const type: 'connect' | 'server' | 'login' = state.type ?? 'connect';
 
-  const cookies = new Cookies(req, res);
+  // sanitize the redirect path in case of invalid characters
+  const redirectPath = (state?.redirect as string) || '/';
+  const redirectUrl = new URL(redirectPath, 'https://tacos4everyone.net');
+  const redirect = redirectUrl.pathname + redirectUrl.search;
 
   const tempAuthCode = req.query.code;
   if (req.query.error || typeof tempAuthCode !== 'string') {


### PR DESCRIPTION
We were unable to redirect a user, because a returnUrl was set with Japanese characters:
```
/henkaku-ochakai/forum/post/visionについて_ld9xxajl
```
I considered encoding the returnUrl when it was set, but I think this solution handles more cases.