### PR TITLE
fix iframe content paste when html is included

### DIFF
--- a/components/common/CharmEditor/components/iframe/iframe.ts
+++ b/components/common/CharmEditor/components/iframe/iframe.ts
@@ -26,12 +26,6 @@ export function plugins() {
             return false;
           }
           const text = event.clipboardData.getData('text/plain');
-          const html = event.clipboardData.getData('text/html');
-          const isPlainText = text && !html;
-
-          if (!isPlainText) {
-            return false;
-          }
           const props = extractIframeProps(text);
           if (props) {
             const { src, height, width } = props;


### PR DESCRIPTION
I think I had checked for html before we had teh check for iframe props. I don't think we need to be so cautious anymore. The case that is currently broken is pasting an iframe code with the URL encoded as a link:


![image](https://user-images.githubusercontent.com/305398/224762548-d6be0415-f6c7-468a-9193-8d5c75734bb1.png)
