### PR TITLE
Guest security improvements

### DIFF
--- a/components/bounties/BountiesPage.tsx
+++ b/components/bounties/BountiesPage.tsx
@@ -21,7 +21,7 @@ import { isTruthy } from 'lib/utilities/types';
 import BountiesKanbanView from './components/BountiesKanbanView';
 import BountiesGalleryView from './components/BountyGalleryView';
 import MultiPaymentModal from './components/MultiPaymentModal';
-import NewBountyButton from './components/NewBountyButton';
+import { NewBountyButton } from './components/NewBountyButton';
 
 const bountyStatuses: BountyStatus[] = ['open', 'inProgress', 'complete', 'paid', 'suggestion'];
 

--- a/components/bounties/components/NewBountyButton.tsx
+++ b/components/bounties/components/NewBountyButton.tsx
@@ -10,7 +10,7 @@ import { usePages } from 'hooks/usePages';
 import { useUser } from 'hooks/useUser';
 import type { BountyWithDetails } from 'lib/bounties';
 
-export default function NewBountyButton() {
+export function NewBountyButton() {
   const { user } = useUser();
   const router = useRouter();
   const currentSpace = useCurrentSpace();

--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -22,6 +22,7 @@ import { SpaceSettingsDialog } from 'components/common/Modal/SettingsDialog';
 import { charmverseDiscordInvite } from 'config/constants';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
+import { useForumCategories } from 'hooks/useForumCategories';
 import { useHasMemberLevel } from 'hooks/useHasMemberLevel';
 import useKeydownPress from 'hooks/useKeydownPress';
 import { useSmallScreen } from 'hooks/useMediaScreens';
@@ -134,6 +135,7 @@ export default function Sidebar({ closeSidebar, favorites, navAction }: SidebarP
   const router = useRouter();
   const { user, logoutUser } = useUser();
   const space = useCurrentSpace();
+  const { categories } = useForumCategories();
   const [userSpacePermissions] = useCurrentSpacePermissions();
   const [isScrolled, setIsScrolled] = useState(false);
   const [showingTrash, setShowingTrash] = useState(false);
@@ -270,51 +272,49 @@ export default function Sidebar({ closeSidebar, favorites, navAction }: SidebarP
               )}
               <Divider sx={{ mx: 2, my: 1 }} />
 
-              {showMemberFeatures && (
-                <>
-                  {!space.hiddenFeatures.includes('member_directory') && (
-                    <SidebarLink
-                      href={`/${space.domain}/members`}
-                      active={router.pathname.startsWith('/[domain]/members')}
-                      icon={<AccountCircleIcon fontSize='small' />}
-                      label='Member Directory'
-                      onClick={navAction}
-                    />
-                  )}
-
-                  {!space.hiddenFeatures.includes('proposals') && (
-                    <SidebarLink
-                      data-test='sidebar-link-proposals'
-                      href={`/${space.domain}/proposals`}
-                      active={router.pathname.startsWith('/[domain]/proposals')}
-                      icon={<TaskOutlinedIcon fontSize='small' />}
-                      label='Proposals'
-                      onClick={navAction}
-                    />
-                  )}
-
-                  {!space.hiddenFeatures.includes('bounties') && (
-                    <SidebarLink
-                      href={`/${space.domain}/bounties`}
-                      active={router.pathname.startsWith('/[domain]/bounties')}
-                      icon={<BountyIcon fontSize='small' />}
-                      label='Bounties'
-                      onClick={navAction}
-                    />
-                  )}
-
-                  {!space.hiddenFeatures.includes('forum') && (
-                    <SidebarLink
-                      href={`/${space.domain}/forum`}
-                      data-test='sidebar-link-forum'
-                      active={router.pathname.startsWith('/[domain]/forum')}
-                      icon={<MessageOutlinedIcon fontSize='small' />}
-                      label='Forum'
-                      onClick={navAction}
-                    />
-                  )}
-                </>
+              {!space.hiddenFeatures.includes('member_directory') && showMemberFeatures && (
+                <SidebarLink
+                  href={`/${space.domain}/members`}
+                  active={router.pathname.startsWith('/[domain]/members')}
+                  icon={<AccountCircleIcon fontSize='small' />}
+                  label='Member Directory'
+                  onClick={navAction}
+                />
               )}
+
+              {!space.hiddenFeatures.includes('proposals') && showMemberFeatures && (
+                <SidebarLink
+                  data-test='sidebar-link-proposals'
+                  href={`/${space.domain}/proposals`}
+                  active={router.pathname.startsWith('/[domain]/proposals')}
+                  icon={<TaskOutlinedIcon fontSize='small' />}
+                  label='Proposals'
+                  onClick={navAction}
+                />
+              )}
+
+              {!space.hiddenFeatures.includes('bounties') && showMemberFeatures && (
+                <SidebarLink
+                  href={`/${space.domain}/bounties`}
+                  active={router.pathname.startsWith('/[domain]/bounties')}
+                  icon={<BountyIcon fontSize='small' />}
+                  label='Bounties'
+                  onClick={navAction}
+                />
+              )}
+
+              {!space.hiddenFeatures.includes('forum') &&
+                // Always show forum to space members. Show it to guests if they have access to at least 1 category
+                (showMemberFeatures || categories.length > 0) && (
+                  <SidebarLink
+                    href={`/${space.domain}/forum`}
+                    data-test='sidebar-link-forum'
+                    active={router.pathname.startsWith('/[domain]/forum')}
+                    icon={<MessageOutlinedIcon fontSize='small' />}
+                    label='Forum'
+                    onClick={navAction}
+                  />
+                )}
             </Box>
             {isMobile ? (
               <div>{pagesNavigation}</div>

--- a/components/members/MemberDirectoryPage.tsx
+++ b/components/members/MemberDirectoryPage.tsx
@@ -6,7 +6,9 @@ import { useState } from 'react';
 
 import { iconForViewType } from 'components/common/BoardEditor/focalboard/src/components/viewMenu';
 import Button from 'components/common/Button';
+import ErrorPage from 'components/common/errors/ErrorPage';
 import { CenteredPageContent } from 'components/common/PageLayout/components/PageContent';
+import { useHasMemberLevel } from 'hooks/useHasMemberLevel';
 import { useMembers } from 'hooks/useMembers';
 import type { Member } from 'lib/members/interfaces';
 import { setUrlWithoutRerender } from 'lib/utilities/browser';
@@ -39,9 +41,15 @@ export default function MemberDirectoryPage() {
   const [currentView, setCurrentView] = useState<View>((router.query.view as View) ?? 'gallery');
   const [isPropertiesDrawerVisible, setIsPropertiesDrawerVisible] = useState(false);
 
+  const showDirectory = useHasMemberLevel('member');
+
   const sortedMembers = searchedMembers.sort((mem1, mem2) =>
     memberNamePropertyValue(mem1) > memberNamePropertyValue(mem2) ? 1 : -1
   );
+
+  if (!showDirectory) {
+    return <ErrorPage message='Guests cannot access the member directory' />;
+  }
 
   return (
     <CenteredPageContent>

--- a/components/proposals/ProposalsPage.tsx
+++ b/components/proposals/ProposalsPage.tsx
@@ -4,6 +4,7 @@ import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import { EmptyStateVideo } from 'components/common/EmptyStateVideo';
+import ErrorPage from 'components/common/errors/ErrorPage';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { PageDialogProvider } from 'components/common/PageDialog/hooks/usePageDialog';
 import PageDialogGlobalModal from 'components/common/PageDialog/PageDialogGlobal';
@@ -12,6 +13,7 @@ import { useProposalCategories } from 'components/proposals/hooks/useProposalCat
 import { useProposalSortAndFilters } from 'components/proposals/hooks/useProposalSortAndFilters';
 import { NewProposalButton } from 'components/votes/components/NewProposalButton';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import { useHasMemberLevel } from 'hooks/useHasMemberLevel';
 
 import ProposalsTable from './components/ProposalsTable';
 import { ProposalsViewOptions } from './components/ProposalsViewOptions';
@@ -42,6 +44,12 @@ export function ProposalsPage() {
   }, []);
 
   const loadingData = !data;
+
+  const canSeeProposals = useHasMemberLevel('member');
+
+  if (!canSeeProposals) {
+    return <ErrorPage message='Guests cannot access proposals' />;
+  }
 
   return (
     <CenteredPageContent>

--- a/hooks/useForumCategories.tsx
+++ b/hooks/useForumCategories.tsx
@@ -4,6 +4,7 @@ import { useContext, createContext, useMemo } from 'react';
 import useSWR from 'swr';
 
 import charmClient from 'charmClient';
+import type { PostCategoryWithPermissions } from 'lib/permissions/forum/interfaces';
 
 import { useCurrentSpace } from './useCurrentSpace';
 import { useSpaces } from './useSpaces';
@@ -11,12 +12,12 @@ import { useSpaces } from './useSpaces';
 type IContext = {
   createForumCategory: (categoryName: string) => Promise<void>;
   deleteForumCategory: (option: PostCategory) => Promise<void>;
-  updateForumCategory: (option: PostCategory) => Promise<PostCategory | undefined>;
+  updateForumCategory: (option: PostCategory) => Promise<PostCategoryWithPermissions | undefined>;
   setDefaultPostCategory: (option: PostCategory) => Promise<void>;
-  getForumCategoryById: (id: string) => PostCategory | undefined;
-  getPostableCategories: () => PostCategory[];
+  getForumCategoryById: (id: string) => PostCategoryWithPermissions | undefined;
+  getPostableCategories: () => PostCategoryWithPermissions[];
   isCategoriesLoaded: boolean;
-  categories: PostCategory[];
+  categories: PostCategoryWithPermissions[];
   error: any;
   disabled: boolean;
 };

--- a/lib/permissions/forum/__tests__/filterAccessiblePostCategories.spec.ts
+++ b/lib/permissions/forum/__tests__/filterAccessiblePostCategories.spec.ts
@@ -133,20 +133,41 @@ describe('filterAccessiblePostCategories', () => {
     expect(visibleCategories).toContainEqual({ ...publicCategory, permissions: moderatorPermissionFlags });
   });
 
-  it('returns only categories accessible to the public if there is no user, or user is not a space member, and create_post set to false', async () => {
+  it('returns only categories accessible to the public if there is no user', async () => {
     const permissions = new AvailablePostCategoryPermissions().empty;
 
-    let visibleCategories = await filterAccessiblePostCategories({
+    const visibleCategories = await filterAccessiblePostCategories({
+      postCategories,
+      userId: undefined
+    });
+
+    expect(visibleCategories.length).toBe(1);
+    expect(visibleCategories).toContainEqual({ ...publicCategory, permissions });
+  });
+
+  it('returns only categories accessible to the public if user is not a space member', async () => {
+    const permissions = new AvailablePostCategoryPermissions().empty;
+
+    const visibleCategories = await filterAccessiblePostCategories({
       postCategories,
       userId: otherSpaceAdminUser.id
     });
 
     expect(visibleCategories.length).toBe(1);
     expect(visibleCategories).toContainEqual({ ...publicCategory, permissions });
+  });
 
-    visibleCategories = await filterAccessiblePostCategories({
+  it('returns only categories accessible to the public if user is a guest of the space', async () => {
+    const guestUser = await generateSpaceUser({
+      spaceId: space.id,
+      isGuest: true
+    });
+
+    const permissions = new AvailablePostCategoryPermissions().empty;
+
+    const visibleCategories = await filterAccessiblePostCategories({
       postCategories,
-      userId: undefined
+      userId: guestUser.id
     });
 
     expect(visibleCategories.length).toBe(1);

--- a/lib/permissions/forum/computePostCategoryPermissions.ts
+++ b/lib/permissions/forum/computePostCategoryPermissions.ts
@@ -29,7 +29,8 @@ export async function computePostCategoryPermissions({
 
   const { error, isAdmin } = await hasAccessToSpace({
     spaceId: postCategory.spaceId,
-    userId
+    userId,
+    disallowGuest: true
   });
 
   const permissions = new AvailablePostCategoryPermissions();

--- a/lib/permissions/forum/computePostPermissions.ts
+++ b/lib/permissions/forum/computePostPermissions.ts
@@ -39,7 +39,9 @@ export async function baseComputePostPermissions({
 
   const { error, isAdmin } = await hasAccessToSpace({
     spaceId: post.spaceId,
-    userId
+    userId,
+    // Provide guest same permission level as public
+    disallowGuest: true
   });
 
   const permissions = new AvailablePostPermissions();

--- a/lib/permissions/forum/filterAccessiblePostCategories.ts
+++ b/lib/permissions/forum/filterAccessiblePostCategories.ts
@@ -34,7 +34,8 @@ export async function filterAccessiblePostCategories({
 
   const { error, isAdmin, spaceRole } = await hasAccessToSpace({
     spaceId,
-    userId
+    userId,
+    disallowGuest: true
   });
 
   if (isAdmin) {

--- a/lib/permissions/proposals/computeProposalCategoryPermissions.ts
+++ b/lib/permissions/proposals/computeProposalCategoryPermissions.ts
@@ -28,7 +28,8 @@ export async function computeProposalCategoryPermissions({
 
   const { error, isAdmin } = await hasAccessToSpace({
     spaceId: proposalCategory.spaceId,
-    userId
+    userId,
+    disallowGuest: true
   });
 
   const permissions = new AvailableProposalCategoryPermissions();

--- a/lib/permissions/proposals/computeProposalPermissions/computeProposalPermissions.ts
+++ b/lib/permissions/proposals/computeProposalPermissions/computeProposalPermissions.ts
@@ -50,7 +50,8 @@ export async function baseComputeProposalPermissions({
 
   const { error, isAdmin } = await hasAccessToSpace({
     spaceId: proposal.spaceId,
-    userId
+    userId,
+    disallowGuest: true
   });
 
   const permissions = new AvailableProposalPermissions();

--- a/lib/users/errors.ts
+++ b/lib/users/errors.ts
@@ -19,3 +19,13 @@ export class UserIsNotSpaceMemberError extends SystemError {
     });
   }
 }
+
+export class UserIsGuestError extends SystemError {
+  constructor() {
+    super({
+      errorType: 'Access denied',
+      message: 'User is only a guest within this space',
+      severity: 'warning'
+    });
+  }
+}

--- a/pages/[domain]/bounties/index.tsx
+++ b/pages/[domain]/bounties/index.tsx
@@ -2,7 +2,7 @@ import BountiesPage from 'components/bounties/BountiesPage';
 import LoadingComponent from 'components/common/LoadingComponent';
 import getPageLayout from 'components/common/PageLayout/getLayout';
 import { useBounties } from 'hooks/useBounties';
-import { useIsSpaceMember } from 'hooks/useIsSpaceMember';
+import { useHasMemberLevel } from 'hooks/useHasMemberLevel';
 import { setTitle } from 'hooks/usePageTitle';
 import { useSharedPage } from 'hooks/useSharedPage';
 
@@ -10,7 +10,7 @@ export default function BountyPage() {
   const { bounties, loadingBounties } = useBounties();
   const { accessChecked } = useSharedPage();
 
-  const { isSpaceMember } = useIsSpaceMember();
+  const isSpaceMember = useHasMemberLevel('member');
 
   setTitle('Bounties');
   if (loadingBounties || !bounties || !accessChecked) {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -34,6 +34,7 @@ import { ColorModeContext } from 'context/darkMode';
 import { BountiesProvider } from 'hooks/useBounties';
 import { CurrentSpaceProvider } from 'hooks/useCurrentSpaceId';
 import { DiscordProvider } from 'hooks/useDiscordConnection';
+import { PostCategoriesProvider } from 'hooks/useForumCategories';
 import { useInterval } from 'hooks/useInterval';
 import { IsSpaceMemberProvider } from 'hooks/useIsSpaceMember';
 import { useLocalStorage } from 'hooks/useLocalStorage';
@@ -273,21 +274,23 @@ function DataProviders({ children }: { children: ReactNode }) {
                 <SpacesProvider>
                   <CurrentSpaceProvider>
                     <CurrentSpaceSetter />
-                    <IsSpaceMemberProvider>
-                      <WebSocketClientProvider>
-                        <MembersProvider>
-                          <BountiesProvider>
-                            <PaymentMethodsProvider>
-                              <PagesProvider>
-                                <MemberProfileProvider>
-                                  <PageTitleProvider>{children}</PageTitleProvider>
-                                </MemberProfileProvider>
-                              </PagesProvider>
-                            </PaymentMethodsProvider>
-                          </BountiesProvider>
-                        </MembersProvider>
-                      </WebSocketClientProvider>
-                    </IsSpaceMemberProvider>
+                    <PostCategoriesProvider>
+                      <IsSpaceMemberProvider>
+                        <WebSocketClientProvider>
+                          <MembersProvider>
+                            <BountiesProvider>
+                              <PaymentMethodsProvider>
+                                <PagesProvider>
+                                  <MemberProfileProvider>
+                                    <PageTitleProvider>{children}</PageTitleProvider>
+                                  </MemberProfileProvider>
+                                </PagesProvider>
+                              </PaymentMethodsProvider>
+                            </BountiesProvider>
+                          </MembersProvider>
+                        </WebSocketClientProvider>
+                      </IsSpaceMemberProvider>
+                    </PostCategoriesProvider>
                   </CurrentSpaceProvider>
                 </SpacesProvider>
               </Web3AccountProvider>

--- a/pages/api/bounties/index.ts
+++ b/pages/api/bounties/index.ts
@@ -4,7 +4,6 @@ import nc from 'next-connect';
 
 import type { BountyCreationData, BountyWithDetails } from 'lib/bounties';
 import { createBounty, listAvailableBounties } from 'lib/bounties';
-import log from 'lib/log';
 import { trackUserAction } from 'lib/metrics/mixpanel/trackUserAction';
 import { logUserFirstBountyEvents, logWorkspaceFirstBountyEvents } from 'lib/metrics/postToDiscord';
 import { onError, onNoMatch, requireUser } from 'lib/middleware';
@@ -42,7 +41,8 @@ async function createBountyController(req: NextApiRequest, res: NextApiResponse<
     const { error } = await hasAccessToSpace({
       spaceId,
       userId,
-      adminOnly: false
+      adminOnly: false,
+      disallowGuest: true
     });
 
     if (error) {


### PR DESCRIPTION
**Forums**
- Only show public forum categories to guest user
- Show forum link in sidebar if there is at least 1 public category (and the feature is enabled)
- Treat guests as members of public with regards to permissions (ie. read only, and only take into account public permissions for computing rights)

**Member Directory**
- Show error if user tries to navigate here

**Bounties**
- Prevent guest from creating bounties (they can still see public bounties)

**Proposals**
- Show error if user tries to navigate here
- Lock down proposal permissions for guest users (at most they can view individual public proposals, but not see the list)
