### PR TITLE
fix order of view source options

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions.tsx
@@ -99,16 +99,15 @@ export function ViewSourceOptions(props: ViewSourceOptionsProps) {
               <TbDatabase style={{ fontSize: 24 }} />
               CharmVerse database
             </SourceType>
+            <SourceType active={false} component='label' htmlFor='dbcsvfile'>
+              <input hidden type='file' id='dbcsvfile' name='dbcsvfile' accept='.csv' onChange={props.onCsvImport} />
+              <BsFiletypeCsv style={{ fontSize: 24 }} />
+              Import CSV
+            </SourceType>
             <SourceType active={activeSourceType === 'google_form'} onClick={selectSourceType('google_form')}>
               <RiGoogleFill style={{ fontSize: 24 }} />
               Google Form
             </SourceType>
-            {props.onCreate && (
-              <SourceType onClick={props.onCreate}>
-                <AddCircleIcon style={{ fontSize: 24 }} />
-                New database
-              </SourceType>
-            )}
             <SourceType
               active={false}
               onClick={() => (isLoadingWebhookApiKeyCreation ? {} : handleApiKeyClick('typeform'))}
@@ -116,11 +115,12 @@ export function ViewSourceOptions(props: ViewSourceOptionsProps) {
               <SiTypeform style={{ fontSize: 24 }} />
               Typeform
             </SourceType>
-            <SourceType active={false} component='label' htmlFor='dbcsvfile'>
-              <input hidden type='file' id='dbcsvfile' name='dbcsvfile' accept='.csv' onChange={props.onCsvImport} />
-              <BsFiletypeCsv style={{ fontSize: 24 }} />
-              CSV
-            </SourceType>
+            {props.onCreate && (
+              <SourceType onClick={props.onCreate}>
+                <AddCircleIcon style={{ fontSize: 24 }} />
+                New database
+              </SourceType>
+            )}
           </Grid>
         )}
         {formStep === 'configure_source' && sourceType === 'board_page' && (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a25960</samp>

This pull request adds a new feature and improves the user interface of the `BoardEditor` component. It allows users to import data from CSV files and rearranges the options for creating new databases in `viewSourceOptions.tsx`.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a25960</samp>

*  Add option to import CSV file as database source ([link](https://github.com/charmverse/app.charmverse.io/pull/2022/files?diff=unified&w=0#diff-1e4fe12edac7a7a851bf9571c4ac67b0224a484a45f13e80d35fa8297e9f8d54L102-R110))
* Move option to create new database to the end of source options ([link](https://github.com/charmverse/app.charmverse.io/pull/2022/files?diff=unified&w=0#diff-1e4fe12edac7a7a851bf9571c4ac67b0224a484a45f13e80d35fa8297e9f8d54L119-R123))
