### PR TITLE
Feat/post draft matt

### DIFF
--- a/components/forum/ForumFeedPage.tsx
+++ b/components/forum/ForumFeedPage.tsx
@@ -22,7 +22,6 @@ import { CategoryMenu } from './components/CategoryMenu';
 import { CategoryNotificationToggle } from './components/CategoryNotificationToggle';
 import { CategorySelect } from './components/CategorySelect';
 import { CreateForumPost } from './components/CreateForumPost';
-import { PostDialog } from './components/PostDialog';
 import { PostSkeleton } from './components/PostList/components/PostSkeleton';
 import { ForumPostList } from './components/PostList/PostList';
 
@@ -31,8 +30,7 @@ export function ForumPage() {
   const router = useRouter();
   const currentSpace = useCurrentSpace();
   const sort = router.query.sort as PostSortOption | undefined;
-  const [showNewPostForm, setShowNewPostForm] = useState(false);
-  const { showPost } = usePostDialog();
+  const { createPost, showPost } = usePostDialog();
   const { categories, isCategoriesLoaded } = useForumCategories();
   const [, setTitle] = usePageTitle();
   const [currentCategory, setCurrentCategory] = useState<PostCategory | null>(null);
@@ -95,13 +93,13 @@ export function ForumPage() {
   }
 
   function showNewPostPopup() {
-    setShowNewPostForm(true);
+    if (currentSpace) {
+      createPost({
+        spaceId: currentSpace.id,
+        category: currentCategory
+      });
+    }
   }
-
-  function hideNewPostPopup() {
-    setShowNewPostForm(false);
-  }
-
   useEffect(() => {
     if (typeof router.query.postId === 'string') {
       showPost({
@@ -176,14 +174,6 @@ export function ForumPage() {
             />
           </Box>
           <CreateForumPost onClick={showNewPostPopup} />
-          {currentSpace && (
-            <PostDialog
-              newPostCategory={currentCategory}
-              open={showNewPostForm}
-              onClose={hideNewPostPopup}
-              spaceId={currentSpace.id}
-            />
-          )}
           {!isCategoriesLoaded ? (
             <PostSkeleton />
           ) : (

--- a/components/forum/components/PostDialog/PostDialogGlobal.tsx
+++ b/components/forum/components/PostDialog/PostDialogGlobal.tsx
@@ -11,11 +11,7 @@ import { PostDialog } from './PostDialog';
 export default function PostDialogGlobal() {
   const [post, setPost] = useState<PostWithVotes | null>(null);
   const { props, hidePost } = usePostDialog();
-  const { postId } = props;
-
-  function closeDialog() {
-    hidePost();
-  }
+  const { newPost, postId } = props;
 
   useEffect(() => {
     if (postId) {
@@ -32,5 +28,19 @@ export default function PostDialogGlobal() {
     }
   }, [postId]);
 
-  return post ? <PostDialog key={post.id} post={post} onClose={closeDialog} spaceId={post.spaceId} /> : null;
+  // include postId: when creating a draft, the dialog is open due to 'newPost' being set.
+  // once we save it, we need to load it as 'post' but keep the dialog open in the meantime
+  if (newPost || post || postId) {
+    return (
+      <PostDialog
+        key={post?.id}
+        isLoading={!post && !newPost}
+        post={post}
+        newPostCategory={newPost?.category}
+        onClose={hidePost}
+        spaceId={post?.spaceId || (newPost?.spaceId as string)}
+      />
+    );
+  }
+  return null;
 }

--- a/components/forum/components/PostDialog/hooks/usePostDialog.tsx
+++ b/components/forum/components/PostDialog/hooks/usePostDialog.tsx
@@ -1,19 +1,23 @@
+import type { PostCategory } from '@prisma/client';
 import type { ReactNode } from 'react';
 import { createContext, useContext, useMemo, useState } from 'react';
 
 interface PostDialogContext {
   postId?: string | null;
+  newPost?: { category: PostCategory | null; spaceId: string };
   onClose?: () => void;
 }
 
 interface Context {
   props: PostDialogContext;
+  createPost: (newPost: PostDialogContext['newPost']) => void;
   hidePost: () => void;
   showPost: (context: PostDialogContext) => void;
 }
 
 const ContextElement = createContext<Readonly<Context>>({
   props: {},
+  createPost: () => {},
   hidePost: () => {},
   showPost: () => {}
 });
@@ -32,9 +36,14 @@ export function PostDialogProvider({ children }: { children: ReactNode }) {
     setProps(_context);
   }
 
+  function createPost(newPost: PostDialogContext['newPost']) {
+    setProps({ newPost });
+  }
+
   const value = useMemo(
     () => ({
       props,
+      createPost,
       hidePost,
       showPost
     }),

--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -66,7 +66,6 @@ export function PostPage({
   showOtherCategoryPosts,
   newPostCategory
 }: Props) {
-  const [isDraftPost, setIsDraftPost] = useState(post?.isDraft ?? false);
   const currentSpace = useCurrentSpace();
   const { user } = useUser();
   const { categories, getForumCategoryById } = useForumCategories();
@@ -120,10 +119,6 @@ export function PostPage({
     }
   }, [post]);
 
-  useEffect(() => {
-    setIsDraftPost(post?.isDraft ?? false);
-  }, [post]);
-
   async function createForumPost(isDraft: boolean) {
     if (checkIsContentEmpty(formInputs.content) || !categoryId) {
       throw new Error('Missing required fields to save forum post');
@@ -168,7 +163,6 @@ export function PostPage({
         isDraft: false
       });
       setIsPublishingDraftPost(false);
-      setIsDraftPost(false);
       router.push(`/${router.query.domain}/forum/post/${draftPost.path}`);
     }
   }
@@ -218,7 +212,7 @@ export function PostPage({
     <>
       {post?.proposalId && <ProposalBanner type='post' proposalId={post.proposalId} />}
       <ScrollableWindow>
-        {isDraftPost && <DraftPostBanner />}
+        {post?.isDraft && <DraftPostBanner />}
         <Stack>
           <Stack flexDirection='row'>
             <Container top={50}>
@@ -247,7 +241,7 @@ export function PostPage({
               </Box>
               {canEdit && (
                 <Stack flexDirection='row' gap={1} justifyContent='flex-end' my={2}>
-                  {!post && (
+                  {(!post || post.isDraft) && (
                     <Button
                       disabled={Boolean(disabledTooltip) || !contentUpdated}
                       disabledTooltip={disabledTooltip}
@@ -255,31 +249,31 @@ export function PostPage({
                       color='secondary'
                       variant='outlined'
                     >
-                      Save draft
+                      {post ? 'Update draft' : 'Save draft'}
                     </Button>
                   )}
-                  {post && isDraftPost && (
+                  {post?.isDraft && (
                     <Button
                       disabled={Boolean(disabledTooltip) || isPublishingDraftPost}
                       disabledTooltip={disabledTooltip}
                       onClick={() => publishDraftPost(post)}
-                      color='secondary'
-                      variant='outlined'
                       loading={isPublishingDraftPost}
                     >
-                      Publish draft
+                      Post
                     </Button>
                   )}
-                  <Button
-                    disabled={Boolean(disabledTooltip) || !contentUpdated}
-                    disabledTooltip={disabledTooltip}
-                    onClick={() => createForumPost(false)}
-                  >
-                    {post ? 'Update' : 'Post'}
-                  </Button>
+                  {!post?.isDraft && (
+                    <Button
+                      disabled={Boolean(disabledTooltip) || !contentUpdated}
+                      disabledTooltip={disabledTooltip}
+                      onClick={() => createForumPost(false)}
+                    >
+                      {post ? 'Update' : 'Post'}
+                    </Button>
+                  )}
                 </Stack>
               )}
-              {post && !isDraftPost && (
+              {post && !post.isDraft && (
                 <>
                   {!!permissions?.add_comment && (
                     <Box my={2} data-test='new-top-level-post-comment'>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e21dce</samp>

This pull request enhances the post dialog component and its usage in the forum feature of the app. It adds the ability to create new posts from the dialog, refactors the dialog logic and rendering, and integrates the dialog with the forum feed and post pages. It also improves the user interface and the code quality of the related components.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3e21dce</samp>

*  Add `newPost` prop and `createPost` function to `PostDialogContext` and `usePostDialog` hook to handle opening the post dialog with a new post form ([link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-a79fba4f16343e8de696c2db975b3b8fbda4fdea3a28dc5cad2b6db054fe144bR1),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-a79fba4f16343e8de696c2db975b3b8fbda4fdea3a28dc5cad2b6db054fe144bR7),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-a79fba4f16343e8de696c2db975b3b8fbda4fdea3a28dc5cad2b6db054fe144bR13),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-a79fba4f16343e8de696c2db975b3b8fbda4fdea3a28dc5cad2b6db054fe144bR20),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-a79fba4f16343e8de696c2db975b3b8fbda4fdea3a28dc5cad2b6db054fe144bL35-R46))
*  Remove `open` prop and add `isLoading` prop to `PostDialog` component to simplify the logic of showing and hiding the post dialog based on the router query or the `usePostDialog` hook ([link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-e07d180de964a3dbbb0b7d7e0455445916427e5ac046c1c1d89901b30124018aL31-R38),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-e07d180de964a3dbbb0b7d7e0455445916427e5ac046c1c1d89901b30124018aL69-R68),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-e07d180de964a3dbbb0b7d7e0455445916427e5ac046c1c1d89901b30124018aL90-L92),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-e07d180de964a3dbbb0b7d7e0455445916427e5ac046c1c1d89901b30124018aL124-L128),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-e07d180de964a3dbbb0b7d7e0455445916427e5ac046c1c1d89901b30124018aL154-R139),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-e07d180de964a3dbbb0b7d7e0455445916427e5ac046c1c1d89901b30124018aL185-R175))
*  Add `newPost` prop to `PostDialogGlobal` component and render `PostDialog` component based on the `newPost` prop and the `postId` prop from the router query ([link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-de6487354f2a2dbd0082a487273e710e1df0c19e97705908001a86a53d49b950L14-R15),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-de6487354f2a2dbd0082a487273e710e1df0c19e97705908001a86a53d49b950L35-R45))
*  Remove `isDraftPost` state variable from `PostPage` component and use `post.isDraft` property instead to render the draft post banner and the buttons to save, update, or publish a draft ([link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0L69),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0L123-L126),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0L171),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0L221-R215),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0L250-R244),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0L258-R276))
*  Remove `showNewPostForm` state variable and `PostDialog` component from `ForumFeedPage` component and use `createPost` function from `usePostDialog` hook instead to open the post dialog with the current space id and category ([link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-1bd0520f055055faf55434a7948abca034156dca6daf9eb854f8e5eb1329fd34L25),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-1bd0520f055055faf55434a7948abca034156dca6daf9eb854f8e5eb1329fd34L34-R33),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-1bd0520f055055faf55434a7948abca034156dca6daf9eb854f8e5eb1329fd34L98-R102),[link](https://github.com/charmverse/app.charmverse.io/pull/2009/files?diff=unified&w=0#diff-1bd0520f055055faf55434a7948abca034156dca6daf9eb854f8e5eb1329fd34L179-L186))
