### PR TITLE
show emojis in table of contents

### DIFF
--- a/components/common/CharmEditor/components/emojiSuggest/emojiSuggest.specs.ts
+++ b/components/common/CharmEditor/components/emojiSuggest/emojiSuggest.specs.ts
@@ -37,6 +37,10 @@ function emojiSpec({ defaultEmoji = '😃' }: { defaultEmoji?: string } = {}): R
       group: 'inline',
       draggable: false,
       atom: true,
+      // format emoji for plain text
+      leafText: (node) => {
+        return node.attrs.emoji;
+      },
       toDOM: (node) => {
         const twemojiImage = getTwitterEmoji(node.attrs.emoji);
         return twemojiImage


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e79d80b</samp>

Add `leafText` property to `emojiSpec` function to support plain text conversion of editor content. Update `toPlainText` method of `CharmEditor` component to use `leafText`.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e79d80b</samp>

*  Add `leafText` property to `emojiSpec` function to return emoji character as plain text ([link](https://github.com/charmverse/app.charmverse.io/pull/2043/files?diff=unified&w=0#diff-dbb855eab311cf8bac9235b51ca31e087ec0882b882579ab545a78a9a0dd122aR40-R43))
