### PR TITLE
Fix visible icon in /u page

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -305,10 +305,8 @@ function CurrentSpaceSetter() {
   const { setCurrentSpaceId } = useCurrentSpaceId();
 
   useEffect(() => {
-    if (spaceFromPath) {
-      setCurrentSpaceId(spaceFromPath.id);
-    }
-  }, [spaceFromPath]);
+    setCurrentSpaceId(spaceFromPath?.id ?? '');
+  }, [spaceFromPath?.id]);
 
   return null;
 }


### PR DESCRIPTION
[Task item](https://app.charmverse.io/charmverse/page-13606663980167877?viewId=2c9d8701-33ff-4c3a-942a-6d403a638565)

Looks like we were not cleaning up the current space id when we were going to a page with no current space from the path.