### PR TITLE
dont delete messages that fail from collabland

### DIFF
--- a/lib/aws/webhookSqs.ts
+++ b/lib/aws/webhookSqs.ts
@@ -68,15 +68,15 @@ export async function processMessages({ processorFn }: ProcessMssagesInput) {
 
     try {
       // process message
-      log.debug('Processing message', msgBody);
+      log.debug('Processing message', { message: msgBody, receiptHandle: message.ReceiptHandle });
       const result = await processorFn(msgBody as WebhookMessage);
 
-      log.debug('Message process successful:', result.success);
-      if (result.message) {
-        log.debug(result.message);
+      log.debug('Message process successful:', { message: result.message, receiptHandle: message.ReceiptHandle });
+      try {
+        await deleteMessage(message.ReceiptHandle || '');
+      } catch (e) {
+        log.error('Could not delete message', { receiptHandle: message.ReceiptHandle, error: e });
       }
-      log.debug('Deleting message', message.ReceiptHandle);
-      await deleteMessage(message.ReceiptHandle || '');
     } catch (e) {
       log.error('Failed to process webhook message', e);
     }

--- a/lib/aws/webhookSqs.ts
+++ b/lib/aws/webhookSqs.ts
@@ -75,11 +75,10 @@ export async function processMessages({ processorFn }: ProcessMssagesInput) {
       if (result.message) {
         log.debug(result.message);
       }
-    } catch (e) {
-      log.error('Failed to process webhook message', e);
-    } finally {
       log.debug('Deleting message', message.ReceiptHandle);
       await deleteMessage(message.ReceiptHandle || '');
+    } catch (e) {
+      log.error('Failed to process webhook message', e);
     }
   } else {
     log.debug('No messages');


### PR DESCRIPTION
With SQS, if you delete the message it's gone forever. Instead, we should let the process retry and AWS will eventually send it to a dead letter queue which I added to AWS already, called "prd-webhook-collabland-dlq.fifo".