### PR TITLE
call page permissions less often

### DIFF
--- a/components/[pageId]/Comments/PageComments.tsx
+++ b/components/[pageId]/Comments/PageComments.tsx
@@ -9,15 +9,16 @@ import { CommentSort } from 'components/common/comments/CommentSort';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { useProposalDetails } from 'components/proposals/hooks/useProposalDetails';
 import { useIsAdmin } from 'hooks/useIsAdmin';
-import { usePagePermissions } from 'hooks/usePagePermissions';
 import type { CommentPermissions } from 'lib/comments';
 import type { PageMeta } from 'lib/pages';
+import type { IPagePermissionFlags } from 'lib/permissions/pages';
 
 type Props = {
   page: PageMeta;
+  permissions?: IPagePermissionFlags;
 };
 
-export function PageComments({ page }: Props) {
+export function PageComments({ page, permissions }: Props) {
   const {
     comments,
     commentSort,
@@ -32,10 +33,6 @@ export function PageComments({ page }: Props) {
   const isProposal = page.type === 'proposal';
 
   const { proposal } = useProposalDetails(isProposal ? page.id : null);
-
-  const { permissions } = usePagePermissions({
-    pageIdOrPath: page.id
-  });
 
   const commentPermissions: CommentPermissions = {
     add_comment: permissions?.comment ?? false,

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -307,7 +307,7 @@ function DocumentPage({ page, setPage, insideModal, readOnly = false }: Document
                 </div>
               </CharmEditor>
 
-              {proposalId && <PageComments page={page} />}
+              {proposalId && <PageComments page={page} permissions={pagePermissions} />}
             </Container>
           </div>
         </ScrollContainer>

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -88,7 +88,7 @@ function DocumentPage({ page, setPage, insideModal, readOnly = false }: Document
   const { pages } = usePages();
   const { cancelVote, castVote, deleteVote, updateDeadline, votes, isLoading } = useVotes();
   // For post we would artificially construct the permissions
-  const { permissions: pagePermissions } = usePagePermissions({
+  const { permissions: pagePermissions, refresh: refreshPagePermissions } = usePagePermissions({
     pageIdOrPath: page.id
   });
   const { draftBounty } = useBounties();
@@ -282,6 +282,8 @@ function DocumentPage({ page, setPage, insideModal, readOnly = false }: Document
                     {proposalId && (
                       <ProposalProperties
                         proposalId={proposalId}
+                        pagePermissions={pagePermissions}
+                        refreshPagePermissions={refreshPagePermissions}
                         readOnly={readonlyProposalProperties}
                         isTemplate={page.type === 'proposal_template'}
                       />

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -19,10 +19,10 @@ import { useProposalPermissions } from 'components/proposals/hooks/useProposalPe
 import { CreateVoteModal } from 'components/votes/components/CreateVoteModal';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useMembers } from 'hooks/useMembers';
-import { usePagePermissions } from 'hooks/usePagePermissions';
 import useRoles from 'hooks/useRoles';
 import { useUser } from 'hooks/useUser';
 import type { Member } from 'lib/members/interfaces';
+import type { IPagePermissionFlags } from 'lib/permissions/pages';
 import type { ProposalCategory } from 'lib/proposal/interface';
 import type { ProposalUserGroup } from 'lib/proposal/proposalStatusTransition';
 import type { ListSpaceRolesResponse } from 'pages/api/roles';
@@ -31,9 +31,17 @@ interface ProposalPropertiesProps {
   readOnly?: boolean;
   proposalId: string;
   isTemplate: boolean;
+  pagePermissions?: IPagePermissionFlags;
+  refreshPagePermissions?: () => void;
 }
 
-export default function ProposalProperties({ proposalId, readOnly, isTemplate }: ProposalPropertiesProps) {
+export default function ProposalProperties({
+  pagePermissions,
+  refreshPagePermissions = () => null,
+  proposalId,
+  readOnly,
+  isTemplate
+}: ProposalPropertiesProps) {
   const { proposal, refreshProposal } = useProposalDetails(proposalId);
   const { categories } = useProposalCategories();
   const { mutate: mutateTasks } = useTasks();
@@ -44,9 +52,6 @@ export default function ProposalProperties({ proposalId, readOnly, isTemplate }:
   });
 
   const { permissions: proposalFlowFlags, refresh: refreshProposalFlowFlags } = useProposalFlowFlags({ proposalId });
-  const { refresh: refreshPagePermissions, permissions } = usePagePermissions({
-    pageIdOrPath: proposalId
-  });
 
   const { members } = useMembers();
   const { roles = [], roleups } = useRoles();
@@ -83,7 +88,7 @@ export default function ProposalProperties({ proposalId, readOnly, isTemplate }:
       return roleups.some((role) => role.id === reviewer.roleId && role.users.some((_user) => _user.id === user.id));
     });
 
-  const canUpdateProposalProperties = permissions?.edit_content || isAdmin;
+  const canUpdateProposalProperties = pagePermissions?.edit_content || isAdmin;
 
   const reviewerOptionsRecord: Record<
     string,

--- a/components/common/PageActionsMenu.tsx
+++ b/components/common/PageActionsMenu.tsx
@@ -53,7 +53,7 @@ export function PageActionsMenu({
   const charmversePage = members.find((member) => member.id === page.createdBy);
   const open = Boolean(anchorEl);
   const { formatDateTime } = useDateFormatter();
-  const { permissions: pagePermissions } = usePagePermissions({ pageIdOrPath: page.id });
+  const { permissions: pagePermissions } = usePagePermissions({ pageIdOrPath: open ? page.id : null });
   const postPermissions = usePostPermissions({
     postIdOrPath: router.pathname.startsWith('/[domain]/forum') ? page.id : (null as any)
   });


### PR DESCRIPTION
1) pass down permissions instead of calling usePagePermissions at various levels. It seems like the way SWR's cache works is that it will use the previous response if one exsits, but it still makes another request to refresh the data anyway.
2) don't get page permissions for action menu until user opens it

As a user, you wouldn't notice anything because it doesn't affect page rendering, but it makes sense to me that this could be contributing to us running out of db connections