### PR TITLE
wait until permissions are loaded to display CharmEditor in DocumentPage

### DIFF
--- a/components/[pageId]/Comments/PageComments.tsx
+++ b/components/[pageId]/Comments/PageComments.tsx
@@ -15,7 +15,7 @@ import type { IPagePermissionFlags } from 'lib/permissions/pages';
 
 type Props = {
   page: PageMeta;
-  permissions?: IPagePermissionFlags;
+  permissions: IPagePermissionFlags;
 };
 
 export function PageComments({ page, permissions }: Props) {
@@ -35,9 +35,9 @@ export function PageComments({ page, permissions }: Props) {
   const { proposal } = useProposalDetails(isProposal ? page.id : null);
 
   const commentPermissions: CommentPermissions = {
-    add_comment: permissions?.comment ?? false,
-    upvote: permissions?.comment ?? false,
-    downvote: permissions?.comment ?? false,
+    add_comment: permissions.comment ?? false,
+    upvote: permissions.comment ?? false,
+    downvote: permissions.comment ?? false,
     delete_comments: isAdmin
   };
 
@@ -49,7 +49,7 @@ export function PageComments({ page, permissions }: Props) {
     <>
       <Divider sx={{ my: 3 }} />
 
-      {permissions?.comment && <CommentForm handleCreateComment={addComment} />}
+      {permissions.comment && <CommentForm handleCreateComment={addComment} />}
 
       {isLoadingComments ? (
         <Box height={100}>
@@ -81,7 +81,7 @@ export function PageComments({ page, permissions }: Props) {
                 No Comments Yet
               </Typography>
 
-              {permissions?.comment && <Typography color='secondary'>Be the first to share what you think!</Typography>}
+              {permissions.comment && <Typography color='secondary'>Be the first to share what you think!</Typography>}
             </Stack>
           )}
         </>

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -206,110 +206,112 @@ function DocumentPage({ page, setPage, insideModal, readOnly = false }: Document
               top={pageTop}
               fullWidth={isSmallScreen || (page.fullWidth ?? false)}
             >
-              <CharmEditor
-                placeholderText={
-                  page.type === 'bounty' || page.type === 'bounty_template'
-                    ? `Describe the bounty. Type '/' to see the list of available commands`
-                    : undefined
-                }
-                key={page.id + editMode + String(pagePermissions?.edit_content)}
-                // content={pageDetails?.content as PageContent}
-                // onContentChange={updatePageContent}
-                readOnly={readOnly}
-                autoFocus={false}
-                pageActionDisplay={!insideModal ? currentPageActionDisplay : null}
-                pageId={page.id}
-                disablePageSpecificFeatures={isSharedPage}
-                enableSuggestingMode={enableSuggestingMode}
-                enableVoting={true}
-                containerWidth={containerWidth}
-                pageType={page.type}
-                pagePermissions={pagePermissions ?? undefined}
-                onParticipantUpdate={onParticipantUpdate}
-                style={{
-                  minHeight: proposalId ? '100px' : 'unset'
-                }}
-                disableNestedPages={page?.type === 'proposal' || page?.type === 'proposal_template'}
-              >
-                {/* temporary? disable editing of page title when in suggestion mode */}
-                <PageHeader
-                  headerImage={page.headerImage}
-                  // Commented for now, as we need to preserve cursor position between re-renders caused by updating this
-                  // key={page.title}
-                  icon={page.icon}
-                  title={page.title}
-                  updatedAt={page.updatedAt.toString()}
-                  readOnly={readOnly || !!enableSuggestingMode}
-                  setPage={setPage}
-                />
-                {page.type === 'proposal' && !isLoading && page.snapshotProposalId && (
-                  <Box my={2}>
-                    <SnapshotVoteDetails snapshotProposalId={page.snapshotProposalId} />
-                  </Box>
-                )}
-                {page.type === 'proposal' && !isLoading && pageVote && (
-                  <Box my={2}>
-                    <VoteDetail
-                      cancelVote={cancelVote}
-                      deleteVote={deleteVote}
-                      castVote={castVote}
-                      updateDeadline={updateDeadline}
-                      vote={pageVote}
-                      detailed={false}
-                      isProposal={true}
-                      disableVote={!proposalPermissions?.vote}
-                    />
-                  </Box>
-                )}
-                <div className='focalboard-body'>
-                  <div className='CardDetail content'>
-                    {/* Property list */}
-                    {card && board && (
-                      <>
-                        <CardDetailProperties
-                          board={board}
-                          card={card}
-                          cards={cards}
-                          activeView={activeView}
-                          views={boardViews}
-                          readOnly={readOnly}
-                          pageUpdatedAt={page.updatedAt.toString()}
-                          pageUpdatedBy={page.updatedBy}
+              {pagePermissions && (
+                <CharmEditor
+                  placeholderText={
+                    page.type === 'bounty' || page.type === 'bounty_template'
+                      ? `Describe the bounty. Type '/' to see the list of available commands`
+                      : undefined
+                  }
+                  key={page.id + editMode + String(pagePermissions?.edit_content)}
+                  // content={pageDetails?.content as PageContent}
+                  // onContentChange={updatePageContent}
+                  readOnly={readOnly}
+                  autoFocus={false}
+                  pageActionDisplay={!insideModal ? currentPageActionDisplay : null}
+                  pageId={page.id}
+                  disablePageSpecificFeatures={isSharedPage}
+                  enableSuggestingMode={enableSuggestingMode}
+                  enableVoting={true}
+                  containerWidth={containerWidth}
+                  pageType={page.type}
+                  pagePermissions={pagePermissions ?? undefined}
+                  onParticipantUpdate={onParticipantUpdate}
+                  style={{
+                    minHeight: proposalId ? '100px' : 'unset'
+                  }}
+                  disableNestedPages={page?.type === 'proposal' || page?.type === 'proposal_template'}
+                >
+                  {/* temporary? disable editing of page title when in suggestion mode */}
+                  <PageHeader
+                    headerImage={page.headerImage}
+                    // Commented for now, as we need to preserve cursor position between re-renders caused by updating this
+                    // key={page.title}
+                    icon={page.icon}
+                    title={page.title}
+                    updatedAt={page.updatedAt.toString()}
+                    readOnly={readOnly || !!enableSuggestingMode}
+                    setPage={setPage}
+                  />
+                  {page.type === 'proposal' && !isLoading && page.snapshotProposalId && (
+                    <Box my={2}>
+                      <SnapshotVoteDetails snapshotProposalId={page.snapshotProposalId} />
+                    </Box>
+                  )}
+                  {page.type === 'proposal' && !isLoading && pageVote && (
+                    <Box my={2}>
+                      <VoteDetail
+                        cancelVote={cancelVote}
+                        deleteVote={deleteVote}
+                        castVote={castVote}
+                        updateDeadline={updateDeadline}
+                        vote={pageVote}
+                        detailed={false}
+                        isProposal={true}
+                        disableVote={!proposalPermissions?.vote}
+                      />
+                    </Box>
+                  )}
+                  <div className='focalboard-body'>
+                    <div className='CardDetail content'>
+                      {/* Property list */}
+                      {card && board && (
+                        <>
+                          <CardDetailProperties
+                            board={board}
+                            card={card}
+                            cards={cards}
+                            activeView={activeView}
+                            views={boardViews}
+                            readOnly={readOnly}
+                            pageUpdatedAt={page.updatedAt.toString()}
+                            pageUpdatedBy={page.updatedBy}
+                          />
+                          <AddBountyButton readOnly={readOnly} cardId={page.id} />
+                        </>
+                      )}
+                      {proposalId && (
+                        <ProposalProperties
+                          proposalId={proposalId}
+                          pagePermissions={pagePermissions}
+                          refreshPagePermissions={refreshPagePermissions}
+                          readOnly={readonlyProposalProperties}
+                          isTemplate={page.type === 'proposal_template'}
                         />
-                        <AddBountyButton readOnly={readOnly} cardId={page.id} />
-                      </>
-                    )}
-                    {proposalId && (
-                      <ProposalProperties
-                        proposalId={proposalId}
-                        pagePermissions={pagePermissions}
-                        refreshPagePermissions={refreshPagePermissions}
-                        readOnly={readonlyProposalProperties}
-                        isTemplate={page.type === 'proposal_template'}
-                      />
-                    )}
-                    {(draftBounty || page.bountyId) && (
-                      <BountyProperties
-                        bountyId={page.bountyId}
-                        pageId={page.id}
-                        readOnly={readOnly}
-                        permissions={bountyPermissions}
-                        refreshBountyPermissions={refreshBountyPermissions}
-                      />
-                    )}
-                    {(page.type === 'bounty' || page.type === 'card') && (
-                      <CommentsList
-                        comments={comments}
-                        rootId={card?.rootId ?? page.id}
-                        cardId={card?.id ?? page.id}
-                        readOnly={cannotComment}
-                      />
-                    )}
+                      )}
+                      {(draftBounty || page.bountyId) && (
+                        <BountyProperties
+                          bountyId={page.bountyId}
+                          pageId={page.id}
+                          readOnly={readOnly}
+                          permissions={bountyPermissions}
+                          refreshBountyPermissions={refreshBountyPermissions}
+                        />
+                      )}
+                      {(page.type === 'bounty' || page.type === 'card') && (
+                        <CommentsList
+                          comments={comments}
+                          rootId={card?.rootId ?? page.id}
+                          cardId={card?.id ?? page.id}
+                          readOnly={cannotComment}
+                        />
+                      )}
+                    </div>
                   </div>
-                </div>
-              </CharmEditor>
+                </CharmEditor>
+              )}
 
-              {proposalId && <PageComments page={page} permissions={pagePermissions} />}
+              {pagePermissions && proposalId && <PageComments page={page} permissions={pagePermissions} />}
             </Container>
           </div>
         </ScrollContainer>

--- a/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
@@ -189,8 +189,10 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
             doc,
             plugins: _editor.view.state.plugins
           };
-          // Set document in prosemirror
-          _editor.view?.setProps({ state: EditorState.create(stateConfig) });
+          if (_editor.view && !_editor.view.isDestroyed) {
+            // Set document in prosemirror
+            _editor.view.setProps({ state: EditorState.create(stateConfig) });
+          }
         }
       });
     }


### PR DESCRIPTION
Page permissions are now loaded async. Once they load, the editor is re-mounted in editable state. This sort of thrashes the UI, but also triggers an error when the initial readonly flow tries to update the original view, which no longer exists:

<img width="955" alt="image" src="https://user-images.githubusercontent.com/305398/223340581-2f3f7f94-4e26-4f52-b279-f26fa68687c5.png">
