### PR TITLE
Feat/mobile header

### DIFF
--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -163,6 +163,11 @@ function PageLayout({ sidebarWidth = 300, children, sidebar: SidebarOverride }: 
   const { hasSharedPageAccess, accessChecked, publicPage } = useSharedPage();
   const open = isMobileSidebar ? mobileOpen : storageOpen;
 
+  let displaySidebarWidth = SidebarOverride ? sidebarWidth : resizableSidebarWidth || sidebarWidth;
+  if (isMobileSidebar) {
+    displaySidebarWidth = 0;
+  }
+
   const handleDrawerOpen = React.useCallback(() => {
     if (isMobileSidebar) {
       setMobileOpen(true);
@@ -218,11 +223,7 @@ function PageLayout({ sidebarWidth = 300, children, sidebar: SidebarOverride }: 
                 <PageActionDisplayProvider>
                   {open !== null && (
                     <>
-                      <AppBar
-                        open={open}
-                        sidebarWidth={isMobileSidebar ? 0 : resizableSidebarWidth || sidebarWidth}
-                        position='fixed'
-                      >
+                      <AppBar open={open} sidebarWidth={displaySidebarWidth} position='fixed'>
                         <Header open={open} openSidebar={handleDrawerOpen} />
                       </AppBar>
                       {isMobileSidebar ? (
@@ -239,11 +240,7 @@ function PageLayout({ sidebarWidth = 300, children, sidebar: SidebarOverride }: 
                           </Box>
                         </MuiDrawer>
                       ) : (
-                        <Drawer
-                          sidebarWidth={SidebarOverride ? sidebarWidth : resizableSidebarWidth || sidebarWidth}
-                          open={open}
-                          variant='permanent'
-                        >
+                        <Drawer sidebarWidth={displaySidebarWidth} open={open} variant='permanent'>
                           {drawerContent}
 
                           <Tooltip

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -388,10 +388,13 @@ export default function Header({ open, openSidebar }: HeaderProps) {
           alignItems: 'center',
           alignSelf: 'stretch',
           gap: 1,
-          width: '100%'
+          width: 'calc(100% - 40px)'
         }}
       >
-        <PageTitleWithBreadcrumbs pageId={basePage?.id} pageType={basePage?.type} />
+        <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          <PageTitleWithBreadcrumbs pageId={basePage?.id} pageType={basePage?.type} />
+        </div>
+
         <Box display='flex' alignItems='center' alignSelf='stretch' mr={-1}>
           {isBountyBoard && <BountyShareButton headerHeight={headerHeight} />}
 

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -85,7 +85,7 @@ export default function Header({ open, openSidebar }: HeaderProps) {
   const { setCurrentPageActionDisplay } = usePageActionDisplay();
   const [userSpacePermissions] = useCurrentSpacePermissions();
   const pagePermissions = basePage ? getPagePermissions(basePage.id) : null;
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'));
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('md'));
 
   const pageType = basePage?.type;
   const isExportablePage =
@@ -130,7 +130,7 @@ export default function Header({ open, openSidebar }: HeaderProps) {
     }
   }
 
-  const isFullWidth = isSmallScreen || (basePage?.fullWidth ?? false);
+  const isFullWidth = !isLargeScreen || (basePage?.fullWidth ?? false);
   const isBasePageDocument = documentTypes.includes(basePage?.type ?? '');
   const isBasePageDatabase = /board/.test(basePage?.type ?? '');
 
@@ -317,7 +317,7 @@ export default function Header({ open, openSidebar }: HeaderProps) {
           </ListItemButton>
         </div>
       </Tooltip>
-      {!isSmallScreen && (
+      {isLargeScreen && (
         <>
           <Divider />
           <ListItemButton>
@@ -375,7 +375,7 @@ export default function Header({ open, openSidebar }: HeaderProps) {
         sx={{
           display: 'inline-flex',
           mr: 2,
-          ...(open && { display: 'none' })
+          ...(open && isLargeScreen && { display: 'none' })
         }}
       >
         <MenuIcon />
@@ -388,7 +388,7 @@ export default function Header({ open, openSidebar }: HeaderProps) {
           alignItems: 'center',
           alignSelf: 'stretch',
           gap: 1,
-          width: 'calc(100% - 40px)'
+          width: { xs: 'calc(100% - 40px)', md: '100%' }
         }}
       >
         <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
@@ -411,7 +411,7 @@ export default function Header({ open, openSidebar }: HeaderProps) {
             <Box ref={pageMenuAnchor} display='flex' alignSelf='stretch' alignItems='center'>
               <div>
                 <IconButton
-                  size='small'
+                  size={isLargeScreen ? 'small' : 'medium'}
                   onClick={() => {
                     setPageMenuOpen(!pageMenuOpen);
                     setPageMenuAnchorElement(pageMenuAnchor.current || null);
@@ -441,7 +441,12 @@ export default function Header({ open, openSidebar }: HeaderProps) {
           {user && (
             <>
               <NotificationsBadge>
-                <IconButton size='small' sx={{ mx: 1 }} LinkComponent={NextLink} href='/nexus' color='inherit'>
+                <IconButton
+                  size={isLargeScreen ? 'small' : 'medium'}
+                  LinkComponent={NextLink}
+                  href='/nexus'
+                  color='inherit'
+                >
                   <NotificationsIcon fontSize='small' color='secondary' />
                 </IconButton>
               </NotificationsBadge>

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -395,7 +395,7 @@ export default function Header({ open, openSidebar }: HeaderProps) {
           <PageTitleWithBreadcrumbs pageId={basePage?.id} pageType={basePage?.type} />
         </div>
 
-        <Box display='flex' alignItems='center' alignSelf='stretch' mr={-1}>
+        <Box display='flex' alignItems='center' alignSelf='stretch' mr={-1} gap={0.25}>
           {isBountyBoard && <BountyShareButton headerHeight={headerHeight} />}
 
           {basePage && (
@@ -410,17 +410,17 @@ export default function Header({ open, openSidebar }: HeaderProps) {
           {pageOptionsList && (
             <Box ref={pageMenuAnchor} display='flex' alignSelf='stretch' alignItems='center'>
               <div>
-                <IconButton
-                  size={isLargeScreen ? 'small' : 'medium'}
-                  onClick={() => {
-                    setPageMenuOpen(!pageMenuOpen);
-                    setPageMenuAnchorElement(pageMenuAnchor.current || null);
-                  }}
-                >
-                  <Tooltip title='View comments, export content and more' arrow>
+                <Tooltip title='View comments, export content and more' arrow>
+                  <IconButton
+                    size={isLargeScreen ? 'small' : 'medium'}
+                    onClick={() => {
+                      setPageMenuOpen(!pageMenuOpen);
+                      setPageMenuAnchorElement(pageMenuAnchor.current || null);
+                    }}
+                  >
                     <MoreHorizIcon color='secondary' />
-                  </Tooltip>
-                </IconButton>
+                  </IconButton>
+                </Tooltip>
               </div>
               <Popover
                 anchorEl={pageMenuAnchorElement}
@@ -452,7 +452,7 @@ export default function Header({ open, openSidebar }: HeaderProps) {
               </NotificationsBadge>
               <IconButton
                 size='small'
-                sx={{ display: { xs: 'none', md: 'inline-flex' }, mx: 1 }}
+                sx={{ display: { xs: 'none', md: 'inline-flex' } }}
                 onClick={colorMode.toggleColorMode}
                 color='inherit'
               >

--- a/components/common/PageLayout/components/Header/components/EditingModeToggle.tsx
+++ b/components/common/PageLayout/components/Header/components/EditingModeToggle.tsx
@@ -1,5 +1,6 @@
 import { ArrowDropDown } from '@mui/icons-material';
-import { ListItemIcon, ListItemText, Menu, MenuItem, Tooltip } from '@mui/material';
+import type { Theme } from '@mui/material';
+import { IconButton, useMediaQuery, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip } from '@mui/material';
 import PopupState, { bindMenu, bindTrigger } from 'material-ui-popup-state';
 import { memo } from 'react';
 
@@ -24,6 +25,7 @@ const editModeConfig = {
 
 function EditModeToggle() {
   const { availableEditModes, editMode, setPageProps } = usePrimaryCharmEditor();
+  const isLargeScreen = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
 
   function setMode(mode: EditMode) {
     setPageProps({ editMode: mode });
@@ -39,19 +41,23 @@ function EditModeToggle() {
     <PopupState variant='popover' popupId='edit-mode-select'>
       {(popupState) => (
         <>
-          <Tooltip title='Toggle suggestion mode'>
-            <Button
-              {...bindTrigger(popupState)}
-              startIcon={EDIT_MODE_CONFIG[editMode].icon}
-              endIcon={<ArrowDropDown />}
-              size='small'
-              disableElevation
-              variant='outlined'
-              color={editModeConfig[editMode].color}
-            >
-              {editModeConfig[editMode].label}
-            </Button>
-          </Tooltip>
+          {isLargeScreen ? (
+            <Tooltip title='Toggle suggestion mode'>
+              <Button
+                {...bindTrigger(popupState)}
+                startIcon={EDIT_MODE_CONFIG[editMode].icon}
+                endIcon={<ArrowDropDown />}
+                size='small'
+                disableElevation
+                variant='outlined'
+                color={editModeConfig[editMode].color}
+              >
+                {editModeConfig[editMode].label}
+              </Button>
+            </Tooltip>
+          ) : (
+            <IconButton {...bindTrigger(popupState)}>{EDIT_MODE_CONFIG[editMode].icon}</IconButton>
+          )}
 
           <Menu
             {...bindMenu(popupState)}

--- a/components/common/PageLayout/components/Header/components/ShareButton/ShareButton.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/ShareButton.tsx
@@ -1,4 +1,6 @@
-import { Box, Divider, Popover, Tooltip } from '@mui/material';
+import { IosShare, Share } from '@mui/icons-material';
+import type { Theme } from '@mui/material';
+import { Box, Divider, IconButton, Popover, Tooltip, useMediaQuery } from '@mui/material';
 import type { PageType } from '@prisma/client';
 import { bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
 import { memo, useEffect } from 'react';
@@ -20,6 +22,7 @@ function ShareButton({ headerHeight, pageId }: { headerHeight: number; pageId: s
     pageId ? `/api/pages/${pageId}/permissions` : null,
     () => charmClient.listPagePermissions(pageId)
   );
+  const isLargeScreen = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
 
   const proposalParentId = findParentOfType({ pageId, pageType: 'proposal', pageMap: pages });
 
@@ -33,18 +36,30 @@ function ShareButton({ headerHeight, pageId }: { headerHeight: number; pageId: s
   return (
     <>
       <Tooltip arrow title='Share or publish to the web'>
-        <Button
-          data-test='toggle-page-permissions-dialog'
-          color='secondary'
-          variant='text'
-          size='small'
-          onClick={() => {
-            refreshPermissions();
-            popupState.open();
-          }}
-        >
-          Share
-        </Button>
+        {isLargeScreen ? (
+          <Button
+            data-test='toggle-page-permissions-dialog'
+            color='secondary'
+            variant='text'
+            size='small'
+            onClick={() => {
+              refreshPermissions();
+              popupState.open();
+            }}
+          >
+            Share
+          </Button>
+        ) : (
+          <IconButton
+            data-test='toggle-page-permissions-dialog'
+            onClick={() => {
+              refreshPermissions();
+              popupState.open();
+            }}
+          >
+            <IosShare color='secondary' fontSize='small' />
+          </IconButton>
+        )}
       </Tooltip>
       <Popover
         {...bindPopover(popupState)}


### PR DESCRIPTION
Fix page header for smallers screens:
- added title ellipsis
- on mobile screens share and page mode buttons will switch to icons to take less space

<img width="405" alt="Screenshot 2023-01-31 at 19 57 10" src="https://user-images.githubusercontent.com/5198394/215856364-57aa959c-3c7e-41e8-9f1c-a5f0905f8bcb.png">
