### PR TITLE
Fix long username

### DIFF
--- a/components/profile/components/UserDetails/UserDetails.tsx
+++ b/components/profile/components/UserDetails/UserDetails.tsx
@@ -208,16 +208,18 @@ function UserDetails({ readOnly, user, updateUser, sx = {} }: UserDetailsProps) 
             isNft={hasNftAvatar(user)}
           />
         </Grid>
-        <Grid item>
+        <Grid item width='100%'>
           <EditIconContainer data-testid='edit-identity' readOnly={readOnly} onClick={identityModalState.open}>
             {user && !isPublic && getIdentityIcon(user.identityType as IdentityType)}
-            <Typography variant='h1'>{shortWalletAddress(user.username)}</Typography>
+            <Typography variant='h1' noWrap>
+              {shortWalletAddress(user.username)}
+            </Typography>
           </EditIconContainer>
         </Grid>
         {!readOnly && (
-          <Grid item>
+          <Grid item width='100%'>
             <EditIconContainer readOnly={readOnly} onClick={userPathModalState.open}>
-              <Typography>
+              <Typography noWrap>
                 {hostname}/u/
                 <Link external href={userLink} target='_blank'>
                   {userPath}

--- a/lib/users/updateUsedIdentity.ts
+++ b/lib/users/updateUsedIdentity.ts
@@ -2,7 +2,6 @@ import type { Prisma } from '@prisma/client';
 import { IdentityType } from '@prisma/client';
 
 import { prisma } from 'db';
-import { getENSName } from 'lib/blockchain/getENSName';
 import { sessionUserRelations } from 'lib/session/config';
 import { InsecureOperationError, InvalidInputError } from 'lib/utilities/errors';
 import { matchWalletAddress, shortWalletAddress } from 'lib/utilities/strings';
@@ -65,7 +64,7 @@ export async function updateUsedIdentity(userId: string, identityUpdate?: Identi
 
   // Priority of identities: [wallet, discord, unstoppable domain, google account]
   if (user.wallets.length) {
-    updateContent.username = user.wallets[0].address;
+    updateContent.username = shortWalletAddress(user.wallets[0].address);
     updateContent.identityType = 'Wallet';
   } else if (user.discordUser) {
     updateContent.username = (user.discordUser.account as any).username;

--- a/lib/users/updateUserProfile.ts
+++ b/lib/users/updateUserProfile.ts
@@ -1,6 +1,7 @@
 import type { User } from '@prisma/client';
 
 import { prisma } from 'db';
+import log from 'lib/log';
 import { sessionUserRelations } from 'lib/session/config';
 import { MissingDataError } from 'lib/utilities/errors';
 import type { LoggedInUser } from 'models';
@@ -37,6 +38,8 @@ export async function updateUserProfile(userId: string, update: Partial<User>): 
       }
     });
   }
+
+  log.info('Updated user information', { userId, update });
 
   return getUserProfile('id', userId);
 }


### PR DESCRIPTION
Sometimes the username is too long or not shortened.

FE - Shorten the typography so it does not spill out.
BE- Found only one place where the username is not shortened + added a log for the future to check in datadog when exactly did a username update happened.