### PR TITLE
Prevent updates to title, header image or icon by people who dont have edit_content permission

### DIFF
--- a/__integration-tests__/server/pages/api/pages/[id]/index.spec.ts
+++ b/__integration-tests__/server/pages/api/pages/[id]/index.spec.ts
@@ -1,10 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import type { Page } from '@prisma/client';
 import request from 'supertest';
 
+import { prisma } from 'db';
 import type { IPageWithPermissions } from 'lib/pages';
+import { getPagePath } from 'lib/pages';
 import { createProposalTemplate } from 'lib/templates/proposals/createProposalTemplate';
+import { generatePageNode } from 'testing/generateStubs';
 import { baseUrl, loginUser } from 'testing/mockApiCall';
-import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+import { generateUserAndSpace, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
 
 const updateContent = {
   content: {
@@ -13,6 +17,94 @@ const updateContent = {
 };
 
 describe('PUT /api/pages/{id} - update page', () => {
+  it('should allow user with permissions to update the page content, title, header image, and icon', async () => {
+    const { user, space } = await generateUserAndSpace({ isAdmin: false });
+
+    const page = await prisma.page.create({
+      data: {
+        title: 'Page 1',
+        type: 'page',
+        updatedBy: user.id,
+        author: { connect: { id: user.id } },
+        space: { connect: { id: space.id } },
+        path: getPagePath(),
+        contentText: '',
+        content: {},
+        permissions: {
+          create: {
+            permissionLevel: 'full_access',
+            space: { connect: { id: space.id } }
+          }
+        }
+      }
+    });
+    const userCookie = await loginUser(user.id);
+
+    const pageUpdate: Pick<Page, 'title' | 'headerImage' | 'icon' | 'content' | 'contentText'> = {
+      content: { paragraph: 'This is a paragraph' },
+      contentText: 'This is a paragraph',
+      headerImage: 'https://example.com/image.png',
+      icon: 'https://example.com/icon.png',
+      title: 'new title'
+    };
+
+    const body = (
+      await request(baseUrl).put(`/api/pages/${page.id}`).set('Cookie', userCookie).send(pageUpdate).expect(200)
+    ).body as IPageWithPermissions;
+
+    expect(body).toMatchObject(expect.objectContaining(pageUpdate));
+  });
+
+  // This is a temporary test, until we get a more fine grained way to evaluate diffs received in content field
+  it('should not allow user with view_comment permission or less to update any other field than the page content', async () => {
+    const { user, space } = await generateUserAndSpace({ isAdmin: false });
+
+    const page = await prisma.page.create({
+      data: {
+        title: 'Page 1',
+        type: 'page',
+        updatedBy: user.id,
+        author: { connect: { id: user.id } },
+        space: { connect: { id: space.id } },
+        path: getPagePath(),
+        contentText: '',
+        content: {},
+        permissions: {
+          create: {
+            permissionLevel: 'view_comment',
+            space: { connect: { id: space.id } }
+          }
+        }
+      }
+    });
+    const userCookie = await loginUser(user.id);
+    // This isn't the exact shape of a comment mark, but it's enough to test the functionality
+    const commentUpdate: Pick<Page, 'content' | 'contentText'> = {
+      content: { paragraph: 'This is a paragraph', marks: ['commentMark'] },
+      contentText: 'This is a paragraph [commentMark]'
+    };
+
+    const body = (
+      await request(baseUrl).put(`/api/pages/${page.id}`).set('Cookie', userCookie).send(commentUpdate).expect(200)
+    ).body as IPageWithPermissions;
+    expect(body).toMatchObject(expect.objectContaining(commentUpdate));
+
+    const titleUpdate: Pick<Page, 'title'> = {
+      title: 'new title'
+    };
+
+    const iconUpdate: Pick<Page, 'icon'> = {
+      icon: 'https://example.com/icon.png'
+    };
+
+    const headerUpdate: Pick<Page, 'headerImage'> = {
+      headerImage: 'https://example.com/image.png'
+    };
+    await request(baseUrl).put(`/api/pages/${page.id}`).set('Cookie', userCookie).send(titleUpdate).expect(401);
+    await request(baseUrl).put(`/api/pages/${page.id}`).set('Cookie', userCookie).send(iconUpdate).expect(401);
+    await request(baseUrl).put(`/api/pages/${page.id}`).set('Cookie', userCookie).send(headerUpdate).expect(401);
+  });
+
   it('should update proposal template page content if the user is an admin and respond 200', async () => {
     const { user: adminUser, space } = await generateUserAndSpaceWithApiToken(undefined, true);
 

--- a/components/[pageId]/DocumentPage/components/PageHeader.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeader.tsx
@@ -87,31 +87,38 @@ function PageHeader({ headerImage, icon, readOnly, setPage, title, updatedAt }: 
         {icon && (
           <MenuWrapper>
             <EmojiIcon size='large' icon={icon} />
-            <Menu>
-              <Menu.Text
-                id='random'
-                icon={<EmojiEmotionsOutlinedIcon />}
-                name='Random'
-                onClick={() => {
-                  updatePageIcon(BlockIcons.shared.randomIcon());
-                }}
-              />
-              <Menu.SubMenu id='pick' icon={<EmojiEmotionsOutlinedIcon />} name='Pick icon'>
-                <EmojiPicker
-                  onSelect={(emoji) => {
-                    updatePageIcon(emoji);
-                  }}
-                />
-              </Menu.SubMenu>
-              <Menu.Text
-                id='remove'
-                icon={<DeleteOutlineOutlinedIcon />}
-                name='Remove icon'
-                onClick={() => {
-                  updatePageIcon(null);
-                }}
-              />
-            </Menu>
+            {
+              // Menu wrapper requires 2 children to show, so we provide an empty div in readonly case
+              readOnly ? (
+                <div></div>
+              ) : (
+                <Menu>
+                  <Menu.Text
+                    id='random'
+                    icon={<EmojiEmotionsOutlinedIcon />}
+                    name='Random'
+                    onClick={() => {
+                      updatePageIcon(BlockIcons.shared.randomIcon());
+                    }}
+                  />
+                  <Menu.SubMenu id='pick' icon={<EmojiEmotionsOutlinedIcon />} name='Pick icon'>
+                    <EmojiPicker
+                      onSelect={(emoji) => {
+                        updatePageIcon(emoji);
+                      }}
+                    />
+                  </Menu.SubMenu>
+                  <Menu.Text
+                    id='remove'
+                    icon={<DeleteOutlineOutlinedIcon />}
+                    name='Remove icon'
+                    onClick={() => {
+                      updatePageIcon(null);
+                    }}
+                  />
+                </Menu>
+              )
+            }
           </MenuWrapper>
         )}
         <Controls className='page-controls'>

--- a/components/common/BoardEditor/focalboard/src/components/viewTitle.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewTitle.tsx
@@ -162,6 +162,7 @@ function ViewTitle(props: ViewTitleProps) {
               onDescriptionChange(content.doc);
             }}
             pageId={board.id}
+            readOnly={props.readOnly}
           />
         </div>
       )}

--- a/pages/api/pages/[id]/index.ts
+++ b/pages/api/pages/[id]/index.ts
@@ -59,16 +59,18 @@ async function updatePageHandler(req: NextApiRequest, res: NextApiResponse<IPage
     userId
   });
 
-  const updateContent = (req.body as Partial<Page>) ?? {};
+  const updateContent = (req.body ?? {}) as Partial<Page>;
   if (
     (typeof updateContent.index === 'number' || updateContent.parentId !== undefined) &&
     permissions.edit_position !== true
   ) {
     throw new ActionNotPermittedError('You do not have permission to reposition this page');
-  }
-  // Allow user with View & Comment permission to edit the page content
-  // This is required as in order to create a comment, the page needs to be updated
-  else if (permissions.edit_content !== true && permissions.comment !== true) {
+  } else if ((updateContent.icon || updateContent.headerImage || updateContent.title) && !permissions.edit_content) {
+    throw new ActionNotPermittedError('You do not have permissions to edit the icon of this page');
+
+    // Allow user with View & Comment permission to edit the page content
+    // This is required as in order to create a comment, the page needs to be updated
+  } else if (permissions.edit_content !== true && permissions.comment !== true) {
     throw new ActionNotPermittedError('You do not have permission to update this page');
   }
 


### PR DESCRIPTION
Applied better readonly to top level page icon as well as the description page