### PR TITLE
Fixed icons for static pages

### DIFF
--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -77,9 +77,9 @@ export default function NestedPage({ node, currentPageId }: NodeViewProps & { cu
         ) : nestedPage ? (
           <PageIcon
             isLinkedPage={isLinkedPage}
-            isEditorEmpty={!nestedPage?.hasContent}
-            icon={nestedPage?.icon}
-            pageType={nestedPage?.type}
+            isEditorEmpty={!nestedPage.hasContent}
+            icon={nestedPage.icon}
+            pageType={nestedPage.type}
           />
         ) : (
           <NoAccessPageIcon />

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -50,7 +50,6 @@ export default function NestedPage({ node, currentPageId }: NodeViewProps & { cu
 
   const pageTitle =
     (nestedPage || nestedStaticPage)?.title || (nestedCategories ? `Forum > ${nestedCategories?.name}` : '');
-
   const pageId = nestedPage?.id || nestedStaticPage?.path || nestedCategories?.id;
 
   const pagePath = nestedPage ? `${space?.domain}/${nestedPage.path}` : '';
@@ -73,17 +72,18 @@ export default function NestedPage({ node, currentPageId }: NodeViewProps & { cu
       data-type={node.attrs.type}
     >
       <div>
-        {nestedPage ? (
+        {nestedStaticPage ? (
+          <PageIcon icon={null} pageType={nestedStaticPage.path} />
+        ) : nestedPage ? (
           <PageIcon
             isLinkedPage={isLinkedPage}
-            isEditorEmpty={!nestedPage.hasContent}
-            icon={nestedPage.icon}
-            pageType={nestedPage.type}
+            isEditorEmpty={!nestedPage?.hasContent}
+            icon={nestedPage?.icon}
+            pageType={nestedPage?.type}
           />
         ) : (
           <NoAccessPageIcon />
         )}
-        {nestedStaticPage && <PageIcon icon={null} pageType={nestedStaticPage.path} />}
         {nestedCategories && <PageIcon icon={null} pageType='forum_category' />}
       </div>
       <StyledTypography>{(pageTitle ? pageTitle || 'Untitled' : null) || 'No access'}</StyledTypography>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 66f37e6</samp>

This pull request enhances the nested page functionality in the `CharmEditor` component. It fixes some bugs and improves the UI of showing page icons for `NestedPage.tsx`.

### WHY
**Before**
![image](https://user-images.githubusercontent.com/34683631/232452897-a86e920e-35c5-4e72-8fd8-8eac532fe216.png)

**After**
![image](https://user-images.githubusercontent.com/34683631/232452781-37d43148-42c4-4910-ba3e-140226d5f741.png)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 66f37e6</samp>

*  Prioritize nested static page over nested page and handle undefined properties when rendering page icons ([link](https://github.com/charmverse/app.charmverse.io/pull/2027/files?diff=unified&w=0#diff-07d37699ccfb200a2a69f035a8c739bc8e89a76193b14c0222381f3c829b8945L76-R86)). This improves the user experience and prevents errors when working with nested pages in `NestedPage.tsx`.
