### PR TITLE
Update space tests

### DIFF
--- a/__e2e__/po/spaceSettings.po.ts
+++ b/__e2e__/po/spaceSettings.po.ts
@@ -1,0 +1,34 @@
+// playwright-dev-page.ts
+import type { Locator, Page } from '@playwright/test';
+
+import { baseUrl } from 'config/constants';
+
+// capture actions on the pages in signup flow
+export class SpaceSettingsPage {
+  readonly page: Page;
+
+  readonly spaceNameField: Locator;
+
+  readonly spaceDomainField: Locator;
+
+  readonly submitSpaceUpdateButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.spaceNameField = page.locator('data-test=set-space-name >> input');
+    this.spaceDomainField = page.locator('data-test=set-space-domain >> input');
+    this.submitSpaceUpdateButton = page.locator('data-test=submit-space-update');
+  }
+
+  async goTo(domain: string) {
+    await this.page.goto(`${baseUrl}/${domain}/settings/space`);
+  }
+
+  async waitForSpaceSettingsURL(domain?: string) {
+    if (domain) {
+      await this.page.waitForURL(`**/${domain}/settings/space`);
+    } else {
+      await this.page.waitForURL('**/settings/space');
+    }
+  }
+}

--- a/__e2e__/updateSpace.spec.ts
+++ b/__e2e__/updateSpace.spec.ts
@@ -1,0 +1,35 @@
+import { test as base } from '@playwright/test';
+import { v4 } from 'uuid';
+
+import { SpaceSettingsPage } from './po/spaceSettings.po';
+import { generateUserAndSpace } from './utils/mocks';
+import { login } from './utils/session';
+
+type Fixtures = {
+  spaceSettingsPage: SpaceSettingsPage;
+};
+
+const test = base.extend<Fixtures>({
+  spaceSettingsPage: ({ page }, use) => use(new SpaceSettingsPage(page))
+});
+
+test('Space settings - update the space name and domain', async ({ page, spaceSettingsPage }) => {
+  const { space, user: spaceUser } = await generateUserAndSpace({ spaceName: v4(), isAdmin: true, onboarded: true });
+  // go to a page to which we don't have access
+
+  await login({ page, userId: spaceUser.id });
+
+  await spaceSettingsPage.goTo(space.domain);
+
+  await spaceSettingsPage.waitForSpaceSettingsURL();
+
+  const newName = `New space name ${v4()}`;
+  const newDomain = `new-space-domain-${v4()}`;
+
+  await spaceSettingsPage.spaceNameField.fill(newName);
+  await spaceSettingsPage.spaceDomainField.fill(newDomain);
+
+  await spaceSettingsPage.submitSpaceUpdateButton.click();
+
+  await spaceSettingsPage.waitForSpaceSettingsURL(newDomain);
+});

--- a/__integration-tests__/server/pages/api/spaces/[id]/index.spec.ts
+++ b/__integration-tests__/server/pages/api/spaces/[id]/index.spec.ts
@@ -1,0 +1,71 @@
+import type { Space } from '@prisma/client';
+import request from 'supertest';
+import { v4 } from 'uuid';
+
+import type { UpdateableSpaceFields } from 'lib/spaces/updateSpace';
+import type { LoggedInUser } from 'models';
+import { baseUrl, loginUser } from 'testing/mockApiCall';
+import { generateSpaceUser, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+
+let space: Space;
+let adminUser: LoggedInUser;
+let memberUser: LoggedInUser;
+
+let adminCookie: string;
+let memberCookie: string;
+
+beforeAll(async () => {
+  const { space: generatedSpace, user: generatedUser } = await generateUserAndSpaceWithApiToken(undefined, true);
+  adminUser = generatedUser;
+  memberUser = await generateSpaceUser({ isAdmin: false, spaceId: generatedSpace.id });
+  space = generatedSpace;
+  adminCookie = await loginUser(adminUser.id);
+  memberCookie = await loginUser(memberUser.id);
+});
+
+describe('PUT /api/spaces - Update space profile', () => {
+  it('Should allow an admin to update the space, responding 200', async () => {
+    const update: UpdateableSpaceFields = {
+      domain: `new-space-domain-${v4()}`,
+      name: 'New Space Name - Admin updated this',
+      spaceImage: `https://new-space-logo-${v4()}.png`
+    };
+    const spaceAfterUpdate = await (
+      await request(baseUrl).put(`/api/spaces/${space.id}`).set('Cookie', adminCookie).send(update).expect(200)
+    ).body;
+
+    expect(spaceAfterUpdate).toMatchObject(update);
+  });
+
+  it('Should work even if unexpected data is sent along with the payload, responding 200', async () => {
+    const allowedProps: UpdateableSpaceFields = {
+      domain: `new-space-domain-${v4()}`,
+      name: 'New Space Name - Admin updated this',
+      spaceImage: `https://new-space-logo-${v4()}.png`
+    };
+
+    const update = {
+      ...allowedProps,
+      randomField1: 234484848,
+      objectField: {
+        arrayOfData: [1, 2, 3, 4, 5]
+      },
+      stringContent: 'random string'
+    };
+
+    const spaceAfterUpdate = await (
+      await request(baseUrl).put(`/api/spaces/${space.id}`).set('Cookie', adminCookie).send(update).expect(200)
+    ).body;
+
+    expect(spaceAfterUpdate).toMatchObject(allowedProps);
+  });
+
+  it('Should fail if user is not a part of the space and respond with 401', async () => {
+    const update: UpdateableSpaceFields = {
+      domain: `different-space-domain-${v4()}`,
+      name: 'Ignored Space Name - Admin updated this',
+      spaceImage: `https://new-space-logo-${v4()}.png`
+    };
+    await request(baseUrl).put(`/api/spaces/${space.id}`).set('Cookie', memberCookie).send(update).expect(401);
+  });
+});

--- a/lib/spaces/__tests__/updateSpace.spec.ts
+++ b/lib/spaces/__tests__/updateSpace.spec.ts
@@ -1,0 +1,163 @@
+import type { Space, User } from '@prisma/client';
+import { v4 } from 'uuid';
+
+import { prisma } from 'db';
+import { DuplicateDataError, InvalidInputError } from 'lib/utilities/errors';
+import { typedKeys } from 'lib/utilities/objects';
+
+import type { UpdateableSpaceFields } from '../updateSpace';
+import { updateSpace } from '../updateSpace';
+
+let firstUser: User;
+let secondUser: User;
+
+let mockedMixpanelFn: jest.Mock;
+
+beforeAll(async () => {
+  firstUser = await prisma.user.create({
+    data: {
+      username: 'firstUser'
+    }
+  });
+  secondUser = await prisma.user.create({
+    data: {
+      username: 'secondUser'
+    }
+  });
+});
+
+afterAll(() => {
+  jest.unmock('lib/metrics/mixpanel/updateTrackGroupProfile');
+  jest.resetModules();
+});
+
+describe('updateSpace', () => {
+  it('should only update the space name, domain and logo', async () => {
+    const update: UpdateableSpaceFields = {
+      name: 'New Space Name',
+      domain: 'new-space-name',
+      spaceImage: 'https://new-space-logo.png'
+    };
+
+    const droppedUpdate: Omit<Space, keyof UpdateableSpaceFields> = {
+      createdBy: secondUser.id,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      id: v4(),
+      defaultPagePermissionGroup: 'view',
+      updatedBy: secondUser.id,
+      xpsEngineId: v4(),
+      snapshotDomain: `snapshot-domain-${v4()}`,
+      deletedAt: new Date(),
+      publicBountyBoard: false,
+      defaultVotingDuration: 20,
+      defaultPostCategoryId: v4(),
+      defaultPublicPages: false,
+      discordServerId: v4(),
+      permissionConfigurationMode: 'readOnly',
+      superApiTokenId: v4()
+    };
+
+    const space = await prisma.space.create({
+      data: {
+        domain: `space-domain-${v4()}`,
+        name: 'Space Name',
+        spaceImage: 'https://space-logo.png',
+        updatedBy: firstUser.id,
+        publicBountyBoard: true,
+        defaultPublicPages: true,
+        permissionConfigurationMode: 'collaborative',
+        author: {
+          connect: {
+            id: firstUser.id
+          }
+        }
+      }
+    });
+
+    const updatedSpace = await updateSpace(space.id, { ...update, ...droppedUpdate });
+
+    typedKeys(update).forEach((key) => {
+      expect(updatedSpace[key]).toEqual(update[key]);
+    });
+
+    typedKeys(droppedUpdate).forEach((key) => {
+      expect(updatedSpace[key]).not.toEqual(droppedUpdate[key]);
+    });
+  });
+  it('should throw an error if no space ID is provided', async () => {
+    await expect(updateSpace(null as any, { name: 'New Space Name' })).rejects.toBeInstanceOf(InvalidInputError);
+  });
+
+  it('should throw an error if the domain is already in use', async () => {
+    const firstSpace = await prisma.space.create({
+      data: {
+        domain: `space-domain-${v4()}`,
+        name: 'Space Name',
+        spaceImage: 'https://space-logo.png',
+        updatedBy: firstUser.id,
+        author: {
+          connect: {
+            id: firstUser.id
+          }
+        }
+      }
+    });
+
+    const secondSpace = await prisma.space.create({
+      data: {
+        domain: `space-domain-${v4()}`,
+        name: 'Space Name',
+        spaceImage: 'https://space-logo.png',
+        updatedBy: firstUser.id,
+        author: {
+          connect: {
+            id: firstUser.id
+          }
+        }
+      }
+    });
+
+    await expect(updateSpace(secondSpace.id, { domain: firstSpace.domain })).rejects.toBeInstanceOf(DuplicateDataError);
+
+    // Make sure sending through the update with current space domain and name doesn't throw an error
+    const { updatedAt, ...secondSpaceWithoutUpdatedAt } = secondSpace;
+
+    await expect(
+      updateSpace(secondSpace.id, {
+        domain: secondSpace.domain,
+        name: secondSpace.name,
+        spaceImage: secondSpace.spaceImage
+      })
+    ).resolves.toMatchObject(secondSpaceWithoutUpdatedAt);
+  });
+
+  it('should update the space profile in mixpanel', async () => {
+    const space = await prisma.space.create({
+      data: {
+        domain: `space-domain-${v4()}`,
+        name: 'Space Name',
+        spaceImage: 'https://space-logo.png',
+        updatedBy: firstUser.id,
+        author: {
+          connect: {
+            id: firstUser.id
+          }
+        }
+      }
+    });
+
+    jest.resetModules();
+
+    mockedMixpanelFn = jest.fn();
+
+    jest.mock('lib/metrics/mixpanel/updateTrackGroupProfile', () => ({
+      updateTrackGroupProfile: mockedMixpanelFn
+    }));
+
+    const { updateSpace: updateSpaceWithMockedMixpanel } = await import('../updateSpace');
+
+    await updateSpaceWithMockedMixpanel(space.id, { name: 'New Space Name' });
+    expect(mockedMixpanelFn).toHaveBeenCalled();
+  });
+});

--- a/lib/spaces/updateSpace.ts
+++ b/lib/spaces/updateSpace.ts
@@ -1,0 +1,46 @@
+import type { Space } from '@prisma/client';
+
+import { prisma } from 'db';
+import { updateTrackGroupProfile } from 'lib/metrics/mixpanel/updateTrackGroupProfile';
+import { DuplicateDataError, InvalidInputError } from 'lib/utilities/errors';
+
+export type UpdateableSpaceFields = Partial<Pick<Space, 'domain' | 'name' | 'spaceImage'>>;
+
+export async function updateSpace(
+  spaceId: string,
+  { domain, name, spaceImage }: UpdateableSpaceFields
+): Promise<Space> {
+  if (!spaceId) {
+    throw new InvalidInputError('A space ID is required');
+  }
+
+  if (domain) {
+    const existingSpace = await prisma.space.findUnique({
+      where: {
+        domain
+      },
+      select: {
+        id: true
+      }
+    });
+
+    if (existingSpace && existingSpace.id !== spaceId) {
+      throw new DuplicateDataError(`A space with the domain ${domain} already exists`);
+    }
+  }
+
+  const updatedSpace = await prisma.space.update({
+    where: {
+      id: spaceId
+    },
+    data: {
+      domain,
+      name,
+      spaceImage
+    }
+  });
+
+  updateTrackGroupProfile(updatedSpace);
+
+  return updatedSpace;
+}

--- a/pages/[domain]/settings/space.tsx
+++ b/pages/[domain]/settings/space.tsx
@@ -127,6 +127,7 @@ export default function WorkspaceSettings() {
               fullWidth
               error={!!errors.name}
               helperText={errors.name?.message}
+              data-test='set-space-name'
             />
           </Grid>
           <Grid item>
@@ -138,12 +139,13 @@ export default function WorkspaceSettings() {
               error={!!errors.domain}
               helperText={errors.domain?.message}
               sx={{ mb: 1 }}
+              data-test='set-space-domain'
             />
             {error && <FormHelperText error>{error}</FormHelperText>}
           </Grid>
           {isAdmin ? (
             <Grid item display='flex' justifyContent='space-between'>
-              <PrimaryButton disabled={!isDirty} type='submit'>
+              <PrimaryButton data-test='submit-space-update' disabled={!isDirty} type='submit'>
                 Save
               </PrimaryButton>
               <Button variant='outlined' color='error' onClick={deleteWorkspace}>

--- a/pages/api/spaces/[id]/index.ts
+++ b/pages/api/spaces/[id]/index.ts
@@ -6,36 +6,21 @@ import { prisma } from 'db';
 import { updateTrackGroupProfile } from 'lib/metrics/mixpanel/updateTrackGroupProfile';
 import { onError, onNoMatch, requireSpaceMembership, ActionNotPermittedError } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
+import { updateSpace } from 'lib/spaces/updateSpace';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler
   .use(requireSpaceMembership({ adminOnly: true, spaceIdKey: 'id' }))
-  .put(updateSpace)
+  .put(updateSpaceController)
   .delete(deleteSpace);
 
-async function updateSpace(req: NextApiRequest, res: NextApiResponse<Space>) {
-  const spaceDomain = req.body.domain as string | undefined;
+async function updateSpaceController(req: NextApiRequest, res: NextApiResponse<Space>) {
+  const spaceId = req.query.id as string;
 
-  const existing =
-    typeof spaceDomain === 'string'
-      ? await prisma.space.findFirst({
-          where: {
-            domain: spaceDomain
-          }
-        })
-      : null;
+  const updatedSpace = await updateSpace(spaceId, req.body);
 
-  if (existing && existing.id !== req.query.id) {
-    throw new ActionNotPermittedError('This domain is already in use');
-  }
-
-  const space = await prisma.space.update({
-    where: {
-      id: req.query.id as string
-    },
-    data: req.body
-  });
+  res.status(200).send(updatedSpace);
 
   updateTrackGroupProfile(space);
 

--- a/pages/api/spaces/[id]/index.ts
+++ b/pages/api/spaces/[id]/index.ts
@@ -21,10 +21,6 @@ async function updateSpaceController(req: NextApiRequest, res: NextApiResponse<S
   const updatedSpace = await updateSpace(spaceId, req.body);
 
   res.status(200).send(updatedSpace);
-
-  updateTrackGroupProfile(space);
-
-  return res.status(200).json(space);
 }
 
 async function deleteSpace(req: NextApiRequest, res: NextApiResponse) {


### PR DESCRIPTION
This pull request makes updating a space in space settings more reliable

- Extracted updateSpace from API to a lib method which only updates name, domain and spaceImage (also stops us sending arbitrary data from req.body straight to Prisma)
- Ensured the API and lib are resilient against inputs with additional unexpected values
- Added an e2e test for changing the space settings form