### PR TITLE
Fix duplicating daylight abilities

### DIFF
--- a/components/settings/invites/components/TokenGates/TokenGates.tsx
+++ b/components/settings/invites/components/TokenGates/TokenGates.tsx
@@ -3,9 +3,10 @@ import styled from '@emotion/styled';
 import type { TokenGate } from '@prisma/client';
 import type { ResourceId, SigningConditions } from 'lit-js-sdk';
 import LitShareModal from 'lit-share-modal-v3';
+import { debounce } from 'lodash';
 import type { PopupState } from 'material-ui-popup-state/hooks';
 import { usePopupState } from 'material-ui-popup-state/hooks';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import useSWR from 'swr';
 import { v4 as uuid } from 'uuid';
 
@@ -85,6 +86,8 @@ export default function TokenGates({ isAdmin, spaceId, popupState }: TokenGatesP
       });
   }
 
+  const throttledOnSubmit = useMemo(() => debounce(onSubmit, 200), [litClient]);
+
   function closeTokenGateDeleteModal() {
     setRemovedTokenGate(null);
     deletePopupState.close();
@@ -136,7 +139,7 @@ export default function TokenGates({ isAdmin, spaceId, popupState }: TokenGatesP
             injectCSS={false}
             permanentDefault={true}
             isModal={false}
-            onUnifiedAccessControlConditionsSelected={onSubmit}
+            onUnifiedAccessControlConditionsSelected={throttledOnSubmit}
           />
         </ShareModalContainer>
       </Modal>

--- a/lib/token-gates/daylight.ts
+++ b/lib/token-gates/daylight.ts
@@ -37,7 +37,7 @@ export async function addDaylightAbility(tokenGate: TokenGate) {
   }
 
   const params = {
-    method: 'POST',
+    method: 'PUT',
     headers: HEADERS,
     body: JSON.stringify({
       requirements: requirementsData.requirements,


### PR DESCRIPTION
We've got a report from daylight that some of our abilities are duplicated. This pr fixes two issues:

1) Turned out you can click "done" on add token gate modal quickly, and it will create duplicated token gate in ou system. This is fixed by debouning button click

2) 1st point should fix duplicates in daylight, but to make it 100% sure I changed daylight create ability method (POST) to updasert ability (PUT) - this way ability will be updated rather than duplicated if we do anything wrong in the future.