### PR TITLE
Enable removing users from spaces

### DIFF
--- a/lib/token-gates/__tests__/verifyTokenGateMembership.spec.ts
+++ b/lib/token-gates/__tests__/verifyTokenGateMembership.spec.ts
@@ -116,7 +116,7 @@ describe('verifyTokenGateMembership', () => {
     expect(verifyUser.user.userTokenGates.length).toBe(1);
     expect(verifyUser.user.userTokenGates[0].tokenGate).toBeNull();
     expect(res).toEqual({ removedRoles: 0, verified: false });
-    expect(spaceUser).not.toBeNull();
+    expect(spaceUser).toBeNull();
   });
 
   it('should not verify and remove user with all token gates being not verified', async () => {
@@ -169,7 +169,7 @@ describe('verifyTokenGateMembership', () => {
     const spaceUser = await getSpaceUser();
     expect(verifyUser.user.userTokenGates.length).toBe(2);
     expect(res).toEqual({ removedRoles: 0, verified: false });
-    expect(spaceUser).not.toBeNull();
+    expect(spaceUser).toBeNull();
   });
 
   it('should verify user with at least one valid token gate', async () => {
@@ -296,7 +296,7 @@ describe('verifyTokenGateMembership', () => {
     expect(verifyUser.spaceRoleToRole.length).toBe(2);
     expect(res).toEqual({ removedRoles: 2, verified: true });
     expect(spaceUser).not.toBeNull();
-    expect(spaceUser?.spaceRoleToRole.length).toBe(2);
+    expect(spaceUser?.spaceRoleToRole.length).toBe(0);
   });
 
   it('should remove roles assigned via deleted token gate', async () => {
@@ -367,8 +367,8 @@ describe('verifyTokenGateMembership', () => {
     expect(verifyUser.spaceRoleToRole.length).toBe(2);
     expect(res).toEqual({ removedRoles: 1, verified: true });
     expect(spaceUser).not.toBeNull();
-    expect(spaceUser?.spaceRoleToRole.length).toBe(2);
-    // expect(spaceUser?.spaceRoleToRole[0].roleId).toBe(role2.id);
+    expect(spaceUser?.spaceRoleToRole.length).toBe(1);
+    expect(spaceUser?.spaceRoleToRole[0].roleId).toBe(role2.id);
   });
 
   it('should not remove role assigned via at least one valid token gate', async () => {
@@ -445,17 +445,15 @@ describe('verifyTokenGateMembership', () => {
     expect(verifyUser.spaceRoleToRole.length).toBe(3);
     expect(res).toEqual({ removedRoles: 1, verified: true });
     expect(spaceUser).not.toBeNull();
-    expect(spaceUser?.spaceRoleToRole.length).toBe(3);
-    // expect(spaceUser?.spaceRoleToRole).toEqual(
-    //   expect.arrayContaining([
-    //     expect.objectContaining({ roleId: role2.id }),
-    //     expect.objectContaining({ roleId: role3.id })
-    //   ])
-    // );
-    // expect(spaceUser?.spaceRoleToRole).toEqual(
-    //   expect.not.arrayContaining([
-    //     expect.objectContaining({ roleId: role.id })
-    //   ])
-    // );
+    expect(spaceUser?.spaceRoleToRole.length).toBe(2);
+    expect(spaceUser?.spaceRoleToRole).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ roleId: role2.id }),
+        expect.objectContaining({ roleId: role3.id })
+      ])
+    );
+    expect(spaceUser?.spaceRoleToRole).toEqual(
+      expect.not.arrayContaining([expect.objectContaining({ roleId: role.id })])
+    );
   });
 });

--- a/lib/token-gates/verifyTokenGateMembership.ts
+++ b/lib/token-gates/verifyTokenGateMembership.ts
@@ -1,6 +1,8 @@
 import type { Role, SpaceRoleToRole, TokenGate, TokenGateToRole, UserTokenGate } from '@prisma/client';
 import * as lit from 'lit-js-sdk';
 
+import { prisma } from 'db';
+
 type TokenGateWithRoles = {
   tokenGate:
     | (TokenGate & {
@@ -76,15 +78,14 @@ export async function verifyTokenGateMembership({
 
   // All token gates are invalid and user did not join via invite link soo he should be removed from space
   if (invalidTokenGates.length === userTokenGates.length && canBeRemovedFromSpace) {
-    // TEMP - run in test mode
-    // await prisma.spaceRole.delete({
-    //   where: {
-    //     spaceUser: {
-    //       userId,
-    //       spaceId
-    //     }
-    //   }
-    // });
+    await prisma.spaceRole.delete({
+      where: {
+        spaceUser: {
+          userId,
+          spaceId
+        }
+      }
+    });
 
     return { verified: false, removedRoles: 0 };
   }
@@ -93,12 +94,11 @@ export async function verifyTokenGateMembership({
 }
 
 async function removeUserRoles(spaceRoleToRoleIds: string[]) {
-  // TEMP - run in test mode
-  // return prisma.spaceRoleToRole.deleteMany({
-  //   where: {
-  //     id: {
-  //       in: spaceRoleToRoleIds
-  //     }
-  //   }
-  // });
+  return prisma.spaceRoleToRole.deleteMany({
+    where: {
+      id: {
+        in: spaceRoleToRoleIds
+      }
+    }
+  });
 }

--- a/lib/token-gates/verifyUserTokenGateMemberships.ts
+++ b/lib/token-gates/verifyUserTokenGateMemberships.ts
@@ -1,0 +1,65 @@
+import { prisma } from 'db';
+import { verifyTokenGateMembership } from 'lib/token-gates/verifyTokenGateMembership';
+
+export async function verifyUserTokenGateMemberships(userId: string) {
+  // user can have more than one space role to be verified
+  const membershipWithTokenGates = await prisma.spaceRole.findMany({
+    where: {
+      // We do not want to delete admins
+      isAdmin: false,
+      user: {
+        id: userId,
+        userTokenGates: {
+          some: {}
+        }
+      }
+    },
+    include: {
+      user: {
+        include: {
+          userTokenGates: {
+            include: {
+              tokenGate: {
+                include: {
+                  tokenGateToRoles: {
+                    include: {
+                      role: true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      spaceRoleToRole: {
+        include: {
+          role: true
+        }
+      }
+    }
+  });
+
+  let removedFromSpacesCount = 0;
+  let removedRoles = 0;
+
+  for (const spaceRole of membershipWithTokenGates) {
+    const res = await verifyTokenGateMembership({
+      userTokenGates: spaceRole.user.userTokenGates,
+      userId: spaceRole.user.id,
+      spaceId: spaceRole.spaceId,
+      userSpaceRoles: spaceRole.spaceRoleToRole,
+      canBeRemovedFromSpace: !spaceRole.joinedViaLink
+    });
+
+    removedRoles += res.removedRoles;
+    if (!res.verified) {
+      removedFromSpacesCount += 1;
+    }
+  }
+
+  return {
+    removedRoles,
+    removedFromSpacesCount
+  };
+}


### PR DESCRIPTION
- enable removing users from spaces when token gates are not valid anymore
- additional method to check single user membership `verifyUserTokenGateMemberships` - @valentinludu  you can use it when disconnecting a wallet.