### PR TITLE
Deleted banner not showing on boards

### DIFF
--- a/components/[pageId]/DatabasePage/DatabasePage.tsx
+++ b/components/[pageId]/DatabasePage/DatabasePage.tsx
@@ -24,8 +24,6 @@ import type { PageMeta } from 'lib/pages';
 import type { IPagePermissionFlags } from 'lib/permissions/pages';
 import { setUrlWithoutRerender } from 'lib/utilities/browser';
 
-import PageDeleteBanner from '../DocumentPage/components/PageDeleteBanner';
-
 /**
  *
  * For the original version of this file, see src/boardPage.tsx in focalboard
@@ -164,6 +162,7 @@ export function DatabasePage({ page, setPage, readOnly = false, pagePermissions 
             showView={showView}
             activeView={activeView || undefined}
             views={boardViews}
+            page={page}
           />
           {typeof shownCardId === 'string' && shownCardId.length !== 0 && (
             <CardDialog

--- a/components/[pageId]/DocumentPage/components/PageDeleteBanner.tsx
+++ b/components/[pageId]/DocumentPage/components/PageDeleteBanner.tsx
@@ -5,6 +5,8 @@ import { useState } from 'react';
 import { mutate } from 'swr';
 
 import charmClient from 'charmClient';
+import { updateBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
+import { useAppDispatch, useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
 
@@ -24,11 +26,27 @@ export default function PageDeleteBanner({ pageId }: { pageId: string }) {
   const space = useCurrentSpace();
   const router = useRouter();
   const { pages } = usePages();
+  const dispatch = useAppDispatch();
+
+  const updatedBoards = useAppSelector((state) => {
+    const board = state.boards.boards[pageId];
+    if (board) {
+      return {
+        ...state.boards.boards,
+        [board.id]: {
+          ...board,
+          deletedAt: null
+        }
+      };
+    }
+    return state.boards.boards;
+  });
 
   async function restorePage() {
     if (space) {
       await charmClient.restorePage(pageId);
       await mutate(`pages/${space.id}`);
+      dispatch(updateBoards(Object.values(updatedBoards)));
     }
   }
 

--- a/components/[pageId]/DocumentPage/components/PageDeleteBanner.tsx
+++ b/components/[pageId]/DocumentPage/components/PageDeleteBanner.tsx
@@ -5,8 +5,6 @@ import { useState } from 'react';
 import { mutate } from 'swr';
 
 import charmClient from 'charmClient';
-import { updateBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
-import { useAppDispatch, useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
 
@@ -26,27 +24,11 @@ export default function PageDeleteBanner({ pageId }: { pageId: string }) {
   const space = useCurrentSpace();
   const router = useRouter();
   const { pages } = usePages();
-  const dispatch = useAppDispatch();
-
-  const updatedBoards = useAppSelector((state) => {
-    const board = state.boards.boards[pageId];
-    if (board) {
-      return {
-        ...state.boards.boards,
-        [board.id]: {
-          ...board,
-          deletedAt: null
-        }
-      };
-    }
-    return state.boards.boards;
-  });
 
   async function restorePage() {
     if (space) {
       await charmClient.restorePage(pageId);
       await mutate(`pages/${space.id}`);
-      dispatch(updateBoards(Object.values(updatedBoards)));
     }
   }
 

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -47,6 +47,7 @@ import { createCard } from 'lib/focalboard/card';
 import type { Card, CardPage } from 'lib/focalboard/card';
 import { CardFilter } from 'lib/focalboard/cardFilter';
 import log from 'lib/log';
+import type { PageMeta } from 'lib/pages';
 import { createNewDataSource } from 'lib/pages/createNewDataSource';
 
 import mutator from '../mutator';
@@ -84,6 +85,7 @@ type Props = WrappedComponentProps &
     disableUpdatingUrl?: boolean;
     maxTabsShown?: number;
     onDeleteView?: (viewId: string) => void;
+    page?: PageMeta;
   };
 
 type State = {
@@ -120,7 +122,7 @@ function CenterPanel(props: Props) {
   }, [activeView?.id, views.length]);
 
   const isEmbedded = !!props.embeddedBoardPath;
-  const boardPage = pages[board.id];
+  const boardPage = pages[board.id] ?? props.page;
   const boardPageType = boardPage?.type;
 
   // for 'linked' boards, each view has its own board which we use to determine the cards to show
@@ -497,9 +499,13 @@ function CenterPanel(props: Props) {
 
   const isLoadingSourceData = !activeBoard && state.showSettings !== 'create-linked-view';
 
+  if (boardPage?.type === 'inline_board' && boardPage.deletedAt) {
+    return null;
+  }
+
   return (
     <>
-      {(!!boardPage?.deletedAt || !!board.deletedAt) && <PageDeleteBanner pageId={boardPage?.id ?? board.id} />}
+      {!!boardPage?.deletedAt && <PageDeleteBanner pageId={boardPage.id} />}
       <div
         // remount components between pages
         className={`BoardComponent ${isEmbedded ? 'embedded-board' : ''}`}

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -499,10 +499,6 @@ function CenterPanel(props: Props) {
 
   const isLoadingSourceData = !activeBoard && state.showSettings !== 'create-linked-view';
 
-  if (boardPage?.type === 'inline_board' && boardPage.deletedAt) {
-    return null;
-  }
-
   return (
     <>
       {!!boardPage?.deletedAt && <PageDeleteBanner pageId={boardPage.id} />}

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -499,7 +499,7 @@ function CenterPanel(props: Props) {
 
   return (
     <>
-      {!!boardPage?.deletedAt && <PageDeleteBanner pageId={boardPage.id} />}
+      {(!!boardPage?.deletedAt || !!board.deletedAt) && <PageDeleteBanner pageId={boardPage?.id ?? board.id} />}
       <div
         // remount components between pages
         className={`BoardComponent ${isEmbedded ? 'embedded-board' : ''}`}

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -110,6 +110,7 @@ export default function DatabaseView({ containerWidth, readOnly: readOnlyOverrid
 
   const boards = useAppSelector(getSortedBoards);
   const board = boards.find((b) => b.id === pageId);
+  const boardPage = pages[pageId];
 
   const { permissions: currentPagePermissions } = usePagePermissions({ pageIdOrPath: pageId });
 
@@ -136,7 +137,7 @@ export default function DatabaseView({ containerWidth, readOnly: readOnlyOverrid
     [setCurrentViewId, views]
   );
 
-  if (!board) {
+  if (!board || !boardPage || boardPage.deletedAt !== null) {
     return null;
   }
 

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -13,7 +13,6 @@ import { untitledPage } from 'lib/pages/untitledPage';
 import type { WebSocketPayload } from 'lib/websockets/interfaces';
 
 import { useCurrentSpace } from './useCurrentSpace';
-import { useIsAdmin } from './useIsAdmin';
 import { useUser } from './useUser';
 import { useWebSocketClient } from './useWebSocketClient';
 
@@ -50,11 +49,10 @@ export const PagesContext = createContext<Readonly<PagesContext>>({
 });
 
 export function PagesProvider({ children }: { children: ReactNode }) {
-  const isAdmin = useIsAdmin();
   const currentSpace = useCurrentSpace();
   const currentSpaceId = useRef<undefined | string>();
   const router = useRouter();
-  const { user, isLoaded: isUserLoaded } = useUser();
+  const { user } = useUser();
   const { subscribe } = useWebSocketClient();
 
   const { data, mutate: mutatePagesList } = useSWR(


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea7cbac</samp>

The pull request adds a feature to restore deleted boards from the document page and refactors some components and hooks to improve code quality. It modifies `PageDeleteBanner.tsx`, `usePages.tsx`, and `centerPanel.tsx` to implement the feature and the refactoring.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea7cbac</samp>

*  Add hooks to dispatch and select focalboard store state ([link](https://github.com/charmverse/app.charmverse.io/pull/2040/files?diff=unified&w=0#diff-ac5f8ce9ce374563fe381fd4af4c85341f572b6231d3ab0d7923aea281e374f5R8-R9))
*  Update board state with restored page and dispatch action ([link](https://github.com/charmverse/app.charmverse.io/pull/2040/files?diff=unified&w=0#diff-ac5f8ce9ce374563fe381fd4af4c85341f572b6231d3ab0d7923aea281e374f5L27-R49))
*  Render `PageDeleteBanner` component if board or page is deleted ([link](https://github.com/charmverse/app.charmverse.io/pull/2040/files?diff=unified&w=0#diff-4861c59cd150d8a9cf079ed0c4e13eddf06ef19ae3cdecdb283d92f2faa012b0L502-R502))
*  Remove unused `useIsAdmin` hook and variables from `usePages` hook ([link](https://github.com/charmverse/app.charmverse.io/pull/2040/files?diff=unified&w=0#diff-e5e8481441b266dbb4f138734e4152f9a8dd7819b2484444b19b372c948e3bf0L16), [link](https://github.com/charmverse/app.charmverse.io/pull/2040/files?diff=unified&w=0#diff-e5e8481441b266dbb4f138734e4152f9a8dd7819b2484444b19b372c948e3bf0L53-R55))
