### PR TITLE
Fix bug relating to display of cards

### DIFF
--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -35,7 +35,7 @@ export function filterVisiblePages(pageMap: PagesMap<PageMeta>, rootPageIds: str
             rootPageIds?.includes(page.id)) &&
           !findParentOfType({
             pageId: page.id,
-            pageType: ['card', 'inline_board', 'board'],
+            pageType: 'card',
             pageMap
           })
       )

--- a/lib/pages/__tests__/findParentOfType.spec.ts
+++ b/lib/pages/__tests__/findParentOfType.spec.ts
@@ -64,13 +64,46 @@ describe('findParentOfType', () => {
     expect(result).toBe(page_1_1.id);
   });
 
-  it('should return the id of the closest parent node matching the given type, when given a pages map', () => {
+  it('should support array as an option to lookup parents type', () => {
+    const rootBoard: PageNode = {
+      ...root_1,
+      type: 'board'
+    };
+
+    const childPage: PageNode = {
+      ...page_1_1,
+      parentId: rootBoard.id,
+      type: 'card'
+    };
+
+    const nestedChildPage: PageNode = {
+      ...page_1_1_1,
+      parentId: childPage.id,
+      type: 'page'
+    };
+
+    const pageMap = {
+      [rootBoard.id]: rootBoard,
+      [childPage.id]: childPage,
+      [nestedChildPage.id]: nestedChildPage
+    };
+
+    const result = findParentOfType({ pageType: ['board'], pageId: nestedChildPage.id, pageMap });
+
+    expect(result).toBe(rootBoard.id);
+
+    const secondResult = findParentOfType({ pageType: ['proposal', 'bounty'], pageId: nestedChildPage.id, pageMap });
+
+    expect(secondResult).toBe(null);
+  });
+
+  it('should return null when no parent node matches the given type, when given a pages map', () => {
     const result = findParentOfType({ pageType: 'board', pageId: page_1_1_1.id, pageMap: pagesMap });
 
     expect(result).toBe(null);
   });
 
-  it('should return the id of the closest parent node matching the given type, when given a resolved page tree', () => {
+  it('should return null when ni parent node matches the given type, when given a resolved page tree', () => {
     const result = findParentOfType({ pageType: 'board', targetPageTree: page_1_1_1_Tree });
 
     expect(result).toBe(null);

--- a/lib/pages/findParentOfType.ts
+++ b/lib/pages/findParentOfType.ts
@@ -3,10 +3,28 @@ import type { PageType } from '@prisma/client';
 import type { PageNode, PagesMap, TargetPageTree } from './interfaces';
 
 export interface FindParentOfTypeOptions<P extends PageNode> {
-  pageType: PageType;
+  pageType: PageType | PageType[];
   pageId?: string;
   pageMap?: PagesMap<P>;
   targetPageTree?: TargetPageTree<P>;
+}
+
+function matcher({
+  evaluatedPageType,
+  searchPageType
+}: {
+  evaluatedPageType?: PageType;
+  searchPageType: PageType | PageType[];
+}) {
+  if (!evaluatedPageType) {
+    return false;
+  }
+
+  if (typeof searchPageType === 'object') {
+    return searchPageType.includes(evaluatedPageType);
+  }
+
+  return searchPageType === evaluatedPageType;
 }
 
 /**
@@ -41,8 +59,8 @@ export function findParentOfType<P extends PageNode = PageNode>({
 
       currentNode = pageMap[parentId];
 
-      if (currentNode?.type === pageType) {
-        return currentNode.id;
+      if (matcher({ evaluatedPageType: currentNode?.type, searchPageType: pageType })) {
+        return currentNode?.id as string;
       }
     }
   } else if (targetPageTree) {
@@ -51,7 +69,7 @@ export function findParentOfType<P extends PageNode = PageNode>({
     for (let i = 0; i < length; i++) {
       const parent = targetPageTree.parents[i];
 
-      if (parent?.type === pageType) {
+      if (matcher({ evaluatedPageType: parent?.type, searchPageType: pageType })) {
         return parent.id;
       }
     }

--- a/pages/[domain]/index.tsx
+++ b/pages/[domain]/index.tsx
@@ -27,7 +27,7 @@ export default function RedirectToMainPage() {
       router.push(defaultPage);
     } else if (!loadingPages) {
       // Find the first top-level page that is not card and hasn't been deleted yet.
-      const topLevelPages = filterVisiblePages(Object.values(pages))
+      const topLevelPages = filterVisiblePages(pages)
         // Remove any child pages (eg. that have a parentId)
         .filter((page) => !page?.parentId);
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 089c135</samp>

Refactored and improved the page navigation menu logic and its related functions and tests. The `findParentOfType` function can now handle multiple page types and uses a helper function for type matching. The `PageNavigation` component uses new types and a helper function to filter out pages that have a parent of a certain type. The `topLevelPages` variable in `pages/[domain]/index.tsx` was simplified to use the `filterVisiblePages` function.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 089c135</samp>

*  Refactor `filterVisiblePages` function to take a `PagesMap` and return an array of `MenuNode` objects, and use `findParentOfType` to exclude pages with certain parent types ([link](https://github.com/charmverse/app.charmverse.io/pull/2019/files?diff=unified&w=0#diff-ec983970361b4f450861024e20da29ad6cd98133f4132d7512b70f980c321f33L18-R20), [link](https://github.com/charmverse/app.charmverse.io/pull/2019/files?diff=unified&w=0#diff-ec983970361b4f450861024e20da29ad6cd98133f4132d7512b70f980c321f33L26-R55), [link](https://github.com/charmverse/app.charmverse.io/pull/2019/files?diff=unified&w=0#diff-ec983970361b4f450861024e20da29ad6cd98133f4132d7512b70f980c321f33L56-R76), [link](https://github.com/charmverse/app.charmverse.io/pull/2019/files?diff=unified&w=0#diff-22ffda8d8af7a93df01ce6cec34538e350a42aba9b1b6c944b6699d41539e204L30-R30))
* Update `findParentOfType` function to support an array of page types as an option, and add a helper `matcher` function to compare page types ([link](https://github.com/charmverse/app.charmverse.io/pull/2019/files?diff=unified&w=0#diff-2b1da163085df4c820128a423c69233f4e93b2fc44b0f0ee0a5e3de28ae09b4bL6-R6), [link](https://github.com/charmverse/app.charmverse.io/pull/2019/files?diff=unified&w=0#diff-2b1da163085df4c820128a423c69233f4e93b2fc44b0f0ee0a5e3de28ae09b4bR12-R29), [link](https://github.com/charmverse/app.charmverse.io/pull/2019/files?diff=unified&w=0#diff-2b1da163085df4c820128a423c69233f4e93b2fc44b0f0ee0a5e3de28ae09b4bL44-R63), [link](https://github.com/charmverse/app.charmverse.io/pull/2019/files?diff=unified&w=0#diff-2b1da163085df4c820128a423c69233f4e93b2fc44b0f0ee0a5e3de28ae09b4bL54-R72))
* Move and modify test cases for `findParentOfType` function from `lib/pages/__tests__/findParentOfType.spec.ts` to `components/common/PageLayout/components/PageNavigation/PageNavigation.tsx` ([link](https://github.com/charmverse/app.charmverse.io/pull/2019/files?diff=unified&w=0#diff-454c1e47aabddb91c21ea00dd1e6a3ec4fe17dfe7603ae4ba3043e2134dbbb85L67-R100), [link](https://github.com/charmverse/app.charmverse.io/pull/2019/files?diff=unified&w=0#diff-454c1e47aabddb91c21ea00dd1e6a3ec4fe17dfe7603ae4ba3043e2134dbbb85L73-R106))
