### PR TITLE
update DB column to support large telegram ids

### DIFF
--- a/components/integrations/components/NewIdentityModal.tsx
+++ b/components/integrations/components/NewIdentityModal.tsx
@@ -17,7 +17,7 @@ import type { LoggedInUser } from 'models';
 import type { TelegramAccount } from 'pages/api/telegram/connect';
 
 import IdentityProviderItem from './IdentityProviderItem';
-import { loginWithTelegram } from './TelegramLoginIframe';
+import { loginWithTelegram, TELEGRAM_BOT_ID } from './TelegramLoginIframe';
 
 type Props = {
   isOpen: boolean;
@@ -50,6 +50,9 @@ export function NewIdentityModal({ isOpen, onClose }: Props) {
     {
       onSuccess(data) {
         setUser((_user: LoggedInUser) => ({ ..._user, telegramUser: data }));
+      },
+      onError(err) {
+        showMessage((err as any).message ?? 'Something went wrong', 'error');
       }
     }
   );
@@ -132,12 +135,14 @@ export function NewIdentityModal({ isOpen, onClose }: Props) {
           {!telegramAccount && (
             <IdentityProviderItem type='Telegram'>
               <PrimaryButton
+                disabled={!TELEGRAM_BOT_ID}
+                loading={isConnectingToTelegram}
+                disabledTooltip='Telegram bot is not configured'
                 size='small'
                 onClick={async () => {
                   await connectTelegram();
                   onClose();
                 }}
-                disabled={isConnectingToTelegram}
               >
                 Connect
               </PrimaryButton>

--- a/components/integrations/components/TelegramLoginIframe.tsx
+++ b/components/integrations/components/TelegramLoginIframe.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import type { TelegramAccount } from 'pages/api/telegram/connect';
 
-const TELEGRAM_BOT_ID = process.env.NEXT_PUBLIC_TELEGRAM_BOT_ID;
+export const TELEGRAM_BOT_ID = process.env.NEXT_PUBLIC_TELEGRAM_BOT_ID;
 
 export function loginWithTelegram(callback: (user: TelegramAccount) => void) {
   // @ts-ignore - defined by the script: https://telegram.org/js/telegram-widget.js

--- a/db.ts
+++ b/db.ts
@@ -1,5 +1,11 @@
+/* eslint-disable no-extend-native */
 import type { Prisma } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
+
+// @ts-ignore - add support for JSON for BigInt (used in telegramuser) - https://github.com/GoogleChromeLabs/jsbi/issues/30
+BigInt.prototype.toJSON = function () {
+  return this.toString();
+};
 
 // @ts-expect-error - dont mutate global for Node.js
 export const prisma: PrismaClient = global.prisma || new PrismaClient({});

--- a/pages/api/telegram/connect.ts
+++ b/pages/api/telegram/connect.ts
@@ -4,7 +4,7 @@ import nc from 'next-connect';
 
 import { prisma } from 'db';
 import log from 'lib/log';
-import { onError, onNoMatch, requireUser } from 'lib/middleware';
+import { onError, InvalidStateError, onNoMatch, requireUser } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
 
 const handler = nc({
@@ -22,14 +22,24 @@ export interface TelegramAccount {
   username: string;
 }
 
-async function connectTelegram(req: NextApiRequest, res: NextApiResponse<TelegramUser | { error: string }>) {
+async function connectTelegram(req: NextApiRequest, res: NextApiResponse<TelegramUser | { message: string }>) {
   const telegramAccount = req.body as TelegramAccount;
 
   const { id, ...rest } = telegramAccount;
   const userId = req.session.user.id;
-  let telegramUser: TelegramUser;
 
-  try {
+  let telegramUser = await prisma.telegramUser.findUnique({
+    where: {
+      telegramId: id
+    }
+  });
+  if (telegramUser) {
+    if (telegramUser.userId !== userId) {
+      throw new InvalidStateError(
+        'Connection to Telegram failed. Another CharmVerse account is already associated with this Telegram account.'
+      );
+    }
+  } else {
     telegramUser = await prisma.telegramUser.create({
       data: {
         account: rest as any,
@@ -41,14 +51,6 @@ async function connectTelegram(req: NextApiRequest, res: NextApiResponse<Telegra
         }
       }
     });
-  } catch (error) {
-    log.warn('Error while connecting to Telegram', error);
-    // If the telegram user is already connected to a charmverse account this code will be run
-    res.status(400).json({
-      error:
-        'Connection to Telegram failed. Another CharmVerse account is already associated with this Telegram account.'
-    });
-    return;
   }
 
   res.status(200).json(telegramUser);

--- a/prisma/migrations/20230412212824_update_telegram_id/migration.sql
+++ b/prisma/migrations/20230412212824_update_telegram_id/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - The primary key for the `TelegramUser` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- AlterTable
+ALTER TABLE "TelegramUser" DROP CONSTRAINT "TelegramUser_pkey",
+ALTER COLUMN "telegramId" SET DATA TYPE BIGINT,
+ADD CONSTRAINT "TelegramUser_pkey" PRIMARY KEY ("telegramId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -599,7 +599,7 @@ model TelegramUser {
   createdAt  DateTime @default(now())
   updatedAt  DateTime @default(now())
   userId     String   @unique @db.Uuid
-  telegramId Int      @id
+  telegramId BigInt   @id
   account    Json
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -1373,14 +1373,14 @@ model PostCategoryPermission {
 }
 
 model ApiPageKey {
-  createdAt DateTime @default(now())
-  updatedAt DateTime  @updatedAt
-  createdBy String @db.Uuid
-  pageId    String @db.Uuid
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
+  createdBy String         @db.Uuid
+  pageId    String         @db.Uuid
   apiKey    String
   type      ApiPageKeyType
-  page      Page   @relation(fields: [pageId], references: [id], onDelete: Cascade)
-  user      User   @relation(fields: [createdBy], references: [id], onDelete: Cascade)
+  page      Page           @relation(fields: [pageId], references: [id], onDelete: Cascade)
+  user      User           @relation(fields: [createdBy], references: [id], onDelete: Cascade)
 
   @@unique([pageId, type])
   @@unique([apiKey])


### PR DESCRIPTION
Some telegram Ids are larger than what "Int" supports (-2147483647 to 2147483647). BigInt will be plenty. For more info, see Integers on https://www.prisma.io/dataguide/postgresql/introduction-to-data-types#numbers-and-numeric-values

I ran this locally, with exsiting IDs and it seems to migrate fine. I do get a warning that if migration fails, this is the primary key of the table and it could cause problems