### PR TITLE
Fix threads error on certain pages

### DIFF
--- a/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
@@ -116,7 +116,7 @@ export function InlineCommentSubMenu({ pluginKey }: { pluginKey: PluginKey }) {
       const threadWithComment = await charmClient.comments.startThread({
         comment: commentContent,
         context: extractTextFromSelection(),
-        pageId: cardId ?? currentPageId
+        pageId: cardId || currentPageId
       });
       setThreads((_threads) => ({ ..._threads, [threadWithComment.id]: threadWithComment }));
       updateInlineComment(threadWithComment.id)(view.state, view.dispatch);


### PR DESCRIPTION
[Task item](https://app.charmverse.io/charmverse/page-8463429056408176?viewId=2c9d8701-33ff-4c3a-942a-6d403a638565)

On pages, comments would crash because cardId was an empty string.