### PR TITLE
Bug fix: document selected by default causes unexpected behavior

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -186,6 +186,7 @@ function DocumentPage({ page, setPage, insideModal, readOnly = false, parentProp
               // content={pageDetails?.content as PageContent}
               // onContentChange={updatePageContent}
               readOnly={readOnly}
+              autoFocus={false}
               pageActionDisplay={!insideModal ? currentPageActionDisplay : null}
               pageId={page.id}
               disablePageSpecificFeatures={isSharedPage}

--- a/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
@@ -78,7 +78,7 @@ export function PageTitleInput({ value, updatedAt: updatedAtExternal, onChange, 
       value={title}
       onChange={_onChange}
       placeholder='Untitled'
-      autoFocus={!readOnly && !isTouchScreen()}
+      autoFocus={!value && !readOnly && !isTouchScreen()}
       multiline
       variant='standard'
       onKeyDown={(e) => {

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -339,6 +339,7 @@ export type UpdatePageContent = (content: ICharmEditorOutput) => any;
 
 interface CharmEditorProps {
   content?: PageContent;
+  autoFocus?: boolean;
   children?: ReactNode;
   enableSuggestingMode?: boolean;
   onContentChange?: UpdatePageContent;
@@ -379,6 +380,7 @@ function CharmEditor({
   pageActionDisplay = null,
   content = defaultContent,
   children,
+  autoFocus,
   onContentChange,
   style,
   readOnly = false,
@@ -531,6 +533,7 @@ function CharmEditor({
       onParticipantUpdate={onParticipantUpdate}
       trackChanges
       readOnly={readOnly}
+      focusOnInit={autoFocus}
       enableComments={enableComments}
       style={{
         ...(style ?? {}),

--- a/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
@@ -55,7 +55,7 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
     state,
     children,
     isContentControlled,
-    focusOnInit = !isTouchScreen(),
+    focusOnInit,
     pmViewOpts,
     renderNodeViews,
     className,
@@ -69,6 +69,8 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
   },
   ref
 ) {
+  focusOnInit = focusOnInit ?? (!readOnly && !isTouchScreen());
+
   const renderRef = useRef<HTMLDivElement>(null);
   const { user } = useUser();
   const enableFidusEditor = Boolean(user && pageId && trackChanges && !isContentControlled);

--- a/components/common/CharmEditor/components/fiduswriter/collab/doc.ts
+++ b/components/common/CharmEditor/components/fiduswriter/collab/doc.ts
@@ -126,9 +126,7 @@ export class ModCollabDoc {
     const stateConfig: EditorStateConfig = {
       schema: this.mod.editor.schema,
       doc: stateDoc,
-      plugins: this.mod.editor.view.state.plugins.concat(plugins),
-      // if we dont include the selection, the first node gets selected for some reason
-      selection: this.mod.editor.view.state.selection
+      plugins: this.mod.editor.view.state.plugins.concat(plugins)
     };
 
     // Set document in prosemirror

--- a/components/common/CharmEditor/components/floatingMenu/Menu.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/Menu.tsx
@@ -5,7 +5,11 @@ import React from 'react';
 
 import type { SubMenu } from './floating-menu';
 
-const StyledMenu = styled(Paper)<{ type?: SubMenu; noScroll?: boolean; inline?: boolean }>`
+const StyledMenu = styled(Paper, { shouldForwardProp: (prop: string) => prop !== 'noScroll' })<{
+  type?: SubMenu;
+  noScroll?: boolean;
+  inline?: boolean;
+}>`
   display: flex;
   padding: ${({ theme }) => theme.spacing(0, 0.5)};
   border-radius: 4px;

--- a/components/forum/components/PostList/components/PostSummary.tsx
+++ b/components/forum/components/PostList/components/PostSummary.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
 
 import CharmEditor from 'components/common/CharmEditor/CharmEditor';
 import type { PageContent } from 'lib/prosemirror/interfaces';

--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -204,6 +204,7 @@ export function PostPage({
           <Box minHeight={300}>
             <CharmEditor
               pageType='post'
+              autoFocus={false}
               readOnly={readOnly}
               pageActionDisplay={null}
               pageId={post?.id}

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -2,26 +2,6 @@
   border-radius: 8px;
 }
 
-.bangle-editor .selected-node {
-  animation-duration: 0.75s;
-  animation-name: editorSelectedNode;
-  animation-timing-function: ease-out;
-}
-
-@keyframes editorSelectedNode {
-  from {
-    border-radius: 4px;
-    background-color: var(--editorCore-selectionChange-bgColor);
-  }
-
-  to {}
-}
-
-:root {
-  --window-tooltip-zIndex: 5;
-  --inlineUniversalPalette-height: 400px;
-}
-
 .bangle-tooltip {
   z-index: var(--z-index-modal);
 }
@@ -30,15 +10,10 @@
   text-decoration: underline;
 }
 
-.bangle-editor p > code {}
-
 .bangle-editor li[data-bangle-is-todo] > span:first-child > input {
   margin-top: 0.45rem;
 }
 
-.bangle-editor .ProseMirror-selectednode {
-  border-radius: var(--window-pill-borderRadius);
-}
 
 .bangle-editor {
   border: none;
@@ -151,16 +126,14 @@
   /* the above doesn't seem to work in Edge */
 }
 
-.ProseMirror-hideselection *::selection {
-  background: transparent;
-}
-
-.ProseMirror-hideselection *::-moz-selection {
-  background: transparent;
+.ProseMirror-hideselection *::selection,
+.ProseMirror-hideselection *::-moz-selection,
+.ProseMirror-hideselection .ProseMirror-selectednode {
+  background-color: transparent !important;
 }
 
 .ProseMirror-hideselection {
-  caret-color: transparent;
+  caret-color: transparent !important;
 }
 
 /* Protect against generic img rules */
@@ -548,7 +521,7 @@ details {
   // add a width so that icons are left-aligned even if counts get large
   width: 40px;
 
-  @media (min-width: 600px)  {
+  @media (min-width: 600px) {
     right: -70px;
   }
 


### PR DESCRIPTION
I introduced this bug when I added a selection to the doc when we got the first handshake with web sockets... basically, the selection type was "all" by default.

I was trying to remove some weirdness where blocks would be highlighted by default, but a better fix was to disable focus on read-only content, and also simplify the focusOnInit logic for documents. It looks like Notion never applies focus on the document by default, just the page title if anything. I'd like to revisit the decision to put smart logic for autoFocus (aka focusOnInit) inside ReactEditor in the future