### PR TITLE
fix redirection to workspace page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,8 +34,13 @@ const config = {
     return [
       {
         source: '/:domain(^(?!.*\bapi\b).*$)/settings',
-        destination: '/:domain/settings/workspace',
+        destination: '/:domain/settings/space',
         permanent: false
+      },
+      {
+        source: '/:domain(^(?!.*\bapi\b).*$)/settings/workspace',
+        destination: '/:domain/settings/space',
+        permanent: true
       },
       {
         source: '/:domain(^(?!.*\bapi\b).*$)/bounties/:id',


### PR DESCRIPTION
There are 2 situations that can lead the user to a 404 page
1. The last visited page of a user is [domain]/settings/workspace
2. A user goes to  [domain]/settings/ and is being redirected to  [domain]/settings/workspace