### PR TITLE
Fix long property names and values

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetail.scss
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetail.scss
@@ -160,6 +160,7 @@
   }
 
   &.content-blocks {
+
     &:hover,
     &:focus-within {
       .CardDetailContentsMenu {

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetail.scss
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetail.scss
@@ -132,7 +132,6 @@
 
     &.octo-propertyname--readonly {
       font-size: 12px;
-      padding: 4px 8px;
       height: 32px;
       display: flex;
       align-items: center;

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
@@ -182,7 +182,9 @@ function CardDetailProperties(props: Props) {
         return (
           <div key={`${propertyTemplate.id}-${propertyTemplate.type}-${propertyValue}`} className='octo-propertyrow'>
             {props.readOnly && (
-              <div className='octo-propertyname octo-propertyname--readonly'>{propertyTemplate.name}</div>
+              <div className='octo-propertyname octo-propertyname--readonly'>
+                <Button>{propertyTemplate.name}</Button>
+              </div>
             )}
             {!props.readOnly && (
               <MenuWrapper isOpen={propertyTemplate.id === newTemplateId}>

--- a/components/common/BoardEditor/focalboard/src/widgets/TextInput.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/TextInput.tsx
@@ -18,16 +18,17 @@ const StyledInput = styled(InputBase)`
   padding: 0; // disable padding added for multi-line input
 `;
 
-function Editable({ maxRows, ..._props }: TextInputProps, ref: React.Ref<Focusable>): JSX.Element {
+function Editable({ maxRows, multiline, ..._props }: TextInputProps, ref: React.Ref<Focusable>): JSX.Element {
   const elementRef = useRef<HTMLTextAreaElement>(null);
   const { className, ...props } = useEditable(_props, ref, elementRef);
   return (
     <StyledInput
-      {...props}
       inputProps={{
         className,
         maxRows
       }}
+      {...props}
+      multiline={multiline}
       // props from Editable that are not implemented
       // saveOnEsc
       //   autoExpand?: boolean;

--- a/theme/focalboard/focalboard.main.scss
+++ b/theme/focalboard/focalboard.main.scss
@@ -117,6 +117,7 @@ html {
   .octo-propertyvalue {
     font-size: 12px;
     color: rgb(var(--center-channel-color-rgb));
+    margin: 2px 0;
 
     &.empty {
       color: rgba(var(--center-channel-color-rgb), 0.4);

--- a/theme/focalboard/focalboard.main.scss
+++ b/theme/focalboard/focalboard.main.scss
@@ -117,7 +117,6 @@ html {
   .octo-propertyvalue {
     font-size: 12px;
     color: rgb(var(--center-channel-color-rgb));
-    margin: 2px 0;
 
     &.empty {
       color: rgba(var(--center-channel-color-rgb), 0.4);


### PR DESCRIPTION
Previous issues
1. Didn't show ellipsis for long property names (only occurred in readonly mode)
2. Showed ellipsis for property values

Now (Note this is in read only mode)
![image](https://user-images.githubusercontent.com/34683631/218756706-e847306b-761e-46e3-89b0-80d764766018.png)
