### PR TITLE
More cleanup for settings sidebar

### DIFF
--- a/components/common/Link.tsx
+++ b/components/common/Link.tsx
@@ -39,7 +39,11 @@ interface Props extends Omit<LinkProps, 'href'> {
 
 export default function Link({ external, href, onClick, children, color = 'primary', ...restProps }: Props) {
   if (!href) {
-    return <div className={restProps.className}>{children}</div>;
+    return (
+      <div className={restProps.className} onClick={onClick}>
+        {children}
+      </div>
+    );
   }
 
   return external ? (

--- a/components/common/Link.tsx
+++ b/components/common/Link.tsx
@@ -35,12 +35,13 @@ const StyledMuiLink = styled(MuiLink)`
 interface Props extends Omit<LinkProps, 'href'> {
   external?: boolean;
   href?: string;
+  'data-test'?: string;
 }
 
 export default function Link({ external, href, onClick, children, color = 'primary', ...restProps }: Props) {
   if (!href) {
     return (
-      <div className={restProps.className} onClick={onClick}>
+      <div className={restProps.className} onClick={onClick} data-test={restProps['data-test']}>
         {children}
       </div>
     );

--- a/components/common/Modal/SettingsDialog.tsx
+++ b/components/common/Modal/SettingsDialog.tsx
@@ -41,7 +41,7 @@ import { SidebarLink } from '../PageLayout/components/Sidebar/SidebarButton';
 import WorkspaceAvatar from '../PageLayout/components/Sidebar/WorkspaceAvatar';
 
 const SpaceSettingsLink = styled(SidebarLink)`
-  padding-left: 44px;
+  padding-left: 36px;
 `;
 
 interface TabPanelProps extends BoxProps {

--- a/components/common/Modal/SettingsDialog.tsx
+++ b/components/common/Modal/SettingsDialog.tsx
@@ -36,7 +36,13 @@ import { useSpaceFromPath } from 'hooks/useSpaceFromPath';
 import { useSpaces } from 'hooks/useSpaces';
 import { useUser } from 'hooks/useUser';
 
+import { SectionName } from '../PageLayout/components/Sidebar/Sidebar';
+import { SidebarLink } from '../PageLayout/components/Sidebar/SidebarButton';
 import WorkspaceAvatar from '../PageLayout/components/Sidebar/WorkspaceAvatar';
+
+const SpaceSettingsLink = styled(SidebarLink)`
+  padding-left: 44px;
+`;
 
 interface TabPanelProps extends BoxProps {
   children?: ReactNode;
@@ -129,15 +135,28 @@ function SpaceSettingsModalComponent() {
         <Box
           component='aside'
           width={{ xs: '100%', md: 300 }}
+          minWidth={{ xs: '100%', md: 300 }}
           display={isMobile ? (open && !activePath && 'block') || 'none' : 'block'}
           borderRight='1px solid'
           borderColor='divider'
           overflow='auto'
           sx={{ backgroundColor: (theme) => theme.palette.sidebar.background }}
         >
-          <Typography p='10px' variant='body1'>
-            {user?.username}
-          </Typography>
+          <Box mt={2} py={0.5}>
+            <SectionName>User settings</SectionName>
+          </Box>
+          {ACCOUNT_TABS.map((tab) => (
+            <SidebarLink
+              key={tab.path}
+              label={tab.label}
+              icon={tab.icon}
+              onClick={() => onClick(tab.path)}
+              active={activePath === tab.path}
+            />
+          ))}
+          <Box mt={2} py={0.5}>
+            <SectionName>Space settings</SectionName>
+          </Box>
           <TreeView
             aria-label='Profile settings tree view'
             defaultCollapseIcon={<ArrowDropDownIcon fontSize='large' />}
@@ -150,51 +169,37 @@ function SpaceSettingsModalComponent() {
               '& .MuiTreeItem-root[aria-expanded] > .MuiTreeItem-content': { py: 1 }
             }}
           >
-            {ACCOUNT_TABS.map((tab) => (
+            {spaces.map((space) => (
               <StyledTreeItem
-                key={tab.path}
-                nodeId={tab.path}
-                label={tab.label}
-                icon={tab.icon}
-                onClick={() => onClick(tab.path)}
-                isActive={activePath === tab.path}
-              />
+                data-test={`space-settings-tab-${space.id}`}
+                key={space.id}
+                onClick={() => {
+                  setCurrentSpaceId(space.id);
+                  onClick(`${space.name}-space`);
+                }}
+                nodeId={space.name}
+                label={
+                  <Box display='flex' alignItems='center' gap={1}>
+                    <WorkspaceAvatar name={space.name} image={space.spaceImage} />
+                    <Typography noWrap>{space.name}</Typography>
+                  </Box>
+                }
+              >
+                {SETTINGS_TABS.map((tab) => (
+                  <SpaceSettingsLink
+                    data-test={`space-settings-tab-${space.id}-${tab.path}`}
+                    key={tab.path}
+                    label={tab.label}
+                    icon={tab.icon}
+                    onClick={() => {
+                      setCurrentSpaceId(space.id);
+                      onClick(`${space.name}-${tab.path}`);
+                    }}
+                    active={activePath === `${space.name}-${tab.path}`}
+                  />
+                ))}
+              </StyledTreeItem>
             ))}
-            <StyledTreeItem nodeId='my-spaces' label='My spaces' sx={{ mt: 1.5 }}>
-              {spaces.map((space) => (
-                <StyledTreeItem
-                  data-test={`space-settings-tab-${space.id}`}
-                  key={space.id}
-                  onClick={() => {
-                    setCurrentSpaceId(space.id);
-                    onClick(`${space.name}-space`);
-                  }}
-                  nodeId={space.name}
-                  label={
-                    <Box display='flex' alignItems='center' gap={1}>
-                      <WorkspaceAvatar name={space.name} image={space.spaceImage} />
-                      <Typography noWrap>{space.name}</Typography>
-                    </Box>
-                  }
-                >
-                  {SETTINGS_TABS.map((tab) => (
-                    <StyledTreeItem
-                      data-test={`space-settings-tab-${space.id}-${tab.path}`}
-                      key={tab.path}
-                      nodeId={`${space.name}-${tab.path}`}
-                      label={tab.label}
-                      icon={tab.icon}
-                      onClick={() => {
-                        setCurrentSpaceId(space.id);
-                        onClick(`${space.name}-${tab.path}`);
-                      }}
-                      isActive={activePath === `${space.name}-${tab.path}`}
-                      ContentProps={{ style: { paddingLeft: 44 } }}
-                    />
-                  ))}
-                </StyledTreeItem>
-              ))}
-            </StyledTreeItem>
           </TreeView>
         </Box>
         <Box flex='1 1 auto' position='relative' overflow='auto'>

--- a/components/common/Modal/SettingsDialog.tsx
+++ b/components/common/Modal/SettingsDialog.tsx
@@ -3,9 +3,7 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import CloseIcon from '@mui/icons-material/Close';
 import MenuIcon from '@mui/icons-material/Menu';
-import { treeItemClasses } from '@mui/lab/TreeItem';
 import TreeView from '@mui/lab/TreeView';
-import { Slide } from '@mui/material';
 import type { BoxProps } from '@mui/material/Box';
 import Box from '@mui/material/Box';
 import Dialog from '@mui/material/Dialog';
@@ -161,7 +159,8 @@ function SpaceSettingsModalComponent() {
             aria-label='Profile settings tree view'
             defaultCollapseIcon={<ArrowDropDownIcon fontSize='large' />}
             defaultExpandIcon={<ArrowRightIcon fontSize='large' />}
-            defaultExpanded={currentSpace?.name ? ['my-spaces', currentSpace?.name] : ['my-spaces']}
+            defaultExpanded={currentSpace?.name ? [currentSpace?.name] : []}
+            selected={activePath}
             sx={{
               '& .MuiTreeItem-content > .MuiTreeItem-label': { pl: 0.5 },
               '& .MuiTreeItem-content': { py: 0.5 },

--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -36,7 +36,7 @@ import PageNavigation from '../PageNavigation';
 import SearchInWorkspaceModal from '../SearchInWorkspaceModal';
 import TrashModal from '../TrashModal';
 
-import { sidebarItemStyles, SidebarLink } from './SidebarBtn';
+import { sidebarItemStyles, SidebarLink } from './SidebarButton';
 import SidebarSubmenu from './SidebarSubmenu';
 
 const WorkspaceLabel = styled.div`
@@ -91,12 +91,13 @@ const SidebarContainer = styled.div`
   }
 `;
 
-const SectionName = styled(Typography)`
+export const SectionName = styled(Typography)`
   padding-left: ${({ theme }) => theme.spacing(2)};
   padding-right: ${({ theme }) => theme.spacing(2)};
   color: ${({ theme }) => theme.palette.secondary.main};
   font-size: 11.5px;
   font-weight: 600;
+  text-transform: uppercase;
   letter-spacing: 0.03em;
 `;
 

--- a/components/common/PageLayout/components/Sidebar/SidebarButton.tsx
+++ b/components/common/PageLayout/components/Sidebar/SidebarButton.tsx
@@ -1,8 +1,6 @@
 import type { Theme } from '@emotion/react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import type { BoxProps } from '@mui/material/Box';
-import Box from '@mui/material/Box';
 
 import Link from 'components/common/Link';
 
@@ -16,6 +14,8 @@ export const sidebarItemStyles = ({ theme }: { theme: Theme }) => css`
   font-weight: 500;
   padding-top: 4px;
   padding-bottom: 4px;
+  margin-top: 1px;
+  margin-bottom: 1px;
   &:hover {
     background-color: ${theme.palette.action.hover};
     color: inherit;
@@ -26,20 +26,6 @@ export const sidebarItemStyles = ({ theme }: { theme: Theme }) => css`
   }
 `;
 
-const StyledSidebarBox = styled(Box)`
-  cursor: pointer;
-  ${sidebarItemStyles}
-`;
-
-export function SidebarBtn({ icon, label, ...props }: { icon: any; label: string } & BoxProps) {
-  return (
-    <StyledSidebarBox {...props}>
-      {icon}
-      {label}
-    </StyledSidebarBox>
-  );
-}
-
 const StyledSidebarLink = styled(Link, { shouldForwardProp: (prop) => prop !== 'active' })<{ active: boolean }>`
   ${sidebarItemStyles}
   ${({ active, theme }) =>
@@ -49,6 +35,12 @@ const StyledSidebarLink = styled(Link, { shouldForwardProp: (prop) => prop !== '
     color: ${theme.palette.text.primary};
   `
       : ''}
+  // disable hover UX on ios which converts first click to a hover event
+  @media (pointer: fine) {
+    &:hover {
+      cursor: pointer;
+    }
+  }
 `;
 
 export function SidebarLink({
@@ -57,17 +49,19 @@ export function SidebarLink({
   icon,
   label,
   target,
-  onClick
+  onClick,
+  className
 }: {
   active: boolean;
-  href: string;
+  href?: string;
   icon: any;
   label: string;
   target?: string;
   onClick?: () => void;
+  className?: string;
 }) {
   return (
-    <StyledSidebarLink href={href} active={active} target={target} onClick={onClick}>
+    <StyledSidebarLink href={href} active={active} target={target} onClick={onClick} className={className}>
       {icon}
       {label}
     </StyledSidebarLink>

--- a/components/common/PageLayout/components/Sidebar/SidebarButton.tsx
+++ b/components/common/PageLayout/components/Sidebar/SidebarButton.tsx
@@ -44,13 +44,9 @@ const StyledSidebarLink = styled(Link, { shouldForwardProp: (prop) => prop !== '
 `;
 
 export function SidebarLink({
-  active,
-  href,
   icon,
   label,
-  target,
-  onClick,
-  className
+  ...props
 }: {
   active: boolean;
   href?: string;
@@ -61,7 +57,7 @@ export function SidebarLink({
   className?: string;
 }) {
   return (
-    <StyledSidebarLink href={href} active={active} target={target} onClick={onClick} className={className}>
+    <StyledSidebarLink {...props}>
       {icon}
       {label}
     </StyledSidebarLink>


### PR DESCRIPTION
I brought over some more styles from the main sidebar, using the component for static links instead of the page tree nodes. 

![image](https://user-images.githubusercontent.com/305398/221022602-8a82cd4f-ed0d-4e34-8b82-a482c66bfa1a.png)
