### PR TITLE
Improved copy for Permissions UI

### DIFF
--- a/components/settings/roles/RoleSettings.tsx
+++ b/components/settings/roles/RoleSettings.tsx
@@ -1,5 +1,5 @@
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import { Box, CircularProgress, Divider, Menu, Typography } from '@mui/material';
+import { Box, Card, CircularProgress, Divider, Menu, Paper, Typography } from '@mui/material';
 import type { Space, Role } from '@prisma/client';
 import { useRef, useState } from 'react';
 
@@ -91,14 +91,11 @@ export function RoleSettings({ space }: { space: Space }) {
       <MemberRoleRow readOnly={!isAdmin} spaceId={space.id} />
       <AdminRoleRow readOnly={!isAdmin} />
       <GuestRoleRow readOnly={!isAdmin} />
-      {roles && roles.length > 0 && (
-        <>
-          <Divider sx={{ my: 2 }} />
-          <Typography variant='body2' fontWeight='bold' color='secondary'>
-            Custom roles
-          </Typography>
-        </>
-      )}
+      <Divider sx={{ my: 2 }} />
+      <Typography variant='body2' fontWeight='bold' color='secondary'>
+        Custom roles
+      </Typography>
+      <Typography variant='caption'>Custom role permissions override Default.</Typography>
       {roles?.map((role) => (
         <RoleRow
           readOnly={!isAdmin}
@@ -109,7 +106,21 @@ export function RoleSettings({ space }: { space: Space }) {
           key={role.id}
         />
       ))}
-      {isCreateFormVisible && <CreateRoleForm onCancel={hideCreateRoleForm} onSubmit={createNewRole} />}
+      {roles?.length === 0 && !isCreateFormVisible && (
+        <Box p={3} mt={2} sx={{ border: '1px solid var(--input-border)', textAlign: 'center' }}>
+          <Typography sx={{ mb: 2 }} variant='body2' color='secondary'>
+            No roles have been created yet.
+          </Typography>
+          <Button onClick={showCreateRoleForm} disabled={isValidating} variant='outlined'>
+            Add a role
+          </Button>
+        </Box>
+      )}
+      {isCreateFormVisible && (
+        <Box mt={2}>
+          <CreateRoleForm onCancel={hideCreateRoleForm} onSubmit={createNewRole} />
+        </Box>
+      )}
       <div id={formAnchorId} />
 
       {isValidating && (

--- a/components/settings/roles/components/MemberRow.tsx
+++ b/components/settings/roles/components/MemberRow.tsx
@@ -216,7 +216,7 @@ function MemberActions({
                   {action === 'removeFromSpace' && (
                     <StyledListItemText
                       primaryTypographyProps={{ fontWeight: 500, color: 'error' }}
-                      primary='Remove from team'
+                      primary='Remove from space'
                     />
                   )}
                   {action === activeRoleAction && (

--- a/components/settings/roles/components/RolePermissions/components/DefaultPagePermissions.tsx
+++ b/components/settings/roles/components/RolePermissions/components/DefaultPagePermissions.tsx
@@ -81,9 +81,9 @@ export function DefaultPagePermissions() {
   return (
     <>
       <Box mb={2}>
-        <Typography fontWeight='bold'>New page permissions</Typography>
+        <Typography fontWeight='bold'>Default permissions for new pages</Typography>
         <Typography variant='caption'>
-          These apply only to new top-level pages. You can still control access to each page individually.
+          This applies to top-level pages only. Subpages will inherit permissions from their parent.
         </Typography>
       </Box>
       <Box mb={2} display='flex' alignItems='center' justifyContent='space-between'>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42547c6</samp>

This pull request enhances the role settings component by improving its appearance, functionality, and wording. It also fixes some inconsistencies in the text of the member and page permissions components.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42547c6</samp>

*  Update the UI and text of the role settings page ([link](https://github.com/charmverse/app.charmverse.io/pull/2025/files?diff=unified&w=0#diff-4382222f4fff0e61d05a761eb5a5535ea87fec3868353c740ceb6a55103111a3L2-R2), [link](https://github.com/charmverse/app.charmverse.io/pull/2025/files?diff=unified&w=0#diff-4382222f4fff0e61d05a761eb5a5535ea87fec3868353c740ceb6a55103111a3L94-R98), [link](https://github.com/charmverse/app.charmverse.io/pull/2025/files?diff=unified&w=0#diff-4382222f4fff0e61d05a761eb5a5535ea87fec3868353c740ceb6a55103111a3L112-R123), [link](https://github.com/charmverse/app.charmverse.io/pull/2025/files?diff=unified&w=0#diff-ff933bb4ef6e0ce18cbd7a9fbca641335a61fc556866c7c58d7226c84ae6f75cL84-R86), [link](https://github.com/charmverse/app.charmverse.io/pull/2025/files?diff=unified&w=0#diff-92143788eebeb36fcea57c582bf7b4dde04806257831108985e1c1401e025212L219-R219))
  - Import `Card` and `Paper` components from `@mui/material` to style the role settings UI ([link](https://github.com/charmverse/app.charmverse.io/pull/2025/files?diff=unified&w=0#diff-4382222f4fff0e61d05a761eb5a5535ea87fec3868353c740ceb6a55103111a3L2-R2))
  - Remove the conditional rendering of the custom roles section and add a caption to explain that custom role permissions override the default ones ([link](https://github.com/charmverse/app.charmverse.io/pull/2025/files?diff=unified&w=0#diff-4382222f4fff0e61d05a761eb5a5535ea87fec3868353c740ceb6a55103111a3L94-R98))
  - Add a conditional rendering of a box with a message and a button to add a role if there are no custom roles created yet ([link](https://github.com/charmverse/app.charmverse.io/pull/2025/files?diff=unified&w=0#diff-4382222f4fff0e61d05a761eb5a5535ea87fec3868353c740ceb6a55103111a3L112-R123))
  - Change the text of the default page permissions section to clarify that it applies to top-level pages only and that subpages will inherit permissions from their parent ([link](https://github.com/charmverse/app.charmverse.io/pull/2025/files?diff=unified&w=0#diff-ff933bb4ef6e0ce18cbd7a9fbca641335a61fc556866c7c58d7226c84ae6f75cL84-R86))
  - Change the text of the menu item to remove a member from the space from 'Remove from team' to 'Remove from space' in `MemberRow.tsx` ([link](https://github.com/charmverse/app.charmverse.io/pull/2025/files?diff=unified&w=0#diff-92143788eebeb36fcea57c582bf7b4dde04806257831108985e1c1401e025212L219-R219))
