### PR TITLE
Fix handling deleted members in person input property

### DIFF
--- a/components/common/BoardEditor/focalboard/src/widgets/propertyMenu.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/propertyMenu.tsx
@@ -5,6 +5,7 @@ import { Stack } from '@mui/system';
 import { bindMenu, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
 import React, { useRef, useState } from 'react';
 import type { IntlShape } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 import type { IPropertyTemplate, PropertyType } from 'lib/focalboard/board';
 
@@ -82,6 +83,8 @@ const PropertyMenu = React.memo((props: Props) => {
   const propertyName = props.property.name;
   const [name, setName] = useState(propertyName);
   const changePropertyTypePopupState = usePopupState({ variant: 'popover', popupId: 'card-property-type' });
+  const intl = useIntl();
+
   return (
     <Stack gap={1}>
       <TextField
@@ -123,7 +126,7 @@ const PropertyMenu = React.memo((props: Props) => {
           justifyContent: 'space-between'
         }}
       >
-        <Typography variant='subtitle1'>Type: {propertyName}</Typography>
+        <Typography variant='subtitle1'>Type: {typeDisplayName(intl, propertyType)}</Typography>
         <ArrowRightIcon fontSize='small' />
       </MenuItem>
       <Menu


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5065af8</samp>

Refactored `UserProperty` component to use hooks and custom function for better performance and type safety. Fixed a bug where undefined member ids could cause errors in `components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx`.

### WHY
https://app.charmverse.io/charmverse/page-08409201468937777

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5065af8</samp>

*  Import `useCallback` and `useMemo` hooks from `react` to optimize `UserProperty` component ([link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL5-R5))
*  Import `Member` type from `lib/members/interfaces` to define member objects ([link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcR11))
*  Add `getFilteredMemberIds` function to remove undefined member ids from array ([link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcR182-R185))
*  Initialize `memberIds` state with filtered array of member ids from `props.memberIds` and `membersRecord` ([link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL100-R118))
*  Add `membersValue` state to memoize array of member objects from `memberIds` and `membersRecord` ([link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL100-R118))
*  Add `updateMemberIds` function to filter and set `memberIds` state ([link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL100-R118))
*  Replace `setMemberIds` prop with `updateMemberIds` function in `MembersDisplay` and `Autocomplete` components to ensure consistent filtering ([link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL112-R129), [link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL132-R154), [link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL157-R174))
*  Replace `value` prop with `membersValue` state in `Autocomplete` component to use memoized array of member objects ([link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcL132-R154))
*  Add blank line for readability and consistency ([link](https://github.com/charmverse/app.charmverse.io/pull/2007/files?diff=unified&w=0#diff-7e7ec4a92a624e245c3d93562f7a2abe8bf71b9959ed50343f9ff73fda81a7fcR76))
