### PR TITLE
Filter out bounties and proposals whose results have been marked as deleted from the API

### DIFF
--- a/__integration-tests__/server/pages/api/v1/proposals/index.spec.ts
+++ b/__integration-tests__/server/pages/api/v1/proposals/index.spec.ts
@@ -1,9 +1,8 @@
-import type { GoogleAccount, Page, Proposal, Role, Space, User, UserWallet } from '@prisma/client';
+import type { GoogleAccount, Page, Proposal, Role, Space, SuperApiToken, User, UserWallet } from '@prisma/client';
 import request from 'supertest';
 import { v4 } from 'uuid';
 
 import { prisma } from 'db';
-import type { PublicApiBounty } from 'pages/api/v1/bounties/index';
 import type { PublicApiProposal } from 'pages/api/v1/proposals';
 import { randomETHWalletAddress } from 'testing/generateStubs';
 import { baseUrl } from 'testing/mockApiCall';
@@ -31,6 +30,8 @@ let proposalAuthor: UserWithDetails;
 let proposalReviewer: UserWithDetails;
 let reviewerRole: Role;
 let space: Space;
+
+let superApiKey: SuperApiToken;
 
 const proposalText = `This is an improvement idea`;
 
@@ -214,6 +215,14 @@ beforeAll(async () => {
       page: true
     }
   })) as ProposalWithDetails;
+
+  superApiKey = await prisma.superApiToken.create({
+    data: {
+      token: v4(),
+      name: `test-super-api-key-${v4()}`,
+      spaces: { connect: { id: space.id } }
+    }
+  });
 });
 
 describe('GET /api/v1/proposals', () => {
@@ -230,7 +239,7 @@ describe('GET /api/v1/proposals', () => {
       await request(baseUrl).get(`/api/v1/proposals?api_key=${normalApiToken.token}`).send().expect(200)
     ).body as PublicApiProposal[];
 
-    // Both bounties should have been returned
+    // Both proposals should have been returned
     expect(response.length).toEqual(1);
 
     const activeProposal = response[0] as PublicApiProposal;
@@ -269,14 +278,6 @@ describe('GET /api/v1/proposals', () => {
   });
 
   it('should return a list of proposals (except draft and private draft) in the space when called with a super API key', async () => {
-    const superApiKey = await prisma.superApiToken.create({
-      data: {
-        token: v4(),
-        name: `test-super-api-key-${v4()}`,
-        spaces: { connect: { id: space.id } }
-      }
-    });
-
     const response = (
       await request(baseUrl)
         .get(`/api/v1/proposals?spaceId=${space.id}`)
@@ -285,7 +286,7 @@ describe('GET /api/v1/proposals', () => {
         .expect(200)
     ).body as PublicApiProposal[];
 
-    // Both bounties should have been returned
+    // Both proposals should have been returned
     expect(response.length).toEqual(1);
 
     const activeProposal = response[0] as PublicApiProposal;
@@ -321,6 +322,51 @@ describe('GET /api/v1/proposals', () => {
         url: `${baseUrl}/${space?.domain}/${proposal.page?.path}`
       })
     );
+  });
+
+  it('should ignore proposals whose page has been soft deleted', async () => {
+    const { space: space2, user: space2User } = await generateUserAndSpace();
+
+    const space2SuperApiToken = await prisma.superApiToken.create({
+      data: {
+        name: `Test super API key for space ${space2.id}`,
+        token: v4(),
+        spaces: { connect: { id: space2.id } }
+      }
+    });
+
+    const deletedProposal = await prisma.proposal.create({
+      data: {
+        createdBy: space2User.id,
+        status: 'discussion',
+        space: { connect: { id: space2.id } },
+        page: {
+          create: {
+            // This is the important part
+            deletedAt: new Date(),
+            title: 'Proposal marked as deleted',
+            author: { connect: { id: space2User.id } },
+            space: { connect: { id: space2.id } },
+            path: `proposal-${v4()}`,
+            type: 'proposal',
+            updatedBy: space2User.id,
+            contentText: proposalText,
+            content: {}
+          }
+        }
+      }
+    });
+
+    const response = (
+      await request(baseUrl)
+        .get(`/api/v1/proposals?spaceId=${space2.id}`)
+        .set({ authorization: `Bearer ${space2SuperApiToken.token}` })
+        .send()
+        .expect(200)
+    ).body as PublicApiProposal[];
+
+    // No data should be returned
+    expect(response.length).toEqual(0);
   });
 
   it('should fail if the requester super API key is not linked to this space', async () => {


### PR DESCRIPTION
Our bounties and proposals API was returning an unexpected amount of results.

This was due to not filtering out pages which had been marked as deleted