### PR TITLE
Open cards full-height to avoid layout jumping

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/dialog.scss
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.scss
@@ -44,6 +44,7 @@
     left: 0;
     right: 0;
     bottom: 0;
+    margin: 0 auto;
     max-width: 100%;
 
     &.fullWidth {
@@ -62,6 +63,7 @@
       top: 50%;
       width: 100%;
       margin: 0;
+      height: calc(100% - 144px);
       min-width: 500px;
       max-width: 975px;
     }

--- a/components/common/BoardEditor/focalboard/src/components/dialog.scss
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.scss
@@ -44,13 +44,12 @@
     left: 0;
     right: 0;
     bottom: 0;
-    margin: 72px auto;
     max-width: 100%;
 
     &.fullWidth {
       max-width: 1280px;
       width: 100%;
-      max-height: 100%;
+      height: 100%;
       height: 100%;
     }
 
@@ -63,7 +62,6 @@
       top: 50%;
       width: 100%;
       margin: 0;
-      max-height: 75%;
       min-width: 500px;
       max-width: 975px;
     }


### PR DESCRIPTION
We show the card before content is loaded, and it usually jumps full height once it is loaded. I think it's a better experience if we just use a fixed height. I also made the dialog be full height in mobile.

https://www.loom.com/share/354dbcbb67704b65864b7cee330218c0