### PR TITLE
fix missing permissions for default role

### DIFF
--- a/lib/permissions/spaces/__tests__/listPermissions.spec.ts
+++ b/lib/permissions/spaces/__tests__/listPermissions.spec.ts
@@ -1,6 +1,6 @@
 import type { Space } from '@prisma/client';
 
-import { generateRole, generateSpaceUser, generateUserAndSpace } from 'testing/setupDatabase';
+import { generateUserAndSpace } from 'testing/setupDatabase';
 
 import { listPermissions } from '../listPermissions';
 

--- a/lib/permissions/spaces/__tests__/listPermissions.spec.ts
+++ b/lib/permissions/spaces/__tests__/listPermissions.spec.ts
@@ -1,0 +1,19 @@
+import type { Space } from '@prisma/client';
+
+import { generateRole, generateSpaceUser, generateUserAndSpace } from 'testing/setupDatabase';
+
+import { listPermissions } from '../listPermissions';
+
+let space: Space;
+
+beforeAll(async () => {
+  const generated = await generateUserAndSpace();
+  space = generated.space;
+});
+
+describe('listPermissions', () => {
+  it('should return space permissions even if none exist in the DB', async () => {
+    const permissions = await listPermissions({ spaceId: space.id });
+    expect(permissions.space.length).toBe(1);
+  });
+});

--- a/lib/permissions/spaces/listPermissions.ts
+++ b/lib/permissions/spaces/listPermissions.ts
@@ -54,6 +54,7 @@ export async function listPermissions({ spaceId }: { spaceId: string }): Promise
         createPage: true,
         createBounty: true,
         createForumCategory: true,
+        moderateForums: false,
         reviewProposals: true
       }
     });

--- a/lib/permissions/spaces/listPermissions.ts
+++ b/lib/permissions/spaces/listPermissions.ts
@@ -43,5 +43,22 @@ export async function listPermissions({ spaceId }: { spaceId: string }): Promise
       .then((permissions) => permissions.map(mapSpacePermissionToAssignee))
   ]);
 
+  // add default member permissions if not defined
+  if (space.filter((s) => s.assignee.group === 'space').length === 0) {
+    space.push({
+      assignee: {
+        group: 'space',
+        id: spaceId
+      },
+      operations: {
+        createPage: true,
+        createBounty: true,
+        createForumCategory: true,
+        moderateForums: true,
+        reviewProposals: true
+      }
+    });
+  }
+
   return { proposalCategories, forumCategories, space };
 }

--- a/lib/permissions/spaces/listPermissions.ts
+++ b/lib/permissions/spaces/listPermissions.ts
@@ -51,11 +51,11 @@ export async function listPermissions({ spaceId }: { spaceId: string }): Promise
         id: spaceId
       },
       operations: {
-        createPage: true,
-        createBounty: true,
-        createForumCategory: true,
+        createPage: false,
+        createBounty: false,
+        createForumCategory: false,
         moderateForums: false,
-        reviewProposals: true
+        reviewProposals: false
       }
     });
   }

--- a/lib/permissions/spaces/listPermissions.ts
+++ b/lib/permissions/spaces/listPermissions.ts
@@ -54,7 +54,6 @@ export async function listPermissions({ spaceId }: { spaceId: string }): Promise
         createPage: true,
         createBounty: true,
         createForumCategory: true,
-        moderateForums: true,
         reviewProposals: true
       }
     });

--- a/pages/api/roles/index.ts
+++ b/pages/api/roles/index.ts
@@ -13,7 +13,7 @@ const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 export type CreateRoleInput = {
   spaceId: string;
   name: string;
-  userIds: string[];
+  userIds?: string[];
 };
 
 handler
@@ -68,18 +68,20 @@ async function createRole(req: NextApiRequest, res: NextApiResponse<Role>) {
         id: data.spaceId
       }
     },
-    spaceRolesToRole: {
-      create: data.userIds.map((userId) => ({
-        spaceRole: {
-          connect: {
-            spaceUser: {
-              userId,
-              spaceId: data.spaceId
+    spaceRolesToRole: data.userIds
+      ? {
+          create: data.userIds.map((userId) => ({
+            spaceRole: {
+              connect: {
+                spaceUser: {
+                  userId,
+                  spaceId: data.spaceId
+                }
+              }
             }
-          }
+          }))
         }
-      }))
-    },
+      : undefined,
     createdBy: req.session.user?.id
   } as Prisma.RoleCreateInput;
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67f9090</samp>

This pull request improves the role creation and management feature by allowing roles without users, avoiding empty relations, and ensuring default member permissions for spaces. It modifies the `CreateRoleInput` type and the `userIds` check in `pages/api/roles/index.ts`, and adds a default member permissions object in `lib/permissions/spaces/listPermissions.ts`.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67f9090</samp>

*  Add default member permissions for spaces ([link](https://github.com/charmverse/app.charmverse.io/pull/1997/files?diff=unified&w=0#diff-ada17ca7ee1336082793c11b475cfea4ec9f5ff22a3910adf01a020122c5a319R46-R62))
*  Make `userIds` optional for creating roles ([link](https://github.com/charmverse/app.charmverse.io/pull/1997/files?diff=unified&w=0#diff-da5eeb2b032c79f526bc12377dc0a0bad5144be77e1121bbea2e5f9167af17b0L16-R16), [link](https://github.com/charmverse/app.charmverse.io/pull/1997/files?diff=unified&w=0#diff-da5eeb2b032c79f526bc12377dc0a0bad5144be77e1121bbea2e5f9167af17b0L71-R84))
