### PR TITLE
add endpoint to log in as another user

### DIFF
--- a/pages/api/profile/remote.ts
+++ b/pages/api/profile/remote.ts
@@ -12,7 +12,7 @@ if (isDevEnv) {
 }
 
 async function register(req: NextApiRequest, res: NextApiResponse) {
-  const userId = req.query.id || (req.query.userId as string);
+  const userId = (req.query.id || req.query.userId) as string | undefined;
   if (!userId) {
     throw new Error('Please provider ?userid=...');
   }

--- a/pages/api/profile/remote.ts
+++ b/pages/api/profile/remote.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
+
+import { isDevEnv } from 'config/constants';
+import { onError, onNoMatch } from 'lib/middleware';
+import { withSessionRoute } from 'lib/session/withSession';
+
+const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+
+if (isDevEnv) {
+  handler.get(register);
+}
+
+async function register(req: NextApiRequest, res: NextApiResponse) {
+  const userId = req.query.id || (req.query.userId as string);
+  if (!userId) {
+    throw new Error('Please provider ?userid=...');
+  }
+  req.session.user = { id: userId };
+  await req.session.save();
+
+  res.redirect('/');
+}
+
+export default withSessionRoute(handler);


### PR DESCRIPTION
I think instructions could be added to our Task Board:

1. run `npm run start:remote`
2. Visit http://localhost:3000/api/profile/remote?userid=