### PR TITLE
Guest label

### DIFF
--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PagePermissions/AddPagePermissionsForm.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PagePermissions/AddPagePermissionsForm.tsx
@@ -19,6 +19,7 @@ import type {
   PagePermissionLevelType
 } from 'lib/permissions/pages/page-permission-interfaces';
 import { permissionLevels } from 'lib/permissions/pages/page-permission-mapping';
+import { isTruthy } from 'lib/utilities/types';
 import type { ListSpaceRolesResponse } from 'pages/api/roles';
 
 export const schema = yup.object({
@@ -59,10 +60,10 @@ export default function AddPagePermissionsForm({
   }, [roles]);
 
   const userIdsToHide = existingPermissions
-    .filter((permission) => {
-      return permission.user;
+    .map((permission) => {
+      return permission.userId;
     })
-    .map((permission) => permission.user!.id);
+    .filter(isTruthy);
 
   const roleIdsToHide = existingPermissions
     .filter((permission) => {

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
+import { Box, Button, Chip, Tooltip } from '@mui/material';
 import InputAdornment from '@mui/material/InputAdornment';
 import Input from '@mui/material/OutlinedInput';
-import Tooltip from '@mui/material/Tooltip';
 import type { PageType } from '@prisma/client';
 import { bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
 import { useEffect } from 'react';
@@ -14,8 +12,10 @@ import Link from 'components/common/Link';
 import Modal from 'components/common/Modal';
 import { Typography } from 'components/common/Typography';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import { useMembers } from 'hooks/useMembers';
 import { usePagePermissions } from 'hooks/usePagePermissions';
 import { usePages } from 'hooks/usePages';
+import type { Member } from 'lib/members/interfaces';
 import { canReceiveManualPermissionUpdates } from 'lib/pages';
 import type {
   IPagePermissionWithAssignee,
@@ -54,21 +54,24 @@ const StyledInput = styled(Input)`
  * @param pagePermissions
  */
 function sortPagePermissions(
-  pagePermissions: IPagePermissionWithAssignee[]
-): (IPagePermissionWithAssignee & { displayName: string })[] {
+  pagePermissions: IPagePermissionWithAssignee[],
+  members: Pick<Member, 'id' | 'isGuest' | 'username'>[]
+): (IPagePermissionWithAssignee & { displayName: string; isGuest?: boolean })[] {
   const sortedPermissions = pagePermissions
     .filter((permission) => {
       return !permission.spaceId && !permission.public;
     })
     .map((permission) => {
-      const permissionSource = permission.user ? 'user' : 'role';
+      const permissionSource = permission.userId ? 'user' : 'role';
+      const member = members.find((m) => m.id === permission.userId);
 
-      const permissionDisplayName = permissionSource === 'user' ? permission.user!.username : permission.role!.name;
+      const permissionDisplayName = (permissionSource === 'user' ? member?.username : permission.role?.name) || '';
 
       return {
         ...permission,
         permissionSource,
-        displayName: permissionDisplayName as string
+        displayName: permissionDisplayName,
+        isGuest: member?.isGuest
       };
     })
     .sort((a, b) => {
@@ -98,6 +101,7 @@ interface Props {
 export default function PagePermissions({ pageId, pagePermissions, refreshPermissions, pageType }: Props) {
   const { pages } = usePages();
   const space = useCurrentSpace();
+  const { members } = useMembers();
   const popupState = usePopupState({ variant: 'popover', popupId: 'add-a-permission' });
 
   const spaceLevelPermission = pagePermissions.find((permission) => space && permission.spaceId === space?.id);
@@ -143,7 +147,7 @@ export default function PagePermissions({ pageId, pagePermissions, refreshPermis
     await refreshPermissions();
   }
 
-  const sortedPermissions = sortPagePermissions(pagePermissions);
+  const sortedPermissions = sortPagePermissions(pagePermissions, members);
 
   // Remove proposal editor as it is not selectable
   // eslint-disable-next-line camelcase
@@ -217,6 +221,7 @@ export default function PagePermissions({ pageId, pagePermissions, refreshPermis
               <Typography overflowEllipsis variant='body2'>
                 {permission.displayName}
               </Typography>
+              {permission.isGuest && <Chip size='small' color='warning' variant='outlined' label='Guest' />}
               <div style={{ width: '160px', textAlign: 'right' }}>
                 {canEdit ? (
                   <SmallSelect

--- a/lib/permissions/pages/actions/list-page-permissions.ts
+++ b/lib/permissions/pages/actions/list-page-permissions.ts
@@ -10,7 +10,6 @@ export async function listPagePermissions(pageId: string): Promise<IPagePermissi
     include: {
       role: true,
       space: true,
-      user: true,
       sourcePermission: true
     }
   });

--- a/lib/permissions/pages/page-permission-interfaces.ts
+++ b/lib/permissions/pages/page-permission-interfaces.ts
@@ -64,7 +64,6 @@ export interface IPageWithNestedSpaceRole extends Page {
 }
 
 export interface IPagePermissionWithAssignee extends PagePermission, IPagePermissionWithSource {
-  user: User | null;
   role: Role | null;
   space: Space | null;
   public: boolean | null;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4e5811</samp>

This pull request refactors and improves the code for managing page permissions in the app. It simplifies the logic and imports of the components that render the page permissions form and display. It also removes the unused user property from the page permission object and the query that fetches it from the database.

### WHY
Let users know if a guest has been added to page permissions
![image](https://user-images.githubusercontent.com/305398/230633864-51e5ebc4-6164-40cf-bd17-6888f7a19ecb.png)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4e5811</samp>

*  Simplify and improve the logic of displaying and sorting the page permissions in the `PagePermissions` component ([link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-590aa115163fff16637626185f3195deb20b4703396b206d58567460ba22a7c8L2-R4), [link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-590aa115163fff16637626185f3195deb20b4703396b206d58567460ba22a7c8L17-R18), [link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-590aa115163fff16637626185f3195deb20b4703396b206d58567460ba22a7c8L57-R59), [link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-590aa115163fff16637626185f3195deb20b4703396b206d58567460ba22a7c8L64-R74), [link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-590aa115163fff16637626185f3195deb20b4703396b206d58567460ba22a7c8R104), [link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-590aa115163fff16637626185f3195deb20b4703396b206d58567460ba22a7c8L146-R150), [link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-590aa115163fff16637626185f3195deb20b4703396b206d58567460ba22a7c8R224), [link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-1a9efe1a30accdc0cb1d1f88a34aae8d5b64efc02a53c606be0e27eb03594dcaR22), [link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-1a9efe1a30accdc0cb1d1f88a34aae8d5b64efc02a53c606be0e27eb03594dcaL62-R66))
* Remove the unused `user` property from the page permission interfaces and queries in `lib/permissions/pages` ([link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-fe19d1bcb07ee3e7f970e46a9314fd547505466d690decf62ec840150b4238b3L13), [link](https://github.com/charmverse/app.charmverse.io/pull/1989/files?diff=unified&w=0#diff-fd4799193875073033537acd2a6cd52c1c6114e3369a20986117a43596c3bf16L67))
