### PR TITLE
Fix forum reply input

### DIFF
--- a/components/forum/components/CreateForumPost.tsx
+++ b/components/forum/components/CreateForumPost.tsx
@@ -18,15 +18,14 @@ export function CreateForumPost({ onClick }: { onClick: () => void }) {
       onClick();
     }
   }
+
   return (
     <Card variant='outlined' sx={{ mb: '15px' }} onClick={clickHandler}>
       <CardActionArea disabled={!userSpacePermissions?.createPage}>
         <CardContent>
-          <Box display='flex' flexDirection='row' justifyContent='space-between' mb='16px'>
-            <UserDisplay user={user} avatarSize='medium' hideName mr='10px' />
-            <TextField variant='outlined' placeholder='Create Post' fullWidth />
-          </Box>
-          <Box display='flex' justifyContent='flex-end'>
+          <Box display='flex' flexDirection='row' justifyContent='space-between' alignItems='center' gap={1}>
+            <UserDisplay user={user} avatarSize='medium' hideName />
+            <TextField variant='outlined' placeholder='Create Post' fullWidth sx={{ pointerEvents: 'none' }} disabled />
             <Button
               disabledTooltip='You are not allowed to create a post'
               disabled={!userSpacePermissions?.createPage}

--- a/components/forum/components/PostPage/components/CommentReplyForm.tsx
+++ b/components/forum/components/PostPage/components/CommentReplyForm.tsx
@@ -61,16 +61,18 @@ export function CommentReplyForm({
     <Stack gap={1}>
       <Box display='flex' gap={1} flexDirection='row' alignItems='flex-start'>
         <UserDisplay user={user} hideName={true} />
-        <InlineCharmEditor
-          colorMode='dark'
-          style={{
-            minHeight: 100
-          }}
-          key={editorKey}
-          content={postContent.doc}
-          onContentChange={updateCommentContent}
-          placeholderText='What are your thoughts?'
-        />
+        <Box width='calc(100% - 48px)'>
+          <InlineCharmEditor
+            colorMode='dark'
+            style={{
+              minHeight: 100
+            }}
+            key={editorKey}
+            content={postContent.doc}
+            onContentChange={updateCommentContent}
+            placeholderText='What are your thoughts?'
+          />
+        </Box>
       </Box>
       <Stack gap={1} flexDirection='row' alignSelf='flex-end'>
         <Button variant='outlined' color='secondary' onClick={onCancelComment}>

--- a/components/forum/components/PostPage/components/PostCommentForm.tsx
+++ b/components/forum/components/PostPage/components/PostCommentForm.tsx
@@ -5,8 +5,8 @@ import type { KeyedMutator } from 'swr';
 
 import charmClient from 'charmClient';
 import Button from 'components/common/Button';
-import CharmEditor from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/InlineCharmEditor';
+import InlineCharmEditor from 'components/common/CharmEditor/InlineCharmEditor';
 import UserDisplay from 'components/common/UserDisplay';
 import { useUser } from 'hooks/useUser';
 import type { PostCommentWithVote } from 'lib/forums/comments/interface';
@@ -52,31 +52,20 @@ export function PostCommentForm({
 
   return (
     <Stack gap={1}>
-      <Box
-        display='flex'
-        gap={1}
-        flexDirection='row'
-        alignItems='flex-start'
-        sx={{
-          'div.ProseMirror.bangle-editor': {
-            paddingLeft: '10px !important'
-          }
-        }}
-      >
+      <Box display='flex' gap={1} flexDirection='row' alignItems='flex-start'>
         <UserDisplay user={user} hideName={true} />
-        <CharmEditor
-          disableRowHandles
-          disablePageSpecificFeatures
-          colorMode='dark'
-          style={{
-            minHeight: 100,
-            left: 0
-          }}
-          key={editorKey}
-          content={postContent.doc}
-          onContentChange={updatePostContent}
-          placeholderText='What are your thoughts?'
-        />
+        <Box width='calc(100% - 48px)'>
+          <InlineCharmEditor
+            colorMode='dark'
+            style={{
+              minHeight: 100
+            }}
+            key={editorKey}
+            content={postContent.doc}
+            onContentChange={updatePostContent}
+            placeholderText='What are your thoughts?'
+          />
+        </Box>
       </Box>
       <Button
         sx={{

--- a/pages/[domain]/settings/api.tsx
+++ b/pages/[domain]/settings/api.tsx
@@ -14,7 +14,7 @@ export default function ApiSettingsPage() {
   if (!space) {
     return null;
   }
-  return <ApiSettings isAdmin={isAdmin} spaceId={space.id} spaceOwner={space.createdBy} />;
+  return <ApiSettings isAdmin={isAdmin} spaceId={space.id} /* spaceOwner={space.createdBy} */ />;
 }
 
 ApiSettingsPage.getLayout = (page: ReactElement) => {


### PR DESCRIPTION
https://discord.com/channels/894960387743698944/1070397116775669760

I am not sure if there was a reason for using `CharmEditor` instead of `InlineCharmEditor` but that + hacky styles broke this.

<img width="844" alt="Screenshot 2023-02-02 at 12 15 28" src="https://user-images.githubusercontent.com/5198394/216310406-e64d4fff-6050-42a7-a8c7-3d20b377e5fc.png">
