### PR TITLE
Fix/bookmark style

### DIFF
--- a/components/common/CharmEditor/components/bookmark/BookmarkNodeView.tsx
+++ b/components/common/CharmEditor/components/bookmark/BookmarkNodeView.tsx
@@ -113,20 +113,17 @@ export function BookmarkNodeView({
           <CardActionArea
             component={Link}
             color='inherit'
-            sx={{ p: 0, m: 0 }}
+            sx={{ p: 0, m: 0, backgroundColor: theme.palette.mode === 'dark' ? 'common.black' : 'inherit' }}
             href={data.meta.canonical}
             target='_blank'
           >
-            <Typography color='secondary' variant='body2' lineHeight='1.3em !important'>
-              {data.meta.description}
-            </Typography>
             <Box display='flex' alignItems='center' gap={2}>
               <Box display='flex' maxWidth='160px' maxHeight='140px' overflow='hidden'>
                 {data.links.icon?.[0] && <PreviewImage src={data.links.icon[0].href} />}
               </Box>
               <Box display='flex' flexDirection='column' alignSelf='flex-start' gap={2} py={3}>
                 <Typography
-                  component='span'
+                  fontSize={17}
                   textOverflow='ellipsis'
                   overflow='hidden'
                   whiteSpace='nowrap'
@@ -135,12 +132,16 @@ export function BookmarkNodeView({
                 >
                   {title}
                 </Typography>
+                <Typography variant='body1' lineHeight='1.3em !important'>
+                  {data.meta.description}
+                </Typography>
                 <Typography
-                  component='span'
+                  textAlign='left'
                   variant='body2'
                   textOverflow='ellipsis'
                   overflow='hidden'
                   whiteSpace='nowrap'
+                  color='secondary'
                 >
                   {data.meta.canonical}
                 </Typography>

--- a/components/common/CharmEditor/components/bookmark/BookmarkNodeView.tsx
+++ b/components/common/CharmEditor/components/bookmark/BookmarkNodeView.tsx
@@ -6,7 +6,6 @@ import Script from 'next/script';
 import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
-import Image from 'components/common/Image';
 import Link from 'components/common/Link';
 import LoadingComponent from 'components/common/LoadingComponent';
 

--- a/components/common/CharmEditor/components/bookmark/BookmarkNodeView.tsx
+++ b/components/common/CharmEditor/components/bookmark/BookmarkNodeView.tsx
@@ -120,7 +120,15 @@ export function BookmarkNodeView({
               <Box display='flex' maxWidth='160px' maxHeight='140px' overflow='hidden'>
                 {data.links.icon?.[0] && <PreviewImage src={data.links.icon[0].href} />}
               </Box>
-              <Box display='flex' flexDirection='column' alignSelf='flex-start' gap={2} py={3}>
+              <Box
+                display='flex'
+                flexDirection='column'
+                flex={1}
+                gap={1}
+                py={3}
+                justifyContent='space-between'
+                alignSelf='stretch'
+              >
                 <Typography
                   fontSize={17}
                   textOverflow='ellipsis'
@@ -131,7 +139,7 @@ export function BookmarkNodeView({
                 >
                   {title}
                 </Typography>
-                <Typography variant='body1' lineHeight='1.3em !important'>
+                <Typography variant='body1' lineHeight='1.3em !important' textAlign='left'>
                   {data.meta.description}
                 </Typography>
                 <Typography


### PR DESCRIPTION
Update styling of custom bookmark (twitter) to looks like iframely bookmarks:

<img width="716" alt="Screenshot 2023-02-06 at 12 04 43" src="https://user-images.githubusercontent.com/5198394/216956082-0758ddd6-0dd4-4e89-8f2d-82fe821bedb9.png">
<img width="715" alt="Screenshot 2023-02-06 at 12 03 41" src="https://user-images.githubusercontent.com/5198394/216956090-8fea43fa-a20f-4b62-8685-a2c189d71267.png">
