### PR TITLE
Mobile dialog

### DIFF
--- a/components/common/MobileDialog/MobileDialog.tsx
+++ b/components/common/MobileDialog/MobileDialog.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+import type { DialogProps } from '@mui/material';
+import { DialogContent, Dialog, Slide } from '@mui/material';
+import type { TransitionProps } from '@mui/material/transitions';
+import type { ReactNode } from 'react';
+import { forwardRef } from 'react';
+
+import { MobileDialogTitle } from 'components/common/MobileDialog/MobileDialogTitle';
+
+const StyledDialog = styled(Dialog)(({ theme }) => ({
+  '& .MuiDialogContent-root': {
+    padding: theme.spacing(2)
+  },
+  '& .MuiDialogActions-root': {
+    padding: theme.spacing(1)
+  }
+}));
+
+const Transition = forwardRef(function Transition(
+  props: TransitionProps & {
+    children: React.ReactElement;
+  },
+  ref: React.Ref<unknown>
+) {
+  return <Slide direction='up' ref={ref} {...props} />;
+});
+
+type Props = {
+  title?: ReactNode | null;
+  rightActions?: ReactNode;
+} & Omit<DialogProps, 'title'>;
+
+export function MobileDialog({ children, title, rightActions, onClose, ...dialogProps }: Props) {
+  const hasTitle = typeof title !== 'undefined' && title !== null;
+
+  return (
+    <StyledDialog fullScreen {...dialogProps} TransitionComponent={Transition} onClose={onClose}>
+      {hasTitle && <MobileDialogTitle title={title} rightActions={rightActions} onClose={onClose as VoidFunction} />}
+
+      <DialogContent dividers>{children}</DialogContent>
+    </StyledDialog>
+  );
+}

--- a/components/common/MobileDialog/MobileDialogTitle.tsx
+++ b/components/common/MobileDialog/MobileDialogTitle.tsx
@@ -1,0 +1,45 @@
+import CloseIcon from '@mui/icons-material/Close';
+import { Box, DialogTitle, IconButton, Typography } from '@mui/material';
+import type { ReactNode } from 'react';
+
+type Props = {
+  title?: ReactNode;
+  onClose?: VoidFunction;
+  rightActions?: ReactNode;
+};
+
+export function MobileDialogTitle({ title, onClose, rightActions }: Props) {
+  return (
+    <DialogTitle
+      sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        pl: 2,
+        pr: 1,
+        py: 0.5,
+        minHeight: '40px'
+      }}
+    >
+      <>
+        <Box display='flex' alignItems='center' overflow='hidden' gap={0.5}>
+          {typeof title === 'string' ? (
+            <Typography fontWeight={600} noWrap>
+              {title}
+            </Typography>
+          ) : (
+            title
+          )}
+        </Box>
+
+        <Box display='flex' alignItems='center' gap={0.5}>
+          {rightActions || null}
+          {!!onClose && (
+            <IconButton aria-label='close' onClick={onClose}>
+              <CloseIcon />
+            </IconButton>
+          )}
+        </Box>
+      </>
+    </DialogTitle>
+  );
+}

--- a/components/common/Modal/Modal.tsx
+++ b/components/common/Modal/Modal.tsx
@@ -1,10 +1,14 @@
 import styled from '@emotion/styled';
 import CloseIcon from '@mui/icons-material/Close';
+import type { Theme } from '@mui/material';
+import { useMediaQuery } from '@mui/material';
 import Box from '@mui/material/Box';
 import MuiDialogTitle from '@mui/material/DialogTitle';
 import IconButton from '@mui/material/IconButton';
 import MuiModal from '@mui/material/Modal';
 import type { ComponentProps, ReactNode } from 'react';
+
+import { MobileDialog } from 'components/common/MobileDialog/MobileDialog';
 
 export type ModalSize = 'large' | 'fluid' | 'small' | string;
 
@@ -67,6 +71,7 @@ export type ModalProps = Omit<ComponentProps<typeof MuiModal>, 'children' | 'onC
   position?: ModalPosition;
   noPadding?: boolean;
   onClose: () => void;
+  mobileDialog?: boolean;
 };
 
 export function Modal({
@@ -75,8 +80,20 @@ export function Modal({
   position = ModalPosition.center,
   size = defaultSize,
   title,
+  mobileDialog,
   ...props
 }: ModalProps) {
+  const isLargeScreen = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
+  const isMobileDialog = !isLargeScreen && mobileDialog;
+
+  if (isMobileDialog) {
+    return (
+      <MobileDialog title={title} {...props}>
+        {children}
+      </MobileDialog>
+    );
+  }
+
   return (
     <MuiModal {...props}>
       <div>

--- a/components/common/PageLayout/components/Sidebar/SidebarSubmenu.tsx
+++ b/components/common/PageLayout/components/Sidebar/SidebarSubmenu.tsx
@@ -1,7 +1,6 @@
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import AddIcon from '@mui/icons-material/Add';
-import NavigateNextIcon from '@mui/icons-material/ArrowRightAlt';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import MenuOpenIcon from '@mui/icons-material/MenuOpen';
 import Box from '@mui/material/Box';
@@ -167,6 +166,7 @@ export default function SidebarSubmenu({
         open={spaceFormOpen}
         sx={{ width: showMobileFullWidthModal ? '100%' : undefined }}
         onClose={closeSpaceForm}
+        mobileDialog
       >
         <CreateSpaceForm onCancel={closeSpaceForm} />
       </Modal>

--- a/components/common/PageLayout/components/Sidebar/Workspaces.tsx
+++ b/components/common/PageLayout/components/Sidebar/Workspaces.tsx
@@ -80,7 +80,7 @@ export default function Workspaces() {
           </Tooltip>
         </Grid>
       </Grid>
-      <Modal size='medium' open={spaceFormOpen} onClose={closeSpaceForm}>
+      <Modal size='medium' open={spaceFormOpen} onClose={closeSpaceForm} mobileDialog>
         <CreateSpaceForm onCancel={closeSpaceForm} />
       </Modal>
     </WorkspacesContainer>


### PR DESCRIPTION
I will need  dialog that will be reusable on mobile for different kinds of content. I made this reusable component + connected it with our current `Modal` for easy use. I added `mobileDialog` prop to our `Modal` and you can enable mobile behavior and animation with a single prop. Added example use to create sapce modals.
Note that `Modal` will work as it was for bigger screens.

https://user-images.githubusercontent.com/5198394/215264159-b3e13419-bb67-4a2d-a054-ec1f90f519b5.mp4

This is how it would look like if you pass `title` as `Modal` prop:

<img width="556" alt="Screenshot 2023-01-28 at 12 32 01" src="https://user-images.githubusercontent.com/5198394/215264229-9bf0fa13-db4f-4c4c-94f4-2cb55670c3c4.png">


