### PR TITLE
Do not refresh posts list when new posts banner is opened

### DIFF
--- a/components/forum/components/PostList/PostList.tsx
+++ b/components/forum/components/PostList/PostList.tsx
@@ -66,7 +66,8 @@ export function ForumPostList({ search, categoryId, sort }: ForumPostsProps) {
         count: resultsPerQuery,
         page: args.arguments.page,
         sort: args.arguments.sort
-      })
+      }),
+    { revalidateOnFocus: !morePostsAvailable }
   );
 
   const {
@@ -191,7 +192,6 @@ export function ForumPostList({ search, categoryId, sort }: ForumPostsProps) {
       <Stack spacing={2} sx={{ width: '100%', position: 'fixed', zIndex: 5000 }}>
         <Snackbar
           open={morePostsAvailable && !search}
-          autoHideDuration={10000}
           anchorOrigin={{
             horizontal: 'center',
             vertical: 'top'


### PR DESCRIPTION
https://app.charmverse.io/charmverse/page-46571373385070425

Issue was caused by refreshing data on focus