### PR TITLE
Pass the git diff env var

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -62,11 +62,11 @@ runs:
     - uses: technote-space/get-diff-action@v6
       id: diffset
       with:
-        SET_ENV_NAME: GIT_DIFF
         PATTERNS: |
           **/*.+(j|t)s
           **/*.+(j|t)sx
           **/*.scss
+          **/*.yml
         SEPARATOR: ','
 
     - run: echo '--- DEBUG ---'

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -60,6 +60,7 @@ runs:
     #   run: echo "$GITHUB_CONTEXT"
 
     - uses: technote-space/get-diff-action@v6
+      name: Get diff
       id: diffset
       with:
         PATTERNS: |

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -74,11 +74,12 @@ runs:
       id: cache_build
       uses: actions/cache@v3
       with:
+        git_diff: ${{ env.GIT_DIFF }}
         path: |
           .next
           .env.test.local
         # including the app_env helps make sure that deploy_staging.yml does not reuse values from test_and_deploy.yml which are meant for production
-        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( $GIT_DIFF ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
+        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( inputs.git_diff ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
 
     - name: Build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,6 +1,9 @@
 name: 'Build application'
 
 inputs:
+  GIT_DIFF:
+    description: '...'
+    required: false
   NEXT_PUBLIC_APP_ENV:
     description: '...'
     required: false
@@ -59,21 +62,7 @@ runs:
     #     GITHUB_CONTEXT: ${{ toJson(github) }}
     #   run: echo "$GITHUB_CONTEXT"
 
-    - uses: technote-space/get-diff-action@v6
-      name: Get diff
-      id: diffset
-      with:
-        PATTERNS: |
-          **/*.+(j|t)s
-          **/*.+(j|t)sx
-          **/*.scss
-          **/*.yml
-        SEPARATOR: ','
-
-    - run: echo '--- DEBUG --- ${{ steps.diffset.outputs.diff }}'
-      shell: bash
-
-    - run: echo '${{ env.GIT_DIFF }}'
+    - run: echo 'GIT DIFF Values ${{ inputs.GIT_DIFF }}'
       shell: bash
     - name: Cache build
       id: cache_build
@@ -83,7 +72,7 @@ runs:
           .next
           .env.test.local
         # including the app_env helps make sure that deploy_staging.yml does not reuse values from test_and_deploy.yml which are meant for production
-        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( env.GIT_DIFF ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
+        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( inputs.GIT_DIFF ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
 
     - name: Build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -62,6 +62,7 @@ runs:
     - uses: technote-space/get-diff-action@v6
       id: diffset
       with:
+        SET_ENV_NAME: GIT_DIFF
         PATTERNS: |
           **/*.+(j|t)s
           **/*.+(j|t)sx

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -69,7 +69,7 @@ runs:
           **/*.yml
         SEPARATOR: ','
 
-    - run: echo '--- DEBUG ---'
+    - run: echo '--- DEBUG --- ${{ steps.diffset.outputs.diff }}'
       shell: bash
 
     - run: echo '${{ env.GIT_DIFF }}'
@@ -82,7 +82,7 @@ runs:
           .next
           .env.test.local
         # including the app_env helps make sure that deploy_staging.yml does not reuse values from test_and_deploy.yml which are meant for production
-        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( steps.diffset.outputs.diff ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
+        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( env.GIT_DIFF ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
 
     - name: Build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -78,7 +78,7 @@ runs:
           .next
           .env.test.local
         # including the app_env helps make sure that deploy_staging.yml does not reuse values from test_and_deploy.yml which are meant for production
-        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( ${{ env.GIT_DIFF }} ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
+        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( $GIT_DIFF ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
 
     - name: Build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -78,7 +78,7 @@ runs:
           .next
           .env.test.local
         # including the app_env helps make sure that deploy_staging.yml does not reuse values from test_and_deploy.yml which are meant for production
-        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( env.GIT_DIFF ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
+        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( ${{ env.GIT_DIFF }} ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
 
     - name: Build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -82,7 +82,7 @@ runs:
           .next
           .env.test.local
         # including the app_env helps make sure that deploy_staging.yml does not reuse values from test_and_deploy.yml which are meant for production
-        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( env.GIT_DIFF ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
+        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( steps.diffset.outputs.diff ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
 
     - name: Build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -68,19 +68,20 @@ runs:
           **/*.scss
         SEPARATOR: ','
 
+    - run: echo '--- DEBUG ---'
+      shell: bash
+
     - run: echo '${{ env.GIT_DIFF }}'
       shell: bash
     - name: Cache build
       id: cache_build
       uses: actions/cache@v3
-      inputs:
-        git_diff: ${{ env.GIT_DIFF }}
       with:
         path: |
           .next
           .env.test.local
         # including the app_env helps make sure that deploy_staging.yml does not reuse values from test_and_deploy.yml which are meant for production
-        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( inputs.git_diff ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
+        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{github.ref_name}}-${{ hashFiles( env.GIT_DIFF ) }}-${{ inputs.NEXT_PUBLIC_APP_ENV }}
 
     - name: Build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -73,8 +73,9 @@ runs:
     - name: Cache build
       id: cache_build
       uses: actions/cache@v3
-      with:
+      inputs:
         git_diff: ${{ env.GIT_DIFF }}
+      with:
         path: |
           .next
           .env.test.local

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,6 +33,11 @@ jobs:
             **/*.yml
           SEPARATOR: ','
 
+      - run: echo '--DUMP GITDIFF Values ${{ env.GIT_DIFF }}'
+        shell: bash
+
+      
+
       - name: Build app
         uses: ./.github/actions/build
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -22,10 +22,22 @@ jobs:
         run: |
           cp .env.test.local.example .env.test.local
 
+      - name: Get github diff
+        id: diffset
+        uses: technote-space/get-diff-action@v6
+        with:
+          PATTERNS: |
+            **/*.+(j|t)s
+            **/*.+(j|t)sx
+            **/*.scss
+            **/*.yml
+          SEPARATOR: ','
+
       - name: Build app
         uses: ./.github/actions/build
         with:
           NEXT_PUBLIC_APP_ENV: 'test'
+          GIT_DIFF: ${{ steps.diffset.outputs.diff }}
 
   test:
     name: Tests


### PR DESCRIPTION
The goal of this PR is to be able to compute git diff correctly. It currently evaluates to empty (see the double dash at the right, which should be a hash with a single dash on either side

<img width="908" alt="Screenshot 2023-02-08 at 15 05 16" src="https://user-images.githubusercontent.com/18669748/217538221-7fe0b772-1be9-4179-9dfb-21ae058779f6.png">
