### PR TITLE
Invalid token error on discord oauth

### DIFF
--- a/components/integrations/components/IdentityProviders.tsx
+++ b/components/integrations/components/IdentityProviders.tsx
@@ -9,6 +9,7 @@ import charmClient from 'charmClient';
 import Button from 'components/common/Button';
 import { WalletConnect } from 'components/login/WalletConnect';
 import Legend from 'components/settings/Legend';
+import { useDiscordConnection } from 'hooks/useDiscordConnection';
 import { useFirebaseAuth } from 'hooks/useFirebaseAuth';
 import { useUser } from 'hooks/useUser';
 import { useWeb3AuthSig } from 'hooks/useWeb3AuthSig';
@@ -18,7 +19,6 @@ import type { TelegramAccount } from 'pages/api/telegram/connect';
 import DiscordIcon from 'public/images/discord_logo.svg';
 import TelegramIcon from 'public/images/telegram_logo.svg';
 
-import { DiscordProvider } from './DiscordProvider';
 import TelegramLoginIframe, { loginWithTelegram } from './TelegramLoginIframe';
 
 const StyledButton = styled(Button)`
@@ -56,6 +56,8 @@ export default function IdentityProviders() {
 
   const connectedWithTelegram = Boolean(user?.telegramUser);
   const connectedWithGoogle = !!user?.googleAccounts.length;
+
+  const { connect, isConnected, isLoading, error } = useDiscordConnection();
 
   // Don't allow a user to remove their last identity
   const cannotDisconnect = !user || countConnectableIdentities(user) <= 1;
@@ -115,42 +117,38 @@ export default function IdentityProviders() {
           <WalletConnect onSuccess={() => null} />
         </ProviderRow>
 
-        <DiscordProvider>
-          {({ isConnected, isLoading, connect, error }) => (
-            <ProviderRow>
-              <SvgIcon sx={{ color: '#5765f2', height: 48, width: 'auto' }}>
-                <DiscordIcon />
-              </SvgIcon>
-              <Typography color='secondary' variant='button'>
-                {isConnected ? 'Connected with Discord' : 'Connect with Discord'}
-              </Typography>
-              <Tooltip
-                arrow
-                placement='top'
-                title={
-                  !!user?.discordUser && cannotDisconnect
-                    ? 'You must have at least one other identity you can login with to disconnect Discord'
-                    : ''
-                }
+        <ProviderRow>
+          <SvgIcon sx={{ color: '#5765f2', height: 48, width: 'auto' }}>
+            <DiscordIcon />
+          </SvgIcon>
+          <Typography color='secondary' variant='button'>
+            {isConnected ? 'Connected with Discord' : 'Connect with Discord'}
+          </Typography>
+          <Tooltip
+            arrow
+            placement='top'
+            title={
+              !!user?.discordUser && cannotDisconnect
+                ? 'You must have at least one other identity you can login with to disconnect Discord'
+                : ''
+            }
+          >
+            {/** div is used to make sure the tooltip is rendered as disabled button doesn't allow tooltip */}
+            <div>
+              <StyledButton
+                variant='outlined'
+                color={isConnected ? 'error' : 'primary'}
+                disabled={(!!user?.discordUser && cannotDisconnect) || isLoggingOut || isLoading}
+                onClick={connect}
+                loading={isLoading}
               >
-                {/** div is used to make sure the tooltip is rendered as disabled button doesn't allow tooltip */}
-                <div>
-                  <StyledButton
-                    variant='outlined'
-                    color={isConnected ? 'error' : 'primary'}
-                    disabled={(!!user?.discordUser && cannotDisconnect) || isLoggingOut || isLoading}
-                    onClick={connect}
-                    loading={isLoading}
-                  >
-                    {isConnected ? 'Disconnect' : 'Connect'}
-                  </StyledButton>
-                </div>
-              </Tooltip>
+                {isConnected ? 'Disconnect' : 'Connect'}
+              </StyledButton>
+            </div>
+          </Tooltip>
 
-              {error && <Alert severity='error'>{error}</Alert>}
-            </ProviderRow>
-          )}
-        </DiscordProvider>
+          {error && <Alert severity='error'>{error}</Alert>}
+        </ProviderRow>
 
         <ProviderRow>
           <SvgIcon sx={{ height: 48, width: 'auto' }}>

--- a/components/login/WalletConnect.tsx
+++ b/components/login/WalletConnect.tsx
@@ -25,12 +25,11 @@ type Props = {
  */
 export function WalletConnect({ onSuccess }: Props) {
   const { account, connectWallet } = useWeb3AuthSig();
-  const { updateUser } = useUser();
+  const { updateUser, user: currentUser } = useUser();
 
   async function signSuccess(signature: AuthSig) {
     const updatedUser = await charmClient.addUserWallets([signature]);
-
-    updateUser(updatedUser);
+    updateUser({ ...currentUser, ...updatedUser });
     onSuccess();
   }
 

--- a/components/login/WalletConnect.tsx
+++ b/components/login/WalletConnect.tsx
@@ -25,11 +25,11 @@ type Props = {
  */
 export function WalletConnect({ onSuccess }: Props) {
   const { account, connectWallet } = useWeb3AuthSig();
-  const { updateUser, user: currentUser } = useUser();
+  const { updateUser } = useUser();
 
   async function signSuccess(signature: AuthSig) {
     const updatedUser = await charmClient.addUserWallets([signature]);
-    updateUser({ ...currentUser, ...updatedUser });
+    updateUser(updatedUser);
     onSuccess();
   }
 

--- a/components/login/WalletSign.tsx
+++ b/components/login/WalletSign.tsx
@@ -10,7 +10,7 @@ import { isTouchScreen } from 'lib/utilities/browser';
 import { lowerCaseEqual } from 'lib/utilities/strings';
 
 interface Props {
-  signSuccess: (authSig: AuthSig) => void | Promise<void>;
+  signSuccess: (authSig: AuthSig) => void | Promise<any>;
   buttonStyle?: SxProps<Theme>;
   ButtonComponent?: typeof PrimaryButton;
   buttonSize?: 'small' | 'medium' | 'large';

--- a/components/login/WalletSign.tsx
+++ b/components/login/WalletSign.tsx
@@ -1,5 +1,5 @@
 import type { SxProps, Theme } from '@mui/material';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import PrimaryButton from 'components/common/PrimaryButton';
 import { useSnackbar } from 'hooks/useSnackbar';
@@ -10,7 +10,7 @@ import { isTouchScreen } from 'lib/utilities/browser';
 import { lowerCaseEqual } from 'lib/utilities/strings';
 
 interface Props {
-  signSuccess: (authSig: AuthSig) => void;
+  signSuccess: (authSig: AuthSig) => void | Promise<void>;
   buttonStyle?: SxProps<Theme>;
   ButtonComponent?: typeof PrimaryButton;
   buttonSize?: 'small' | 'medium' | 'large';
@@ -40,8 +40,8 @@ export function WalletSign({
     isConnectingIdentity
   } = useWeb3AuthSig();
   const { showMessage } = useSnackbar();
-
-  const showLoadingState = loading || isSigning;
+  const [isVerifyingWallet, setIsVerifyingWallet] = useState(false);
+  const showLoadingState = loading || isSigning || isVerifyingWallet;
   useEffect(() => {
     // Do not trigger signature if user is on a mobile device
     if (!isTouchScreen() && !isSigning && enableAutosign && verifiableWalletDetected && !isConnectingIdentity) {
@@ -50,14 +50,19 @@ export function WalletSign({
   }, [verifiableWalletDetected]);
 
   async function generateWalletAuth() {
+    setIsVerifyingWallet(true);
     if (account && walletAuthSignature && lowerCaseEqual(walletAuthSignature.address, account)) {
-      signSuccess(walletAuthSignature);
+      await signSuccess(walletAuthSignature);
+      setIsVerifyingWallet(false);
     } else {
       sign()
         .then(signSuccess)
         .catch((error) => {
           log.error('Error requesting wallet signature in login page', error);
           showMessage('Wallet signature cancelled', 'info');
+        })
+        .finally(() => {
+          setIsVerifyingWallet(false);
         });
     }
   }

--- a/hooks/useDiscordConnection.tsx
+++ b/hooks/useDiscordConnection.tsx
@@ -109,7 +109,8 @@ export function DiscordProvider({ children }: Props) {
       connect,
       error
     }),
-    [isConnected, isLoading, error]
+    // This connect deps is necessary otherwise setUser uses stale user
+    [isConnected, isLoading, error, connect]
   );
 
   return <DiscordConnectionContext.Provider value={value}>{children}</DiscordConnectionContext.Provider>;

--- a/hooks/useDiscordConnection.tsx
+++ b/hooks/useDiscordConnection.tsx
@@ -76,23 +76,25 @@ export function DiscordProvider({ children }: Props) {
   // It can either be fail or success
   useEffect(() => {
     // Connection with discord
-    if (authCode && user && !user.discordUser) {
+    if (authCode && user) {
       deleteCookie(AUTH_CODE_COOKIE);
-      setIsConnectDiscordLoading(true);
+      if (!user.discordUser) {
+        setIsConnectDiscordLoading(true);
 
-      charmClient.discord
-        .connectDiscord({
-          code: authCode
-        })
-        .then((updatedUserFields) => {
-          setUser({ ...user, ...updatedUserFields });
-        })
-        .catch((err) => {
-          setDiscordError(err.message || err.error || 'Something went wrong. Please try again');
-        })
-        .finally(() => {
-          setIsConnectDiscordLoading(false);
-        });
+        charmClient.discord
+          .connectDiscord({
+            code: authCode
+          })
+          .then((updatedUserFields) => {
+            setUser({ ...user, ...updatedUserFields });
+          })
+          .catch((err) => {
+            setDiscordError(err.message || err.error || 'Something went wrong. Please try again');
+          })
+          .finally(() => {
+            setIsConnectDiscordLoading(false);
+          });
+      }
     }
   }, [user]);
 

--- a/hooks/useDiscordConnection.tsx
+++ b/hooks/useDiscordConnection.tsx
@@ -96,7 +96,7 @@ export function DiscordProvider({ children }: Props) {
           });
       }
     }
-  }, [user]);
+  }, [user, authCode]);
 
   const isConnected = connectedWithDiscord;
   const isLoading = !discordError && (!!authCode || isDisconnectingDiscord || isConnectDiscordLoading);
@@ -109,8 +109,7 @@ export function DiscordProvider({ children }: Props) {
       connect,
       error
     }),
-    // This connect deps is necessary otherwise setUser uses stale user
-    [isConnected, isLoading, error, connect]
+    [isConnected, isLoading, error]
   );
 
   return <DiscordConnectionContext.Provider value={value}>{children}</DiscordConnectionContext.Provider>;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -32,6 +32,7 @@ import { isDevEnv } from 'config/constants';
 import { ColorModeContext } from 'context/darkMode';
 import { BountiesProvider } from 'hooks/useBounties';
 import { CurrentSpaceProvider, useCurrentSpaceId } from 'hooks/useCurrentSpaceId';
+import { DiscordProvider } from 'hooks/useDiscordConnection';
 import { useInterval } from 'hooks/useInterval';
 import { IsSpaceMemberProvider } from 'hooks/useIsSpaceMember';
 import { useLocalStorage } from 'hooks/useLocalStorage';
@@ -263,32 +264,34 @@ function DataProviders({ children }: { children: ReactNode }) {
       }}
     >
       <UserProvider>
-        <Web3ReactProvider getLibrary={getLibrary}>
-          <Web3ConnectionManager>
-            <Web3AccountProvider>
-              <SpacesProvider>
-                <CurrentSpaceProvider>
-                  <CurrentSpaceSetter />
-                  <IsSpaceMemberProvider>
-                    <WebSocketClientProvider>
-                      <MembersProvider>
-                        <BountiesProvider>
-                          <PaymentMethodsProvider>
-                            <PagesProvider>
-                              <MemberProfileProvider>
-                                <PageTitleProvider>{children}</PageTitleProvider>
-                              </MemberProfileProvider>
-                            </PagesProvider>
-                          </PaymentMethodsProvider>
-                        </BountiesProvider>
-                      </MembersProvider>
-                    </WebSocketClientProvider>
-                  </IsSpaceMemberProvider>
-                </CurrentSpaceProvider>
-              </SpacesProvider>
-            </Web3AccountProvider>
-          </Web3ConnectionManager>
-        </Web3ReactProvider>
+        <DiscordProvider>
+          <Web3ReactProvider getLibrary={getLibrary}>
+            <Web3ConnectionManager>
+              <Web3AccountProvider>
+                <SpacesProvider>
+                  <CurrentSpaceProvider>
+                    <CurrentSpaceSetter />
+                    <IsSpaceMemberProvider>
+                      <WebSocketClientProvider>
+                        <MembersProvider>
+                          <BountiesProvider>
+                            <PaymentMethodsProvider>
+                              <PagesProvider>
+                                <MemberProfileProvider>
+                                  <PageTitleProvider>{children}</PageTitleProvider>
+                                </MemberProfileProvider>
+                              </PagesProvider>
+                            </PaymentMethodsProvider>
+                          </BountiesProvider>
+                        </MembersProvider>
+                      </WebSocketClientProvider>
+                    </IsSpaceMemberProvider>
+                  </CurrentSpaceProvider>
+                </SpacesProvider>
+              </Web3AccountProvider>
+            </Web3ConnectionManager>
+          </Web3ReactProvider>
+        </DiscordProvider>
       </UserProvider>
     </SWRConfig>
   );

--- a/pages/api/discord/callback.ts
+++ b/pages/api/discord/callback.ts
@@ -71,11 +71,7 @@ handler.get(async (req, res) => {
   }
 
   // When login with discord ?returnUrl is passed after oauth flow, that messes up the whole url
-  res.redirect(
-    `${redirect.split('?')[0]}?code=${tempAuthCode}&discord=1&type=${type}${
-      req.query.guild_id ? `&guild_id=${req.query.guild_id}` : ''
-    }`
-  );
+  res.redirect(`${redirect.split('?')[0]}${req.query.guild_id ? `?guild_id=${req.query.guild_id}` : ''}`);
 });
 
 export default withSessionRoute(handler);


### PR DESCRIPTION
There are still two issues with our wallet identity provider.
1. Wallet provider shows `Connect wallet` even though a wallet is already connected. Its due to `{account: undefined}` from `useWeb3React`. Since its undefined `storedAccount` is not updated from `null`. I was not able to figure out the reason though

2. "cancelled the wallet signature" error still shows up if a discord only user tries to connect their wallet that is already attached with another account (due to `Unique constraint failed on the fields: (`address`)`). We should lock the wallet after a user has logged out or show a better error message @mattcasey 