### PR TITLE
Revert old hotfix

### DIFF
--- a/.github/actions/build_docker_image/action.yml
+++ b/.github/actions/build_docker_image/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Configure AWS credentials
       # Locked version as temporary workaround to failing deps
       # https://github.com/aws-actions/configure-aws-credentials/issues/670#issuecomment-1444620155
-      uses: aws-actions/configure-aws-credentials@567d4149d67f15f52b09796bea6573fc32952783
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -99,7 +99,7 @@ jobs:
           transient: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@567d4149d67f15f52b09796bea6573fc32952783
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/destroy_staging.yml
+++ b/.github/workflows/destroy_staging.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@567d4149d67f15f52b09796bea6573fc32952783
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Use the standard Amazon lib for CI process.

This reverts a hotfix we used when a buggy version was deployed.

We should make sure CI and staging deploy runs properly before merging this