### PR TITLE
fix toggle for public bounties

### DIFF
--- a/lib/spaces/interfaces.ts
+++ b/lib/spaces/interfaces.ts
@@ -5,7 +5,7 @@ import type { Space } from '@prisma/client';
 // If we use it, we will need to update the space-related hooks so they also use this subset. This way, we can guarantee consistent behaviour between logged-in and public mode.
 export type PublicSpaceInfo = Pick<Space, 'domain' | 'id'>;
 
-export interface PublicBountyToggle<T extends boolean = boolean> {
+export interface PublicBountyToggle {
   spaceId: string;
-  publicBountyBoard: T;
+  publicBountyBoard: boolean;
 }

--- a/lib/spaces/togglePublicBounties.ts
+++ b/lib/spaces/togglePublicBounties.ts
@@ -4,22 +4,12 @@ import { v4, validate } from 'uuid';
 import { prisma } from 'db';
 import type { PageNodeWithChildren, PageNodeWithPermissions } from 'lib/pages';
 import { multiResolvePageTree } from 'lib/pages/server/resolvePageTree';
-import { hasSameOrMorePermissions, IPagePermissionWithSource } from 'lib/permissions/pages';
+import { hasSameOrMorePermissions } from 'lib/permissions/pages';
 
-import { DataNotFoundError, InvalidInputError } from '../utilities/errors';
+import { InvalidInputError } from '../utilities/errors';
 
 import type { PublicBountyToggle } from './interfaces';
 
-async function generatePublicBountyPermissionArgs({
-  publicBountyBoard,
-  spaceId
-}: PublicBountyToggle<false>): Promise<[Prisma.PagePermissionDeleteManyArgs | null]>;
-async function generatePublicBountyPermissionArgs({
-  publicBountyBoard,
-  spaceId
-}: PublicBountyToggle<true>): Promise<
-  [Prisma.PagePermissionDeleteManyArgs | null, Prisma.PagePermissionCreateManyArgs, Prisma.PagePermissionCreateManyArgs]
->;
 async function generatePublicBountyPermissionArgs({
   publicBountyBoard,
   spaceId
@@ -150,41 +140,33 @@ export async function togglePublicBounties({ spaceId, publicBountyBoard }: Publi
     throw new InvalidInputError('Please provide a valid space ID.');
   }
 
-  try {
-    const spaceAfterUpdate = await prisma.$transaction(async (tx) => {
-      const updatedSpace = await tx.space.update({
-        where: { id: spaceId },
-        data: {
-          publicBountyBoard
-        }
-      });
+  const [deleteArgs, createArgs, childCreateArgs] = await generatePublicBountyPermissionArgs({
+    publicBountyBoard,
+    spaceId
+  });
 
-      if (publicBountyBoard === true) {
-        const [deleteArgs, createArgs, childCreateArgs] = await generatePublicBountyPermissionArgs({
-          publicBountyBoard,
-          spaceId
-        });
-
-        if (deleteArgs) {
-          await tx.pagePermission.deleteMany(deleteArgs);
-        }
-
-        await tx.pagePermission.createMany(createArgs);
-
-        await tx.pagePermission.createMany(childCreateArgs);
-      } else {
-        const [deleteArgs] = await generatePublicBountyPermissionArgs({ publicBountyBoard, spaceId });
-
-        if (deleteArgs) {
-          await tx.pagePermission.deleteMany(deleteArgs);
-        }
+  const spaceAfterUpdate = await prisma.$transaction(async (tx) => {
+    const updatedSpace = await tx.space.update({
+      where: { id: spaceId },
+      data: {
+        publicBountyBoard
       }
-
-      return updatedSpace;
     });
 
-    return spaceAfterUpdate;
-  } catch (err) {
-    throw new DataNotFoundError(`Space ${spaceId} not found.`);
-  }
+    if (publicBountyBoard === true) {
+      if (deleteArgs) {
+        await tx.pagePermission.deleteMany(deleteArgs);
+      }
+
+      await tx.pagePermission.createMany(createArgs);
+
+      await tx.pagePermission.createMany(childCreateArgs);
+    } else if (deleteArgs) {
+      await tx.pagePermission.deleteMany(deleteArgs);
+    }
+
+    return updatedSpace;
+  });
+
+  return spaceAfterUpdate;
 }


### PR DESCRIPTION
I removed the call to retrieve pages when updating bounties. Conceptually, it's nice, but it takes too long to resolve the whole page tree. I think it is extremely unlikely (knock on wood) that someone would be moving bounty cards around while someone else is toggling this setting in a way that would break permissions. 