### PR TITLE
Close dialog for vote

### DIFF
--- a/components/nexus/BountyTasksList.tsx
+++ b/components/nexus/BountyTasksList.tsx
@@ -13,13 +13,14 @@ import { BountyStatusNexusChip } from 'components/bounties/components/BountyStat
 import Button from 'components/common/Button';
 import Link from 'components/common/Link';
 import LoadingComponent from 'components/common/LoadingComponent';
+import { useSettingsDialog } from 'hooks/useSettingsDialog';
 import type { BountyTask } from 'lib/bounties/getBountyTasks';
 import type { GetTasksResponse } from 'pages/api/tasks/list';
 
 import { EmptyTaskState } from './components/EmptyTaskState';
 import Table from './components/NexusTable';
 
-function BountiesTasksListRow({ bountyTask }: { bountyTask: BountyTask }) {
+function BountiesTasksListRow({ bountyTask, onClose }: { bountyTask: BountyTask; onClose: () => void }) {
   const { pageTitle, spaceName, spaceDomain, pagePath, action } = bountyTask;
   const bountyLink = `/${spaceDomain}/${pagePath}`;
   const workspaceBounties = `/${spaceDomain}/bounties`;
@@ -27,14 +28,14 @@ function BountiesTasksListRow({ bountyTask }: { bountyTask: BountyTask }) {
   return (
     <TableRow>
       <TableCell>
-        <Link color='inherit' href={bountyLink}>
+        <Link color='inherit' href={bountyLink} onClick={onClose}>
           <Typography variant='body1' noWrap>
             {pageTitle || 'Untitled'}
           </Typography>
         </Link>
       </TableCell>
       <TableCell>
-        <Link color='inherit' href={workspaceBounties}>
+        <Link color='inherit' href={workspaceBounties} onClick={onClose}>
           <Typography variant='body1'>{spaceName}</Typography>
         </Link>
       </TableCell>
@@ -50,6 +51,7 @@ function BountiesTasksListRow({ bountyTask }: { bountyTask: BountyTask }) {
           }}
           href={bountyLink}
           disabled={!action}
+          onClick={onClose}
         >
           Review
         </Button>
@@ -67,6 +69,7 @@ function BountiesTasksList({
   error: any;
   tasks: GetTasksResponse | undefined;
 }) {
+  const { onClose } = useSettingsDialog();
   const bounties = tasks?.bounties ? [...tasks.bounties.unmarked, ...tasks.bounties.marked] : [];
 
   useEffect(() => {
@@ -129,7 +132,7 @@ function BountiesTasksList({
         </TableHead>
         <TableBody>
           {filteredBounties.map((bounty) => (
-            <BountiesTasksListRow key={bounty.id} bountyTask={bounty} />
+            <BountiesTasksListRow key={bounty.id} bountyTask={bounty} onClose={onClose} />
           ))}
         </TableBody>
       </Table>

--- a/components/nexus/DiscussionTasksList.tsx
+++ b/components/nexus/DiscussionTasksList.tsx
@@ -15,6 +15,7 @@ import charmClient from 'charmClient';
 import Link from 'components/common/Link';
 import LoadingComponent from 'components/common/LoadingComponent';
 import UserDisplay from 'components/common/UserDisplay';
+import { useSettingsDialog } from 'hooks/useSettingsDialog';
 import type { DiscussionTask } from 'lib/discussion/interfaces';
 import type { GetTasksResponse } from 'pages/api/tasks/list';
 
@@ -33,8 +34,9 @@ function DiscussionTaskRow({
   text,
   bountyId,
   type,
-  commentId
-}: DiscussionTask & { marked: boolean }) {
+  commentId,
+  onClose
+}: DiscussionTask & { marked: boolean; onClose: () => void }) {
   const { discussionLink, discussionTitle } = useMemo(() => {
     const baseUrl = typeof window !== 'undefined' ? window.location.origin : null;
 
@@ -95,12 +97,12 @@ function DiscussionTaskRow({
         <Typography noWrap>{spaceName}</Typography>
       </TableCell>
       <TableCell>
-        <Link color='inherit' href={discussionLink} variant='body1' noWrap>
+        <Link color='inherit' href={discussionLink} variant='body1' noWrap onClick={onClose}>
           {discussionTitle}
         </Link>
       </TableCell>
       <TableCell align='center'>
-        <Link color='inherit' href={discussionLink} variant='body1' noWrap>
+        <Link color='inherit' href={discussionLink} variant='body1' noWrap onClick={onClose}>
           {DateTime.fromISO(createdAt).toRelative({ base: DateTime.now() })}
         </Link>
       </TableCell>
@@ -115,6 +117,8 @@ interface DiscussionTasksListProps {
 }
 
 export default function DiscussionTasksList({ tasks, error, mutateTasks }: DiscussionTasksListProps) {
+  const { onClose } = useSettingsDialog();
+
   useEffect(() => {
     async function main() {
       if (tasks?.discussions && tasks.discussions.unmarked.length !== 0) {
@@ -187,6 +191,7 @@ export default function DiscussionTasksList({ tasks, error, mutateTasks }: Discu
               key={discussionTask.commentId ?? discussionTask.mentionId ?? ''}
               {...discussionTask}
               marked={false}
+              onClose={onClose}
             />
           ))}
           {tasks.discussions.marked.map((discussionTask) => (
@@ -194,6 +199,7 @@ export default function DiscussionTasksList({ tasks, error, mutateTasks }: Discu
               key={discussionTask.commentId ?? discussionTask.mentionId ?? ''}
               {...discussionTask}
               marked
+              onClose={onClose}
             />
           ))}
         </TableBody>

--- a/components/nexus/ForumTasksList.tsx
+++ b/components/nexus/ForumTasksList.tsx
@@ -16,6 +16,7 @@ import charmClient from 'charmClient';
 import Link from 'components/common/Link';
 import LoadingComponent from 'components/common/LoadingComponent';
 import UserDisplay from 'components/common/UserDisplay';
+import { useSettingsDialog } from 'hooks/useSettingsDialog';
 import type { ForumTask } from 'lib/forums/comments/interface';
 import { isTruthy } from 'lib/utilities/types';
 import type { GetTasksResponse } from 'pages/api/tasks/list';
@@ -31,8 +32,9 @@ function ForumTaskRow({
   postPath,
   spaceDomain,
   spaceName,
-  postTitle
-}: ForumTask & { marked: boolean }) {
+  postTitle,
+  onClose
+}: ForumTask & { marked: boolean; onClose: () => void }) {
   const baseUrl = typeof window !== 'undefined' ? window.location.origin : null;
   const commentLink = `${baseUrl}/${spaceDomain}/forum/post/${postPath}`;
 
@@ -61,6 +63,7 @@ function ForumTaskRow({
               variant='body1'
               noWrap
               color='inherit'
+              onClick={onClose}
               sx={{
                 maxWidth: {
                   xs: '130px',
@@ -78,12 +81,12 @@ function ForumTaskRow({
         <Typography noWrap>{spaceName}</Typography>
       </TableCell>
       <TableCell>
-        <Link color='inherit' href={commentLink} variant='body1' noWrap>
+        <Link color='inherit' href={commentLink} variant='body1' noWrap onClick={onClose}>
           {postTitle}
         </Link>
       </TableCell>
       <TableCell align='center'>
-        <Link color='inherit' href={commentLink} variant='body1' noWrap>
+        <Link color='inherit' href={commentLink} variant='body1' noWrap onClick={onClose}>
           {DateTime.fromISO(createdAt).toRelative({ base: DateTime.now() })}
         </Link>
       </TableCell>
@@ -98,6 +101,8 @@ interface DiscussionTasksListProps {
 }
 
 export default function ForumTasksList({ tasks, error, mutateTasks }: DiscussionTasksListProps) {
+  const { onClose } = useSettingsDialog();
+
   useEffect(() => {
     async function main() {
       if (tasks?.forum && tasks.forum.unmarked.length !== 0) {
@@ -179,10 +184,10 @@ export default function ForumTasksList({ tasks, error, mutateTasks }: Discussion
         </TableHead>
         <TableBody>
           {tasks.forum.unmarked.map((forumTask) => (
-            <ForumTaskRow key={forumTask.commentId} {...forumTask} marked={false} />
+            <ForumTaskRow key={forumTask.commentId} {...forumTask} marked={false} onClose={onClose} />
           ))}
           {tasks.forum.marked.map((forumTask) => (
-            <ForumTaskRow key={forumTask.commentId} {...forumTask} marked />
+            <ForumTaskRow key={forumTask.commentId} {...forumTask} marked onClose={onClose} />
           ))}
         </TableBody>
       </Table>

--- a/components/nexus/ProposalTasksList.tsx
+++ b/components/nexus/ProposalTasksList.tsx
@@ -14,6 +14,7 @@ import Button from 'components/common/Button';
 import Link from 'components/common/Link';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { ProposalStatusChip } from 'components/proposals/components/ProposalStatusBadge';
+import { useSettingsDialog } from 'hooks/useSettingsDialog';
 import type { ProposalTask, ProposalTaskAction } from 'lib/proposal/getProposalTasks';
 import type { GetTasksResponse } from 'pages/api/tasks/list';
 
@@ -35,9 +36,11 @@ const SMALL_TABLE_CELL_WIDTH = 150;
  * Page only needs to be provided for proposal type proposals
  */
 export function ProposalTasksListRow({
-  proposalTask: { spaceDomain, pagePath, spaceName, pageTitle, action, status }
+  proposalTask: { spaceDomain, pagePath, spaceName, pageTitle, action, status },
+  onClose
 }: {
   proposalTask: ProposalTask;
+  onClose: () => void;
 }) {
   const proposalLink = `/${spaceDomain}/${pagePath}`;
   const workspaceProposals = `/${spaceDomain}/proposals`;
@@ -81,6 +84,7 @@ export function ProposalTasksListRow({
             }
           }}
           href={proposalLink}
+          onClick={onClose}
           variant={action ? 'contained' : 'outlined'}
         >
           {action ? ProposalActionRecord[action] : 'View'}
@@ -100,6 +104,7 @@ export default function ProposalTasksList({
   tasks: GetTasksResponse | undefined;
 }) {
   const proposals = tasks?.proposals ? [...tasks.proposals.unmarked, ...tasks.proposals.marked] : [];
+  const { onClose } = useSettingsDialog();
 
   useEffect(() => {
     async function main() {
@@ -162,7 +167,7 @@ export default function ProposalTasksList({
         </TableHead>
         <TableBody>
           {proposals.map((proposal) => (
-            <ProposalTasksListRow key={proposal.id} proposalTask={proposal} />
+            <ProposalTasksListRow key={proposal.id} proposalTask={proposal} onClose={onClose} />
           ))}
         </TableBody>
       </Table>

--- a/components/nexus/VoteTasksList.tsx
+++ b/components/nexus/VoteTasksList.tsx
@@ -17,6 +17,7 @@ import Link from 'components/common/Link';
 import LoadingComponent from 'components/common/LoadingComponent';
 import Modal from 'components/common/Modal';
 import VoteIcon from 'components/votes/components/VoteIcon';
+import { useSettingsDialog } from 'hooks/useSettingsDialog';
 import type { VoteTask } from 'lib/votes/interfaces';
 import type { GetTasksResponse } from 'pages/api/tasks/list';
 
@@ -34,10 +35,12 @@ interface VoteTasksListProps {
  */
 export function VoteTasksListRow({
   voteTask,
-  handleVoteId
+  handleVoteId,
+  onClose
 }: {
   voteTask: VoteTask;
   handleVoteId: (voteId: string) => void;
+  onClose: () => void;
 }) {
   const {
     page: { path: pagePath, title: pageTitle },
@@ -65,7 +68,7 @@ export function VoteTasksListRow({
         </Box>
       </TableCell>
       <TableCell>
-        <Link href={voteLink} variant='body1' color='inherit'>
+        <Link href={voteLink} variant='body1' color='inherit' onClick={onClose}>
           {voteLocation}
         </Link>
       </TableCell>
@@ -96,6 +99,7 @@ export function VoteTasksListRow({
 
 export function VoteTasksList({ error, tasks, mutateTasks }: VoteTasksListProps) {
   const [selectedVoteId, setSelectedVoteId] = useState<string | undefined>();
+  const { onClose } = useSettingsDialog();
 
   const closeModal = () => setSelectedVoteId(undefined);
 
@@ -172,7 +176,7 @@ export function VoteTasksList({ error, tasks, mutateTasks }: VoteTasksListProps)
         </TableHead>
         <TableBody>
           {tasks.votes.map((vote) => (
-            <VoteTasksListRow handleVoteId={handleVoteId} key={vote.id} voteTask={vote} />
+            <VoteTasksListRow handleVoteId={handleVoteId} key={vote.id} voteTask={vote} onClose={onClose} />
           ))}
         </TableBody>
       </Table>


### PR DESCRIPTION
Clicking on a page link inside the Settings modal should close the modal. That way, the user will see the page he landed on.