### PR TITLE
add xps engine id to user table

### DIFF
--- a/components/common/UserDisplay.tsx
+++ b/components/common/UserDisplay.tsx
@@ -72,7 +72,7 @@ export const AnonUserDisplay = memo(AnonUserDisplayComponent);
  * @linkToProfile Whether we show a link to user's public profile. Defaults to false.
  */
 interface UserDisplayProps extends StyleProps {
-  user?: Omit<User, 'addresses'> | null;
+  user?: Pick<User, 'avatar' | 'username' | 'path' | 'id'> | null;
   linkToProfile?: boolean;
   showMiniProfile?: boolean;
 }

--- a/lib/discussion/interfaces.ts
+++ b/lib/discussion/interfaces.ts
@@ -1,5 +1,7 @@
 import type { User } from '@prisma/client';
 
+export type TaskUser = Pick<User, 'id' | 'username' | 'path' | 'avatar' | 'avatarTokenId'>;
+
 export interface DiscussionTask {
   spaceId: string;
   spaceDomain: string;
@@ -12,7 +14,7 @@ export interface DiscussionTask {
   commentId: string | null;
   mentionId: string | null;
   createdAt: string;
-  createdBy: User | null;
+  createdBy: TaskUser | null;
   text: string;
   type: 'bounty' | 'page';
 }

--- a/lib/forums/comments/interface.ts
+++ b/lib/forums/comments/interface.ts
@@ -2,6 +2,8 @@ import type { PostComment, User } from '@prisma/client';
 
 import type { PageContent } from 'lib/prosemirror/interfaces';
 
+export type TaskUser = Pick<User, 'id' | 'username' | 'path' | 'avatar' | 'avatarTokenId'>;
+
 export type PostCommentWithVote = PostComment & {
   upvotes: number;
   downvotes: number;
@@ -36,7 +38,7 @@ export type ForumTask = {
   commentId: string | null;
   mentionId: string | null;
   commentText: string;
-  createdBy: User | null;
+  createdBy: TaskUser | null;
 };
 
 export type ForumTasksGroup = {

--- a/lib/summon/addUserToSpace.ts
+++ b/lib/summon/addUserToSpace.ts
@@ -5,9 +5,10 @@ import { prisma } from 'db';
 type Props = {
   spaceId: string;
   userId: string;
+  userXpsEngineId: string;
 };
 
-export async function addUserToSpace({ spaceId, userId }: Props): Promise<Space | null> {
+export async function addUserToSpace({ spaceId, userId, userXpsEngineId }: Props): Promise<Space | null> {
   const space = await prisma.space.findFirstOrThrow({ where: { id: spaceId } });
 
   const spaceMembership = await prisma.spaceRole.findFirst({
@@ -34,6 +35,14 @@ export async function addUserToSpace({ spaceId, userId }: Props): Promise<Space 
       }
     });
   }
+  await prisma.user.update({
+    where: {
+      id: userId
+    },
+    data: {
+      xpsEngineId: userXpsEngineId
+    }
+  });
 
   return space;
 }

--- a/lib/users/hasNftAvatar.ts
+++ b/lib/users/hasNftAvatar.ts
@@ -1,10 +1,8 @@
 export type CheckAvatar = {
   avatar?: string | null;
-  avatarContract?: string | null;
   avatarTokenId?: string | null;
-  avatarChain?: number | null;
 };
 
 export const hasNftAvatar = (data: CheckAvatar | null) => {
-  return Boolean(data && data.avatar && data.avatarContract && data.avatarChain && data.avatarTokenId);
+  return Boolean(data && data.avatar && data.avatarTokenId);
 };

--- a/pages/api/email-templates/index.ts
+++ b/pages/api/email-templates/index.ts
@@ -41,19 +41,10 @@ const createDiscussionTask = ({
     type: 'page',
     createdBy: {
       id: v4(),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      email: '',
       username: '',
       avatar: '',
       path: '',
-      isBot: false,
-      identityType: 'Discord',
-      avatarContract: null,
-      avatarTokenId: null,
-      avatarChain: null,
-      deletedAt: null,
-      spacesOrder: []
+      avatarTokenId: null
     }
   };
 };
@@ -80,19 +71,10 @@ const createForumTask = ({
     mentionId: v4(),
     createdBy: {
       id: v4(),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      email: '',
       username: '',
       avatar: '',
       path: '',
-      isBot: false,
-      identityType: 'Discord',
-      avatarContract: null,
-      avatarTokenId: null,
-      avatarChain: null,
-      deletedAt: null,
-      spacesOrder: []
+      avatarTokenId: null
     }
   };
 };

--- a/pages/api/summon/join-space.ts
+++ b/pages/api/summon/join-space.ts
@@ -31,7 +31,7 @@ async function joinSpaceEndpoint(req: NextApiRequest, res: NextApiResponse) {
     throw new InvalidInputError('You are not a member of this space');
   }
 
-  await addUserToSpace({ spaceId, userId });
+  await addUserToSpace({ spaceId, userId, userXpsEngineId: result.summonUserId });
 
   trackUserAction('join_a_workspace', {
     spaceId,

--- a/prisma/migrations/20230228173525_add_user_xps_id/migration.sql
+++ b/prisma/migrations/20230228173525_add_user_xps_id/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[xpsEngineId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "xpsEngineId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_xpsEngineId_key" ON "User"("xpsEngineId");

--- a/prisma/migrations/20230228180529_unique_xps_space/migration.sql
+++ b/prisma/migrations/20230228180529_unique_xps_space/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[xpsEngineId]` on the table `Space` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Space_xpsEngineId_key" ON "Space"("xpsEngineId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -222,7 +222,7 @@ model Space {
   defaultPublicPages          Boolean?                          @default(false)
   permissionConfigurationMode SpacePermissionConfigurationMode? @default(custom)
   publicBountyBoard           Boolean?                          @default(false)
-  xpsEngineId                 String?
+  xpsEngineId                 String?                           @unique
   author                      User                              @relation(fields: [createdBy], references: [id], onDelete: Cascade)
   blocks                      Block[]
   bounties                    Bounty[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -428,6 +428,7 @@ model User {
   path                 String?                @unique
   identityType         IdentityType?
   email                String?
+  xpsEngineId          String?                @unique
   applications         Application[]
   blocks               Block[]
   bounties             Bounty[]
@@ -737,24 +738,24 @@ model UserGnosisSafe {
 }
 
 model Role {
-  id                        String                     @id @default(uuid()) @db.Uuid
-  createdAt                 DateTime                   @default(now())
-  createdBy                 String                     @db.Uuid
-  externalId                String?
-  name                      String
-  spaceId                   String                     @db.Uuid
-  source                    RoleSource?
-  sourceId                  String?
-  space                     Space                      @relation(fields: [spaceId], references: [id], onDelete: Cascade)
-  bountyPermissions         BountyPermission[]
-  permissions               PagePermission[]
-  spacePermissions          SpacePermission[]
-  spaceRolesToRole          SpaceRoleToRole[]
-  tokenGateToRoles          TokenGateToRole[]
-  proposalReviewer          ProposalReviewer[]
-  inviteLinkToRoles         InviteLinkToRole[]
-  memberPropertyPermissions MemberPropertyPermission[]
-  postCategoryPermissions   PostCategoryPermission[]
+  id                          String                       @id @default(uuid()) @db.Uuid
+  createdAt                   DateTime                     @default(now())
+  createdBy                   String                       @db.Uuid
+  externalId                  String?
+  name                        String
+  spaceId                     String                       @db.Uuid
+  source                      RoleSource?
+  sourceId                    String?
+  space                       Space                        @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  bountyPermissions           BountyPermission[]
+  permissions                 PagePermission[]
+  spacePermissions            SpacePermission[]
+  spaceRolesToRole            SpaceRoleToRole[]
+  tokenGateToRoles            TokenGateToRole[]
+  proposalReviewer            ProposalReviewer[]
+  inviteLinkToRoles           InviteLinkToRole[]
+  memberPropertyPermissions   MemberPropertyPermission[]
+  postCategoryPermissions     PostCategoryPermission[]
   proposalCategoryPermissions ProposalCategoryPermission[]
 
   @@unique([spaceId, name])
@@ -967,7 +968,6 @@ model WorkspaceEvent {
   @@index([pageId])
 }
 
-
 enum ProposalCategoryOperation {
   manage_permissions
   create_proposal
@@ -993,14 +993,14 @@ enum ProposalCategoryPermissionLevel {
 }
 
 model ProposalCategoryPermission {
-  id                 String                      @id @default(uuid()) @db.Uuid
+  id                 String                          @id @default(uuid()) @db.Uuid
   permissionLevel    ProposalCategoryPermissionLevel
-  proposalCategoryId     String                      @db.Uuid
-  proposalCategory       ProposalCategory            @relation(fields: [proposalCategoryId], references: [id], onDelete: Cascade)
+  proposalCategoryId String                          @db.Uuid
+  proposalCategory   ProposalCategory                @relation(fields: [proposalCategoryId], references: [id], onDelete: Cascade)
   // These fields will only be used when the custom permission level is used
   // For now adding these to the schema so that Prisma Client doesn't drop the enums at generator stage
-  categoryOperations     ProposalCategoryOperation[]
-  proposalOperations     ProposalOperation[]
+  categoryOperations ProposalCategoryOperation[]
+  proposalOperations ProposalOperation[]
 
   // Permission assignees
   roleId  String?  @db.Uuid
@@ -1018,18 +1018,17 @@ model ProposalCategoryPermission {
   @@index([proposalCategoryId, public])
 }
 
-
 model ProposalCategory {
-  id       String     @id @default(uuid()) @db.Uuid
-  spaceId  String     @db.Uuid
-  space    Space      @relation(fields: [spaceId], references: [id], onDelete: Cascade)
-  title    String
-  color    String
-  proposal Proposal[]
+  id                          String                       @id @default(uuid()) @db.Uuid
+  spaceId                     String                       @db.Uuid
+  space                       Space                        @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  title                       String
+  color                       String
+  proposal                    Proposal[]
   proposalCategoryPermissions ProposalCategoryPermission[]
 
-  @@index([spaceId])
   @@unique([spaceId, title])
+  @@index([spaceId])
 }
 
 model MemberProperty {


### PR DESCRIPTION
We should have another table for XPS-related info, similar to what we do for Discord, Gmail, and wallets. But I'm waiting to work on the story for profiles so we know what we actually need, just want to get the token gating stuff working properly. In the meantime I'll just get the info by calling their api