### PR TITLE
CSS tweaks to board filters

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/filterComponent.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/filterComponent.tsx
@@ -91,9 +91,10 @@ const FilterComponent = React.memo((props: Props) => {
               <Stack sx={{ width: 75 }} flexDirection='row' justifyContent='flex-end'>
                 {filterIndex === 1 ? (
                   <Select<FilterGroupOperation>
+                    size='small'
                     value={activeView.fields.filter.operation}
                     onChange={(e) => changeFilterGroupOperation(e.target.value as FilterGroupOperation)}
-                    renderValue={(selected) => <Typography>{capitalize(selected)}</Typography>}
+                    renderValue={(selected) => <Typography fontSize='small'>{capitalize(selected)}</Typography>}
                   >
                     {['Or', 'And'].map((option) => {
                       return (
@@ -104,7 +105,7 @@ const FilterComponent = React.memo((props: Props) => {
                     })}
                   </Select>
                 ) : (
-                  <Typography>
+                  <Typography fontSize='small'>
                     {filterIndex === 0 ? 'Where' : capitalize(activeView.fields.filter.operation)}
                   </Typography>
                 )}

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/filterComponent.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/filterComponent.tsx
@@ -27,12 +27,9 @@ type Props = {
 };
 
 const StyledFilterComponent = styled(Box)`
-  min-width: 430px;
+  min-width: 560px;
+  max-width: 100%;
   padding: 10px;
-
-  ${({ theme }) => theme.breakpoints.down('sm')} {
-    min-width: 350px;
-  }
 `;
 
 const FilterComponent = React.memo((props: Props) => {

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/filterEntry.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/filterEntry.tsx
@@ -171,6 +171,11 @@ function FilterPropertyValue({
         value={filter.values[0]}
         onChange={updateTextValue}
         placeholder='Value'
+        inputProps={{
+          sx: {
+            fontSize: 'small'
+          }
+        }}
       />
     );
   } else if (propertyDataType === 'boolean') {
@@ -179,13 +184,16 @@ function FilterPropertyValue({
     if (isPropertyTypeMultiSelect) {
       return (
         <Select<string[]>
+          size='small'
           multiple
           displayEmpty
           value={filter.values}
           onChange={updateMultiSelectValue}
           renderValue={(selected) => {
             return selected.length === 0 ? (
-              <Typography color='secondary'>Select an option</Typography>
+              <Typography fontSize='small' color='secondary'>
+                Select an option
+              </Typography>
             ) : (
               <SelectMenuItemsContainer>
                 {selected.map((optionId) => {
@@ -221,13 +229,16 @@ function FilterPropertyValue({
     } else if (isPropertyTypePerson) {
       return (
         <Select<string[]>
+          size='small'
           multiple
           displayEmpty
           value={filter.values}
           onChange={updateMultiSelectValue}
           renderValue={(selectedMemberIds) => {
             return selectedMemberIds.length === 0 ? (
-              <Typography color='secondary'>Select a person</Typography>
+              <Typography color='secondary' fontSize='small'>
+                Select a person
+              </Typography>
             ) : (
               <SelectMenuItemsContainer>
                 {selectedMemberIds.map((selectedMemberId) => {
@@ -260,7 +271,9 @@ function FilterPropertyValue({
           return foundOption ? (
             <Chip size='small' label={foundOption.value} color={focalboardColorsMap[foundOption.color]} />
           ) : (
-            <Typography color='secondary'>Select an option</Typography>
+            <Typography fontSize='small' color='secondary'>
+              Select an option
+            </Typography>
           );
         }}
       >
@@ -289,6 +302,7 @@ function FilterPropertyValue({
             {...props}
             inputProps={{
               ...props.inputProps,
+              sx: { fontSize: 'small' },
               readOnly: true,
               placeholder: 'Select a date'
             }}
@@ -353,7 +367,7 @@ function FilterEntry(props: Props) {
                   sx={{ whiteSpace: 'nowrap', overflow: 'hidden' }}
                 >
                   {iconForPropertyType(template.type, { color: 'secondary' })}
-                  <EllipsisText>{template.name}</EllipsisText>
+                  <EllipsisText fontSize='small'>{template.name}</EllipsisText>
                 </Stack>
               </Button>
               <Menu {...bindMenu(popupState)} sx={{ maxWidth: 350 }}>
@@ -378,7 +392,7 @@ function FilterEntry(props: Props) {
                     }}
                   >
                     <ListItemIcon>{iconForPropertyType(property.type)}</ListItemIcon>
-                    <EllipsisText>{property.name}</EllipsisText>
+                    <EllipsisText fontSize='small'>{property.name}</EllipsisText>
                   </MenuItem>
                 ))}
               </Menu>
@@ -396,7 +410,9 @@ function FilterEntry(props: Props) {
                 variant='outlined'
                 endIcon={<KeyboardArrowDownIcon fontSize='small' />}
               >
-                <EllipsisText variant='subtitle1'>{formatCondition(filter.condition)}</EllipsisText>
+                <EllipsisText fontSize='small' variant='subtitle1'>
+                  {formatCondition(filter.condition)}
+                </EllipsisText>
               </Button>
               <Menu {...bindMenu(popupState)}>
                 {propertyConfigs[template.type].conditions.map((condition) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a63d50</samp>

Improved the layout and usability of the filter component in the board view header of `focalboard`. Reduced the width and height of the component and its subcomponents, and adjusted the font size of various elements. This makes the filter options more compact and consistent, and allows more filter entries to fit in one row.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a63d50</samp>

*  Reduced the font size of various filter components to save space and prevent overflow ([link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-4338d9e3c19c5574df5b1592b1a29d62810e989a3b18bab20b62d56e2b751436L94-R94), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-4338d9e3c19c5574df5b1592b1a29d62810e989a3b18bab20b62d56e2b751436L107-R105), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-e72e6f1f81fe91564cb0558122f0a1a540f06821cd40a01b9adecc8ceb25dd2eR174-R178), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-e72e6f1f81fe91564cb0558122f0a1a540f06821cd40a01b9adecc8ceb25dd2eR187), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-e72e6f1f81fe91564cb0558122f0a1a540f06821cd40a01b9adecc8ceb25dd2eL188-R196), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-e72e6f1f81fe91564cb0558122f0a1a540f06821cd40a01b9adecc8ceb25dd2eR232), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-e72e6f1f81fe91564cb0558122f0a1a540f06821cd40a01b9adecc8ceb25dd2eL230-R241), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-e72e6f1f81fe91564cb0558122f0a1a540f06821cd40a01b9adecc8ceb25dd2eL263-R276), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-e72e6f1f81fe91564cb0558122f0a1a540f06821cd40a01b9adecc8ceb25dd2eR305), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-e72e6f1f81fe91564cb0558122f0a1a540f06821cd40a01b9adecc8ceb25dd2eL356-R370), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-e72e6f1f81fe91564cb0558122f0a1a540f06821cd40a01b9adecc8ceb25dd2eL381-R395), [link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-e72e6f1f81fe91564cb0558122f0a1a540f06821cd40a01b9adecc8ceb25dd2eL399-R415))
* Increased the minimum width and set the maximum width to 100% of the `StyledFilterComponent` to accommodate more filter options and adapt to smaller screens ([link](https://github.com/charmverse/app.charmverse.io/pull/2042/files?diff=unified&w=0#diff-4338d9e3c19c5574df5b1592b1a29d62810e989a3b18bab20b62d56e2b751436L30-R32))
