### PR TITLE
always let user disconnect wallet

### DIFF
--- a/components/integrations/components/IdentityProviders.tsx
+++ b/components/integrations/components/IdentityProviders.tsx
@@ -179,13 +179,16 @@ export function IdentityProviders() {
               loading={isConnectingIdentity || isVerifyingWallet || isSigning}
               disabled={cannotDisconnect}
               connected={true}
-              actions={
+              actions={[
                 verifiableWalletDetected && !account && !isConnectingIdentity ? (
-                  <MenuItem onClick={generateWalletAuth}>Verify Wallet</MenuItem>
-                ) : account ? (
-                  <MenuItem onClick={deleteWalletPopupState.open}>Disconnect Wallet</MenuItem>
-                ) : null
-              }
+                  <MenuItem key='verify' onClick={generateWalletAuth}>
+                    Verify Wallet
+                  </MenuItem>
+                ) : null,
+                <MenuItem key='disconnect' onClick={deleteWalletPopupState.open}>
+                  Disconnect Wallet
+                </MenuItem>
+              ]}
             />
             <ConfirmDeleteModal
               title='Disconnect wallet'


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a282e4</samp>

Fixed a React warning and improved the UI of the identity providers component. Changed the `actions` prop of the `IdentityProvider` component to accept an array of elements in `components/integrations/components/IdentityProviders.tsx`.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a282e4</samp>

*  Changed `actions` prop of `IdentityProvider` component to accept an array of elements and added unique `key` props to each element ([link](https://github.com/charmverse/app.charmverse.io/pull/2018/files?diff=unified&w=0#diff-0e2e60c84b1db8b0f88a6567480417a9ffeae63667033db1c7014a0d5fe744c9L182-R191)). This fixed a React warning and enabled both verify and disconnect actions for connected wallets.
