### PR TITLE
prevent paste commands from escaping database

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
@@ -158,7 +158,6 @@ function TableRow(props: Props) {
           return (
             <Box
               className='octo-table-cell title-cell'
-              id='mainBoardHeader'
               sx={{
                 width: columnWidth(
                   props.resizingColumn,
@@ -169,6 +168,7 @@ function TableRow(props: Props) {
               }}
               ref={columnRefs.get(Constants.titleColumnId)}
               key={template.id}
+              onPaste={(e) => e.stopPropagation()}
             >
               {!props.readOnly && (
                 <IconButton className='icons' onClick={handleClick} size='small'>
@@ -206,6 +206,7 @@ function TableRow(props: Props) {
               width: columnWidth(props.resizingColumn, props.activeView.fields.columnWidths, props.offset, template.id)
             }}
             ref={columnRefs.get(template.id)}
+            onPaste={(e) => e.stopPropagation()}
           >
             <PropertyValueElement
               readOnly={props.readOnly}

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -3,7 +3,8 @@ import styled from '@emotion/styled';
 import type { Page } from '@prisma/client';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import { useCallback, useMemo, useState, useEffect } from 'react';
+import type { KeyboardEvent, MouseEvent, ClipboardEvent } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import CardDialog from 'components/common/BoardEditor/focalboard/src/components/cardDialog';
 import { getSortedBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
@@ -118,7 +119,7 @@ export default function DatabaseView({ containerWidth, readOnly: readOnlyOverrid
     }, 500);
   }, [updatePage]);
 
-  function stopPropagation(e: React.KeyboardEvent | React.MouseEvent) {
+  function stopPropagation(e: KeyboardEvent | MouseEvent | ClipboardEvent) {
     e.stopPropagation();
   }
 
@@ -145,6 +146,7 @@ export default function DatabaseView({ containerWidth, readOnly: readOnlyOverrid
         containerWidth={containerWidth}
         onKeyPress={stopPropagation}
         onKeyDown={stopPropagation}
+        onPaste={stopPropagation}
       >
         <CenterPanel
           disableUpdatingUrl


### PR DESCRIPTION
User was trying to paste a URL into the table of an embedded DB, and it would either paste in the page document outside the table or jsut delete the table :(

https://www.loom.com/share/e24f7ea63e1841a1a02e252e4f4046d0