### PR TITLE
hide bots and guests from member directory

### DIFF
--- a/components/members/hooks/useFilteredMembers.ts
+++ b/components/members/hooks/useFilteredMembers.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { useMembers } from 'hooks/useMembers';
 
-export function useFilteredMembers(searchQuery: string, includeBots = false) {
+export function useFilteredMembers(searchQuery: string, includeGuestsAndBots = false) {
   const { members } = useMembers();
 
   const filteredMembers = useMemo(() => {
@@ -12,7 +12,7 @@ export function useFilteredMembers(searchQuery: string, includeBots = false) {
     }
 
     return members.filter((member) => {
-      if (member.isBot && !includeBots) {
+      if ((member.isBot || member.isGuest) && !includeGuestsAndBots) {
         return false;
       }
       if (member.searchValue?.includes(query)) {

--- a/components/members/hooks/useFilteredMembers.ts
+++ b/components/members/hooks/useFilteredMembers.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { useMembers } from 'hooks/useMembers';
 
-export function useFilteredMembers(searchQuery: string) {
+export function useFilteredMembers(searchQuery: string, includeBots = false) {
   const { members } = useMembers();
 
   const filteredMembers = useMemo(() => {
@@ -12,6 +12,9 @@ export function useFilteredMembers(searchQuery: string) {
     }
 
     return members.filter((member) => {
+      if (member.isBot && !includeBots) {
+        return false;
+      }
       if (member.searchValue?.includes(query)) {
         return true;
       }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af4ca48</samp>

Added a feature to search for bot members in the `members` component. Modified the `useFilteredMembers` hook and its usage to support the new feature.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af4ca48</samp>

*  Add an optional parameter `includeBots` to the `useFilteredMembers` hook to control whether to include bot members in the search results ([link](https://github.com/charmverse/app.charmverse.io/pull/2023/files?diff=unified&w=0#diff-3d049f26312d53d6faefc2df1d8456eb4c7019d78d4b0d420a0e7f7e62982a32L5-R5))
*  Filter out bot members from the results if the `includeBots` parameter is false, using the `isBot` property of each member ([link](https://github.com/charmverse/app.charmverse.io/pull/2023/files?diff=unified&w=0#diff-3d049f26312d53d6faefc2df1d8456eb4c7019d78d4b0d420a0e7f7e62982a32R15-R17))
*  Update the file `components/members/hooks/useFilteredMembers.ts` with the modified hook logic and type annotations ([link](https://github.com/charmverse/app.charmverse.io/pull/2023/files?diff=unified&w=0#diff-3d049f26312d53d6faefc2df1d8456eb4c7019d78d4b0d420a0e7f7e62982a32L5-R5), [link](https://github.com/charmverse/app.charmverse.io/pull/2023/files?diff=unified&w=0#diff-3d049f26312d53d6faefc2df1d8456eb4c7019d78d4b0d420a0e7f7e62982a32R15-R17))
