### PR TITLE
support wrapping for page titles

### DIFF
--- a/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
@@ -82,6 +82,7 @@ export function PageTitleInput({ value, updatedAt: updatedAtExternal, onChange, 
         data-test='editor-page-title'
         inputRef={titleInput}
         value={title}
+        multiline
         onChange={_onChange}
         placeholder='Untitled'
         autoFocus={!value && !readOnly && !isTouchScreen()}


### PR DESCRIPTION
multiline was removed in this PR: https://github.com/charmverse/app.charmverse.io/commit/470948e0bb591714736a4b578b06ca8bb8c40e71, not sure if it was an accident. Titles are currently cropped inside the card modal and you have to scroll the input to read it