### PR TITLE
remove mutatePage prop that is not valid but not used

### DIFF
--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -204,7 +204,6 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
 
   return (
     <TreeRoot
-      mutatePage={mutatePage}
       expanded={expanded ?? []}
       // @ts-ignore - we use null instead of undefined to control the element
       selected={selectedNodeId}

--- a/components/common/PageLayout/components/PageNavigation/components/TreeRoot.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/TreeRoot.tsx
@@ -4,12 +4,9 @@ import { useRouter } from 'next/router';
 import type { ComponentProps, ReactNode } from 'react';
 import { useEffect, useRef } from 'react';
 
-import type { PageUpdates } from 'lib/pages';
-
 type TreeRootProps = {
   children: ReactNode;
   isFavorites?: boolean;
-  mutatePage: (page: PageUpdates) => void;
 } & ComponentProps<typeof TreeView>;
 
 export function TreeRoot({ children, isFavorites, ...rest }: TreeRootProps) {


### PR DESCRIPTION
I noticed this in dev:
<img width="513" alt="image" src="https://user-images.githubusercontent.com/305398/217435690-9e1f2fbe-d03c-4a81-8802-d958e9ae738a.png">


We are just passing this 'mutatePage' prop straight to the MUI 'TreeView' component, I think this was also just leftover from some refactor :)