### PR TITLE
Show correct members

### DIFF
--- a/components/common/Modal/SettingsDialog.tsx
+++ b/components/common/Modal/SettingsDialog.tsx
@@ -28,6 +28,7 @@ import SpaceSettings from 'components/settings/workspace/Space';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { CurrentSpaceProvider, useCurrentSpaceId } from 'hooks/useCurrentSpaceId';
 import { useSmallScreen } from 'hooks/useMediaScreens';
+import { MembersProvider } from 'hooks/useMembers';
 import { useSettingsDialog } from 'hooks/useSettingsDialog';
 import { useSpaceFromPath } from 'hooks/useSpaceFromPath';
 import { useSpaces } from 'hooks/useSpaces';
@@ -245,7 +246,9 @@ function SpaceSettingsModalComponent() {
 export function SpaceSettingsDialog() {
   return (
     <CurrentSpaceProvider>
-      <SpaceSettingsModalComponent />
+      <MembersProvider>
+        <SpaceSettingsModalComponent />
+      </MembersProvider>
     </CurrentSpaceProvider>
   );
 }


### PR DESCRIPTION
@mattcasey Last step of fixing space modal!

I noticed Members were still out of sync, but roles were fine. Upon further research, I understood.

The members depends on a global context. So even though we were setting useSpaceId locally, the useMembers hook was bound to global context and reading from global space.

I readded it below CurrentSpace and it works now.

Below are the global providers. MembersProvider is only provider it made sense to add, but please do double check.

<img width="571" alt="Screenshot 2023-02-10 at 06 58 23" src="https://user-images.githubusercontent.com/18669748/218004812-fec88334-b5f8-430c-8332-0b0a3753861a.png">


For hooks which just return results (like useRoles) no work needed, they'll pick up the closest provided context.