### PR TITLE
Fix scroll to comment

### DIFF
--- a/components/common/CharmEditor/components/inlineComment/inlineComment.utils.ts
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.utils.ts
@@ -128,7 +128,6 @@ export function scrollToThread(threadId: string) {
 
     if (parentElement) {
       createHighlightDomElement(parentElement);
-      parentElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
   }
 }

--- a/components/common/CharmEditor/components/inlineComment/inlineComment.utils.ts
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.utils.ts
@@ -119,12 +119,16 @@ export function scrollToThread(threadId: string) {
     for (let i = 0; i < 10; i++) {
       element = element?.parentElement ?? null;
       // Get the first paragraph parent element
-      if (element?.tagName === 'p' || element?.tagName.startsWith('h')) {
+      const tagName = element?.tagName.toLowerCase() || '';
+      if (tagName === 'p' || tagName.startsWith('h')) {
         parentElement = element;
         break;
       }
     }
 
-    createHighlightDomElement(parentElement);
+    if (parentElement) {
+      createHighlightDomElement(parentElement);
+      parentElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
   }
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 691ce1a</samp>

Improved the inline comment feature in `CharmEditor` by adding functions to locate and display the relevant paragraph for each comment. Refactored the element search code using the `tagName` variable.

### WHY
Fix scrolling / highlighting comments from thread:
https://app.charmverse.io/charmverse/page-09710036007458855


https://user-images.githubusercontent.com/5198394/231752427-140b74eb-0da0-4900-a8e9-e096d9aafe35.mp4



### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 691ce1a</samp>

*  Add logic to highlight and scroll to the paragraph element that contains the comment anchor ([link](https://github.com/charmverse/app.charmverse.io/pull/2014/files?diff=unified&w=0#diff-b91a7dc01adfcf583a9ff1d9f99f5d6a86be6d3651382dfc03773bd17719116fL122-R123), [link](https://github.com/charmverse/app.charmverse.io/pull/2014/files?diff=unified&w=0#diff-b91a7dc01adfcf583a9ff1d9f99f5d6a86be6d3651382dfc03773bd17719116fL128-R132))
  - Use `tagName` variable to store the lowercased tag name of the element and compare it with 'p' and 'h' tags ([link](https://github.com/charmverse/app.charmverse.io/pull/2014/files?diff=unified&w=0#diff-b91a7dc01adfcf583a9ff1d9f99f5d6a86be6d3651382dfc03773bd17719116fL122-R123))
  - Check if a valid paragraph parent element was found and call `createHighlightDomElement` and `scrollIntoView` functions ([link](https://github.com/charmverse/app.charmverse.io/pull/2014/files?diff=unified&w=0#diff-b91a7dc01adfcf583a9ff1d9f99f5d6a86be6d3651382dfc03773bd17719116fL128-R132))
