### PR TITLE
refine setup for emotion cache based on MUI

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,5 @@
-// testing github diff
-import createCache from '@emotion/cache';
 import { CacheProvider, Global } from '@emotion/react';
+import type { EmotionCache } from '@emotion/utils';
 import type { ExternalProvider, JsonRpcFetchFunc } from '@ethersproject/providers';
 import { Web3Provider } from '@ethersproject/providers';
 import RefreshIcon from '@mui/icons-material/Refresh';
@@ -47,6 +46,7 @@ import { useUserAcquisition } from 'hooks/useUserAcquisition';
 import { Web3AccountProvider } from 'hooks/useWeb3AuthSig';
 import { WebSocketClientProvider } from 'hooks/useWebSocketClient';
 import { createThemeLightSensitive } from 'theme';
+import { createEmotionCache } from 'theme/createEmotionCache';
 import cssVariables from 'theme/cssVariables';
 import { setDarkMode } from 'theme/darkMode';
 import { darkTheme, lightTheme } from 'theme/focalboard/theme';
@@ -129,20 +129,17 @@ import 'theme/styles.scss';
 
 const getLibrary = (provider: ExternalProvider | JsonRpcFetchFunc) => new Web3Provider(provider);
 
+const clientSideEmotionCache = createEmotionCache();
+
 type NextPageWithLayout = NextPage & {
   getLayout: (page: ReactElement) => ReactElement;
 };
 
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
+  emotionCache?: EmotionCache;
 };
-
-// set up styles in Next.js for MUI based on https://github.com/mui-org/material-ui/blob/next/examples/nextjs-with-typescript/pages/_document.tsx
-// Set up MUI xample: https://github.com/mui/material-ui/blob/master/examples/nextjs/pages/_document.js
-// See also https://github.com/emotion-js/emotion/issues/1061 for why we need a cache provider to avoid duplicate style tags
-const emotionCache = createCache({ key: 'mui-style' });
-
-export default function App({ Component, pageProps }: AppPropsWithLayout) {
+export default function App({ Component, emotionCache = clientSideEmotionCache, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout ?? ((page) => page);
   const router = useRouter();
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,9 +1,9 @@
-import createCache from '@emotion/cache';
 import createEmotionServer from '@emotion/server/create-instance';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 import React from 'react';
 
 import { blueColor } from 'theme/colors';
+import { createEmotionCache } from 'theme/createEmotionCache';
 
 // Source for Emotion SSR: https://github.com/mui/material-ui/tree/332081eb5e5e107d915e3c70f92e430dc364048f/examples/nextjs-with-typescript
 
@@ -42,10 +42,6 @@ class MyDocument extends Document<{ emotionStyleTags: any }> {
       </Html>
     );
   }
-}
-
-function createEmotionCache() {
-  return createCache({ key: 'mui-style' });
 }
 
 // `getInitialProps` belongs to `_document` (instead of `_app`),
@@ -100,7 +96,7 @@ MyDocument.getInitialProps = async (ctx) => {
 
   return {
     ...initialProps,
-    styles: [...React.Children.toArray(initialProps.styles), ...emotionStyleTags]
+    emotionStyleTags
   };
 };
 

--- a/theme/createEmotionCache.ts
+++ b/theme/createEmotionCache.ts
@@ -1,0 +1,9 @@
+import createCache from '@emotion/cache';
+
+// set up styles in Next.js for MUI based on https://github.com/mui-org/material-ui/blob/next/examples/nextjs-with-typescript/pages/_document.tsx
+// Set up MUI xample: https://github.com/mui/material-ui/blob/master/examples/nextjs/pages/_document.js
+// See also https://github.com/emotion-js/emotion/issues/1061 for why we need a cache provider to avoid duplicate style tags
+
+export function createEmotionCache() {
+  return createCache({ key: 'charm-styles' });
+}


### PR DESCRIPTION
This is the config for caching the stylesheets gnerated by styled components. I'm not sure this is necessary.. but was looking at this code again for a performance bug, and one thing I noticed that I didn't copy from the original example I followed has the Document component (renders once no first page load) passing the cache to the App component (re-renders for every page). Seems useful https://github.com/mui/material-ui/tree/master/examples/nextjs