### PR TITLE
clear cache when user logs out

### DIFF
--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { mutate } from 'swr';
 
 import charmClient from 'charmClient';
 import type { LoggedInUser } from 'models';
@@ -31,6 +32,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
   async function logoutUser() {
     await charmClient.logout();
     setUser(null);
+    clearSWRCache();
   }
 
   /**
@@ -78,6 +80,11 @@ export function UserProvider({ children }: { children: ReactNode }) {
   }, [user, isLoaded]);
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+}
+
+// clear cache from SWR - https://swr.vercel.app/docs/mutation
+function clearSWRCache() {
+  return mutate(() => true, undefined, { revalidate: false });
 }
 
 export const useUser = () => useContext(UserContext);


### PR DESCRIPTION
Currently when I log out, sometimes i see a lightning bolt appear for a minute as the view tries to catch up with the new state. This is an experiment to see if clearing the cache will make it better or worse. 

Something else we could try is redirecting the user to "/" immediately, instead of waiting for RouteGuard