### PR TITLE
fix collapsible proposal info

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -69,10 +69,6 @@ export default function ProposalProperties({ proposalId, readOnly, isTemplate }:
   const isProposalAuthor = user && proposalAuthors.some((author) => author.userId === user.id);
 
   useEffect(() => {
-    if (proposal?.status === 'vote_active' && detailsExpanded) {
-      setDetailsExpanded(false);
-    }
-
     if (!prevStatusRef.current && ['private_draft', 'draft'].includes(proposal?.status || '')) {
       setDetailsExpanded(true);
     }
@@ -194,7 +190,6 @@ export default function ProposalProperties({ proposalId, readOnly, isTemplate }:
           </Stack>
         </>
       )}
-
       <Collapse in={isTemplate ? true : detailsExpanded} timeout='auto' unmountOnExit>
         {!isTemplate && (
           <Grid container mb={2} mt={2}>


### PR DESCRIPTION
I think this rule was added for the admin when they set the next proposal status to vote active - but it is also active when any user is looking at a 'vote active' proposal so it can't be expanded while votes are active :P