### PR TITLE
use constructor to generate empty permissions

### DIFF
--- a/lib/permissions/spaces/listPermissions.ts
+++ b/lib/permissions/spaces/listPermissions.ts
@@ -5,6 +5,7 @@ import { mapPostCategoryPermissionToAssignee } from '../forum/mapPostCategoryPer
 import type { AssignedProposalCategoryPermission } from '../proposals/interfaces';
 import { mapProposalCategoryPermissionToAssignee } from '../proposals/mapProposalCategoryPermissionToAssignee';
 
+import { AvailableSpacePermissions } from './availableSpacePermissions';
 import type { AssignedSpacePermission } from './mapSpacePermissionToAssignee';
 import { mapSpacePermissionToAssignee } from './mapSpacePermissionToAssignee';
 
@@ -45,18 +46,13 @@ export async function listPermissions({ spaceId }: { spaceId: string }): Promise
 
   // add default member permissions if not defined
   if (space.filter((s) => s.assignee.group === 'space').length === 0) {
+    const allowedOperations = new AvailableSpacePermissions();
     space.push({
       assignee: {
         group: 'space',
         id: spaceId
       },
-      operations: {
-        createPage: false,
-        createBounty: false,
-        createForumCategory: false,
-        moderateForums: false,
-        reviewProposals: false
-      }
+      operations: allowedOperations.empty
     });
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c7a28b</samp>

Refactored space permissions code to use `AvailableSpacePermissions` class. This improves readability and maintainability of the code for managing space operations.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0c7a28b</samp>

*  Import `AvailableSpacePermissions` class to define possible space permissions ([link](https://github.com/charmverse/app.charmverse.io/pull/2001/files?diff=unified&w=0#diff-ada17ca7ee1336082793c11b475cfea4ec9f5ff22a3910adf01a020122c5a319R8))
*  Create `allowedOperations` variable to store user permissions for space ([link](https://github.com/charmverse/app.charmverse.io/pull/2001/files?diff=unified&w=0#diff-ada17ca7ee1336082793c11b475cfea4ec9f5ff22a3910adf01a020122c5a319R49))
*  Use `allowedOperations.empty` to initialize `permissions.operations` with no permissions ([link](https://github.com/charmverse/app.charmverse.io/pull/2001/files?diff=unified&w=0#diff-ada17ca7ee1336082793c11b475cfea4ec9f5ff22a3910adf01a020122c5a319L53-R55))
