### PR TITLE
Use pdf block when embedding pdf

### DIFF
--- a/components/common/CharmEditor/components/ResizablePDF.tsx
+++ b/components/common/CharmEditor/components/ResizablePDF.tsx
@@ -91,6 +91,11 @@ function EmptyPDFContainer({
   );
 }
 
+export type PdfNodeAttrs = {
+  src?: string | null;
+  size: number;
+};
+
 export function pdfSpec() {
   const spec: BaseRawNodeSpec = {
     name: 'pdf',

--- a/components/common/CharmEditor/components/iframe/IframeComponent.tsx
+++ b/components/common/CharmEditor/components/iframe/IframeComponent.tsx
@@ -1,13 +1,14 @@
-import { useState, memo, useEffect } from 'react';
+import { memo, useEffect, useState } from 'react';
 
 import MultiTabs from 'components/common/MultiTabs';
+import { isPdfEmbedLink } from 'lib/pdf/extractPdfEmbedLink';
 import { isUrl } from 'lib/utilities/strings';
 
 import BlockAligner from '../BlockAligner';
 import { IframeContainer } from '../common/IframeContainer';
 import { MediaSelectionPopup } from '../common/MediaSelectionPopup';
 import { MediaUrlInput } from '../common/MediaUrlInput';
-import { extractIframeProps } from '../iframe/utils';
+import { extractEmbedType, extractIframeProps } from '../iframe/utils';
 import { extractAttrsFromUrl as extractNFTAttrs } from '../nft/nftUtils';
 import type { CharmNodeViewProps } from '../nodeView/nodeView';
 import VerticalResizer from '../Resizable/VerticalResizer';
@@ -15,9 +16,8 @@ import { extractTweetAttrs } from '../tweet/tweetSpec';
 import { extractYoutubeLinkType } from '../video/utils';
 
 import { EmbedIcon } from './components/EmbedIcon';
-import type { IframeNodeAttrs, Embed, EmbedType } from './config';
-import { embeds, MAX_EMBED_WIDTH, MIN_EMBED_WIDTH, MIN_EMBED_HEIGHT, MAX_EMBED_HEIGHT } from './config';
-import { extractEmbedType } from './utils';
+import type { Embed, EmbedType, IframeNodeAttrs } from './config';
+import { embeds, MAX_EMBED_HEIGHT, MAX_EMBED_WIDTH, MIN_EMBED_HEIGHT, MIN_EMBED_WIDTH } from './config';
 
 function IframeComponent({ readOnly, node, getPos, view, deleteNode, selected, updateAttrs }: CharmNodeViewProps) {
   const attrs = node.attrs as IframeNodeAttrs;
@@ -49,9 +49,16 @@ function IframeComponent({ readOnly, node, getPos, view, deleteNode, selected, u
         const nftAttrs = extractNFTAttrs(parsedUrl);
         const tweetAttrs = extractTweetAttrs(parsedUrl);
         const isYoutube = extractYoutubeLinkType(parsedUrl);
+        const isPdf = isPdfEmbedLink(parsedUrl);
         if (isYoutube) {
           const pos = getPos();
           const _node = view.state.schema.nodes.video.createAndFill({ src: parsedUrl });
+          if (_node) {
+            view.dispatch(view.state.tr.replaceWith(pos, pos + node.nodeSize, _node));
+          }
+        } else if (isPdf) {
+          const pos = getPos();
+          const _node = view.state.schema.nodes.pdf.createAndFill({ src: parsedUrl });
           if (_node) {
             view.dispatch(view.state.tr.replaceWith(pos, pos + node.nodeSize, _node));
           }

--- a/components/common/CharmEditor/components/iframe/iframe.ts
+++ b/components/common/CharmEditor/components/iframe/iframe.ts
@@ -1,8 +1,10 @@
 import { Plugin, NodeView } from '@bangle.dev/core';
 import type { EditorView, Slice } from '@bangle.dev/pm';
 
+import { isPdfEmbedLink } from 'lib/pdf/extractPdfEmbedLink';
 import { insertNode } from 'lib/prosemirror/insertNode';
 
+import type { PdfNodeAttrs } from '../ResizablePDF';
 import { extractYoutubeLinkType } from '../video/utils';
 import type { VideoNodeAttrs } from '../video/videoSpec';
 import { name as videoName } from '../video/videoSpec';
@@ -32,6 +34,9 @@ export function plugins() {
             if (extractYoutubeLinkType(src)) {
               const attrs: Partial<VideoNodeAttrs> = { src };
               insertNode(videoName, view.state, view.dispatch, view, attrs);
+            } else if (isPdfEmbedLink(src)) {
+              const attrs: Partial<PdfNodeAttrs> = { src };
+              insertNode('pdf', view.state, view.dispatch, view, attrs);
             } else {
               const embedType = extractEmbedType(src);
               const attrs: Partial<IframeNodeAttrs> = {

--- a/lib/notion/NotionImporter/NotionBlock.ts
+++ b/lib/notion/NotionImporter/NotionBlock.ts
@@ -10,6 +10,7 @@ import { extractTweetAttrs } from 'components/common/CharmEditor/components/twee
 import { extractYoutubeLinkType } from 'components/common/CharmEditor/components/video/utils';
 import { VIDEO_ASPECT_RATIO } from 'components/common/CharmEditor/components/video/videoSpec';
 import log from 'lib/log';
+import { isPdfEmbedLink } from 'lib/pdf/extractPdfEmbedLink';
 import type {
   TextContent,
   MentionNode,
@@ -346,6 +347,7 @@ export class NotionBlock {
         const tweetAttrs = extractTweetAttrs(url);
         const nftAttrs = extractNFTAttrs(url);
         const isYoutube = extractYoutubeLinkType(url);
+        const isPdf = isPdfEmbedLink(url);
 
         if (tweetAttrs) {
           return {
@@ -355,9 +357,7 @@ export class NotionBlock {
               id: tweetAttrs.id
             }
           };
-        }
-
-        if (nftAttrs) {
+        } else if (nftAttrs) {
           return {
             type: 'nft',
             attrs: {
@@ -366,9 +366,7 @@ export class NotionBlock {
               contract: nftAttrs.contract
             }
           };
-        }
-
-        if (isYoutube) {
+        } else if (isYoutube) {
           return {
             type: 'video',
             attrs: {
@@ -377,11 +375,16 @@ export class NotionBlock {
               height: MAX_EMBED_WIDTH / VIDEO_ASPECT_RATIO
             }
           };
-        }
-
-        if (block.type === 'bookmark') {
+        } else if (block.type === 'bookmark') {
           return {
             type: 'bookmark',
+            attrs: {
+              url
+            }
+          };
+        } else if (isPdf) {
+          return {
+            type: 'pdf',
             attrs: {
               url
             }

--- a/lib/pdf/extractPdfEmbedLink.ts
+++ b/lib/pdf/extractPdfEmbedLink.ts
@@ -1,0 +1,3 @@
+export function isPdfEmbedLink(url: string) {
+  return new URL(url).pathname.endsWith('.pdf');
+}


### PR DESCRIPTION
- [x] Works with `<iframe>` with `src` linking to `pdf`
- [x] Detects and uses pdf block inside `embed` link
- [x] Uses `pdf` block when importing from notion 