### PR TITLE
Fix snapshot voting type select

### DIFF
--- a/components/common/PageLayout/components/Header/components/Snapshot/PublishingForm.tsx
+++ b/components/common/PageLayout/components/Header/components/Snapshot/PublishingForm.tsx
@@ -308,8 +308,8 @@ export default function PublishingForm({ onSubmit, page }: Props) {
             <Grid item>
               <FieldLabel>Voting type</FieldLabel>
               <InputEnumToOption
+                defaultValue={snapshotVoteMode}
                 keyAndLabel={SnapshotVotingMode}
-                defaultValue='single-choice'
                 onChange={(voteMode) => setSnapshotVoteMode(voteMode as SnapshotVotingModeType)}
               />
             </Grid>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ccb32e</samp>

Fixed a bug where the input for voting mode in the publishing form did not match the user's selection. Used the `snapshotVoteMode` state variable to set the `defaultValue` prop of the `InputEnumToOption` component.

### WHY
Voting type got broken by changes in https://github.com/charmverse/app.charmverse.io/pull/1948

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ccb32e</samp>

*  Update the `defaultValue` prop of the `InputEnumToOption` component to use the `snapshotVoteMode` state variable ([link](https://github.com/charmverse/app.charmverse.io/pull/2006/files?diff=unified&w=0#diff-9c30a48f33f5e0473a9fee36d20df8a6957799870f1742a5e04d4ab24ec07207L311-R312)). This makes the component more dynamic and consistent with the user's choice of voting mode when editing a proposal in `components/common/PageLayout/components/Header/components/Snapshot/PublishingForm.tsx`.
