### PR TITLE
static width for page dialog on mobile

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/dialog.scss
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.scss
@@ -37,7 +37,6 @@
     overflow-x: hidden;
     overflow-y: auto;
 
-    width: fit-content;
 
     position: fixed;
     top: 0;


### PR DESCRIPTION
this was just a leftover when we used to wait for content to load to stretch the modal accordingly.