### PR TITLE
follow guidelines for google sign-in

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/GoogleDataSource/GoogleDataSource.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/GoogleDataSource/GoogleDataSource.tsx
@@ -44,7 +44,7 @@ export function GoogleDataSource(props: Props) {
     return (
       <>
         <Script src={googleIdentityServiceScript} onReady={onLoadScript} />
-        <ConnectButton onClick={() => loginWithGoogle()} label='Connect Google Account' />
+        <ConnectButton onClick={() => loginWithGoogle()} />
         <ListItem>
           <Typography variant='caption'>Find and embed your Google forms</Typography>
         </ListItem>
@@ -97,20 +97,15 @@ function GoogleAuthWarning() {
   );
 }
 
-function ConnectButton({
-  label = 'Connect Google Account',
-  onClick
-}: {
-  label?: string;
-  onClick?: MouseEventHandler<HTMLLIElement>;
-}) {
+function ConnectButton({ onClick }: { onClick?: MouseEventHandler<HTMLLIElement> }) {
   return (
     <MenuItem onClick={onClick}>
       <ListItemIcon>
         <FcGoogle fontSize='large' />
       </ListItemIcon>
       <Typography color='primary' variant='body2' fontWeight='bold'>
-        {label}
+        {/* {label} */}
+        Sign-in with Google
       </Typography>
     </MenuItem>
   );
@@ -145,7 +140,7 @@ function GoogleFormSelect({
     if (error.status === 401) {
       return (
         <>
-          <ConnectButton label='Reconnect Account' onClick={() => loginWithGoogle({ hint: credential.name })} />
+          <ConnectButton onClick={() => loginWithGoogle({ hint: credential.name })} />
           <ListItem>
             <Box display='flex' gap={2} justifyContent='center'>
               <ReportProblemIcon sx={{ color: 'var(--danger-text)' }} fontSize='small' />


### PR DESCRIPTION
Google said we dont follow sign-in guidelines. We do include the logo, so I think they didn't like that it says "Reconnect accounts" in our demo video - not telling the user they are signing in again with Google. Guidelines: https://developers.google.com/identity/branding-guidelines?hl=en#g+signin-social-scopes

<img width="287" alt="image" src="https://user-images.githubusercontent.com/305398/226841691-b7b1713d-fd1a-4202-a849-38a72c9dcb21.png">


https://app.charmverse.io/charmverse/page-49366552253645923?viewId=2c9d8701-33ff-4c3a-942a-6d403a638565&cardId=1a3c7596-6b8d-45d1-ad03-867b308932a8