### PR TITLE
Fix nexus links

### DIFF
--- a/__e2e__/po/settings/settings.po.ts
+++ b/__e2e__/po/settings/settings.po.ts
@@ -23,6 +23,10 @@ export class SettingsModal {
     await this.settingsBtn.click();
   }
 
+  getActivePath({ activePath }: { activePath: string }): Locator {
+    return this.page.locator(`[data-test-active-path=${activePath}]`);
+  }
+
   getSpaceSettingsLocator(spaceId: string): Locator {
     return this.page.locator(`data-test=space-settings-tab-${spaceId}`);
   }

--- a/__e2e__/settings/notificationsRedirect.spec.ts
+++ b/__e2e__/settings/notificationsRedirect.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test as base } from '@playwright/test';
+import { v4 } from 'uuid';
+
+import { SettingsModal } from '../po/settings/settings.po';
+import { generateUserAndSpace } from '../utils/mocks';
+import { login } from '../utils/session';
+
+type Fixtures = {
+  spaceSettings: SettingsModal;
+};
+
+const test = base.extend<Fixtures>({
+  spaceSettings: ({ page }, use) => use(new SettingsModal(page))
+});
+
+test('Space settings - opens modal when coming from a notification email', async ({ page, spaceSettings }) => {
+  const { user: spaceUser } = await generateUserAndSpace({ spaceName: v4(), isAdmin: true, onboarded: true });
+
+  await login({ page, userId: spaceUser.id });
+
+  await spaceSettings.goTo('/nexus?task=proposal');
+
+  // wait for a bit while redirect happens
+  await expect(spaceSettings.getActivePath({ activePath: 'notifications' })).toBeVisible({ timeout: 20000 });
+});

--- a/components/common/Modal/SettingsDialog.tsx
+++ b/components/common/Modal/SettingsDialog.tsx
@@ -11,6 +11,7 @@ import DialogContent from '@mui/material/DialogContent';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import type { Space } from '@prisma/client';
+import { usePopupState } from 'material-ui-popup-state/hooks';
 import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 
@@ -112,7 +113,16 @@ function SpaceSettingsModalComponent() {
   const currentSpace = useCurrentSpace();
 
   const isMobile = useSmallScreen();
-  const { activePath, onClose, onClick, open } = useSettingsDialog();
+  const modalState = usePopupState({ variant: 'dialog', popupId: 'settings-dialog' });
+  const { activePath, onClose, onClick } = useSettingsDialog();
+
+  useEffect(() => {
+    if (activePath) {
+      modalState.open();
+    } else {
+      modalState.close();
+    }
+  }, [activePath]);
 
   return (
     <Dialog
@@ -121,10 +131,15 @@ function SpaceSettingsModalComponent() {
       fullScreen={isMobile}
       PaperProps={{ sx: { height: { md: '90vh' }, borderRadius: (theme) => theme.spacing(1) } }}
       onClose={onClose}
-      open={open}
+      open={modalState.isOpen}
     >
       <Box display='flex' flexDirection='row' flex='1' overflow='hidden'>
-        <Slide direction='right' in={isMobile ? open && !activePath : true} appear={isMobile} unmountOnExit>
+        <Slide
+          direction='right'
+          in={isMobile ? modalState.isOpen && !activePath : true}
+          appear={isMobile}
+          unmountOnExit
+        >
           <Box
             component='aside'
             maxWidth={{ xs: '100%', md: 350 }}

--- a/components/common/Modal/SettingsDialog.tsx
+++ b/components/common/Modal/SettingsDialog.tsx
@@ -133,7 +133,7 @@ function SpaceSettingsModalComponent() {
       onClose={onClose}
       open={modalState.isOpen}
     >
-      <Box display='flex' flexDirection='row' flex='1' overflow='hidden'>
+      <Box data-test-active-path={activePath} display='flex' flexDirection='row' flex='1' overflow='hidden'>
         <Slide
           direction='right'
           in={isMobile ? modalState.isOpen && !activePath : true}

--- a/components/common/RouteGuard.tsx
+++ b/components/common/RouteGuard.tsx
@@ -12,7 +12,7 @@ import log from 'lib/log';
 import { isSpaceDomain } from 'lib/spaces/utils';
 
 // Pages shared to the public that don't require user login
-const publicPages = ['/', 'share', 'api-docs', 'u', 'join', 'invite'];
+const publicPages = ['/', 'share', 'api-docs', 'u', 'join', 'invite', 'nexus'];
 const accountPages = ['profile'];
 
 export default function RouteGuard({ children }: { children: ReactNode }) {

--- a/components/nexus/TasksPage.tsx
+++ b/components/nexus/TasksPage.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 
 import charmClient from 'charmClient';
 import Legend from 'components/settings/Legend';
+import { useSettingsDialog } from 'hooks/useSettingsDialog';
 import { useUser } from 'hooks/useUser';
 import { setUrlWithoutRerender } from 'lib/utilities/browser';
 
@@ -57,10 +58,13 @@ const TASK_TABS = [
 
 type TaskType = (typeof TASK_TABS)[number]['type'];
 
+export type TasksPageProps = { taskType?: TaskType };
+
 export default function TasksPage() {
   const router = useRouter();
   const { user } = useUser();
-  const [currentTaskType, setCurrentTaskType] = useState<TaskType>((router.query?.task ?? 'multisig') as TaskType);
+  const { pathProps } = useSettingsDialog();
+  const [currentTaskType, setCurrentTaskType] = useState<TaskType>(pathProps?.taskType ?? TASK_TABS[0].type);
   const { error, mutate: mutateTasks, tasks, gnosisTasks, gnosisTasksServerError, mutateGnosisTasks } = useTasks();
   const theme = useTheme();
 

--- a/components/nexus/TasksPage.tsx
+++ b/components/nexus/TasksPage.tsx
@@ -64,7 +64,9 @@ export default function TasksPage() {
   const router = useRouter();
   const { user } = useUser();
   const { pathProps } = useSettingsDialog();
-  const [currentTaskType, setCurrentTaskType] = useState<TaskType>(pathProps?.taskType ?? TASK_TABS[0].type);
+  // check from list of tabs to make sure task type is valid
+  const defaultTab = TASK_TABS.find((taskTab) => taskTab.type === pathProps?.taskType);
+  const [currentTaskType, setCurrentTaskType] = useState<TaskType>(defaultTab?.type ?? TASK_TABS[0].type);
   const { error, mutate: mutateTasks, tasks, gnosisTasks, gnosisTasksServerError, mutateGnosisTasks } = useTasks();
   const theme = useTheme();
 

--- a/hooks/useSettingsDialog.tsx
+++ b/hooks/useSettingsDialog.tsx
@@ -1,43 +1,44 @@
-import { usePopupState } from 'material-ui-popup-state/hooks';
 import type { ReactNode } from 'react';
 import { useMemo, createContext, useContext, useState } from 'react';
 
+import type { TasksPageProps } from 'components/nexus/TasksPage';
+
+export type PathProps = TasksPageProps;
+
 type IContext = {
   activePath: string;
-  open: boolean;
+  pathProps?: PathProps | null;
   onClose: () => any;
-  onClick: (path?: string) => void;
+  onClick: (path?: string, props?: PathProps) => void;
 };
 
 export const SettingsDialogContext = createContext<Readonly<IContext>>({
   activePath: '',
-  open: false,
   onClose: () => {},
   onClick: () => undefined
 });
 
 export function SettingsDialogProvider({ children }: { children: ReactNode }) {
-  const settingsModalState = usePopupState({ variant: 'dialog', popupId: 'settings-dialog' });
   const [activePath, setActivePath] = useState('');
+  const [pathProps, setPathProps] = useState<PathProps | undefined>();
 
-  const onClick = (_path?: string) => {
+  const onClick = (_path?: string, props?: PathProps) => {
     setActivePath(_path ?? '');
-    settingsModalState.open(settingsModalState.anchorEl);
+    setPathProps(props);
   };
 
   const onClose = () => {
-    settingsModalState.close();
     setActivePath('');
   };
 
   const value = useMemo<IContext>(
     () => ({
       activePath,
+      pathProps,
       onClick,
-      onClose,
-      open: settingsModalState.isOpen
+      onClose
     }),
-    [settingsModalState.isOpen, activePath]
+    [activePath]
   );
 
   return <SettingsDialogContext.Provider value={value}>{children}</SettingsDialogContext.Provider>;

--- a/pages/nexus.tsx
+++ b/pages/nexus.tsx
@@ -11,7 +11,7 @@ export default function NexusRedirect() {
 
   useEffect(() => {
     if (router.isReady) {
-      log.info('Show tasks to user', router.asPath, router.query.task);
+      log.info('Show tasks to user');
       router.push('/');
       onClick('notifications', { taskType: router.query.task } as PathProps);
     }

--- a/pages/nexus.tsx
+++ b/pages/nexus.tsx
@@ -1,0 +1,21 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+import type { PathProps } from 'hooks/useSettingsDialog';
+import { useSettingsDialog } from 'hooks/useSettingsDialog';
+import log from 'lib/log';
+
+export default function NexusRedirect() {
+  const { onClick } = useSettingsDialog();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (router.isReady) {
+      log.info('Show tasks to user', router.asPath, router.query.task);
+      router.push('/');
+      onClick('notifications', { taskType: router.query.task } as PathProps);
+    }
+  }, [router.isReady]);
+
+  return null;
+}


### PR DESCRIPTION
we are still sending users to /nexus from notification emails:
```
  const nexusDiscussionLink = `${charmverseUrl}/nexus?task=discussion`;
  const nexusVoteLink = `${charmverseUrl}/nexus?task=vote`;
  const nexusMultisigLink = `${charmverseUrl}/nexus?task=multisig`;
  const nexusProposalLink = `${charmverseUrl}/nexus?task=proposal`;
  const nexusBountyLink = `${charmverseUrl}/nexus?task=bounty`;
  const nexusForumLink = `${charmverseUrl}/nexus?task=forum`;
  ```
  
  This redirects user to open the settigns modal for now. I also did a little cleanup on the settings context while making it so i can pass in the default task tab