### PR TITLE
Removed duplicate props from charmeditor

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -562,7 +562,6 @@ function CharmEditor({
       onParticipantUpdate={onParticipantUpdate}
       trackChanges
       readOnly={readOnly}
-      focusOnInit={autoFocus}
       enableComments={enableComments}
       style={{
         ...(style ?? {}),

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "db-tool:dev": "dotenv -e .env.local -- npx prisma studio",
     "db-tool:test": "dotenv -e .env.test.local -- npx prisma studio",
     "test:typecheck": "tsc --project tsconfig.test.json --noEmit",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
     "test:setup-db": "./scripts/configure-db.sh",
     "test:browser": "jest --config='./jest.config-browser.ts'",
     "test:e2e": "dotenv -e .env.test.local -- npx playwright test --timeout=0",


### PR DESCRIPTION
One of my PR's failed in `deploy` job due to incorrect automatic merging with main. `focusOnInit` prop was duplicated in `CharmEditor`. I've checked for any other type issues, but found none.