### PR TITLE
Fix inline comment box not showing for bounty and proposal cards

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -371,6 +371,7 @@ const defaultContent: PageContent = {
 export type UpdatePageContent = (content: ICharmEditorOutput) => any;
 
 interface CharmEditorProps {
+  insideModal?: boolean;
   colorMode?: 'dark';
   content?: PageContent;
   autoFocus?: boolean;
@@ -402,6 +403,7 @@ function CharmEditor({
   content = defaultContent,
   children,
   autoFocus,
+  insideModal,
   onContentChange,
   style,
   readOnly = false,
@@ -722,6 +724,7 @@ function CharmEditor({
           <InlineCommentThread pluginKey={inlineCommentPluginKey} />
           {currentSpace && pageId && (
             <SuggestionsPopup
+              insideModal={insideModal}
               pageId={pageId}
               spaceId={currentSpace.id}
               pluginKey={suggestionsPluginKey}

--- a/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
@@ -48,7 +48,8 @@ export default function InlineCommentThread({ pluginKey }: { pluginKey: PluginKe
   const { tooltipContentDOM, show: isVisible, ids } = usePluginState(pluginKey) as InlineCommentPluginState;
   const { threads } = useThreads();
 
-  const cardId = new URLSearchParams(window.location.href).get('cardId');
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  const cardId = urlSearchParams.get('cardId') || urlSearchParams.get('id') || urlSearchParams.get('bountyId');
 
   const { currentPageActionDisplay } = usePageActionDisplay();
   // Find unresolved threads in the thread ids and sort them based on desc order of createdAt
@@ -111,7 +112,7 @@ export function InlineCommentSubMenu({ pluginKey }: { pluginKey: PluginKey }) {
 
   const handleSubmit = async (e: React.KeyboardEvent<HTMLElement> | React.MouseEvent<HTMLElement, MouseEvent>) => {
     if (!isEmpty) {
-      const cardId = typeof window !== 'undefined' ? new URLSearchParams(window.location.href).get('cardId') : null;
+      const cardId = typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get('cardId') : null;
       e.preventDefault();
       const threadWithComment = await charmClient.comments.startThread({
         comment: commentContent,

--- a/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.components.tsx
@@ -47,9 +47,7 @@ export default function InlineCommentThread({ pluginKey }: { pluginKey: PluginKe
   const view = useEditorViewContext();
   const { tooltipContentDOM, show: isVisible, ids } = usePluginState(pluginKey) as InlineCommentPluginState;
   const { threads } = useThreads();
-
-  const urlSearchParams = new URLSearchParams(window.location.search);
-  const cardId = urlSearchParams.get('cardId') || urlSearchParams.get('id') || urlSearchParams.get('bountyId');
+  const page = useCurrentPage();
 
   const { currentPageActionDisplay } = usePageActionDisplay();
   // Find unresolved threads in the thread ids and sort them based on desc order of createdAt
@@ -61,7 +59,7 @@ export default function InlineCommentThread({ pluginKey }: { pluginKey: PluginKe
       threadA && threadB ? new Date(threadB.createdAt).getTime() - new Date(threadA.createdAt).getTime() : 0
     );
 
-  if ((currentPageActionDisplay !== 'comments' || cardId) && isVisible && unResolvedThreads.length !== 0) {
+  if ((currentPageActionDisplay !== 'comments' || page) && isVisible && unResolvedThreads.length !== 0) {
     // Only show comment thread on inline comment if the page threads list is not active
     return createPortal(
       <ClickAwayListener

--- a/components/common/CharmEditor/components/suggestions/SuggestionPopup.tsx
+++ b/components/common/CharmEditor/components/suggestions/SuggestionPopup.tsx
@@ -18,8 +18,10 @@ export function SuggestionsPopup({
   pluginKey,
   readOnly,
   pageId,
-  spaceId
+  spaceId,
+  insideModal
 }: {
+  insideModal?: boolean;
   pluginKey: PluginKey<SuggestionPluginState>;
   readOnly: boolean;
   pageId: string;
@@ -30,8 +32,7 @@ export function SuggestionsPopup({
   const { currentPageActionDisplay } = usePageActionDisplay();
   const { user } = useUser();
 
-  const isInPageDialog = new URLSearchParams(window.location.search).get('cardId');
-  const popupIsVisible = (currentPageActionDisplay !== 'suggestions' || isInPageDialog) && isVisible;
+  const popupIsVisible = (currentPageActionDisplay !== 'suggestions' || insideModal) && isVisible;
 
   if (popupIsVisible) {
     const rows = getEventsFromDoc({ state: view.state });

--- a/components/common/CharmEditor/components/suggestions/SuggestionPopup.tsx
+++ b/components/common/CharmEditor/components/suggestions/SuggestionPopup.tsx
@@ -30,7 +30,7 @@ export function SuggestionsPopup({
   const { currentPageActionDisplay } = usePageActionDisplay();
   const { user } = useUser();
 
-  const isInPageDialog = new URLSearchParams(window.location.href).get('cardId');
+  const isInPageDialog = new URLSearchParams(window.location.search).get('cardId');
   const popupIsVisible = (currentPageActionDisplay !== 'suggestions' || isInPageDialog) && isVisible;
 
   if (popupIsVisible) {

--- a/lib/prosemirror/highlightMarkedElement.ts
+++ b/lib/prosemirror/highlightMarkedElement.ts
@@ -52,7 +52,7 @@ export function highlightElement({
   // Page action list node might not be present
   const isShowingActionList = !!pageActionListNode && pageActionListNode.style.visibility !== 'hidden';
   // Check if we are inside a card page modal
-  const cardId = new URLSearchParams(window.location.href).get('cardId');
+  const cardId = new URLSearchParams(window.location.search).get('cardId');
   if (ids.length > 0) {
     // If we are showing the thread list on the right, then navigate to the appropriate thread and highlight it
     if (isShowingActionList && !cardId) {

--- a/lib/prosemirror/highlightMarkedElement.ts
+++ b/lib/prosemirror/highlightMarkedElement.ts
@@ -52,10 +52,9 @@ export function highlightElement({
   // Page action list node might not be present
   const isShowingActionList = !!pageActionListNode && pageActionListNode.style.visibility !== 'hidden';
   // Check if we are inside a card page modal
-  const cardId = new URLSearchParams(window.location.search).get('cardId');
   if (ids.length > 0) {
     // If we are showing the thread list on the right, then navigate to the appropriate thread and highlight it
-    if (isShowingActionList && !cardId) {
+    if (isShowingActionList) {
       // Use regular dom methods as we have no access to a ref inside a plugin
       // Plus this is only a cosmetic change which doesn't impact any of the state
       const actionDocument = document.getElementById(`${prefix}.${ids[0]}`);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d1341e</samp>

The pull request refactors the logic for getting the `cardId` parameter from the URL in several components and functions related to inline commenting and highlighting in the editor. It also moves the `SuggestionsPopup` component to the same file as the `InlineCommentSubMenu` component for better cohesion.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d1341e</samp>

*  Extract `cardId` parameter from URL query string and add fallbacks for `id` and `bountyId` in `inlineComment.components.tsx` and `highlightMarkedElement.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2028/files?diff=unified&w=0#diff-275e846564ebd2c6850d6c25f2b00a47870c6bf633abdbaf9c53a4005326cd62L51-R52), [link](https://github.com/charmverse/app.charmverse.io/pull/2028/files?diff=unified&w=0#diff-275e846564ebd2c6850d6c25f2b00a47870c6bf633abdbaf9c53a4005326cd62L114-R115), [link](https://github.com/charmverse/app.charmverse.io/pull/2028/files?diff=unified&w=0#diff-005518828a991147f9f230bb147cb316d26eaae08981cbc7aafee05b31989babL33-R33), [link](https://github.com/charmverse/app.charmverse.io/pull/2028/files?diff=unified&w=0#diff-303290dcca61f52b43238d613694b1caebbb7f87bc1586ffc1852b0fa0e77bf4L55-R55))
* Move `SuggestionsPopup` component from `SuggestionPopup.tsx` to `inlineComment.components.tsx` and update `isInPageDialog` variable computation ([link](https://github.com/charmverse/app.charmverse.io/pull/2028/files?diff=unified&w=0#diff-005518828a991147f9f230bb147cb316d26eaae08981cbc7aafee05b31989babL33-R33))
