### PR TITLE
fix error when searching for undefined profile path

### DIFF
--- a/charmClient/charmClient.ts
+++ b/charmClient/charmClient.ts
@@ -152,7 +152,7 @@ class CharmClient {
     return http.PUT<LoggedInUser>('/api/profile', data);
   }
 
-  checkNexusPath(path: string) {
+  checkPublicProfilePath(path: string) {
     return http.GET<{ available: boolean }>('/api/profile/check-path-availability', { path });
   }
 

--- a/components/profile/components/UserPathModal.tsx
+++ b/components/profile/components/UserPathModal.tsx
@@ -12,7 +12,10 @@ import { DialogTitle, Modal } from 'components/common/Modal';
 import debouncePromise from 'lib/utilities/debouncePromise';
 
 async function validatePath(path: string) {
-  const result = await charmClient.checkNexusPath(path);
+  if (!path || path.length < 3) {
+    return false;
+  }
+  const result = await charmClient.checkPublicProfilePath(path);
   return result.available;
 }
 

--- a/pages/api/profile/check-path-availability.ts
+++ b/pages/api/profile/check-path-availability.ts
@@ -10,8 +10,12 @@ const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 handler.use(requireUser).get(checkPathExists);
 
 export async function checkPathExists(req: NextApiRequest, res: NextApiResponse<{ available: boolean }>) {
-  const path = req.query.path as string;
-  const isAvailable = await isProfilePathAvailable(path, req.session.user.id);
+  let isAvailable = false;
+
+  const path = req.query.path;
+  if (typeof path === 'string') {
+    isAvailable = await isProfilePathAvailable(path, req.session.user.id);
+  }
 
   res.status(200).json({ available: isAvailable });
 }


### PR DESCRIPTION
if you clear out the profile path input, we'd still request the backend to check for pages, but the value would be undefined