### PR TITLE
use inherited color for default iconButton color

### DIFF
--- a/theme/index.ts
+++ b/theme/index.ts
@@ -303,6 +303,9 @@ export const createThemeLightSensitive = (mode: PaletteMode) => {
               backgroundColor: 'var(--input-bg)'
             }
           }
+        },
+        defaultProps: {
+          color: 'inherit' // set to inherit, the default is rgba (0,0,0, .54) which makes icons half-opaque
         }
       },
       MuiMenuItem: {


### PR DESCRIPTION
The issue is IconButton is making emojis appear faded out when inside IconButton.

I see this effect even on MUI's website: https://mui.com/material-ui/react-button/ if you look at the first example under "Icon Button". Seems like an odd choice, and we sometimes use 'color=secondary' on the button that's wrapped which has a similar effect