### PR TITLE
Capture and alert user when an error occurs receving document updates

### DIFF
--- a/components/common/CharmEditor/components/fiduswriter/fiduseditor.ts
+++ b/components/common/CharmEditor/components/fiduswriter/fiduseditor.ts
@@ -153,7 +153,12 @@ export class FidusEditor {
           }
           case 'doc_data':
             this.onDocLoaded(); // call this first so that the loading state is up-to-date before transactions occur
-            this.mod.collab.doc.receiveDocument(data);
+            try {
+              this.mod.collab.doc.receiveDocument(data);
+            } catch (error) {
+              log.error('Error loading document from sockets', { error });
+              onError(error as Error);
+            }
             // console.log('received doc');
             break;
           case 'confirm_version':

--- a/lib/templates/importWorkspacePages.ts
+++ b/lib/templates/importWorkspacePages.ts
@@ -174,6 +174,7 @@ export async function generateImportWorkspacePages({
       spaceId,
       cardId,
       proposalId,
+      version,
       parentId,
       bountyId,
       blocks,

--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -169,6 +169,7 @@ export class DocumentEventHandler {
     } catch (error) {
       log.error('Error handling socket message', {
         error: (error as any).stack || error,
+        message,
         ...logData
       });
     }


### PR DESCRIPTION

### WHY
Xandra lost an hour of work. It looks like she was opening a document mid-deploy of the socket service. I am having trouble figuring out the order of events still, but for now I want to propagate the error to the user so they know to reload the page. 

The error happens inside the RecreateTransform which is part of the merging plugin when the doc is validated (for when the server and client need to merge a lot of updates)

Luckily it hasn't happened too much in the past month (3-4 users): https://app.datadoghq.com/logs?query=%22Invalid%20content%20for%20node%20doc%22&cols=host%2Cservice&index=%2A&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1678214069378&to_ts=1680806069378&live=true
