### PR TITLE
Mark as read in notifications

### DIFF
--- a/components/common/PageLayout/components/Header/components/NotificationPreview/NotificationPreview.tsx
+++ b/components/common/PageLayout/components/Header/components/NotificationPreview/NotificationPreview.tsx
@@ -1,3 +1,4 @@
+import { CheckCircle } from '@mui/icons-material';
 import CloseIcon from '@mui/icons-material/Close';
 import CommentIcon from '@mui/icons-material/Comment';
 import ForumIcon from '@mui/icons-material/Forum';
@@ -5,7 +6,7 @@ import HowToVoteIcon from '@mui/icons-material/HowToVote';
 import KeyIcon from '@mui/icons-material/Key';
 import BountyIcon from '@mui/icons-material/RequestPageOutlined';
 import TaskOutlinedIcon from '@mui/icons-material/TaskOutlined';
-import { Badge, Box, IconButton, Stack, Typography } from '@mui/material';
+import { Badge, Box, IconButton, Stack, Tooltip, Typography } from '@mui/material';
 import { useMemo } from 'react';
 
 import Avatar from 'components/common/Avatar';
@@ -23,10 +24,9 @@ type Props = {
   markAsRead: MarkNotificationAsRead;
   onClose: VoidFunction;
   large?: boolean;
-  unmarked?: boolean;
 };
-export function NotificationPreview({ notification, markAsRead, onClose, large, unmarked }: Props) {
-  const { groupType, type, spaceName, createdBy, taskId, href, content, title, createdAt } = notification;
+export function NotificationPreview({ notification, markAsRead, onClose, large }: Props) {
+  const { groupType, type, spaceName, createdBy, taskId, href, content, title, createdAt, unmarked } = notification;
 
   const { formatDate, formatTime } = useDateFormatter();
   const date = new Date(createdAt);
@@ -59,7 +59,7 @@ export function NotificationPreview({ notification, markAsRead, onClose, large, 
         justifyContent='space-between'
         gap={2}
         pl={2}
-        pr={large ? 2 : 0.5}
+        pr={unmarked ? 0.5 : 2}
         py={1.5}
       >
         <Box display='flex' justifyContent='space-between' width='100%'>
@@ -115,19 +115,21 @@ export function NotificationPreview({ notification, markAsRead, onClose, large, 
               {content}
             </Typography>
           </Box>
-          {!large && (
-            <Box display='flex' alignItems='flex-start' ml={0.5} mt={-0.25}>
-              <IconButton
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  markAsRead({ taskId, groupType, type });
-                }}
-                size='small'
-              >
-                <CloseIcon fontSize='small' />
-              </IconButton>
-            </Box>
+          {unmarked && (
+            <Tooltip title='Mark as read'>
+              <Box display='flex' alignItems='flex-start' ml={0.5} mt={-0.55}>
+                <IconButton
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    markAsRead({ taskId, groupType, type });
+                  }}
+                  size='small'
+                >
+                  <CheckCircle color='secondary' fontSize='small' />
+                </IconButton>
+              </Box>
+            </Tooltip>
           )}
         </Box>
       </Box>

--- a/components/common/PageLayout/components/Header/components/NotificationPreview/useNotifications.tsx
+++ b/components/common/PageLayout/components/Header/components/NotificationPreview/useNotifications.tsx
@@ -30,6 +30,7 @@ export type NotificationDetails = {
   content: string;
   href: string;
   title: string;
+  unmarked: boolean;
 };
 
 export type NotificationDisplayType = 'all' | 'bounty' | 'vote' | 'mention' | 'proposal' | 'forum';
@@ -74,22 +75,30 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
   const unmarkedNotificationPreviews: NotificationDetails[] = useMemo(() => {
     if (!tasks) return [];
     return [
-      ...getVoteNotificationPreviewItems(tasks.votes.unmarked, currentUserId),
-      ...getProposalsNotificationPreviewItems(tasks.proposals.unmarked, currentUserId),
-      ...getBountiesNotificationPreviewItems(tasks.bounties.unmarked),
-      ...getDiscussionsNotificationPreviewItems(tasks.discussions.unmarked),
-      ...getForumNotificationPreviewItems(tasks.forum.unmarked)
+      ...getVoteNotificationPreviewItems({ notifications: tasks.votes.unmarked, currentUserId, unmarked: true }),
+      ...getProposalsNotificationPreviewItems({
+        notifications: tasks.proposals.unmarked,
+        currentUserId,
+        unmarked: true
+      }),
+      ...getBountiesNotificationPreviewItems({ notifications: tasks.bounties.unmarked, unmarked: true }),
+      ...getDiscussionsNotificationPreviewItems({ notifications: tasks.discussions.unmarked, unmarked: true }),
+      ...getForumNotificationPreviewItems({ notifications: tasks.forum.unmarked, unmarked: true })
     ].sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1));
   }, [tasks]);
 
   const markedNotificationPreviews: NotificationDetails[] = useMemo(() => {
     if (!tasks) return [];
     return [
-      ...getVoteNotificationPreviewItems(tasks.votes.marked, currentUserId),
-      ...getProposalsNotificationPreviewItems(tasks.proposals.marked, currentUserId),
-      ...getBountiesNotificationPreviewItems(tasks.bounties.marked),
-      ...getDiscussionsNotificationPreviewItems(tasks.discussions.marked),
-      ...getForumNotificationPreviewItems(tasks.forum.marked)
+      ...getVoteNotificationPreviewItems({ notifications: tasks.votes.marked, currentUserId, unmarked: false }),
+      ...getProposalsNotificationPreviewItems({
+        notifications: tasks.proposals.marked,
+        currentUserId,
+        unmarked: false
+      }),
+      ...getBountiesNotificationPreviewItems({ notifications: tasks.bounties.marked, unmarked: false }),
+      ...getDiscussionsNotificationPreviewItems({ notifications: tasks.discussions.marked, unmarked: false }),
+      ...getForumNotificationPreviewItems({ notifications: tasks.forum.marked, unmarked: false })
     ].sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1));
   }, [tasks]);
 
@@ -113,7 +122,8 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
 
           const taskIndex = _tasks?.[groupType].unmarked.findIndex((t) => t.taskId === taskId);
           if (typeof taskIndex === 'number' && taskIndex > -1) {
-            const marked = [_tasks?.[groupType].unmarked[taskIndex], ..._tasks[groupType].marked];
+            const markedTask = { ..._tasks?.[groupType].unmarked[taskIndex], unmarked: false };
+            const marked = [markedTask, ..._tasks[groupType].marked];
             const unmarkedItems = _tasks[groupType].unmarked;
             const unmarked = [...unmarkedItems.slice(0, taskIndex), ...unmarkedItems.slice(taskIndex + 1)];
 

--- a/components/common/PageLayout/components/Header/components/NotificationPreview/utils.ts
+++ b/components/common/PageLayout/components/Header/components/NotificationPreview/utils.ts
@@ -21,7 +21,13 @@ function getForumContent(n: ForumTask) {
     : `New forum post "${postTitle}"`;
 }
 
-export function getForumNotificationPreviewItems(notifications: ForumTask[]) {
+export function getForumNotificationPreviewItems({
+  notifications,
+  unmarked
+}: {
+  notifications: ForumTask[];
+  unmarked: boolean;
+}) {
   return notifications.map((n) => ({
     taskId: n.taskId,
     createdAt: n.createdAt,
@@ -31,7 +37,8 @@ export function getForumNotificationPreviewItems(notifications: ForumTask[]) {
     type: NotificationType.forum,
     href: `/${n.spaceDomain}/forum/post/${n.postPath}`,
     content: getForumContent(n),
-    title: 'Forum Post'
+    title: 'Forum Post',
+    unmarked
   }));
 }
 
@@ -42,7 +49,13 @@ function getDiscussionContent(n: DiscussionTask) {
     : `${createdBy?.username} left a comment.`;
 }
 
-export function getDiscussionsNotificationPreviewItems(notifications: DiscussionTask[]) {
+export function getDiscussionsNotificationPreviewItems({
+  notifications,
+  unmarked
+}: {
+  notifications: DiscussionTask[];
+  unmarked: boolean;
+}) {
   return notifications.map((n) => ({
     taskId: n.taskId,
     createdAt: n.createdAt,
@@ -54,7 +67,8 @@ export function getDiscussionsNotificationPreviewItems(notifications: Discussion
       n.commentId ? `commentId=${n.commentId}` : `mentionId=${n.mentionId}`
     }`,
     content: getDiscussionContent(n),
-    title: 'Discussion'
+    title: 'Discussion',
+    unmarked
   }));
 }
 
@@ -98,7 +112,13 @@ function getBountyContent(n: BountyTask) {
     : `Bounty status ${title} updated.`;
 }
 
-export function getBountiesNotificationPreviewItems(notifications: BountyTask[]) {
+export function getBountiesNotificationPreviewItems({
+  notifications,
+  unmarked
+}: {
+  notifications: BountyTask[];
+  unmarked: boolean;
+}) {
   return notifications.map((n) => ({
     taskId: n.taskId,
     createdAt: n.createdAt,
@@ -108,7 +128,8 @@ export function getBountiesNotificationPreviewItems(notifications: BountyTask[])
     type: NotificationType.bounty,
     href: `/${n.spaceDomain}/${n.pagePath}`,
     content: getBountyContent(n),
-    title: 'Bounty'
+    title: 'Bounty',
+    unmarked
   }));
 }
 
@@ -145,7 +166,15 @@ function getProposalNotificationStatus(status: ProposalStatus) {
   }
 }
 
-export function getProposalsNotificationPreviewItems(notifications: ProposalTask[], currentUserId?: string) {
+export function getProposalsNotificationPreviewItems({
+  notifications,
+  currentUserId,
+  unmarked
+}: {
+  notifications: ProposalTask[];
+  currentUserId?: string;
+  unmarked: boolean;
+}) {
   return notifications.map((n) => ({
     taskId: n.taskId,
     createdAt: n.createdAt,
@@ -155,7 +184,8 @@ export function getProposalsNotificationPreviewItems(notifications: ProposalTask
     type: NotificationType.proposal,
     href: `/${n.spaceDomain}/${n.pagePath}`,
     content: getProposalContent(n, currentUserId || ''),
-    title: `Proposal: ${getProposalNotificationStatus(n.status)}`
+    title: `Proposal: ${getProposalNotificationStatus(n.status)}`,
+    unmarked
   }));
 }
 
@@ -173,7 +203,15 @@ const getVoteContent = (n: VoteTask, currentUserId: string) => {
     : `Poll "${title}" created.`;
 };
 
-export function getVoteNotificationPreviewItems(notifications: VoteTask[], currentUserId?: string) {
+export function getVoteNotificationPreviewItems({
+  notifications,
+  unmarked,
+  currentUserId
+}: {
+  notifications: VoteTask[];
+  currentUserId?: string;
+  unmarked: boolean;
+}) {
   return notifications.map((n) => ({
     taskId: n.taskId,
     createdAt: n.createdAt,
@@ -183,6 +221,7 @@ export function getVoteNotificationPreviewItems(notifications: VoteTask[], curre
     type: NotificationType.vote,
     href: `/${n.spaceDomain}/${n.pagePath}?voteId=${n.taskId}`,
     content: getVoteContent(n, currentUserId || ''),
-    title: 'New Poll'
+    title: 'New Poll',
+    unmarked
   }));
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89b9fc4</samp>

This pull request enhances the notification preview feature in the header component of the app. It allows users to mark notifications as read from the preview, and shows a visual indicator of the read status. It modifies the `NotificationPreview` component, the `useNotifications` hook, and the `utils` file to implement this feature.

### WHY
Mark as read button for unread notifications
<img width="507" alt="Screenshot 2023-04-11 at 16 22 08" src="https://user-images.githubusercontent.com/5198394/231193493-3fceb0b8-b9ba-4f53-a930-f3734d1b396f.png">


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89b9fc4</samp>

*  Add the feature of marking notifications as read from the NotificationPreview component ([link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-cddcab5e843d076bbf65fd5431dedc1b0bcb40defbc85acaea2025cbc141bbb7R1), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-cddcab5e843d076bbf65fd5431dedc1b0bcb40defbc85acaea2025cbc141bbb7L8-R9), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-cddcab5e843d076bbf65fd5431dedc1b0bcb40defbc85acaea2025cbc141bbb7L26-R29), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-cddcab5e843d076bbf65fd5431dedc1b0bcb40defbc85acaea2025cbc141bbb7L62-R62), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-cddcab5e843d076bbf65fd5431dedc1b0bcb40defbc85acaea2025cbc141bbb7L118-R132))
*  Modify the useNotifications hook to store and update the unmarked status of the notifications in the state ([link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-c074e5d733b9b63fe5b3cdce7a468aa4ae95aec5df942156f66b4038b6e0f81fR33), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-c074e5d733b9b63fe5b3cdce7a468aa4ae95aec5df942156f66b4038b6e0f81fL77-R86), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-c074e5d733b9b63fe5b3cdce7a468aa4ae95aec5df942156f66b4038b6e0f81fL88-R101), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-c074e5d733b9b63fe5b3cdce7a468aa4ae95aec5df942156f66b4038b6e0f81fL116-R126))
*  Modify the utils functions to pass and return the unmarked status of the notifications to and from the notification preview items ([link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-a149cef0a16fc737ba7e073f6397e8e7d15c4eba56b1a0f718429db5462ae1e7L24-R30), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-a149cef0a16fc737ba7e073f6397e8e7d15c4eba56b1a0f718429db5462ae1e7L34-R41), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-a149cef0a16fc737ba7e073f6397e8e7d15c4eba56b1a0f718429db5462ae1e7L45-R58), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-a149cef0a16fc737ba7e073f6397e8e7d15c4eba56b1a0f718429db5462ae1e7L57-R71), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-a149cef0a16fc737ba7e073f6397e8e7d15c4eba56b1a0f718429db5462ae1e7L101-R121), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-a149cef0a16fc737ba7e073f6397e8e7d15c4eba56b1a0f718429db5462ae1e7L111-R132), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-a149cef0a16fc737ba7e073f6397e8e7d15c4eba56b1a0f718429db5462ae1e7L148-R177), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-a149cef0a16fc737ba7e073f6397e8e7d15c4eba56b1a0f718429db5462ae1e7L158-R188), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-a149cef0a16fc737ba7e073f6397e8e7d15c4eba56b1a0f718429db5462ae1e7L176-R214), [link](https://github.com/charmverse/app.charmverse.io/pull/2000/files?diff=unified&w=0#diff-a149cef0a16fc737ba7e073f6397e8e7d15c4eba56b1a0f718429db5462ae1e7L186-R225))
