### PR TITLE
remove user data from result of inline comments

### DIFF
--- a/__integration-tests__/server/pages/api/comments/index.spec.ts
+++ b/__integration-tests__/server/pages/api/comments/index.spec.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { Space, User } from '@prisma/client';
+import type { Space, Comment } from '@prisma/client';
 import request from 'supertest';
 
-import type { CommentCreate, CommentWithUser } from 'lib/comments';
+import type { CommentCreate } from 'lib/comments';
 import { upsertPermission } from 'lib/permissions/pages';
 import type { LoggedInUser } from 'models';
 import { baseUrl, loginUser } from 'testing/mockApiCall';
@@ -51,17 +51,16 @@ describe('POST /api/comments - create a comment', () => {
 
     const createdComment = (
       await request(baseUrl).post('/api/comments').set('Cookie', nonAdminCookie).send(creationContent).expect(201)
-    ).body as CommentWithUser;
+    ).body as Comment;
 
     expect(createdComment).toEqual(
-      expect.objectContaining<Partial<CommentWithUser>>({
+      expect.objectContaining<Partial<Comment>>({
         content: creationContent.content,
         pageId: page.id
       })
     );
 
-    expect(createdComment.user).toBeDefined();
-    expect(createdComment.user.id).toBe(nonAdminUser.id);
+    expect(createdComment.userId).toBe(nonAdminUser.id);
   });
 
   it('should fail if the user does not have a comment permission, even if they are an admin, and respond 401', async () => {

--- a/__integration-tests__/server/pages/api/threads/index.spec.ts
+++ b/__integration-tests__/server/pages/api/threads/index.spec.ts
@@ -62,7 +62,7 @@ describe('POST /api/threads - create a thread', () => {
 
     expect(createdThread.comments).toBeDefined();
     expect(createdThread.comments[0].content).toBe(creationContent.comment);
-    expect(createdThread.comments[0].user.id).toBe(nonAdminUser.id);
+    expect(createdThread.comments[0].userId).toBe(nonAdminUser.id);
   });
 
   it('should fail if the user does not have a comment permission, and respond 401', async () => {

--- a/charmClient/apis/commentsApi.ts
+++ b/charmClient/apis/commentsApi.ts
@@ -1,15 +1,22 @@
+import type { Comment } from '@prisma/client';
+
 import * as http from 'adapters/http';
 import type { CommentCreate, CommentWithUser } from 'lib/comments/interfaces';
 import type { PageContent } from 'lib/prosemirror/interfaces';
-import type { MultipleThreadsInput, ThreadCreate, ThreadWithCommentsAndAuthors } from 'lib/threads/interfaces';
+import type {
+  MultipleThreadsInput,
+  ThreadCreate,
+  ThreadWithComments,
+  ThreadWithCommentsAndAuthors
+} from 'lib/threads/interfaces';
 import type { ResolveThreadRequest } from 'pages/api/threads/[id]/resolve';
 
 export class CommentsApi {
-  addComment(request: Omit<CommentCreate, 'userId'>): Promise<CommentWithUser> {
+  addComment(request: Omit<CommentCreate, 'userId'>): Promise<Comment | CommentWithUser> {
     return http.POST('/api/comments', request);
   }
 
-  editComment(commentId: string, content: PageContent): Promise<CommentWithUser> {
+  editComment(commentId: string, content: PageContent): Promise<Comment | CommentWithUser> {
     return http.PUT(`/api/comments/${commentId}`, { content });
   }
 
@@ -17,11 +24,11 @@ export class CommentsApi {
     return http.DELETE(`/api/comments/${commentId}`);
   }
 
-  getThreads(pageId: string): Promise<ThreadWithCommentsAndAuthors[]> {
+  getThreads(pageId: string): Promise<ThreadWithComments[] | ThreadWithCommentsAndAuthors[]> {
     return http.GET(`/api/pages/${pageId}/threads`);
   }
 
-  startThread(request: Omit<ThreadCreate, 'userId'>): Promise<ThreadWithCommentsAndAuthors> {
+  startThread(request: Omit<ThreadCreate, 'userId'>): Promise<ThreadWithComments | ThreadWithCommentsAndAuthors> {
     return http.POST('/api/threads', request);
   }
 

--- a/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
@@ -104,7 +104,7 @@ export function InlineCommentSubMenu({ pluginKey }: { pluginKey: PluginKey }) {
     ]
   });
   const { extractTextFromSelection } = useInlineComment();
-  const { setThreads } = useThreads();
+  const { setThreads, refetchThreads } = useThreads();
   const { currentPageId } = useCurrentPage();
   const isEmpty = checkIsContentEmpty(commentContent);
   const isSmallScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
@@ -118,7 +118,9 @@ export function InlineCommentSubMenu({ pluginKey }: { pluginKey: PluginKey }) {
         context: extractTextFromSelection(),
         pageId: cardId || currentPageId
       });
-      setThreads((_threads) => ({ ..._threads, [threadWithComment.id]: threadWithComment }));
+      // jsut refetch threads for now to make sure member is attached properly - optimize later by not needing to append members to output of useThreads
+      refetchThreads();
+      // setThreads((_threads) => ({ ..._threads, [threadWithComment.id]: threadWithComment }));
       updateInlineComment(threadWithComment.id)(view.state, view.dispatch);
       hideSelectionTooltip(pluginKey)(view.state, view.dispatch, view);
       const tr = view.state.tr.setSelection(new TextSelection(view.state.doc.resolve(view.state.selection.$to.pos)));

--- a/lib/comments/__tests__/addComment.spec.ts
+++ b/lib/comments/__tests__/addComment.spec.ts
@@ -35,8 +35,7 @@ describe('addComment', () => {
 
     expect(newComment.content).toBe(newCommentMessage);
 
-    expect(newComment.user).toBeDefined();
-    expect(newComment.user.id).toBe(user.id);
+    expect(newComment.userId).toBe(user.id);
   });
 
   it('should fail if the comment content is empty', async () => {

--- a/lib/comments/__tests__/updateComment.spec.ts
+++ b/lib/comments/__tests__/updateComment.spec.ts
@@ -33,8 +33,7 @@ describe('updateComment', () => {
 
     expect(updated.content).toBe(newCommentMessage);
 
-    expect(updated.user).toBeDefined();
-    expect(updated.user.id).toBe(user.id);
+    expect(updated.userId).toBe(user.id);
   });
 
   it('should fail if the comment does not exist', async () => {

--- a/lib/comments/addComment.ts
+++ b/lib/comments/addComment.ts
@@ -1,9 +1,11 @@
+import type { Comment } from '@prisma/client';
+
 import { prisma } from 'db';
 import { DataNotFoundError, InvalidInputError } from 'lib/utilities/errors';
 
-import type { CommentCreate, CommentWithUser } from './interfaces';
+import type { CommentCreate } from './interfaces';
 
-export async function addComment({ content, threadId, userId }: CommentCreate): Promise<CommentWithUser> {
+export async function addComment({ content, threadId, userId }: CommentCreate): Promise<Comment> {
   if (!content) {
     throw new InvalidInputError('Please provide non-empty content to create a comment');
   }
@@ -49,9 +51,6 @@ export async function addComment({ content, threadId, userId }: CommentCreate): 
           id: thread.pageId
         }
       }
-    },
-    include: {
-      user: true
     }
   });
 

--- a/lib/comments/interfaces.ts
+++ b/lib/comments/interfaces.ts
@@ -8,7 +8,7 @@ export type CommentCreate = Pick<Comment, 'content' | 'threadId' | 'userId'>;
 export type CommentUpdate = Pick<Comment, 'content' | 'id'>;
 
 export interface CommentWithUser extends Comment {
-  user: User;
+  user: { id: string; username: string; avatar: string };
 }
 
 export type GenericCommentVote = {

--- a/lib/comments/updateComment.ts
+++ b/lib/comments/updateComment.ts
@@ -1,9 +1,11 @@
+import type { Comment } from '@prisma/client';
+
 import { prisma } from 'db';
 import { DataNotFoundError, InvalidInputError } from 'lib/utilities/errors';
 
-import type { CommentUpdate, CommentWithUser } from './interfaces';
+import type { CommentUpdate } from './interfaces';
 
-export async function updateComment({ content, id }: CommentUpdate): Promise<CommentWithUser> {
+export async function updateComment({ content, id }: CommentUpdate): Promise<Comment> {
   if (!content) {
     throw new InvalidInputError('Please provide a non empty input to update this comment.');
   }
@@ -28,9 +30,6 @@ export async function updateComment({ content, id }: CommentUpdate): Promise<Com
     data: {
       content,
       updatedAt: new Date()
-    },
-    include: {
-      user: true
     }
   });
 

--- a/lib/threads/__tests__/createThread.spec.ts
+++ b/lib/threads/__tests__/createThread.spec.ts
@@ -34,9 +34,7 @@ describe('createThread', () => {
 
     expect(thread.comments).toBeDefined();
     expect(thread.comments[0].content).toBe(firstComment);
-
-    expect(thread.comments[0].user).toBeDefined();
-    expect(thread.comments[0].user.id).toBe(user.id);
+    expect(thread.comments[0].userId).toBe(user.id);
 
     expect(thread.spaceId).toBe(page.spaceId);
   });

--- a/lib/threads/createThread.ts
+++ b/lib/threads/createThread.ts
@@ -1,14 +1,9 @@
 import { prisma } from 'db';
 import { DataNotFoundError, InvalidInputError } from 'lib/utilities/errors';
 
-import type { ThreadCreate, ThreadWithCommentsAndAuthors } from './interfaces';
+import type { ThreadCreate, ThreadWithComments } from './interfaces';
 
-export async function createThread({
-  comment,
-  pageId,
-  userId,
-  context
-}: ThreadCreate): Promise<ThreadWithCommentsAndAuthors> {
+export async function createThread({ comment, pageId, userId, context }: ThreadCreate): Promise<ThreadWithComments> {
   if (!comment) {
     throw new InvalidInputError('Please provide a valid comment');
   }
@@ -72,11 +67,7 @@ export async function createThread({
       }
     },
     include: {
-      comments: {
-        include: {
-          user: true
-        }
-      }
+      comments: true
     }
   });
 

--- a/lib/threads/interfaces.ts
+++ b/lib/threads/interfaces.ts
@@ -1,5 +1,4 @@
-import type { Thread } from '@prisma/client';
-import { Comment } from '@prisma/client';
+import type { Thread, Comment } from '@prisma/client';
 
 import type { CommentWithUser } from 'lib/comments/interfaces';
 import type { PageContent } from 'lib/prosemirror/interfaces';
@@ -24,6 +23,10 @@ export interface ThreadCreate {
   pageId: string;
   userId: string;
   context: string;
+}
+
+export interface ThreadWithComments extends Thread {
+  comments: Comment[];
 }
 
 export interface ThreadWithCommentsAndAuthors extends Thread {

--- a/lib/threads/toggleThreadStatus.ts
+++ b/lib/threads/toggleThreadStatus.ts
@@ -1,10 +1,10 @@
 import { prisma } from 'db';
 import { InvalidInputError } from 'lib/utilities/errors';
 
-import type { ThreadStatusUpdate, ThreadWithCommentsAndAuthors } from './interfaces';
+import type { ThreadStatusUpdate, ThreadWithComments } from './interfaces';
 import { ThreadStatus } from './interfaces';
 
-export async function toggleThreadStatus({ id, status }: ThreadStatusUpdate): Promise<ThreadWithCommentsAndAuthors> {
+export async function toggleThreadStatus({ id, status }: ThreadStatusUpdate): Promise<ThreadWithComments> {
   if (Object.keys(ThreadStatus).indexOf(status) === -1) {
     throw new InvalidInputError('Provide a valid status for the thread');
   }
@@ -29,11 +29,7 @@ export async function toggleThreadStatus({ id, status }: ThreadStatusUpdate): Pr
       resolved: resolvedStatus
     },
     include: {
-      comments: {
-        include: {
-          user: true
-        }
-      }
+      comments: true
     }
   });
 

--- a/pages/api/threads/[id]/resolve.ts
+++ b/pages/api/threads/[id]/resolve.ts
@@ -6,7 +6,7 @@ import { trackUserAction } from 'lib/metrics/mixpanel/trackUserAction';
 import { ActionNotPermittedError, onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
 import { computeUserPagePermissions } from 'lib/permissions/pages/page-permission-compute';
 import { withSessionRoute } from 'lib/session/withSession';
-import type { ThreadWithCommentsAndAuthors } from 'lib/threads';
+import type { ThreadWithComments } from 'lib/threads';
 import { toggleThreadStatus } from 'lib/threads';
 import { DataNotFoundError } from 'lib/utilities/errors';
 
@@ -18,7 +18,7 @@ export interface ResolveThreadRequest {
   resolved: boolean;
 }
 
-async function resolveThread(req: NextApiRequest, res: NextApiResponse<ThreadWithCommentsAndAuthors>) {
+async function resolveThread(req: NextApiRequest, res: NextApiResponse<ThreadWithComments>) {
   const userId = req.session.user.id as string;
   const threadId = req.query.id as string;
   const thread = await prisma.thread.findUnique({

--- a/pages/api/threads/index.ts
+++ b/pages/api/threads/index.ts
@@ -5,14 +5,14 @@ import { trackUserAction } from 'lib/metrics/mixpanel/trackUserAction';
 import { ActionNotPermittedError, onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
 import { computeUserPagePermissions } from 'lib/permissions/pages';
 import { withSessionRoute } from 'lib/session/withSession';
-import type { ThreadCreate, ThreadWithCommentsAndAuthors } from 'lib/threads';
+import type { ThreadCreate, ThreadWithComments } from 'lib/threads';
 import { createThread } from 'lib/threads';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler.use(requireUser).post(requireKeys<ThreadCreate>(['context', 'pageId', 'comment'], 'body'), startThread);
 
-async function startThread(req: NextApiRequest, res: NextApiResponse<ThreadWithCommentsAndAuthors>) {
+async function startThread(req: NextApiRequest, res: NextApiResponse<ThreadWithComments>) {
   const { comment, context, pageId } = req.body as ThreadCreate;
 
   const userId = req.session.user.id;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9974c22</samp>

Refactored the types and queries of comments and threads in the app to simplify the data structure and reduce unnecessary data fetching. Removed the user details from the `Comment` type and the comments API, and added them to the threads hook using `useMembers`. Updated the integration tests, the CharmEditor component, and the threads API to reflect these changes.


My next step will be to change the interface of useThreads, and have compnents get member info from useMembers() instead. I'd also like to consider renaming that to "useInliineComments" cc @Devorein 