### PR TITLE
Remove duplicate loader from login page

### DIFF
--- a/pages/authenticate.tsx
+++ b/pages/authenticate.tsx
@@ -71,7 +71,6 @@ export default function Authenticate() {
 
   return getLayout(
     <Box height='100%' display='flex' flexDirection='column'>
-      {isAuthenticating && <LoadingComponent label='Logging you in' />}
       <LoginPageContent hideLoginOptions isLoggingIn={isAuthenticating} />
 
       <CollectEmailDialog


### PR DESCRIPTION
I noticed a duplicate loader in the authenticate page we use for logging you in via email.

Removed it, probably added after a bad merge