### PR TITLE
Focalboard ui bug fixes

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
@@ -69,6 +69,11 @@ function UserProperty(props: Props): JSX.Element | null {
   }, {});
 
   const [isOpen, setIsOpen] = useState(false);
+
+  if (props.readOnly && memberIds.length === 0) {
+    return null;
+  }
+
   return (
     <StyledUserPropertyContainer
       onClick={() => {

--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewPropertyOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewPropertyOptions.tsx
@@ -164,7 +164,7 @@ function PropertyOptions(props: LayoutOptionsProps) {
       {Object.keys(visibleProperties).length ? (
         <Stack gap={0.5}>
           <Stack alignItems='center' ml={2} mr={1} justifyContent='space-between' flexDirection='row'>
-            <Typography variant='subtitle2'>Shown in table</Typography>
+            <Typography variant='subtitle2'>Shown in {view.fields.viewType}</Typography>
             <Button size='small' variant='text' onClick={hideAllProperties}>
               <Typography color='primary' variant='subtitle1'>
                 Hide all
@@ -189,7 +189,7 @@ function PropertyOptions(props: LayoutOptionsProps) {
       {Object.keys(hiddenProperties).length ? (
         <Stack gap={0.5}>
           <Stack alignItems='center' ml={2} mr={1} justifyContent='space-between' flexDirection='row'>
-            <Typography variant='subtitle2'>Hidden in table</Typography>
+            <Typography variant='subtitle2'>Hidden in {view.fields.viewType}</Typography>
             <Button size='small' variant='text' onClick={showAllProperties}>
               <Typography color='primary' variant='subtitle1'>
                 Show all

--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewPropertyOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewPropertyOptions.tsx
@@ -19,6 +19,13 @@ interface LayoutOptionsProps {
   view: BoardView;
 }
 
+const titleProperty: IPropertyTemplate = {
+  id: Constants.titleColumnId,
+  name: 'Title',
+  options: [],
+  type: 'text'
+};
+
 function PropertyMenuItem({
   isVisible,
   property,
@@ -72,6 +79,10 @@ function PropertyOptions(props: LayoutOptionsProps) {
   const visiblePropertyIdsWithTitle =
     titlePropertyIndex === -1 ? [Constants.titleColumnId, ...visiblePropertyIds] : visiblePropertyIds;
 
+  const propertiesWithTitle = properties.find((property) => property.id === Constants.titleColumnId)
+    ? properties
+    : [titleProperty, ...properties];
+
   const { hiddenProperties, visibleProperties } = useMemo(() => {
     const propertyIds = properties.map((property) => property.id);
     const _propertiesRecord = properties.reduce<Record<string, IPropertyTemplate>>((__propertiesRecord, property) => {
@@ -81,12 +92,7 @@ function PropertyOptions(props: LayoutOptionsProps) {
 
     // Manually add __title column as its not present by default
     if (!_propertiesRecord[Constants.titleColumnId]) {
-      _propertiesRecord[Constants.titleColumnId] = {
-        id: Constants.titleColumnId,
-        name: 'Title',
-        options: [],
-        type: 'text'
-      };
+      _propertiesRecord[Constants.titleColumnId] = titleProperty;
     }
 
     const _visibleProperties = visiblePropertyIdsWithTitle.map(
@@ -149,7 +155,7 @@ function PropertyOptions(props: LayoutOptionsProps) {
     mutator.changeViewVisibleProperties(
       view.id,
       visiblePropertyIdsWithTitle,
-      properties.map((property) => property.id)
+      propertiesWithTitle.map((property) => property.id)
     );
   };
 


### PR DESCRIPTION
- [x] Person property not shown for empty values (unless `!readOnly`)
- [x] Fixed title property now showing when clicking on `Show all`
- [x] Fixed `show in #view` for properties sidebar