### PR TITLE
Fixed email invite not being updated in permissions list

### DIFF
--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -101,7 +101,7 @@ interface Props {
 export default function PagePermissions({ pageId, pagePermissions, refreshPermissions, pageType }: Props) {
   const { pages } = usePages();
   const space = useCurrentSpace();
-  const { members } = useMembers();
+  const { members, mutateMembers } = useMembers();
   const popupState = usePopupState({ variant: 'popover', popupId: 'add-a-permission' });
 
   const spaceLevelPermission = pagePermissions.find((permission) => space && permission.spaceId === space?.id);
@@ -257,6 +257,7 @@ export default function PagePermissions({ pageId, pagePermissions, refreshPermis
           pageId={pageId}
           permissionsAdded={() => {
             refreshPermissions();
+            mutateMembers();
             popupState.close();
           }}
         />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25f15d7</samp>

Improved the functionality of the `ShareButton` component in the `Header` of the `PageLayout` by revalidating the members data after changing page permissions. This ensures that the members list reflects the latest permissions for the current page.

### WHY
[Discord conversation](https://discord.com/channels/894960387743698944/933026321683066991/1097488556097814569)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25f15d7</samp>

*  Added a function to revalidate members data after permission changes ([link](https://github.com/charmverse/app.charmverse.io/pull/2029/files?diff=unified&w=0#diff-590aa115163fff16637626185f3195deb20b4703396b206d58567460ba22a7c8L104-R104))
*  Called the revalidation function after updating page permission with a mutation ([link](https://github.com/charmverse/app.charmverse.io/pull/2029/files?diff=unified&w=0#diff-590aa115163fff16637626185f3195deb20b4703396b206d58567460ba22a7c8R260))
