### PR TITLE
Allow admin to edit proposal when it is in reviewed status

### DIFF
--- a/lib/permissions/proposals/computeProposalPermissions/__tests__/computeProposalPermissions.spec.ts
+++ b/lib/permissions/proposals/computeProposalPermissions/__tests__/computeProposalPermissions.spec.ts
@@ -1,4 +1,4 @@
-import type { ProposalCategory, ProposalOperation, ProposalStatus, Role, Space, User } from '@prisma/client';
+import type { ProposalCategory, ProposalStatus, Role, Space, User } from '@prisma/client';
 import { v4 } from 'uuid';
 
 import { prisma } from 'db';
@@ -7,11 +7,8 @@ import type { ProposalWithUsers } from 'lib/proposal/interface';
 import { InvalidInputError } from 'lib/utilities/errors';
 import { generateRole, generateSpaceUser, generateUserAndSpace } from 'testing/setupDatabase';
 import { generateProposal, generateProposalCategory } from 'testing/utils/proposals';
-import { generateUser } from 'testing/utils/users';
 
 import type { AvailableProposalPermissionFlags } from '../../interfaces';
-import { proposalOperations } from '../../interfaces';
-import { proposalPermissionsMapping } from '../../mapping';
 import { upsertProposalCategoryPermission } from '../../upsertProposalCategoryPermission';
 import { computeProposalPermissions } from '../computeProposalPermissions';
 
@@ -148,7 +145,7 @@ describe('computeProposalPermissions', () => {
     });
   });
 
-  it('should allow the admin to always see proposals, but only edit the proposal during the discussion and review stages', async () => {
+  it('should allow the admin to always see proposals, but only edit the proposal during the discussion, review and reviewed stages', async () => {
     const testedProposal = await generateProposal({
       spaceId: space.id,
       categoryId: proposalCategory.id,
@@ -170,7 +167,7 @@ describe('computeProposalPermissions', () => {
 
     expect(permissions.edit).toBe(false);
 
-    const editableStatuses: ProposalStatus[] = ['discussion', 'review'];
+    const editableStatuses: ProposalStatus[] = ['discussion', 'review', 'reviewed'];
 
     for (const status of editableStatuses) {
       await prisma.proposal.update({ where: { id: testedProposal.id }, data: { status } });
@@ -183,7 +180,7 @@ describe('computeProposalPermissions', () => {
       expect(permissionsAtStage.view).toBe(true);
     }
 
-    const readonlyStatuses: ProposalStatus[] = ['reviewed', 'vote_active', 'vote_closed'];
+    const readonlyStatuses: ProposalStatus[] = ['vote_active', 'vote_closed'];
 
     for (const status of readonlyStatuses) {
       await prisma.proposal.update({ where: { id: testedProposal.id }, data: { status } });

--- a/lib/permissions/proposals/computeProposalPermissions/__tests__/policyStatusReviewedOnlyCreateVote.spec.ts
+++ b/lib/permissions/proposals/computeProposalPermissions/__tests__/policyStatusReviewedOnlyCreateVote.spec.ts
@@ -88,7 +88,7 @@ describe('policyStatusReviewedOnlyCreateVote', () => {
     });
   });
 
-  it('should allow the admin to view, delete, create_vote and make public', async () => {
+  it('should allow the admin to view, delete, edit, create_vote and make public', async () => {
     const permissions = await policyStatusReviewedOnlyCreateVote({
       flags: fullPermissions,
       isAdmin: true,
@@ -101,7 +101,7 @@ describe('policyStatusReviewedOnlyCreateVote', () => {
       delete: true,
       create_vote: true,
       make_public: true,
-      edit: false,
+      edit: true,
       review: false,
       comment: false,
       vote: false

--- a/lib/permissions/proposals/computeProposalPermissions/policyStatusReviewedOnlyCreateVote.ts
+++ b/lib/permissions/proposals/computeProposalPermissions/policyStatusReviewedOnlyCreateVote.ts
@@ -21,10 +21,18 @@ export async function policyStatusReviewedOnlyCreateVote({
   }
 
   const allowedAuthorOperations: ProposalOperation[] = ['view', 'create_vote', 'delete', 'make_public'];
+  const allowedAdminOperations: ProposalOperation[] = [...allowedAuthorOperations, 'edit'];
 
-  if (isProposalAuthor({ proposal: resource, userId }) || isAdmin) {
+  if (isProposalAuthor({ proposal: resource, userId })) {
     typedKeys(flags).forEach((flag) => {
       if (!allowedAuthorOperations.includes(flag)) {
+        newPermissions[flag] = false;
+      }
+    });
+    return newPermissions;
+  } else if (isAdmin) {
+    typedKeys(flags).forEach((flag) => {
+      if (!allowedAdminOperations.includes(flag)) {
         newPermissions[flag] = false;
       }
     });


### PR DESCRIPTION
Small fix, Admin can now edit proposal when in reviewed status (but not after). Confirmed with product team