### PR TITLE
clean up space templates UI

### DIFF
--- a/__e2e__/po/signup.po.ts
+++ b/__e2e__/po/signup.po.ts
@@ -2,7 +2,7 @@
 import type { Locator, Page } from '@playwright/test';
 import type { Space } from '@prisma/client';
 
-import type { SpaceCreateTemplate } from 'lib/spaces/utils';
+import type { SpaceCreateTemplate } from 'lib/spaces/config';
 
 // capture actions on the pages in signup flow
 export class SignUpPage {

--- a/components/common/CharmEditor/components/markdownParser/ImportZippedMarkdown.tsx
+++ b/components/common/CharmEditor/components/markdownParser/ImportZippedMarkdown.tsx
@@ -3,6 +3,7 @@ import SvgIcon from '@mui/material/SvgIcon';
 import { useState } from 'react';
 
 import charmClient from 'charmClient';
+import type { InputProps } from 'components/common/Button';
 import Button from 'components/common/Button';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useFilePicker } from 'hooks/useFilePicker';
@@ -10,13 +11,12 @@ import useIsAdmin from 'hooks/useIsAdmin';
 import { usePages } from 'hooks/usePages';
 import { useSnackbar } from 'hooks/useSnackbar';
 import type { PagesMap } from 'lib/pages';
-import { SystemError } from 'lib/utilities/errors';
 
-type Props = {
+type Props = InputProps & {
   onFile?: (file: File) => void;
 };
 
-export function ImportZippedMarkdown({ onFile }: Props) {
+export function ImportZippedMarkdown({ onFile, ...props }: Props) {
   const space = useCurrentSpace();
   const { mutatePagesList } = usePages();
   const [uploading, setIsUploading] = useState(false);
@@ -65,6 +65,7 @@ export function ImportZippedMarkdown({ onFile }: Props) {
         loading={uploading}
         variant='outlined'
         onClick={openFilePicker}
+        {...props}
       >
         {uploading ? 'Uploading...' : 'Import zipped Markdown files'}
       </Button>

--- a/components/common/CreateSpaceForm/CreateSpaceForm.tsx
+++ b/components/common/CreateSpaceForm/CreateSpaceForm.tsx
@@ -195,10 +195,11 @@ export function CreateSpaceForm({ defaultValues, onCancel, submitText }: Props) 
           Create a space{' '}
         </Box>
       </DialogTitle>
-      <Typography textAlign='center' variant='body2'>
-        A space is where your organization collaborates
-      </Typography>
-      <Divider sx={{ my: 2 }} />
+      <Box mb={2}>
+        <Typography textAlign='center' variant='body2' whiteSpace='nowrap'>
+          A space is where your organization collaborates
+        </Typography>
+      </Box>
 
       {step === 'select_template' && (
         <>

--- a/components/common/CreateSpaceForm/CreateSpaceForm.tsx
+++ b/components/common/CreateSpaceForm/CreateSpaceForm.tsx
@@ -15,6 +15,7 @@ import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
 import charmClient from 'charmClient';
+import Button from 'components/common/Button';
 import FieldLabel from 'components/common/form/FieldLabel';
 import { DialogTitle } from 'components/common/Modal';
 import PrimaryButton from 'components/common/PrimaryButton';
@@ -23,8 +24,8 @@ import { useSnackbar } from 'hooks/useSnackbar';
 import { useSpaces } from 'hooks/useSpaces';
 import log from 'lib/log';
 import { generateNotionImportRedirectUrl } from 'lib/notion/generateNotionImportRedirectUrl';
-import type { SpaceCreateTemplate } from 'lib/spaces/utils';
-import { defaultTemplate } from 'lib/spaces/utils';
+import { spaceCreateTemplates } from 'lib/spaces/config';
+import type { SpaceCreateTemplate } from 'lib/spaces/config';
 import randomName from 'lib/utilities/randomName';
 
 import { ImportZippedMarkdown } from '../CharmEditor/components/markdownParser/ImportZippedMarkdown';
@@ -35,7 +36,7 @@ import { SelectNewSpaceTemplate } from './SelectNewSpaceTemplate';
 const schema = yup.object({
   name: yup.string().ensure().trim().min(3, 'Name must be at least 3 characters').required('Name is required'),
   spaceImage: yup.string().nullable(true),
-  spaceTemplateOption: yup.string().default(defaultTemplate)
+  spaceTemplateOption: yup.mixed<SpaceCreateTemplate>().oneOf(spaceCreateTemplates).default('default')
 });
 
 type FormValues = yup.InferType<typeof schema>;
@@ -100,7 +101,7 @@ export function CreateSpaceForm({ defaultValues, onCancel, submitText }: Props) 
           name: watchName,
           spaceImage: watchSpaceImage
         },
-        createSpaceOption: watchSpaceTemplate as SpaceCreateTemplate
+        createSpaceOption: watchSpaceTemplate
       })
         .then((_space) => {
           setNewSpace(_space);
@@ -185,8 +186,12 @@ export function CreateSpaceForm({ defaultValues, onCancel, submitText }: Props) 
   return (
     <div>
       <DialogTitle onClose={onCancel ? onClose : undefined} sx={{ textAlign: 'center' }}>
-        <Box display='flex' alignItems='center' gap={2}>
-          {step !== 'select_template' && <ArrowBackIosNewIcon onClick={goToSelectTemplate} />}
+        <Box display='flex' alignItems='center' gap={1}>
+          {step !== 'select_template' && (
+            <IconButton onClick={goToSelectTemplate} size='small'>
+              <ArrowBackIosNewIcon />
+            </IconButton>
+          )}
           Create a space{' '}
         </Box>
       </DialogTitle>
@@ -197,17 +202,14 @@ export function CreateSpaceForm({ defaultValues, onCancel, submitText }: Props) 
 
       {step === 'select_template' && (
         <>
-          <SelectNewSpaceTemplate
-            selectedTemplate={watchSpaceTemplate as SpaceCreateTemplate}
-            onSelect={handleNewSpaceTemplate}
-          />
+          <SelectNewSpaceTemplate onSelect={handleNewSpaceTemplate} />
           <Divider sx={{ my: 2 }} />
           <Typography sx={{ mb: 2 }} textAlign='center' fontWeight='bold'>
             Join an existing space
           </Typography>
-          <PrimaryButton fullWidth onClick={() => setStep('join_space')}>
+          <Button size='large' disableElevation fullWidth onClick={() => setStep('join_space')}>
             Search for space
-          </PrimaryButton>
+          </Button>
         </>
       )}
 
@@ -259,10 +261,17 @@ export function CreateSpaceForm({ defaultValues, onCancel, submitText }: Props) 
                   data-test='create-workspace'
                   loading={isCreatingSpace}
                 >
-                  {submitText || 'Create Space'}
+                  {submitText || 'Create'}
                 </PrimaryButton>
               )}
-              {watchSpaceTemplate === 'importMarkdown' && <ImportZippedMarkdown onFile={uploadMarkdownToNewSpace} />}
+              {watchSpaceTemplate === 'importMarkdown' && (
+                <ImportZippedMarkdown
+                  size='large'
+                  variant='contained'
+                  disableElevation
+                  onFile={uploadMarkdownToNewSpace}
+                />
+              )}
             </Grid>
             {saveError && (
               <Grid item>

--- a/components/common/CreateSpaceForm/SelectNewSpaceTemplate.tsx
+++ b/components/common/CreateSpaceForm/SelectNewSpaceTemplate.tsx
@@ -29,7 +29,7 @@ export function SelectNewSpaceTemplate({ onSelect }: SelectNewSpaceTemplateProps
         />
       </Grid>
       <Grid item>
-        <Typography variant='caption' textTransform='uppercase' fontWeight='bold'>
+        <Typography variant='caption' color='secondary' textTransform='uppercase' fontWeight='bold'>
           Start from a template
         </Typography>
       </Grid>

--- a/components/common/CreateSpaceForm/SelectNewSpaceTemplate.tsx
+++ b/components/common/CreateSpaceForm/SelectNewSpaceTemplate.tsx
@@ -1,5 +1,5 @@
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
-import { Typography } from '@mui/material';
+import { Divider, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { AiOutlineFileMarkdown } from 'react-icons/ai';
 import { MdOutlineBuild } from 'react-icons/md';
@@ -44,8 +44,8 @@ export function SelectNewSpaceTemplate({ onSelect }: SelectNewSpaceTemplateProps
           />
         </Grid>
       ))}
-
       <Grid item>
+        <Divider flexItem sx={{ mb: 2 }} />
         <TemplateOption
           onSelect={() => onSelect('importNotion')}
           label='Import from Notion'

--- a/components/common/CreateSpaceForm/SelectNewSpaceTemplate.tsx
+++ b/components/common/CreateSpaceForm/SelectNewSpaceTemplate.tsx
@@ -1,45 +1,64 @@
-import styled from '@emotion/styled';
+import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 import { Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
+import { AiOutlineFileMarkdown } from 'react-icons/ai';
+import { MdOutlineBuild } from 'react-icons/md';
+import { SiNotion } from 'react-icons/si';
+import { SlBadge } from 'react-icons/sl';
 
-import Button from 'components/common/Button';
-import type { SpaceCreateTemplate } from 'lib/spaces/utils';
-import { spaceContentTemplates, spaceCreateTemplates } from 'lib/spaces/utils';
+import { spaceContentTemplates } from 'lib/spaces/config';
+import type { SpaceCreateTemplate } from 'lib/spaces/config';
 import { typedKeys } from 'lib/utilities/objects';
 
 import { TemplateOption } from './TemplateOption';
 
 type SelectNewSpaceTemplateProps = {
-  onSelect: (option: SpaceCreateTemplate) => void;
-  selectedTemplate: SpaceCreateTemplate;
+  onSelect: (value: SpaceCreateTemplate) => void;
 };
 
-const templates = typedKeys(spaceContentTemplates);
+const fontSize = 24;
 
-export function SelectNewSpaceTemplate({ onSelect, selectedTemplate }: SelectNewSpaceTemplateProps) {
+export function SelectNewSpaceTemplate({ onSelect }: SelectNewSpaceTemplateProps) {
   return (
     <Grid container spacing={2} flexDirection='column'>
       <Grid item>
-        <TemplateOption onSelect={onSelect} option='default' currentSelection={selectedTemplate} />
+        <TemplateOption
+          onSelect={() => onSelect('default')}
+          label='Create my own'
+          icon={<MdOutlineBuild color='var(--secondary-text)' size={fontSize} />}
+        />
       </Grid>
       <Grid item>
-        <Typography textAlign='center' fontWeight='bold'>
+        <Typography variant='caption' textTransform='uppercase' fontWeight='bold'>
           Start from a template
         </Typography>
       </Grid>
 
-      {templates.map((template) => (
+      {typedKeys(spaceContentTemplates).map((template) => (
         <Grid item key={template}>
-          <TemplateOption onSelect={onSelect} option={template} currentSelection={selectedTemplate} />
+          <TemplateOption
+            data-test={`space-template-${template}`}
+            onSelect={() => onSelect(template)}
+            label={spaceContentTemplates[template]}
+            icon={<SlBadge color='var(--secondary-text)' size={fontSize} />}
+          />
         </Grid>
       ))}
 
       <Grid item>
-        <TemplateOption onSelect={onSelect} option='importNotion' currentSelection={selectedTemplate} />
+        <TemplateOption
+          onSelect={() => onSelect('importNotion')}
+          label='Import from Notion'
+          icon={<SiNotion color='var(--secondary-text)' size={fontSize} />}
+        />
       </Grid>
 
       <Grid item>
-        <TemplateOption onSelect={onSelect} option='importMarkdown' currentSelection={selectedTemplate} />
+        <TemplateOption
+          onSelect={() => onSelect('importMarkdown')}
+          label='Import from Markdown'
+          icon={<DriveFolderUploadIcon color='secondary' sx={{ fontSize }} />}
+        />
       </Grid>
     </Grid>
   );

--- a/components/common/CreateSpaceForm/SelectNewSpaceTemplate.tsx
+++ b/components/common/CreateSpaceForm/SelectNewSpaceTemplate.tsx
@@ -1,7 +1,6 @@
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 import { Divider, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
-import { AiOutlineFileMarkdown } from 'react-icons/ai';
 import { MdOutlineBuild } from 'react-icons/md';
 import { SiNotion } from 'react-icons/si';
 import { SlBadge } from 'react-icons/sl';
@@ -23,8 +22,9 @@ export function SelectNewSpaceTemplate({ onSelect }: SelectNewSpaceTemplateProps
     <Grid container spacing={2} flexDirection='column'>
       <Grid item>
         <TemplateOption
-          onSelect={() => onSelect('default')}
+          onClick={() => onSelect('default')}
           label='Create my own'
+          data-test='space-template-default'
           icon={<MdOutlineBuild color='var(--secondary-text)' size={fontSize} />}
         />
       </Grid>
@@ -38,7 +38,7 @@ export function SelectNewSpaceTemplate({ onSelect }: SelectNewSpaceTemplateProps
         <Grid item key={template}>
           <TemplateOption
             data-test={`space-template-${template}`}
-            onSelect={() => onSelect(template)}
+            onClick={() => onSelect(template)}
             label={spaceContentTemplates[template]}
             icon={<SlBadge color='var(--secondary-text)' size={fontSize} />}
           />
@@ -47,7 +47,8 @@ export function SelectNewSpaceTemplate({ onSelect }: SelectNewSpaceTemplateProps
       <Grid item>
         <Divider flexItem sx={{ mb: 2 }} />
         <TemplateOption
-          onSelect={() => onSelect('importNotion')}
+          data-test='space-template-importNotion'
+          onClick={() => onSelect('importNotion')}
           label='Import from Notion'
           icon={<SiNotion color='var(--secondary-text)' size={fontSize} />}
         />
@@ -55,7 +56,8 @@ export function SelectNewSpaceTemplate({ onSelect }: SelectNewSpaceTemplateProps
 
       <Grid item>
         <TemplateOption
-          onSelect={() => onSelect('importMarkdown')}
+          data-test='space-template-importMarkdown'
+          onClick={() => onSelect('importMarkdown')}
           label='Import from Markdown'
           icon={<DriveFolderUploadIcon color='secondary' sx={{ fontSize }} />}
         />

--- a/components/common/CreateSpaceForm/TemplateOption.tsx
+++ b/components/common/CreateSpaceForm/TemplateOption.tsx
@@ -1,39 +1,30 @@
-import styled from '@emotion/styled';
+import { KeyboardArrowRight } from '@mui/icons-material';
+import { Box } from '@mui/material';
+import type { ReactNode } from 'react';
 
 import Button from 'components/common/Button';
-import type { SpaceCreateTemplate } from 'lib/spaces/utils';
-import { spaceCreateTemplates } from 'lib/spaces/utils';
-
-const ButtonContent = styled.div`
-  display: block;
-  text-align: center;
-  width: 100%;
-`;
 
 type TemplateOptionProps = {
-  option: SpaceCreateTemplate;
-  currentSelection: SpaceCreateTemplate;
-  onSelect: (option: SpaceCreateTemplate) => void;
+  icon?: ReactNode;
+  label: string;
+  onSelect: () => void;
 };
 
-export function TemplateOption({ option, onSelect, currentSelection }: TemplateOptionProps) {
-  const isSelected = option === currentSelection;
-
+export function TemplateOption({ icon, label, onSelect }: TemplateOptionProps) {
   return (
     <Button
-      data-test={`space-template-${option}`}
-      onClick={() => onSelect(option)}
-      color={isSelected ? 'primary' : 'secondary'}
+      onClick={onSelect}
+      color='inherit'
       variant='outlined'
-      sx={{
-        width: '100%',
-        justifyContent: 'space-between',
-        display: 'flex'
-      }}
+      sx={{ justifyContent: 'space-between', py: 2, fontWeight: 'bold' }}
       fullWidth
+      endIcon={<KeyboardArrowRight />}
       size='large'
     >
-      <ButtonContent>{spaceCreateTemplates[option]}</ButtonContent>
+      <Box display='flex' gap={2} alignItems='center'>
+        {icon}
+        {label}
+      </Box>
     </Button>
   );
 }

--- a/components/common/CreateSpaceForm/TemplateOption.tsx
+++ b/components/common/CreateSpaceForm/TemplateOption.tsx
@@ -7,13 +7,14 @@ import Button from 'components/common/Button';
 type TemplateOptionProps = {
   icon?: ReactNode;
   label: string;
-  onSelect: () => void;
+  onClick: () => void;
+  'data-test'?: string;
 };
 
-export function TemplateOption({ icon, label, onSelect }: TemplateOptionProps) {
+export function TemplateOption({ icon, label, ...props }: TemplateOptionProps) {
   return (
     <Button
-      onClick={onSelect}
+      {...props}
       color='secondary'
       variant='outlined'
       sx={{ justifyContent: 'space-between', py: 2 }}

--- a/components/common/CreateSpaceForm/TemplateOption.tsx
+++ b/components/common/CreateSpaceForm/TemplateOption.tsx
@@ -1,5 +1,5 @@
 import { KeyboardArrowRight } from '@mui/icons-material';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
 
 import Button from 'components/common/Button';
@@ -14,16 +14,18 @@ export function TemplateOption({ icon, label, onSelect }: TemplateOptionProps) {
   return (
     <Button
       onClick={onSelect}
-      color='inherit'
+      color='secondary'
       variant='outlined'
-      sx={{ justifyContent: 'space-between', py: 2, fontWeight: 'bold' }}
+      sx={{ justifyContent: 'space-between', py: 2 }}
       fullWidth
       endIcon={<KeyboardArrowRight />}
       size='large'
     >
       <Box display='flex' gap={2} alignItems='center'>
         {icon}
-        {label}
+        <Typography color='textPrimary' fontWeight='bold'>
+          {label}
+        </Typography>
       </Box>
     </Button>
   );

--- a/components/common/TokenGateForm/JoinDynamicSpaceForm.tsx
+++ b/components/common/TokenGateForm/JoinDynamicSpaceForm.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
-import { Autocomplete, Popper, Stack, TextField, Typography } from '@mui/material';
+import { Autocomplete, IconButton, Popper, Stack, TextField, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import type { Space } from '@prisma/client';
 import { debounce } from 'lodash';
@@ -68,8 +68,12 @@ export function JoinDynamicSpaceForm({ goBack }: Props) {
   return (
     <Box sx={{ minHeight: '200px' }}>
       <br />
-      <FieldLabel sx={{ display: 'flex', justifyContent: 'center', gap: 2, pb: 1 }}>
-        {goBack && <ArrowBackIosNewIcon onClick={goBack} />}
+      <FieldLabel sx={{ display: 'flex', alignItems: 'center', gap: 1, pb: 1 }}>
+        {goBack && (
+          <IconButton size='small' onClick={goBack}>
+            <ArrowBackIosNewIcon />
+          </IconButton>
+        )}
         Enter a CharmVerse space name
       </FieldLabel>
       <Autocomplete<Space>

--- a/lib/metrics/mixpanel/interfaces/UserEvent.ts
+++ b/lib/metrics/mixpanel/interfaces/UserEvent.ts
@@ -1,6 +1,6 @@
 import type { IdentityType } from '@prisma/client';
 
-import type { SpaceCreateTemplate } from 'lib/spaces/utils';
+import type { SpaceCreateTemplate } from 'lib/spaces/config';
 import type { TokenGateJoinType } from 'lib/token-gates/interfaces';
 
 import type { BaseEvent, BaseEventWithoutGroup } from './BaseEvent';

--- a/lib/spaces/__tests__/createWorkspace.spec.ts
+++ b/lib/spaces/__tests__/createWorkspace.spec.ts
@@ -7,9 +7,9 @@ import { typedKeys } from 'lib/utilities/objects';
 import { uid } from 'lib/utilities/strings';
 import { gettingStartedPage } from 'seedData/gettingStartedPage';
 
+import { spaceCreateTemplates } from '../config';
 import type { SpaceCreateInput } from '../createWorkspace';
 import { createWorkspace } from '../createWorkspace';
-import { spaceCreateTemplates } from '../utils';
 
 let user: User;
 

--- a/lib/spaces/__tests__/createWorkspace.spec.ts
+++ b/lib/spaces/__tests__/createWorkspace.spec.ts
@@ -213,9 +213,7 @@ describe('createWorkspace', () => {
   });
 
   it('should always include the getting started page when creating a space', async () => {
-    const spaceCreateOptions = typedKeys(spaceCreateTemplates);
-
-    for (const options of spaceCreateOptions) {
+    for (const options of spaceCreateTemplates) {
       const newSpace = await createWorkspace({
         userId: user.id,
         createSpaceOption: options,

--- a/lib/spaces/config.ts
+++ b/lib/spaces/config.ts
@@ -1,0 +1,27 @@
+import { typedKeys } from 'lib/utilities/objects';
+
+export const DOMAIN_BLACKLIST = [
+  'api',
+  'api-docs',
+  'createWorkspace',
+  'integrations',
+  'invite',
+  'login',
+  'images',
+  'join',
+  'nexus',
+  'profile',
+  'share',
+  'signup',
+  'u'
+];
+
+export const spaceContentTemplates = {
+  templateNftCommunity: 'NFT Community'
+};
+
+const staticTemplateOptions = ['default', 'importNotion', 'importMarkdown'] as const;
+
+export const spaceCreateTemplates = [...typedKeys(spaceContentTemplates), ...staticTemplateOptions];
+
+export type SpaceCreateTemplate = (typeof spaceCreateTemplates)[number];

--- a/lib/spaces/createWorkspace.ts
+++ b/lib/spaces/createWorkspace.ts
@@ -10,18 +10,17 @@ import { trackUserAction } from 'lib/metrics/mixpanel/trackUserAction';
 import { updateTrackGroupProfile } from 'lib/metrics/mixpanel/updateTrackGroupProfile';
 import { updateTrackUserProfileById } from 'lib/metrics/mixpanel/updateTrackUserProfileById';
 import { logSpaceCreation } from 'lib/metrics/postToDiscord';
-import { getPagePath } from 'lib/pages';
 import { convertJsonPagesToPrisma } from 'lib/pages/server/convertJsonPagesToPrisma';
 import { createPage } from 'lib/pages/server/createPage';
 import { setupDefaultPaymentMethods } from 'lib/payment-methods/defaultPaymentMethods';
-import { permissionTemplates, updateSpacePermissionConfigurationMode } from 'lib/permissions/meta';
+import { updateSpacePermissionConfigurationMode } from 'lib/permissions/meta';
 import { generateDefaultCategoriesInput } from 'lib/proposal/generateDefaultCategoriesInput';
 import { importWorkspacePages } from 'lib/templates/importWorkspacePages';
 import { gettingStartedPage } from 'seedData/gettingStartedPage';
 
+import type { SpaceCreateTemplate } from './config';
 import { getAvailableDomainName } from './getAvailableDomainName';
 import { getSpaceByDomain } from './getSpaceByDomain';
-import type { SpaceCreateTemplate } from './utils';
 
 export type SpaceCreateInput = Pick<Space, 'name'> &
   Partial<

--- a/lib/spaces/getAvailableDomainName.ts
+++ b/lib/spaces/getAvailableDomainName.ts
@@ -1,5 +1,6 @@
+import { DOMAIN_BLACKLIST } from 'lib/spaces/config';
 import { getSpaceByDomain } from 'lib/spaces/getSpaceByDomain';
-import { DOMAIN_BLACKLIST, getSpaceDomainFromName } from 'lib/spaces/utils';
+import { getSpaceDomainFromName } from 'lib/spaces/utils';
 import randomName from 'lib/utilities/randomName';
 
 export async function getAvailableDomainName(name?: string, randomize = false): Promise<string> {

--- a/lib/spaces/utils.ts
+++ b/lib/spaces/utils.ts
@@ -1,18 +1,4 @@
-export const DOMAIN_BLACKLIST = [
-  'api',
-  'api-docs',
-  'createWorkspace',
-  'integrations',
-  'invite',
-  'login',
-  'images',
-  'join',
-  'nexus',
-  'profile',
-  'share',
-  'signup',
-  'u'
-];
+import { DOMAIN_BLACKLIST } from './config';
 
 export function isSpaceDomain(path?: string) {
   if (!path) {
@@ -30,18 +16,3 @@ export function getSpaceDomainFromName(name: string) {
     .replace(/\s/g, '-')
     .toLowerCase();
 }
-
-export const spaceContentTemplates = {
-  templateNftCommunity: 'NFT Community'
-};
-
-export const spaceCreateTemplates = {
-  ...spaceContentTemplates,
-  default: 'Create my own',
-  importNotion: 'Import from Notion',
-  importMarkdown: 'Import from Markdown'
-} as const;
-
-export type SpaceCreateTemplate = keyof typeof spaceCreateTemplates;
-
-export const defaultTemplate: SpaceCreateTemplate = 'default';

--- a/lib/spaces/validateDomainName.ts
+++ b/lib/spaces/validateDomainName.ts
@@ -1,6 +1,6 @@
 import { string } from 'yup';
 
-import { DOMAIN_BLACKLIST } from 'lib/spaces/utils';
+import { DOMAIN_BLACKLIST } from 'lib/spaces/config';
 
 export const domainSchema = string()
   .ensure()


### PR DESCRIPTION
It was bothering me that the buttons on the Create Space template were less emphasized than the labels, and 'join' was so prominent. I think once we find some colored icons, we could make the 'Join a space' button grey as well to stand out less, it's the least likely option to be used.

I also did some cleanup. I left the important config (the enum of possible templates) in lib, but display-related config doesn't really need to be there, we need custom react components, etc. too so I just consolidated it as part of the form template

Before:
![image](https://user-images.githubusercontent.com/305398/217270806-8bd85830-c99e-4789-9066-ca4d521e9c64.png)

After:
![image](https://user-images.githubusercontent.com/305398/217271587-1669ddb5-6901-4d0c-8262-fcf168f37fee.png)

