### PR TITLE
fix github regex

### DIFF
--- a/components/profile/components/SocialInputs.tsx
+++ b/components/profile/components/SocialInputs.tsx
@@ -23,7 +23,7 @@ export const schema = yup.object({
     .notRequired()
     .ensure()
     .trim()
-    .matches(/^$|^http(?:s)?:\/\/(?:www\.)?github\.([a-z])+\/([A-Za-z0-9]{1,})+\/?$/i, 'Invalid GitHub link'),
+    .matches(/^$|^http(?:s)?:\/\/(?:www\.)?github\.([a-z])+\/([^\s\\]{1,})+\/?$/i, 'Invalid GitHub link'),
   discordUsername: yup
     .string()
     .notRequired()


### PR DESCRIPTION
Github names can include "-" which the regex doesn't match. I just tried to make it more relaxed by checking non-whitespace - we dont have to be so perfect imo