### PR TITLE
show pages in sidebar even if their parent is invisible

### DIFF
--- a/lib/pages/mapPageTree.ts
+++ b/lib/pages/mapPageTree.ts
@@ -68,6 +68,10 @@ export function reducePagesToPageTree<T extends PageNode = PageNode>({
     else if (node.parentId === null && !rootPageIds && includableNode(node)) {
       roots.push(node);
     }
+    // parent may be undefined if user has no access to it
+    else if (node.parentId && !parentNode) {
+      roots.push(node);
+    }
 
     if (rootPageIds?.includes(node.id)) {
       roots.push(node);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5d78e0</samp>

Fix page tree generation for nodes with missing parents. Add nodes with inaccessible parent IDs to the `roots` array in `lib/pages/mapPageTree.ts` to show them in the map view.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b5d78e0</samp>

*  Handle missing parent nodes in page tree ([link](https://github.com/charmverse/app.charmverse.io/pull/2016/files?diff=unified&w=0#diff-4bf9454cc16254ed2bb138ef8f74fbbc5cb166ab1f6a855279a8fb4c4e6f37f4R71-R74))
