### PR TITLE
Fix sort&filter items in database

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
@@ -18,7 +18,9 @@ type Props = {
   displayType?: PropertyValueDisplayType;
 };
 
-const StyledUserPropertyContainer = styled(Box)<{ hideInput?: boolean }>`
+const StyledUserPropertyContainer = styled(Box, { shouldForwardProp: (prop) => prop !== 'hideInput' })<{
+  hideInput?: boolean;
+}>`
   width: 100%;
   height: 100%;
   overflow: hidden;

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/filterEntry.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/filterEntry.tsx
@@ -1,8 +1,10 @@
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
+import { Box, Menu, MenuItem, Popover } from '@mui/material';
+import PopupState, { bindMenu, bindPopover, bindTrigger } from 'material-ui-popup-state';
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import type { Board, IPropertyTemplate } from 'lib/focalboard/board';
+import type { IPropertyTemplate } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';
 import type { FilterClause } from 'lib/focalboard/filterClause';
 import { areEqual as areFilterClausesEqual } from 'lib/focalboard/filterClause';
@@ -12,10 +14,7 @@ import mutator from '../../mutator';
 import { OctoUtils } from '../../octoUtils';
 import { Utils } from '../../utils';
 import Button from '../../widgets/buttons/button';
-import Menu from '../../widgets/menu';
-import MenuWrapper from '../../widgets/menuWrapper';
-
-import FilterValue from './filterValue';
+import SwitchOption from '../../widgets/menu/switchOption';
 
 type Props = {
   properties: IPropertyTemplate[];
@@ -27,64 +26,136 @@ type Props = {
 function FilterEntry(props: Props): JSX.Element {
   const { properties, view, filter } = props;
   const intl = useIntl();
-
   const template = properties.find((o: IPropertyTemplate) => o.id === filter.propertyId);
+
   const propertyName = template ? template.name : '(unknown)';
   const key = `${filter.propertyId}-${filter.condition}-${filter.values.join(',')}`;
+
+  let displayValue: string;
+  if (filter.values.length > 0 && template) {
+    displayValue = filter.values
+      .map((id) => {
+        const option = template.options.find((o) => o.id === id);
+        return option?.value || '(Unknown)';
+      })
+      .join(', ');
+  } else {
+    displayValue = '(empty)';
+  }
+
   return (
     <div className='FilterEntry' key={key}>
-      <MenuWrapper>
-        <Button>{propertyName}</Button>
-        <Menu>
-          {properties
-            .filter((o: IPropertyTemplate) => o.type === 'select' || o.type === 'multiSelect')
-            .map((o: IPropertyTemplate) => (
-              <Menu.Text
-                key={o.id}
-                id={o.id}
-                name={o.name}
-                onClick={(optionId: string) => {
-                  const filterIndex = view.fields.filter.filters.indexOf(filter);
-                  Utils.assert(filterIndex >= 0, "Can't find filter");
-                  const filterGroup = createFilterGroup(view.fields.filter);
-                  const newFilter = filterGroup.filters[filterIndex] as FilterClause;
-                  Utils.assert(newFilter, `No filter at index ${filterIndex}`);
-                  if (newFilter.propertyId !== optionId) {
-                    newFilter.propertyId = optionId;
-                    newFilter.values = [];
-                    mutator.changeViewFilter(view.id, view.fields.filter, filterGroup);
+      <PopupState variant='popover' popupId='view-filter'>
+        {(popupState) => (
+          <>
+            <Button {...bindTrigger(popupState)}>{propertyName}</Button>
+            <Menu {...bindMenu(popupState)}>
+              {properties
+                .filter((o: IPropertyTemplate) => o.type === 'select' || o.type === 'multiSelect')
+                .map((o: IPropertyTemplate) => (
+                  <MenuItem
+                    key={o.id}
+                    id={o.id}
+                    onClick={() => {
+                      const filterIndex = view.fields.filter.filters.indexOf(filter);
+                      Utils.assert(filterIndex >= 0, "Can't find filter");
+                      const filterGroup = createFilterGroup(view.fields.filter);
+                      const newFilter = filterGroup.filters[filterIndex] as FilterClause;
+                      Utils.assert(newFilter, `No filter at index ${filterIndex}`);
+                      if (newFilter.propertyId !== o.id) {
+                        newFilter.propertyId = o.id;
+                        newFilter.values = [];
+                        mutator.changeViewFilter(view.id, view.fields.filter, filterGroup);
+                      }
+                    }}
+                  >
+                    {o.name}
+                  </MenuItem>
+                ))}
+            </Menu>
+          </>
+        )}
+      </PopupState>
+
+      <PopupState variant='popover' popupId='view-filter'>
+        {(popupState) => (
+          <>
+            <Button {...bindTrigger(popupState)}>
+              {OctoUtils.filterConditionDisplayString(filter.condition, intl)}
+            </Button>
+            <Menu {...bindMenu(popupState)}>
+              <MenuItem id='includes' onClick={() => props.conditionClicked('includes', filter)}>
+                {intl.formatMessage({ id: 'Filter.includes', defaultMessage: 'includes' })}
+              </MenuItem>
+              <MenuItem id='notIncludes' onClick={() => props.conditionClicked('notIncludes', filter)}>
+                {intl.formatMessage({ id: 'Filter.not-includes', defaultMessage: 'does not include' })}
+              </MenuItem>
+              <MenuItem id='isEmpty' onClick={() => props.conditionClicked('isEmpty', filter)}>
+                {intl.formatMessage({ id: 'Filter.is-empty', defaultMessage: 'is empty' })}
+              </MenuItem>
+              <MenuItem id='isNotEmpty' onClick={() => props.conditionClicked('isNotEmpty', filter)}>
+                {intl.formatMessage({ id: 'Filter.is-not-empty', defaultMessage: 'is not empty' })}
+              </MenuItem>
+            </Menu>
+          </>
+        )}
+      </PopupState>
+
+      {(filter.condition === 'includes' || filter.condition === 'notIncludes') && (
+        <PopupState variant='popover' popupId='view-filter-value'>
+          {(popupState) => (
+            <>
+              <Button {...bindTrigger(popupState)}>{displayValue}</Button>
+              <Popover
+                {...bindPopover(popupState)}
+                PaperProps={{
+                  sx: {
+                    overflow: 'visible'
                   }
                 }}
-              />
-            ))}
-        </Menu>
-      </MenuWrapper>
-      <MenuWrapper>
-        <Button>{OctoUtils.filterConditionDisplayString(filter.condition, intl)}</Button>
-        <Menu>
-          <Menu.Text
-            id='includes'
-            name={intl.formatMessage({ id: 'Filter.includes', defaultMessage: 'includes' })}
-            onClick={(id) => props.conditionClicked(id, filter)}
-          />
-          <Menu.Text
-            id='notIncludes'
-            name={intl.formatMessage({ id: 'Filter.not-includes', defaultMessage: "doesn't include" })}
-            onClick={(id) => props.conditionClicked(id, filter)}
-          />
-          <Menu.Text
-            id='isEmpty'
-            name={intl.formatMessage({ id: 'Filter.is-empty', defaultMessage: 'is empty' })}
-            onClick={(id) => props.conditionClicked(id, filter)}
-          />
-          <Menu.Text
-            id='isNotEmpty'
-            name={intl.formatMessage({ id: 'Filter.is-not-empty', defaultMessage: 'is not empty' })}
-            onClick={(id) => props.conditionClicked(id, filter)}
-          />
-        </Menu>
-      </MenuWrapper>
-      {template && <FilterValue filter={filter} template={template} view={view} />}
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'left'
+                }}
+              >
+                {template?.options.map((o) => (
+                  <Box
+                    key={o.id}
+                    py={1}
+                    sx={{
+                      background: 'rgb(var(--center-channel-bg-rgb))',
+                      '& > div': { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
+                      '& .Switch': { mx: 1 },
+                      '& .menu-name': { ml: 1 }
+                    }}
+                  >
+                    <SwitchOption
+                      id={o.id}
+                      name={o.value}
+                      isOn={filter.values.includes(o.id)}
+                      onClick={() => {
+                        const filterIndex = view.fields.filter.filters.indexOf(filter);
+                        Utils.assert(filterIndex >= 0, "Can't find filter");
+
+                        const filterGroup = createFilterGroup(view.fields.filter);
+                        const newFilter = filterGroup.filters[filterIndex] as FilterClause;
+                        Utils.assert(newFilter, `No filter at index ${filterIndex}`);
+                        if (filter.values.includes(o.id)) {
+                          newFilter.values = newFilter.values.filter((id) => id !== o.id);
+                          mutator.changeViewFilter(view.id, view.fields.filter, filterGroup);
+                        } else {
+                          newFilter.values.push(o.id);
+                          mutator.changeViewFilter(view.id, view.fields.filter, filterGroup);
+                        }
+                      }}
+                    />
+                  </Box>
+                ))}
+              </Popover>
+            </>
+          )}
+        </PopupState>
+      )}
       <div className='octo-spacer' />
       <Button
         onClick={() => {

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
@@ -1,6 +1,6 @@
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
-import { Box, Popover, Tooltip } from '@mui/material';
-import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
+import { Box, Menu, Popover, Tooltip } from '@mui/material';
+import PopupState, { bindTrigger, bindPopover, bindMenu } from 'material-ui-popup-state';
 import { useRouter } from 'next/router';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -174,11 +174,45 @@ function ViewHeader(props: Props) {
             {/* Sort */}
 
             {withSortBy && (
-              <ViewHeaderSortMenu
-                properties={activeBoard?.fields.cardProperties ?? []}
-                activeView={activeView}
-                orderedCards={cards}
-              />
+              <PopupState variant='popover' popupId='view-sort'>
+                {(popupState) => (
+                  <>
+                    <Button
+                      color={activeView.fields.sortOptions?.length > 0 ? 'primary' : 'secondary'}
+                      variant='text'
+                      size='small'
+                      sx={{ minWidth: 0 }}
+                      {...bindTrigger(popupState)}
+                    >
+                      <FormattedMessage id='ViewHeader.sort' defaultMessage='Sort' />
+                    </Button>
+                    <Menu
+                      {...bindMenu(popupState)}
+                      disablePortal
+                      PaperProps={{
+                        sx: {
+                          overflow: 'visible'
+                        }
+                      }}
+                      anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'right'
+                      }}
+                      transformOrigin={{
+                        vertical: 'top',
+                        horizontal: 'right'
+                      }}
+                      onClick={() => popupState.close()}
+                    >
+                      <ViewHeaderSortMenu
+                        properties={activeBoard?.fields.cardProperties ?? []}
+                        activeView={activeView}
+                        orderedCards={cards}
+                      />
+                    </Menu>
+                  </>
+                )}
+              </PopupState>
             )}
           </>
         )}

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
@@ -1,6 +1,7 @@
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 import { Box, Menu, Popover, Tooltip } from '@mui/material';
-import PopupState, { bindTrigger, bindPopover, bindMenu } from 'material-ui-popup-state';
+import { bindTrigger, bindPopover, bindMenu } from 'material-ui-popup-state';
+import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useRouter } from 'next/router';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -55,6 +56,8 @@ function ViewHeader(props: Props) {
   const router = useRouter();
   const { pages, refreshPage } = usePages();
   const cardTemplates: Card[] = useAppSelector(getCurrentBoardTemplates);
+  const viewFilterPopup = usePopupState({ variant: 'popover', popupId: 'view-filter' });
+  const viewSortPopup = usePopupState({ variant: 'popover', popupId: 'view-sort' });
 
   const views = props.views.filter((view) => !view.fields.inline);
 
@@ -125,7 +128,10 @@ function ViewHeader(props: Props) {
 
       <div className='octo-spacer' />
 
-      <div className='view-actions'>
+      <Box
+        sx={{ opacity: viewSortPopup.isOpen || viewFilterPopup.isOpen ? '1!important' : 'initial!important' }}
+        className='view-actions'
+      >
         {!props.readOnly && activeView && (
           <>
             {/* Display by */}
@@ -139,80 +145,69 @@ function ViewHeader(props: Props) {
             )}
 
             {/* Filter */}
-
-            <PopupState variant='popover' popupId='view-filter'>
-              {(popupState) => (
-                <>
-                  <Button
-                    color={hasFilter ? 'primary' : 'secondary'}
-                    variant='text'
-                    size='small'
-                    sx={{ minWidth: 0 }}
-                    {...bindTrigger(popupState)}
-                  >
-                    <FormattedMessage id='ViewHeader.filter' defaultMessage='Filter' />
-                  </Button>
-                  <Popover
-                    {...bindPopover(popupState)}
-                    disablePortal
-                    PaperProps={{
-                      sx: {
-                        overflow: 'visible'
-                      }
-                    }}
-                    anchorOrigin={{
-                      vertical: 'bottom',
-                      horizontal: 'left'
-                    }}
-                  >
-                    <FilterComponent properties={activeBoard?.fields.cardProperties ?? []} activeView={activeView} />
-                  </Popover>
-                </>
-              )}
-            </PopupState>
+            <Button
+              color={hasFilter ? 'primary' : 'secondary'}
+              variant='text'
+              size='small'
+              sx={{ minWidth: 0 }}
+              {...bindTrigger(viewFilterPopup)}
+            >
+              <FormattedMessage id='ViewHeader.filter' defaultMessage='Filter' />
+            </Button>
+            <Popover
+              {...bindPopover(viewFilterPopup)}
+              disablePortal
+              PaperProps={{
+                sx: {
+                  overflow: 'visible'
+                }
+              }}
+              anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'left'
+              }}
+            >
+              <FilterComponent properties={activeBoard?.fields.cardProperties ?? []} activeView={activeView} />
+            </Popover>
 
             {/* Sort */}
 
             {withSortBy && (
-              <PopupState variant='popover' popupId='view-sort'>
-                {(popupState) => (
-                  <>
-                    <Button
-                      color={activeView.fields.sortOptions?.length > 0 ? 'primary' : 'secondary'}
-                      variant='text'
-                      size='small'
-                      sx={{ minWidth: 0 }}
-                      {...bindTrigger(popupState)}
-                    >
-                      <FormattedMessage id='ViewHeader.sort' defaultMessage='Sort' />
-                    </Button>
-                    <Menu
-                      {...bindMenu(popupState)}
-                      disablePortal
-                      PaperProps={{
-                        sx: {
-                          overflow: 'visible'
-                        }
-                      }}
-                      anchorOrigin={{
-                        vertical: 'bottom',
-                        horizontal: 'right'
-                      }}
-                      transformOrigin={{
-                        vertical: 'top',
-                        horizontal: 'right'
-                      }}
-                      onClick={() => popupState.close()}
-                    >
-                      <ViewHeaderSortMenu
-                        properties={activeBoard?.fields.cardProperties ?? []}
-                        activeView={activeView}
-                        orderedCards={cards}
-                      />
-                    </Menu>
-                  </>
-                )}
-              </PopupState>
+              <>
+                <Button
+                  color={activeView.fields.sortOptions?.length > 0 ? 'primary' : 'secondary'}
+                  variant='text'
+                  size='small'
+                  sx={{ minWidth: 0 }}
+                  {...bindTrigger(viewSortPopup)}
+                >
+                  <FormattedMessage id='ViewHeader.sort' defaultMessage='Sort' />
+                </Button>
+                <Menu
+                  {...bindMenu(viewSortPopup)}
+                  disablePortal
+                  PaperProps={{
+                    sx: {
+                      overflow: 'visible'
+                    }
+                  }}
+                  anchorOrigin={{
+                    vertical: 'bottom',
+                    horizontal: 'right'
+                  }}
+                  transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right'
+                  }}
+                  onClick={() => viewSortPopup.close()}
+                >
+                  <ViewHeaderSortMenu
+                    properties={activeBoard?.fields.cardProperties ?? []}
+                    activeView={activeView}
+                    orderedCards={cards}
+                  />
+                </Menu>
+              </>
             )}
           </>
         )}
@@ -251,7 +246,7 @@ function ViewHeader(props: Props) {
             )}
           </>
         )}
-      </div>
+      </Box>
     </div>
   );
 }

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderSortMenu.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderSortMenu.tsx
@@ -1,17 +1,14 @@
 import ArrowDownwardOutlinedIcon from '@mui/icons-material/ArrowDownwardOutlined';
 import ArrowUpwardOutlinedIcon from '@mui/icons-material/ArrowUpwardOutlined';
+import { Divider, ListItemIcon, ListItemText, MenuItem } from '@mui/material';
 import React, { useCallback } from 'react';
-import { FormattedMessage } from 'react-intl';
 
-import Button from 'components/common/Button';
 import type { IPropertyTemplate } from 'lib/focalboard/board';
 import type { BoardView, ISortOption } from 'lib/focalboard/boardView';
 import type { Card } from 'lib/focalboard/card';
 
 import { Constants } from '../../constants';
 import mutator from '../../mutator';
-import Menu from '../../widgets/menu';
-import MenuWrapper from '../../widgets/menuWrapper';
 
 type Props = {
   properties: readonly IPropertyTemplate[];
@@ -20,7 +17,6 @@ type Props = {
 };
 const ViewHeaderSortMenu = React.memo((props: Props) => {
   const { properties, activeView, orderedCards } = props;
-  const hasSort = activeView.fields.sortOptions?.length > 0;
   const sortDisplayOptions = properties?.map((o) => ({ id: o.id, name: o.name }));
   sortDisplayOptions?.unshift({ id: Constants.titleColumnId, name: 'Name' });
 
@@ -56,39 +52,39 @@ const ViewHeaderSortMenu = React.memo((props: Props) => {
   }, [activeView.id, activeView.fields.sortOptions]);
 
   return (
-    <MenuWrapper>
-      <Button color={hasSort ? 'primary' : 'secondary'} variant='text' size='small' sx={{ minWidth: 0 }}>
-        <FormattedMessage id='ViewHeader.sort' defaultMessage='Sort' />
-      </Button>
-      <Menu>
-        {activeView.fields.sortOptions?.length > 0 && (
-          <>
-            <Menu.Text id='manual' name='Manual' onClick={onManualSort} />
+    <>
+      {activeView.fields.sortOptions?.length > 0 && (
+        <>
+          <MenuItem id='manual' onClick={onManualSort}>
+            Manual
+          </MenuItem>
+          <MenuItem id='revert' onClick={onRevertSort}>
+            Revert
+          </MenuItem>
+          <Divider />
+        </>
+      )}
 
-            <Menu.Text id='revert' name='Revert' onClick={onRevertSort} />
-
-            <Menu.Separator />
-          </>
-        )}
-
-        {sortDisplayOptions?.map((option) => {
-          let rightIcon: JSX.Element | undefined;
-          if (activeView.fields.sortOptions?.length > 0) {
-            const sortOption = activeView.fields.sortOptions[0];
-            if (sortOption.propertyId === option.id) {
-              rightIcon = sortOption.reversed ? (
-                <ArrowDownwardOutlinedIcon fontSize='small' />
-              ) : (
-                <ArrowUpwardOutlinedIcon fontSize='small' />
-              );
-            }
+      {sortDisplayOptions?.map((option) => {
+        let rightIcon: JSX.Element | undefined;
+        if (activeView.fields.sortOptions?.length > 0) {
+          const sortOption = activeView.fields.sortOptions[0];
+          if (sortOption.propertyId === option.id) {
+            rightIcon = sortOption.reversed ? (
+              <ArrowDownwardOutlinedIcon fontSize='small' />
+            ) : (
+              <ArrowUpwardOutlinedIcon fontSize='small' />
+            );
           }
-          return (
-            <Menu.Text key={option.id} id={option.id} name={option.name} rightIcon={rightIcon} onClick={sortChanged} />
-          );
-        })}
-      </Menu>
-    </MenuWrapper>
+        }
+        return (
+          <MenuItem key={option.id} id={option.id} onClick={() => sortChanged(option.id)}>
+            <ListItemText>{option.name}</ListItemText>
+            <ListItemIcon>{rightIcon}</ListItemIcon>
+          </MenuItem>
+        );
+      })}
+    </>
   );
 });
 

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/switchOption.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/switchOption.tsx
@@ -23,7 +23,7 @@ function SwitchOption(props: SwitchOptionProps): JSX.Element {
         props.onClick(props.id);
       }}
     >
-      {icon ?? <div className='noicon' />}
+      {icon && <div className='noicon' />}
       <div className='menu-name'>{name}</div>
       <Switch isOn={isOn} onChanged={() => {}} />
     </div>


### PR DESCRIPTION
+ Redone sort&filter dropdown
+ fix a warning in styled prop

To test: databases and inline databases & other types if exist
*The behaviour should be the same.

I just added mui because of the popover instead of a dropdown that can't be on top of an overflowed table