### PR TITLE
Updated person property display

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
@@ -80,6 +80,7 @@ function UserProperty(props: Props): JSX.Element | null {
       hideInput={props.readOnly || (props.displayType !== 'details' && !clicked)}
     >
       <InputSearchMemberMultiple
+        disableClearable
         open={isOpen}
         disableCloseOnSelect
         defaultValue={memberIds}

--- a/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import CloseIcon from '@mui/icons-material/Close';
 import { IconButton } from '@mui/material';
 import { Box, Stack } from '@mui/system';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { PropertyValueDisplayType } from 'components/common/BoardEditor/interfaces';
 import { InputSearchMemberMultiple } from 'components/common/form/InputSearchMember';
@@ -64,8 +64,39 @@ function UserProperty(props: Props): JSX.Element | null {
 
   const [isOpen, setIsOpen] = useState(false);
 
-  if (props.readOnly && memberIds.length === 0) {
-    return null;
+  const membersDisplayComponent = useMemo(() => {
+    return memberIds.length === 0 ? null : (
+      <Stack flexDirection='row' flexWrap='wrap' gap={1}>
+        {memberIds.map((memberId) => {
+          const user = membersRecord[memberId];
+          if (!user) {
+            return null;
+          }
+          return (
+            <Stack alignItems='center' flexDirection='row' key={user.id} gap={0.5}>
+              <UserDisplay fontSize={14} avatarSize='xSmall' user={user} />
+              {!props.readOnly && clicked && (
+                <IconButton size='small'>
+                  <CloseIcon
+                    sx={{
+                      fontSize: 14
+                    }}
+                    cursor='pointer'
+                    fontSize='small'
+                    color='secondary'
+                    onClick={() => setMemberIds(memberIds.filter((_memberId) => _memberId !== user.id))}
+                  />
+                </IconButton>
+              )}
+            </Stack>
+          );
+        })}
+      </Stack>
+    );
+  }, [memberIds, membersRecord, props.readOnly, clicked, setMemberIds]);
+
+  if (props.readOnly) {
+    return membersDisplayComponent;
   }
 
   return (
@@ -104,34 +135,7 @@ function UserProperty(props: Props): JSX.Element | null {
         getOptionLabel={(user) => (typeof user === 'string' ? user : user?.username)}
         readOnly={props.readOnly}
         placeholder={props.showEmptyPlaceholder && memberIds.length === 0 ? 'Empty' : ''}
-        renderTags={() => (
-          <Stack flexDirection='row' flexWrap='wrap' gap={1}>
-            {memberIds.map((memberId) => {
-              const user = membersRecord[memberId];
-              if (!user) {
-                return null;
-              }
-              return (
-                <Stack alignItems='center' flexDirection='row' key={user.id} gap={0.5}>
-                  <UserDisplay fontSize={14} avatarSize='xSmall' user={user} />
-                  {!props.readOnly && clicked && (
-                    <IconButton size='small'>
-                      <CloseIcon
-                        sx={{
-                          fontSize: 14
-                        }}
-                        cursor='pointer'
-                        fontSize='small'
-                        color='secondary'
-                        onClick={() => setMemberIds(memberIds.filter((_memberId) => _memberId !== user.id))}
-                      />
-                    </IconButton>
-                  )}
-                </Stack>
-              );
-            })}
-          </Stack>
-        )}
+        renderTags={() => membersDisplayComponent}
       />
     </StyledUserPropertyContainer>
   );

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -210,7 +210,7 @@ function PropertyValueElement(props: Props) {
   if (props.showTooltip) {
     return (
       <Tooltip title={props.propertyTemplate.name}>
-        <div>{propertyValueElement}</div>
+        <div style={{ width: '100%' }}>{propertyValueElement}</div>
       </Tooltip>
     );
   }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77f7140</samp>

Improved the user interface and performance of the user property component in the board editor. Fixed a layout bug in the `propertyValueElement` component. Updated `user.tsx` and `propertyValueElement.tsx` files.

### WHY
<!-- author to complete -->
1. All `person` properties in board view were not shown
2. Removed clearable icon for table view (notion)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77f7140</samp>

* Optimize the rendering of the members display component in the user property value element by using `useMemo` hook and extracting the component from the `renderTags` prop of the `Autocomplete` component ([link](https://github.com/charmverse/app.charmverse.io/pull/1988/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL5-R5), [link](https://github.com/charmverse/app.charmverse.io/pull/1988/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL67-R99), [link](https://github.com/charmverse/app.charmverse.io/pull/1988/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL106-R138)) in `user.tsx`
