### PR TITLE
Fixed clicking inline comments

### DIFF
--- a/components/common/CharmEditor/specRegistry.ts
+++ b/components/common/CharmEditor/specRegistry.ts
@@ -54,7 +54,6 @@ export const specRegistry = new SpecRegistry([
   // MAKE SURE THIS IS ALWAYS AT THE TOP! Or deleting all contents will leave the wrong component in the editor
   paragraph.spec(), // OK
   mentionSpecs(), // NO
-  inlineComment.spec(),
   inlineVote.spec(),
   bold.spec(), // OK
   bulletList.spec(), // OK
@@ -88,6 +87,8 @@ export const specRegistry = new SpecRegistry([
   deletion,
   insertion,
   formatChange,
+  // This should be below text format and track specs
+  inlineComment.spec(),
   video.spec(),
   textColor.spec(),
   nft.spec(),


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9194ba</samp>

This pull request improves the charm editor functionality by fixing a bug with the `inline comment spec`. It changes the `components/common/CharmEditor/specRegistry.ts` file to prevent the spec from interfering with other charm editing features.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9194ba</samp>

*  Adjust the inline comment spec to avoid conflicts with other specs ([link](https://github.com/charmverse/app.charmverse.io/pull/2026/files?diff=unified&w=0#diff-3707d3aea700881fc2e310324b90f45209fa7496c3082f20607ef217b984eb10L57), [link](https://github.com/charmverse/app.charmverse.io/pull/2026/files?diff=unified&w=0#diff-3707d3aea700881fc2e310324b90f45209fa7496c3082f20607ef217b984eb10R90-R91))
