### PR TITLE
Some more UI fixes with dropdowns:

### DIFF
--- a/components/[pageId]/DatabasePage/DatabasePage.tsx
+++ b/components/[pageId]/DatabasePage/DatabasePage.tsx
@@ -12,10 +12,9 @@ import {
   setCurrent as setCurrentBoard
 } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import { useAppDispatch, useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
-import { initialLoad, initialReadOnlyLoad } from 'components/common/BoardEditor/focalboard/src/store/initialLoad';
+import { initialReadOnlyLoad } from 'components/common/BoardEditor/focalboard/src/store/initialLoad';
 import {
   getCurrentBoardViews,
-  getView,
   setCurrent as setCurrentView
 } from 'components/common/BoardEditor/focalboard/src/store/views';
 import { Utils } from 'components/common/BoardEditor/focalboard/src/utils';
@@ -51,6 +50,12 @@ export function DatabasePage({ page, setPage, readOnly = false, pagePermissions 
   const { setFocalboardViewsRecord } = useFocalboardViews();
   const readOnlyBoard = readOnly || !pagePermissions?.edit_content;
   const readOnlySourceData = activeView?.fields?.sourceType === 'google_form'; // blocks that are synced cannot be edited
+  useEffect(() => {
+    if (typeof router.query.cardId === 'string') {
+      setShownCardId(router.query.cardId);
+    }
+  }, [router.query.cardId]);
+
   useEffect(() => {
     const boardId = page.boardId;
     const urlViewId = router.query.viewId as string;
@@ -171,7 +176,6 @@ export function DatabasePage({ page, setPage, readOnly = false, pagePermissions 
               cardId={shownCardId}
               onClose={() => {
                 showCard(null);
-                setShownCardId(null);
               }}
               readOnly={readOnly}
             />

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
@@ -85,7 +85,7 @@ function ViewTabs(props: ViewTabsProps) {
     views: viewsProp
   } = props;
   const router = useRouter();
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [viewMenuAnchorEl, setViewMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [dropdownView, setDropdownView] = useState<BoardView | null>(null);
   const renameViewPopupState = usePopupState({ variant: 'popover', popupId: 'rename-view-popup' });
   const hiddenViewsPopupState = usePopupState({ variant: 'popover', popupId: 'show-views-popup' });
@@ -128,7 +128,7 @@ function ViewTabs(props: ViewTabsProps) {
       return;
     }
     if (view && !readOnly && event.currentTarget.id === activeView?.id) {
-      setAnchorEl(event.currentTarget);
+      setViewMenuAnchorEl(event.currentTarget);
       setDropdownView(view);
     } else {
       showView(viewId);
@@ -137,6 +137,10 @@ function ViewTabs(props: ViewTabsProps) {
 
   function handleClose() {
     hiddenViewsPopupState.close();
+  }
+
+  function closeViewMenu() {
+    setViewMenuAnchorEl(null);
   }
 
   function getViewUrl(viewId: string) {
@@ -166,7 +170,7 @@ function ViewTabs(props: ViewTabsProps) {
     Utils.log('deleteView');
     if (!dropdownView) return;
 
-    setAnchorEl(null);
+    setViewMenuAnchorEl(null);
     const nextView = views.find((o) => o !== dropdownView);
     await mutator.deleteBlock(dropdownView, 'delete view');
     onDeleteView?.(dropdownView.id);
@@ -182,18 +186,18 @@ function ViewTabs(props: ViewTabsProps) {
       const { boardId, ...sourceDataWithoutBoard } = newView.fields.sourceData!;
       newView.fields.sourceData = sourceDataWithoutBoard;
       mutator.updateBlock(newView, dropdownView, 'reset Google view source');
-      setAnchorEl(null);
+      setViewMenuAnchorEl(null);
     }
   }
 
   function handleRenameView() {
-    setAnchorEl(null);
+    setViewMenuAnchorEl(null);
     renameViewPopupState.open();
   }
 
   function handleViewOptions() {
     openViewOptions();
-    setAnchorEl(null);
+    setViewMenuAnchorEl(null);
   }
 
   function saveViewTitle(form: { title: string }) {
@@ -268,7 +272,7 @@ function ViewTabs(props: ViewTabsProps) {
           />
         )}
       </Tabs>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+      <Menu anchorEl={viewMenuAnchorEl} open={Boolean(viewMenuAnchorEl)} onClose={closeViewMenu}>
         <MenuItem dense onClick={handleRenameView}>
           <ListItemIcon>
             <EditIcon fontSize='small' />

--- a/components/common/PageLayout/components/AddNewCard.tsx
+++ b/components/common/PageLayout/components/AddNewCard.tsx
@@ -31,8 +31,6 @@ function AddNewCard({ pageId }: { pageId: string }) {
             card.fields.properties = { ...card.fields.properties };
             card.fields.contentOrder = [];
             await charmClient.insertBlocks([card], () => null);
-            mutate(`pages/${space.id}`);
-            dispatch(addCard(card));
             router.push(`/${space.domain}/${page.path}?cardId=${card.id}`);
           }
           e.stopPropagation();

--- a/components/common/PageLayout/components/AddNewCard.tsx
+++ b/components/common/PageLayout/components/AddNewCard.tsx
@@ -7,10 +7,11 @@ import { mutate } from 'swr';
 import charmClient from 'charmClient';
 import { addCard } from 'components/common/BoardEditor/focalboard/src/store/cards';
 import { useAppDispatch } from 'components/common/BoardEditor/focalboard/src/store/hooks';
-import { StyledIconButton } from 'components/common/PageLayout/components/NewPageMenu';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
 import { createCard } from 'lib/focalboard/card';
+
+import { StyledIconButton } from './NewPageMenu';
 
 function AddNewCard({ pageId }: { pageId: string }) {
   const router = useRouter();
@@ -21,7 +22,7 @@ function AddNewCard({ pageId }: { pageId: string }) {
   return (
     <Tooltip disableInteractive title='Add a page inside' leaveDelay={0} placement='top' arrow>
       <StyledIconButton
-        onClick={async () => {
+        onClick={async (e) => {
           const card = createCard();
           const page = pages[pageId];
           if (page && page.boardId && space) {
@@ -30,10 +31,11 @@ function AddNewCard({ pageId }: { pageId: string }) {
             card.fields.properties = { ...card.fields.properties };
             card.fields.contentOrder = [];
             await charmClient.insertBlocks([card], () => null);
-            router.push(`/${space.domain}/${page.path}?cardId=${card.id}`);
             mutate(`pages/${space.id}`);
             dispatch(addCard(card));
+            router.push(`/${space.domain}/${page.path}?cardId=${card.id}`);
           }
+          e.stopPropagation();
         }}
       >
         <AddIcon color='secondary' />

--- a/components/common/PageLayout/components/NewPageMenu.tsx
+++ b/components/common/PageLayout/components/NewPageMenu.tsx
@@ -34,40 +34,43 @@ export const StyledArticleIcon = styled(ArticleIcon)`
   font-size: 22px;
 `;
 
-type Props = { addPage: (p: Partial<Page>) => void; tooltip: string; sx?: any };
+type Props = { addPage: (p: Partial<Page>) => void; tooltip: string };
 
-function NewPageMenu({ addPage, tooltip, ...props }: Props) {
+function NewPageMenu({ addPage, tooltip }: Props) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
     event.preventDefault();
+    event.stopPropagation();
   };
-  const handleClose = () => {
+  const handleClose = (event?: any) => {
     setAnchorEl(null);
+    event?.stopPropagation();
   };
-  const createPage = (page: { type: Page['type'] }) => {
+  const createPage = (event: any | undefined, page: { type: Page['type'] }) => {
     addPage(page);
     handleClose();
+    event?.stopPropagation();
   };
 
   return (
     <>
       <Tooltip disableInteractive title={tooltip} leaveDelay={0} placement='top' arrow>
-        <StyledIconButton onClick={handleClick} {...props}>
+        <StyledIconButton onClick={handleClick}>
           <AddIcon color='secondary' />
         </StyledIconButton>
       </Tooltip>
 
       <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
-        <MenuItem onClick={() => createPage({ type: 'page' })}>
+        <MenuItem onClick={(e) => createPage(e, { type: 'page' })}>
           <ListItemIcon>
             <StyledArticleIcon fontSize='small' />
           </ListItemIcon>
           <Typography sx={{ fontSize: 15, fontWeight: 600 }}>Add Page</Typography>
         </MenuItem>
         {/* create a linked board page by default, which can be changed to 'board' by the user */}
-        <MenuItem onClick={() => createPage({ type: 'linked_board' })}>
+        <MenuItem onClick={(e) => createPage(e, { type: 'linked_board' })}>
           <ListItemIcon>
             <StyledDatabaseIcon fontSize='small' />
           </ListItemIcon>

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -30,7 +30,7 @@ import { isTouchScreen } from 'lib/utilities/browser';
 import { greyColor2 } from 'theme/colors';
 
 import AddNewCard from '../../AddNewCard';
-import NewPageMenu from '../../NewPageMenu';
+import NewPageMenu, { StyledIconButton } from '../../NewPageMenu';
 import { PageIcon } from '../../PageIcon';
 import PageTitle from '../../PageTitle';
 
@@ -258,8 +258,6 @@ const TreeItemComponent = React.forwardRef<React.Ref<HTMLDivElement>, TreeItemCo
   )
 );
 
-const MemoizedIconButton = memo(IconButton);
-
 const PageMenuItem = styled(ListItemButton)`
   .MuiTypography-root {
     font-weight: 600;
@@ -318,9 +316,9 @@ const PageTreeItem = forwardRef<any, PageTreeItemProps>((props, ref) => {
         onClick={onClick}
       >
         <div className='page-actions'>
-          <MemoizedIconButton size='small' onClick={showMenu}>
+          <StyledIconButton size='small' onClick={showMenu}>
             <MoreHorizIcon color='secondary' fontSize='small' />
-          </MemoizedIconButton>
+          </StyledIconButton>
 
           {userSpacePermissions?.createPage && pageType === 'board' && <AddNewCard pageId={pageId} />}
           {userSpacePermissions?.createPage && pageType === 'page' && (

--- a/lib/middleware/onError.ts
+++ b/lib/middleware/onError.ts
@@ -20,7 +20,9 @@ export function onError(err: any, req: NextApiRequest, res: NextApiResponse) {
   } else {
     log.warn(`Client Error: ${errorAsSystemError.message}`, {
       url: req.url,
-      body: req.body
+      body: req.body,
+      userId: req.session?.user?.id,
+      spaceId: req.query?.spaceId || req.body?.spaceId
     });
   }
 

--- a/lib/middleware/onError.ts
+++ b/lib/middleware/onError.ts
@@ -13,6 +13,7 @@ export function onError(err: any, req: NextApiRequest, res: NextApiResponse) {
       error: err instanceof SystemError === false ? err.message || 'Something went wrong' : errorAsSystemError,
       stack: err.error?.stack || err.stack,
       userId: req.session?.user?.id,
+      pageId: req.query?.pageId || req.body?.pageId,
       spaceId: req.query?.spaceId || req.body?.spaceId,
       url: req.url,
       body: req.body
@@ -22,6 +23,7 @@ export function onError(err: any, req: NextApiRequest, res: NextApiResponse) {
       url: req.url,
       body: req.body,
       userId: req.session?.user?.id,
+      pageId: req.query?.pageId || req.body?.pageId,
       spaceId: req.query?.spaceId || req.body?.spaceId
     });
   }

--- a/lib/middleware/onError.ts
+++ b/lib/middleware/onError.ts
@@ -13,6 +13,7 @@ export function onError(err: any, req: NextApiRequest, res: NextApiResponse) {
       error: err instanceof SystemError === false ? err.message || 'Something went wrong' : errorAsSystemError,
       stack: err.error?.stack || err.stack,
       userId: req.session?.user?.id,
+      spaceId: req.query?.spaceId || req.body?.spaceId,
       url: req.url,
       body: req.body
     });

--- a/pages/api/blocks/index.ts
+++ b/pages/api/blocks/index.ts
@@ -213,7 +213,7 @@ async function createBlocks(req: NextApiRequest, res: NextApiResponse<Omit<Block
   ]);
 
   await Promise.all([
-    async () => {
+    (async () => {
       const blocksToNotify = await prisma.block.findMany({
         where: {
           id: {
@@ -229,10 +229,9 @@ async function createBlocks(req: NextApiRequest, res: NextApiResponse<Omit<Block
         },
         space.id
       );
-    },
-    async () => {
+    })(),
+    (async () => {
       const createdPages = await getPageMetaList(newBlocks.map((b) => b.id));
-
       if (createdPages.length) {
         relay.broadcast(
           {
@@ -242,7 +241,7 @@ async function createBlocks(req: NextApiRequest, res: NextApiResponse<Omit<Block
           space.id
         );
       }
-    }
+    })()
   ]);
 
   return res.status(200).json(newBlocks);


### PR DESCRIPTION
- user could not close 'edit view menu' when clicking on a view tab to edit it, unless they selected an item in the menu
- clicking 'add page' or page action menu on the sidebar no longer navigates you to that page after clicking it
- made the card appear reliably when creating a new one inside a database from the sidebar
- we were not sending socket events at all when inserting focalboard blocks! I tested this out -if I make a new database page in one tab, the other tab will see it in the sidebar but there will be no content until I reload the page.