### PR TITLE
Comments sidebar default

### DIFF
--- a/components/[pageId]/DocumentPage/components/CommentsSidebar.tsx
+++ b/components/[pageId]/DocumentPage/components/CommentsSidebar.tsx
@@ -96,10 +96,10 @@ function CommentsSidebarComponent({ inline }: BoxProps & { inline?: boolean }) {
 
     if (typeof highlightedCommentId === 'string' && highlightedCommentId !== lastHighlightedCommentId.current) {
       setCurrentPageActionDisplay('comments');
-      setThreadFilter('all');
-      // Remove query parameters from url
 
+      // Remove query parameters from url
       setUrlWithoutRerender(router.pathname, { commentId: null });
+
       requestAnimationFrame(() => {
         const highlightedCommentElement = document.getElementById(`comment.${highlightedCommentId}`);
         if (!highlightedCommentElement) {

--- a/components/[pageId]/DocumentPage/components/CommentsSidebar.tsx
+++ b/components/[pageId]/DocumentPage/components/CommentsSidebar.tsx
@@ -96,6 +96,12 @@ function CommentsSidebarComponent({ inline }: BoxProps & { inline?: boolean }) {
 
     if (typeof highlightedCommentId === 'string' && highlightedCommentId !== lastHighlightedCommentId.current) {
       setCurrentPageActionDisplay('comments');
+      const isHighlightedResolved = resolvedThreads.some((thread) =>
+        thread.comments.some((comment) => comment.id === highlightedCommentId)
+      );
+      if (isHighlightedResolved) {
+        setThreadFilter('resolved');
+      }
 
       // Remove query parameters from url
       setUrlWithoutRerender(router.pathname, { commentId: null });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c63e5d</samp>

Improve comment navigation in `CommentsSidebar` component. The change makes the thread filter match the status of the highlighted comment, whether it is resolved or unresolved.


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c63e5d</samp>

*  Add a condition to set the thread filter to 'resolved' when highlighting a resolved comment ([link](https://github.com/charmverse/app.charmverse.io/pull/1986/files?diff=unified&w=0#diff-f1ef7c50d879f3b7956140d72e83dd2034e9663b357af097291a72d6f46bed22L99-R108))
