### PR TITLE
Fix: sidebar navigation showing incorrect link when going from a databse to document page

### DIFF
--- a/components/[pageId]/DatabasePage/DatabasePage.tsx
+++ b/components/[pageId]/DatabasePage/DatabasePage.tsx
@@ -85,7 +85,7 @@ export function DatabasePage({ page, setPage, readOnly = false, pagePermissions 
       dispatch(setCurrentView(urlViewId || ''));
       setFocalboardViewsRecord((focalboardViewsRecord) => ({ ...focalboardViewsRecord, [boardId]: urlViewId }));
     }
-  }, [page.boardId, router.query.viewId, boardViews]);
+  }, [page.boardId, boardViews]);
 
   // load initial data for readonly boards - otherwise its loaded in _app.tsx
   // inline linked board will be loaded manually


### PR DESCRIPTION
What's happening is a delay in updating the 'currentPage' defined in EditorPage based on URL, but there is logic in DatabasePage to add a viewId if none exists (and assuming we're on a board URL still). 