### PR TITLE
Fix broken popup style

### DIFF
--- a/components/common/CharmEditor/components/common/MediaSelectionPopup.tsx
+++ b/components/common/CharmEditor/components/common/MediaSelectionPopup.tsx
@@ -15,7 +15,10 @@ export function MediaSelectionPopup(props: InputProps) {
   const autoOpen = props.node.marks.some((mark) => mark.type.name === 'tooltip-marker');
 
   return (
-    <PopperPopup autoOpen={autoOpen} popupContent={<Box>{props.children}</Box>}>
+    <PopperPopup
+      autoOpen={autoOpen}
+      popupContent={<Box width={{ xs: '90vw', md: 500, lg: 750 }}>{props.children}</Box>}
+    >
       <EmptyEmbed {...props} />
     </PopperPopup>
   );

--- a/components/common/ImageSelector/ImageSelector.tsx
+++ b/components/common/ImageSelector/ImageSelector.tsx
@@ -36,7 +36,7 @@ export default function ImageSelector({
     <PopperPopup
       autoOpen={autoOpen}
       popupContent={
-        <Box>
+        <Box sx={{ width: { xs: '90vw', md: 500, lg: 750 } }}>
           <MultiTabs
             disabled={isUploading}
             tabs={[

--- a/components/common/PdfSelector/PdfSelector.tsx
+++ b/components/common/PdfSelector/PdfSelector.tsx
@@ -18,7 +18,7 @@ export default function PdfSelector({ autoOpen = false, children, onPdfSelect }:
     <PopperPopup
       autoOpen={autoOpen}
       popupContent={
-        <Box>
+        <Box sx={{ width: { xs: '90vw', md: 500, lg: 750 } }}>
           <MultiTabs
             tabs={[
               ...tabs,

--- a/components/common/PopperPopup.tsx
+++ b/components/common/PopperPopup.tsx
@@ -78,7 +78,7 @@ export default function PopperPopup(props: PopperPopupProps) {
         </div>
       )}
       <Popover disableRestoreFocus {...popoverProps}>
-        <Paper sx={{ width: { xs: '90vw', md: 500, lg: 750 } }}>{popupContent}</Paper>
+        <Paper>{popupContent}</Paper>
       </Popover>
     </div>
   );


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4eaa61d</samp>

The pull request improves the responsiveness and layout of the popup components used for media selection in the `CharmEditor`. It applies a consistent width style to the `MediaSelectionPopup`, `ImageSelector`, and `PdfSelector` components, and simplifies the `PopperPopup` component.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4eaa61d</samp>

> _Responsive width for_
> _`MediaSelectionPopup`_
> _Spring cleaning for code_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4eaa61d</samp>

*  Make popup content width responsive for better layout and usability on different screen sizes ([link](https://github.com/charmverse/app.charmverse.io/pull/1982/files?diff=unified&w=0#diff-257054f41d419940563c52abad8eaa37e408f543759789baa0d85daff9a950a4L18-R21), [link](https://github.com/charmverse/app.charmverse.io/pull/1982/files?diff=unified&w=0#diff-d50426faf0d6b4f04e170eeecb03cef02e3563f44368e08d6a202580c462b450L39-R39), [link](https://github.com/charmverse/app.charmverse.io/pull/1982/files?diff=unified&w=0#diff-c22ef16ac93d866d1acfda89f5e26c592eaa27bf8db9b50f300427fcf16d0a0eL21-R21))
*  Simplify `PopperPopup` component by removing redundant width styling for paper element ([link](https://github.com/charmverse/app.charmverse.io/pull/1982/files?diff=unified&w=0#diff-e45bfc88466d6c960d04e86d6b9efe64492813c7309aa2ec681ee2838cb16621L81-R81))
