### PR TITLE
de-dupe mentions in pages

### DIFF
--- a/lib/discussion/getDiscussionTasks.ts
+++ b/lib/discussion/getDiscussionTasks.ts
@@ -586,15 +586,18 @@ async function getPageMentions({
         // Skip mentions not for the user, self mentions and inside user created pages
         if (mention.value === userId && mention.createdBy !== userId) {
           discussionUserIds.push(mention.createdBy);
-          mentions.push({
-            ...getPropertiesFromPage(page, spaceRecord[page.spaceId]),
-            mentionId: mention.id,
-            taskId: mention.id,
-            createdAt: mention.createdAt,
-            userId: mention.createdBy,
-            text: mention.text,
-            commentId: null
-          });
+          // Check if another mention already exists (this is possible if the page was duplicated)
+          if (!mentions.some(({ taskId }) => mention.id === taskId)) {
+            mentions.push({
+              ...getPropertiesFromPage(page, spaceRecord[page.spaceId]),
+              mentionId: mention.id,
+              taskId: mention.id,
+              createdAt: mention.createdAt,
+              userId: mention.createdBy,
+              text: mention.text,
+              commentId: null
+            });
+          }
         }
       });
     }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d2cc517</samp>

Prevent duplicate tasks for mentions in discussion panel. Fix a bug in `lib/discussion/getDiscussionTasks.ts` that added the same mention multiple times to the `mentions` array.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d2cc517</samp>

*  Prevent duplicate mentions in discussion tasks ([link](https://github.com/charmverse/app.charmverse.io/pull/1995/files?diff=unified&w=0#diff-5999112284d608c17b2a1e1ed7dcf130b1de1a708861a7aef700b568b8e4c8edL589-R600))
