### PR TITLE
Dont show deleted proposals

### DIFF
--- a/components/proposals/components/ProposalsTable.tsx
+++ b/components/proposals/components/ProposalsTable.tsx
@@ -61,7 +61,9 @@ export default function ProposalsTable({
   }, [router.query.id]);
 
   // Make sure not to show templates here
-  const filteredProposals = proposals?.filter((p) => pages[p.id]?.type === 'proposal');
+  const filteredProposals = proposals?.filter(
+    (p) => !!pages[p.id] && pages[p.id]?.type === 'proposal' && !pages[p.id]?.deletedAt
+  );
 
   return (
     <>


### PR DESCRIPTION
Deleted proposals should not show in the UI

I noticed we got a page_meta_updated event when deleting a proposal, so just went with the updated deletedAt value for now (also avoids any manual mutations)