### PR TITLE
Fix sending notifications for person property

### DIFF
--- a/lib/discussion/getDiscussionTasks.ts
+++ b/lib/discussion/getDiscussionTasks.ts
@@ -495,7 +495,7 @@ async function getBoardPersonPropertyMentions({
       },
       type: 'card',
       deletedAt: null,
-      updatedAt: {
+      createdAt: {
         gt: new Date(Date.now() - 1000 * 60 * 60 * 24)
       }
     },


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7feb019</samp>

Fixed a bug in `getBoardPersonPropertyMentions` that caused outdated cards to appear in discussion tasks. Changed the filter criterion from `updatedAt` to `createdAt` in `lib/discussion/getDiscussionTasks.ts`.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7feb019</samp>

*  Fixed a bug where cards that were updated but not created in the last 24 hours were incorrectly included in the discussion tasks ([link](https://github.com/charmverse/app.charmverse.io/pull/1990/files?diff=unified&w=0#diff-5999112284d608c17b2a1e1ed7dcf130b1de1a708861a7aef700b568b8e4c8edL498-R498))
*  Changed the `getBoardPersonPropertyMentions` function to use the `createdAt` field instead of the `updatedAt` field to filter the cards by date ([link](https://github.com/charmverse/app.charmverse.io/pull/1990/files?diff=unified&w=0#diff-5999112284d608c17b2a1e1ed7dcf130b1de1a708861a7aef700b568b8e4c8edL498-R498))
