### PR TITLE
Fix issue of post not being editable on initial page load

### DIFF
--- a/__e2e__/forum/editPost.spec.ts
+++ b/__e2e__/forum/editPost.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test as base } from '@playwright/test';
+import type { Post, Space } from '@prisma/client';
+
+import { upsertPostCategoryPermission } from 'lib/permissions/forum/upsertPostCategoryPermission';
+import { randomETHWalletAddress } from 'testing/generateStubs';
+import { generateForumPost, generatePostCategory } from 'testing/utils/forums';
+
+import { ForumPostPage } from '../po/forumPost.po';
+import { createUser, createUserAndSpace, generateSpaceRole } from '../utils/mocks';
+import { login } from '../utils/session';
+
+type Fixtures = {
+  forumPostPage: ForumPostPage;
+};
+
+const test = base.extend<Fixtures>({
+  forumPostPage: ({ page }, use) => use(new ForumPostPage(page))
+});
+
+let space: Space;
+let post: Post;
+
+test.describe.serial('Edit a forum post', () => {
+  test('editable for the author - navigate to a forum post and be able to edit post if user is the author', async ({
+    page,
+    forumPostPage
+  }) => {
+    const generated = await createUserAndSpace({
+      browserPage: page,
+      permissionConfigurationMode: 'collaborative'
+    });
+
+    space = generated.space;
+
+    const memberUser = await createUser({
+      browserPage: page,
+      address: randomETHWalletAddress()
+    });
+    await generateSpaceRole({
+      spaceId: space.id,
+      userId: memberUser.id,
+      isAdmin: false
+    });
+    const categoryName = 'Example category';
+
+    const category = await generatePostCategory({
+      spaceId: space.id,
+      name: categoryName
+    });
+
+    await upsertPostCategoryPermission({
+      assignee: { group: 'space', id: space.id },
+      permissionLevel: 'full_access',
+      postCategoryId: category.id
+    });
+
+    const postName = 'Example post';
+
+    //
+    post = await generateForumPost({
+      spaceId: space.id,
+      userId: memberUser.id,
+      categoryId: category.id,
+      title: postName
+    });
+    await login({
+      page,
+      userId: memberUser.id
+    });
+
+    // Start the navigation steps
+    await forumPostPage.goToPostPage({
+      domain: space.domain,
+      path: post.path
+    });
+
+    await forumPostPage.waitForPostLoad({
+      domain: space.domain,
+      path: post.path
+    });
+
+    const isEditable = await forumPostPage.isPostEditable();
+
+    expect(isEditable).toBe(true);
+  });
+
+  test('noneditable for the admin - navigate to a forum post and be unable to edit post if user is not the author, even if they are an admin', async ({
+    page,
+    forumPostPage
+  }) => {
+    const adminUser = await createUser({
+      browserPage: page,
+      address: randomETHWalletAddress()
+    });
+
+    await generateSpaceRole({
+      spaceId: space.id,
+      userId: adminUser.id,
+      isAdmin: true
+    });
+
+    await login({
+      page,
+      userId: adminUser.id
+    });
+
+    // Start the navigation steps
+
+    await forumPostPage.goToPostPage({
+      domain: space.domain,
+      path: post.path
+    });
+
+    await forumPostPage.waitForPostLoad({
+      domain: space.domain,
+      path: post.path
+    });
+
+    await page.locator('data-test=close-modal').click();
+
+    const isEditable = await forumPostPage.isPostEditable();
+
+    expect(isEditable).toBe(false);
+  });
+});

--- a/__e2e__/po/forumPost.po.ts
+++ b/__e2e__/po/forumPost.po.ts
@@ -21,24 +21,51 @@ export class ForumPostPage {
     this.postCharmeditor = this.page.locator('data-test=post-charmeditor').locator('div[contenteditable]');
   }
 
-  async isPostEditable() {
-    const isEditable = await this.postCharmeditor.getAttribute('contenteditable');
-    return isEditable === 'true';
-  }
-
+  // Navigation utilities
   async goToPostPage({ domain, path }: { domain: string; path: string }) {
     await this.page.goto(`${baseUrl}/${domain}/forum/post/${path}`);
-  }
-
-  getCommentLocator(commentId: string) {
-    return this.page.locator(`data-test=post-comment-${commentId}`);
   }
 
   getPostPageTitleLocator() {
     return this.page.locator('data-test=editor-page-title');
   }
 
+  // Post charmeditor utilities
+  async isPostEditable() {
+    const isEditable = await this.postCharmeditor.getAttribute('contenteditable');
+    return isEditable === 'true';
+  }
+
   async waitForPostLoad({ domain, path }: { domain: string; path: string }) {
     await this.page.waitForURL(`**/${domain}/forum/post/${path}`);
+  }
+
+  // Comment-level utilities
+  getCommentLocator(commentId: string) {
+    return this.page.locator(`data-test=post-comment-${commentId}`);
+  }
+
+  async isCommentEditable(commentId: string) {
+    const commentEditor = await this.page.locator(
+      `data-test=post-comment-charmeditor-${commentId} >> div[contenteditable]`
+    );
+    const isEditable = await commentEditor.getAttribute('contenteditable');
+    return isEditable === 'true';
+  }
+
+  getPostCommentMenuLocator(commentId: string) {
+    return this.page.locator(`data-test=post-comment-menu-${commentId}`);
+  }
+
+  getPostEditCommentLocator(commentId: string) {
+    return this.page.locator(`data-test=edit-comment-${commentId}`);
+  }
+
+  getPostDeleteCommentLocator(commentId: string) {
+    return this.page.locator(`data-test=delete-comment-${commentId}`);
+  }
+
+  getPostSaveCommentButtonLocator(commentId: string) {
+    return this.page.locator(`data-test=save-comment-${commentId}`);
   }
 }

--- a/__e2e__/po/forumPost.po.ts
+++ b/__e2e__/po/forumPost.po.ts
@@ -1,5 +1,7 @@
 // playwright-dev-page.ts
 import type { Locator, Page } from '@playwright/test';
+
+import { baseUrl } from 'config/constants';
 // capture actions on the pages in signup flow
 export class ForumPostPage {
   readonly page: Page;
@@ -8,12 +10,24 @@ export class ForumPostPage {
 
   readonly newTopLevelCommentSubmitButtonLocator: Locator;
 
+  readonly postCharmeditor: Locator;
+
   constructor(page: Page) {
     this.page = page;
     this.newTopLevelCommentInputLocator = this.page.locator('data-test=new-top-level-post-comment');
     this.newTopLevelCommentSubmitButtonLocator = this.newTopLevelCommentInputLocator.locator(
       'data-test=post-comment-button'
     );
+    this.postCharmeditor = this.page.locator('data-test=post-charmeditor').locator('div[contenteditable]');
+  }
+
+  async isPostEditable() {
+    const isEditable = await this.postCharmeditor.getAttribute('contenteditable');
+    return isEditable === 'true';
+  }
+
+  async goToPostPage({ domain, path }: { domain: string; path: string }) {
+    await this.page.goto(`${baseUrl}/${domain}/forum/post/${path}`);
   }
 
   getCommentLocator(commentId: string) {

--- a/components/forum/components/ForumVote.tsx
+++ b/components/forum/components/ForumVote.tsx
@@ -2,10 +2,9 @@ import { useTheme } from '@emotion/react';
 import { IconButton, Tooltip, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import type { MouseEvent } from 'react';
-import { ImArrowUp, ImArrowDown } from 'react-icons/im';
+import { ImArrowDown, ImArrowUp } from 'react-icons/im';
 
 import type { ForumVotes } from 'lib/forums/posts/interfaces';
-import type { AvailablePostPermissions } from 'lib/permissions/forum/availablePostPermissions.class';
 import type { AvailablePostPermissionFlags } from 'lib/permissions/forum/interfaces';
 
 type Props = {

--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -11,6 +11,7 @@ import { Container } from 'components/[pageId]/DocumentPage/DocumentPage';
 import Button from 'components/common/Button';
 import CharmEditor from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
+import ErrorPage from 'components/common/errors/ErrorPage';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { ScrollableWindow } from 'components/common/PageLayout';
 import UserDisplay from 'components/common/UserDisplay';
@@ -210,8 +211,10 @@ export function PostPage({
 
   const canEdit = !!permissions?.edit_post;
 
-  if (!permissions.view_post) {
-    return null;
+  if (!permissions) {
+    return <LoadingComponent />;
+  } else if (!permissions.view_post) {
+    return <ErrorPage message='Post not found' />;
   }
 
   return (

--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -221,7 +221,7 @@ export function PostPage({
     <ScrollableWindow>
       <Stack flexDirection='row'>
         <Container top={50}>
-          <Box minHeight={300}>
+          <Box minHeight={300} data-test='post-charmeditor'>
             <CharmEditor
               pageType='post'
               autoFocus={false}

--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -84,7 +84,6 @@ function sortComments({ comments, sort }: { comments: PostCommentWithVoteAndChil
   }
   return comments;
 }
-
 export function PostPage({
   shouldUpdateTitleState = false,
   post,
@@ -188,7 +187,6 @@ export function PostPage({
       contentText: rawText
     });
   }
-
   let disabledTooltip = '';
   if (!formInputs.title) {
     disabledTooltip = 'Title is required';
@@ -211,6 +209,10 @@ export function PostPage({
   }, [postComments, post, commentSort]);
 
   const canEdit = !!permissions?.edit_post;
+
+  if (!permissions.view_post) {
+    return null;
+  }
 
   return (
     <ScrollableWindow>

--- a/components/forum/components/PostPage/components/PostComment.tsx
+++ b/components/forum/components/PostPage/components/PostComment.tsx
@@ -173,6 +173,7 @@ export function PostComment({ comment, setPostComments, permissions }: Props) {
             <IconButton
               className='comment-actions'
               size='small'
+              data-test={`post-comment-menu-${comment.id}`}
               onClick={(event) => {
                 menuState.open(event.currentTarget);
               }}
@@ -192,6 +193,7 @@ export function PostComment({ comment, setPostComments, permissions }: Props) {
           }}
         />
         <Box
+          data-test={`post-comment-charmeditor-${comment.id}`}
           ml={3}
           sx={{
             'div.ProseMirror.bangle-editor': {
@@ -217,7 +219,7 @@ export function PostComment({ comment, setPostComments, permissions }: Props) {
                 content={commentEditContent.doc}
               />
               <Stack flexDirection='row' my={1} ml={1} gap={1}>
-                <Button size='small' onClick={saveCommentContent}>
+                <Button data-test={`save-comment-${comment.id}`} size='small' onClick={saveCommentContent}>
                   Save
                 </Button>
                 <Button size='small' variant='outlined' color='secondary' onClick={cancelEditingComment}>
@@ -291,13 +293,13 @@ export function PostComment({ comment, setPostComments, permissions }: Props) {
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         onClick={(e) => e.stopPropagation()}
       >
-        <MenuItem onClick={onClickEditComment}>
+        <MenuItem data-test={`edit-comment-${comment.id}`} onClick={onClickEditComment}>
           <ListItemIcon>
             <EditIcon />
           </ListItemIcon>
           <ListItemText>Edit comment</ListItemText>
         </MenuItem>
-        <MenuItem onClick={onClickDeleteComment}>
+        <MenuItem data-test={`delete-comment-${comment.id}`} onClick={onClickDeleteComment}>
           <ListItemIcon>
             <DeleteOutlinedIcon />
           </ListItemIcon>

--- a/components/forum/hooks/usePostPermissions.ts
+++ b/components/forum/hooks/usePostPermissions.ts
@@ -4,12 +4,8 @@ import charmClient from 'charmClient';
 import { AvailablePostPermissions } from 'lib/permissions/forum/availablePostPermissions.class';
 
 export function usePostPermissions(postId: string, isNewPost?: boolean) {
-  const { data } = useSWR(
-    !postId ? null : `compute-post-category-permissions-${postId}`,
-    () => charmClient.permissions.computePostPermissions(postId),
-    {
-      fallbackData: new AvailablePostPermissions().empty
-    }
+  const { data } = useSWR(!postId ? null : `compute-post-category-permissions-${postId}`, () =>
+    charmClient.permissions.computePostPermissions(postId)
   );
 
   if (isNewPost) {


### PR DESCRIPTION
We have an ongoing issue where CharmEditor readonly mode cannot be changed once the editor mounts. It needs to be remounted with a fresh state.

I've updated usePostPermissions hook to undefined initially, so we can know it's loading in consumer components.

In the post page, I then added a loading and error state.