### PR TITLE
Import CSV and then get typeform responses implementation

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions.tsx
@@ -60,7 +60,7 @@ export function ViewSourceOptions(props: ViewSourceOptionsProps) {
     trigger: createWebhookApiKey,
     isMutating: isLoadingWebhookApiKeyCreation
   } = useSWRMutation(
-    `/api/pages/${currentPageId}/api-key`,
+    `/api/api-page-key`,
     (_url, { arg }: Readonly<{ arg: { pageId: string; type: ApiPageKey['type'] } }>) =>
       charmClient.createApiPageKey(arg)
   );

--- a/components/common/Modal/ConfirmImportModal.tsx
+++ b/components/common/Modal/ConfirmImportModal.tsx
@@ -8,7 +8,7 @@ import Button from 'components/common/Button';
 import type { ModalProps } from 'components/common/Modal';
 import { Modal } from 'components/common/Modal';
 
-type ImportAction = 'merge' | 'delete';
+export type ImportAction = 'merge' | 'delete';
 
 type Props = Pick<ModalProps, 'onClose' | 'open' | 'size'> & {
   question: ReactNode;

--- a/components/common/PageLayout/components/Header/components/DatabasePageOptions.tsx
+++ b/components/common/PageLayout/components/Header/components/DatabasePageOptions.tsx
@@ -28,6 +28,7 @@ import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/sto
 import { getCurrentBoardViews, getView } from 'components/common/BoardEditor/focalboard/src/store/views';
 import { Utils } from 'components/common/BoardEditor/focalboard/src/utils';
 import { DuplicatePageAction } from 'components/common/DuplicatePageAction';
+import type { ImportAction } from 'components/common/Modal/ConfirmImportModal';
 import ConfirmImportModal from 'components/common/Modal/ConfirmImportModal';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useDateFormatter } from 'hooks/useDateFormatter';
@@ -135,7 +136,7 @@ export default function DatabaseOptions({ pagePermissions, closeMenu, pageId }: 
     closeMenu();
   }
 
-  const importCsv = (event: ChangeEvent<HTMLInputElement>, importAction?: 'merge' | 'delete'): void => {
+  const importCsv = (event: ChangeEvent<HTMLInputElement>, importAction?: ImportAction): void => {
     if (board && event.target.files && event.target.files[0]) {
       Papa.parse(event.target.files[0], {
         header: true,

--- a/lib/pages/createFormResponseCard.ts
+++ b/lib/pages/createFormResponseCard.ts
@@ -36,7 +36,7 @@ export async function createFormResponseCard({
   const fields = (board.fields as any) || {};
   const cardProperties = fields?.cardProperties || [];
   const existingResponseProperties: FormResponseProperty[] =
-    cardProperties.filter((p: FormResponseProperty) => p.isQuestion) || [];
+    cardProperties.filter((p: FormResponseProperty) => formResponses.some((f) => f.question === p.description)) || [];
 
   // Map properties, create new onses for non-existing questions
   const { newProperties, mappedProperties } = mapAndCreateProperties(formResponses, existingResponseProperties);
@@ -107,8 +107,7 @@ function createNewFormProperty(description: string): FormResponseProperty {
     name: description,
     type: 'text',
     options: [],
-    description,
-    isQuestion: true
+    description
   };
 }
 

--- a/lib/pages/interfaces.ts
+++ b/lib/pages/interfaces.ts
@@ -140,7 +140,6 @@ export type PageDetailsUpdates = Partial<PageDetails> & { id: string };
 
 export type FormResponseProperty = IPropertyTemplate & {
   description: string;
-  isQuestion?: true;
 };
 
 export interface IPageMetaWithPermissions extends PageMeta {


### PR DESCRIPTION
Fixes:
- on csv import sometimes the title was undefined
- on csv import sometimes the title was pushed to the last column
- on csv import sometimes the title was doubled If the first column was named different then 'Title'

Improvements:
- standardise everywhere that the Title should be the single name for the first column. That means the first column from a csv will be renamed Title and everywhere will be referenced by 'Title' key
- Add a description label to every card property so we can compare it with source data like typeform and check the name of the question even tho we rename the question in the future.
- isQuestion prop is not necessary anymore. I am just comparing the 'description' key for each cardProperty