### PR TITLE
Drag and drop page and image blocks

### DIFF
--- a/components/common/CharmEditor/components/ResizableImage.tsx
+++ b/components/common/CharmEditor/components/ResizableImage.tsx
@@ -1,5 +1,6 @@
 import type { RawSpecs } from '@bangle.dev/core';
 import type { Node } from '@bangle.dev/pm';
+import { NodeSelection, TextSelection } from '@bangle.dev/pm';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import ImageIcon from '@mui/icons-material/Image';
@@ -200,7 +201,18 @@ function ResizableImage({
   } else {
     return (
       <Resizable initialSize={node.attrs.size} minWidth={MIN_IMAGE_WIDTH} updateAttrs={updateAttrs} onDelete={onDelete}>
-        <StyledImage draggable={false} src={node.attrs.src} alt={node.attrs.alt} />
+        <StyledImage
+          onDragStart={() => {
+            const nodePos = getPos();
+            view.dispatch(
+              view.state.tr
+                .setMeta('row-handle-is-dragging', true)
+                .setSelection(new TextSelection(view.state.doc.resolve(nodePos), view.state.doc.resolve(nodePos + 1)))
+            );
+          }}
+          src={node.attrs.src}
+          alt={node.attrs.alt}
+        />
       </Resizable>
     );
   }

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -1,4 +1,6 @@
 import type { NodeViewProps } from '@bangle.dev/core';
+import { TextSelection } from '@bangle.dev/pm';
+import { useEditorViewContext } from '@bangle.dev/react';
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 
@@ -42,8 +44,9 @@ const StyledTypography = styled(Typography, {
   `}
 `;
 
-export default function NestedPage({ node, currentPageId }: NodeViewProps & { currentPageId?: string }) {
+export default function NestedPage({ node, currentPageId, getPos }: NodeViewProps & { currentPageId?: string }) {
   const space = useCurrentSpace();
+  const view = useEditorViewContext();
   const { pages } = usePages();
   const nestedPage = pages[node.attrs.id];
   const parentPage = nestedPage?.parentId ? pages[nestedPage.parentId] : null;
@@ -62,6 +65,14 @@ export default function NestedPage({ node, currentPageId }: NodeViewProps & { cu
       data-id={`page-${nestedPage?.id}`}
       data-title={nestedPage?.title}
       data-path={fullPath}
+      onDragStart={() => {
+        const nodePos = getPos();
+        view.dispatch(
+          view.state.tr
+            .setMeta('row-handle-is-dragging', true)
+            .setSelection(new TextSelection(view.state.doc.resolve(nodePos), view.state.doc.resolve(nodePos + 1)))
+        );
+      }}
     >
       <div>
         {nestedPage && (

--- a/components/common/CharmEditor/components/rowActions/rowActions.ts
+++ b/components/common/CharmEditor/components/rowActions/rowActions.ts
@@ -1,7 +1,6 @@
 import { createElement } from '@bangle.dev/core';
 import type { EditorView, PluginKey } from '@bangle.dev/pm';
 import { Plugin } from '@bangle.dev/pm';
-import { isMarkActiveInSelection } from '@bangle.dev/utils';
 import throttle from 'lodash/throttle';
 import { NodeSelection } from 'prosemirror-state';
 // @ts-ignore


### PR DESCRIPTION
It works for both page and image blocks (we can extend that to other non-text blocks)
But this error comes up at times. Interestingly it work gets triggered when I move anything upwards not downwards.

![image](https://user-images.githubusercontent.com/34683631/219391642-8531bd62-46d6-4ef3-b243-7414689d13f6.png)
