### PR TITLE
set pagePermissions to null until user is loaded

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -115,7 +115,7 @@ function DocumentPage({ page, setPage, insideModal, readOnly = false, parentProp
 
   const cannotComment = readOnly || !pagePermissions?.comment;
 
-  const enableSuggestingMode = editMode === 'suggesting' && !readOnly && pagePermissions?.comment;
+  const enableSuggestingMode = editMode === 'suggesting' && !readOnly && !!pagePermissions?.comment;
 
   const pageVote = Object.values(votes).find((v) => v.context === 'proposal');
 

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -212,7 +212,7 @@ function DocumentPage({ page, setPage, insideModal, readOnly = false, parentProp
                 enableVoting={true}
                 containerWidth={containerWidth}
                 pageType={page.type}
-                pagePermissions={pagePermissions}
+                pagePermissions={pagePermissions ?? undefined}
                 onParticipantUpdate={onParticipantUpdate}
               >
                 {/* temporary? disable editing of page title when in suggestion mode */}

--- a/components/[pageId]/EditorPage/EditorPage.tsx
+++ b/components/[pageId]/EditorPage/EditorPage.tsx
@@ -29,6 +29,7 @@ export default function EditorPage({ pageId: pageIdOrPath }: { pageId: string })
     () => currentPage && getPagePermissions(currentPage.id, currentPage),
     [currentPage]
   );
+
   const readOnly =
     (currentPagePermissions?.edit_content === false && editMode !== 'suggesting') || editMode === 'viewing';
   const parentProposalId = findParentOfType({ pageId: currentPageId, pageType: 'proposal', pageMap: pages });

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -379,7 +379,7 @@ interface CharmEditorProps {
   pageId?: string;
   containerWidth?: number;
   pageType?: PageType | 'post';
-  pagePermissions?: IPagePermissionFlags | null;
+  pagePermissions?: IPagePermissionFlags;
   onParticipantUpdate?: (participants: FrontendParticipant[]) => void;
   placeholderText?: string;
   focusOnInit?: boolean;

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -379,7 +379,7 @@ interface CharmEditorProps {
   pageId?: string;
   containerWidth?: number;
   pageType?: PageType | 'post';
-  pagePermissions?: IPagePermissionFlags;
+  pagePermissions?: IPagePermissionFlags | null;
   onParticipantUpdate?: (participants: FrontendParticipant[]) => void;
   placeholderText?: string;
   focusOnInit?: boolean;

--- a/components/common/CharmEditor/components/PageThread.tsx
+++ b/components/common/CharmEditor/components/PageThread.tsx
@@ -386,7 +386,7 @@ const PageThread = forwardRef<HTMLDivElement, PageThreadProps>(
                       {commentIndex === 0 && !isSmallScreen && (
                         <ThreadHeaderButton
                           text={thread.resolved ? 'Un-resolve' : 'Resolve'}
-                          disabled={isMutating || !permissions.comment}
+                          disabled={isMutating || !permissions?.comment}
                           onClick={toggleResolved}
                         />
                       )}
@@ -479,7 +479,7 @@ const PageThread = forwardRef<HTMLDivElement, PageThreadProps>(
             </MenuItem>
           </Menu>
         </div>
-        {permissions.comment && (
+        {permissions?.comment && (
           <AddCommentCharmEditor
             key={thread.comments[thread.comments.length - 1]?.id}
             readOnly={Boolean(editedCommentId)}

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -126,7 +126,7 @@ export default function DatabaseView({ containerWidth, readOnly: readOnlyOverrid
   }
 
   const readOnly =
-    typeof readOnlyOverride === 'undefined' ? currentPagePermissions.edit_content !== true : readOnlyOverride;
+    typeof readOnlyOverride === 'undefined' ? currentPagePermissions?.edit_content !== true : readOnlyOverride;
 
   const readOnlySourceData = currentView?.fields?.sourceType === 'google_form'; // blocks that are synced cannot be edited
   const deleteView = useCallback(

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/ShareToWeb.tsx
@@ -67,7 +67,7 @@ export default function ShareToWeb({ pageId, pagePermissions, refreshPermissions
 
   const currentPage = pages[pageId];
 
-  const disablePublicToggle = currentPagePermissions.edit_isPublic !== true || Boolean(proposalParentId);
+  const disablePublicToggle = currentPagePermissions?.edit_isPublic !== true || Boolean(proposalParentId);
 
   // Current values of the public permission
   const [shareLink, setShareLink] = useState<null | string>(null);
@@ -125,7 +125,7 @@ export default function ShareToWeb({ pageId, pagePermissions, refreshPermissions
         </Box>
         <Tooltip
           title={
-            currentPagePermissions.edit_isPublic && Boolean(proposalParentId)
+            currentPagePermissions?.edit_isPublic && Boolean(proposalParentId)
               ? 'You can only change this setting from the top proposal page.'
               : ''
           }

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -383,7 +383,7 @@ function PageActionsMenu({ closeMenu, pageId, pagePath }: { closeMenu: () => voi
   const permissions = getPagePermissions(pageId);
   const router = useRouter();
 
-  const deletePageDisabled = !permissions.delete;
+  const deletePageDisabled = !permissions?.delete;
 
   async function deletePageWithBoard() {
     if (deletePageDisabled) {

--- a/components/common/PageLayout/components/TrashModal.tsx
+++ b/components/common/PageLayout/components/TrashModal.tsx
@@ -94,7 +94,7 @@ export default function TrashModal({ onClose, isOpen }: { onClose: () => void; i
           if (
             archivedPage &&
             archivedPage.deletedAt !== null &&
-            getPagePermissions(archivedPage.id, archivedPage).delete
+            getPagePermissions(archivedPage.id, archivedPage)?.delete
           ) {
             const pageTitle = archivedPage.title || 'Untitled';
             _archivedPages.push({ ...archivedPage, title: pageTitle });


### PR DESCRIPTION
While working on a page with access via my user role, I would see the "Access denied" error page briefly sometimes on page load. I traced it to the fact that userSpaceRole was undefined inside getPagePermissions(), which is being called inside of <EditorPage /> as soon as the page is loaded. If we just return null, than the components can choose to wait to display errors or whatnot until real permissions are defined.

Alternative solution could be that the EditorPage component should wait til user is loaded itself, but I feel like it's the responsibility of getPagePermissions() since it is retrieving the user internally.