### PR TITLE
Dont let errors fail silently in collab worker

### DIFF
--- a/lib/aws/webhookSqs.ts
+++ b/lib/aws/webhookSqs.ts
@@ -71,11 +71,15 @@ export async function processMessages({ processorFn }: ProcessMssagesInput) {
       log.debug('Processing message', { message: msgBody, receiptHandle: message.ReceiptHandle });
       const result = await processorFn(msgBody as WebhookMessage);
 
-      log.debug('Message process successful:', { message: result.message, receiptHandle: message.ReceiptHandle });
-      try {
-        await deleteMessage(message.ReceiptHandle || '');
-      } catch (e) {
-        log.error('Could not delete message', { receiptHandle: message.ReceiptHandle, error: e });
+      if (result.success) {
+        log.info('Message process successful:', { message: result.message, receiptHandle: message.ReceiptHandle });
+        try {
+          await deleteMessage(message.ReceiptHandle || '');
+        } catch (e) {
+          log.error('Could not delete message', { receiptHandle: message.ReceiptHandle, error: e });
+        }
+      } else {
+        log.warn('Message process failed:', { message: result.message, receiptHandle: message.ReceiptHandle });
       }
     } catch (e) {
       log.error('Failed to process webhook message', e);

--- a/lib/collabland/assignRolesCollabland.ts
+++ b/lib/collabland/assignRolesCollabland.ts
@@ -13,20 +13,14 @@ export async function assignRolesCollabland({
   roles: string[] | string;
 }) {
   const roleIdsToAdd = Array.isArray(roles) ? roles : [roles];
-  try {
-    const discordRoles = await getGuildRoles(discordServerId);
-    const rolesToAdd = roleIdsToAdd
-      .map((roleId) => discordRoles.find((role) => role.id === roleId))
-      .filter(Boolean) as ExternalRole[];
+  const discordRoles = await getGuildRoles(discordServerId);
+  const rolesToAdd = roleIdsToAdd
+    .map((roleId) => discordRoles.find((role) => role.id === roleId))
+    .filter(Boolean) as ExternalRole[];
 
-    const spacesData = await getSpacesAndUserFromDiscord({ discordUserId, discordServerId });
+  const spacesData = await getSpacesAndUserFromDiscord({ discordUserId, discordServerId });
 
-    return Promise.allSettled(
-      spacesData.map(({ space, user }) =>
-        createAndAssignRoles({ userId: user.id, spaceId: space.id, roles: rolesToAdd })
-      )
-    );
-  } catch (e) {
-    return null;
-  }
+  return Promise.allSettled(
+    spacesData.map(({ space, user }) => createAndAssignRoles({ userId: user.id, spaceId: space.id, roles: rolesToAdd }))
+  );
 }

--- a/lib/collabland/collablandClient.ts
+++ b/lib/collabland/collablandClient.ts
@@ -143,16 +143,10 @@ export async function canJoinSpaceViaDiscord({
 }
 
 export async function getGuildRoles(discordServerId: string) {
-  try {
-    const allRoles = await fetch<ExternalRole[]>(`${COLLABLAND_API_URL}/discord/${discordServerId}/roles`, {
-      headers: getHeaders()
-    });
+  const allRoles = await fetch<ExternalRole[]>(`${COLLABLAND_API_URL}/discord/${discordServerId}/roles`, {
+    headers: getHeaders()
+  });
 
-    // filter out irrelevant roles
-    return allRoles.filter((role) => role.name !== '@everyone' && !role.managed);
-  } catch (error) {
-    log.error(`Failed to fetch roles for server ${discordServerId}`, { error, apiDomain: COLLABLAND_API_URL });
-
-    return [];
-  }
+  // filter out irrelevant roles
+  return allRoles.filter((role) => role.name !== '@everyone' && !role.managed);
 }


### PR DESCRIPTION
Currently, we are "handling" all incoming messages even though our API was incorrect. This PR makes it so that the error can propagate. With SQS, we only want to remove a message from queue if it succeeds. SQS will re-send it a preset number of times and then put it in a dead letter queue so that we can debug and retry them manually later (and we can put an alarm on the size of this queue as well). The visibility timeout determines how often the message will appear as a available to consumers of the queue. (So if the time out is 30s, it will appear available again 30s after we first request it).
