### PR TITLE
use page title instead of board title for inline boards

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -496,7 +496,6 @@ function CenterPanel(props: Props) {
   };
 
   const isLoadingSourceData = !activeBoard && state.showSettings !== 'create-linked-view';
-
   return (
     <>
       {!!boardPage?.deletedAt && <PageDeleteBanner pageId={boardPage.id} />}
@@ -520,10 +519,11 @@ function CenterPanel(props: Props) {
           </Box>
         )}
         <div className='top-head'>
-          {board && (boardPageType === 'board' || !isEmbedded) && (
+          {board && boardPage && (boardPageType === 'board' || !isEmbedded) && (
             <ViewTitle
-              key={board.id + board.title}
+              key={boardPage.id + boardPage.title}
               board={board}
+              pageTitle={boardPage.title}
               pageIcon={pageIcon}
               readOnly={props.readOnly}
               setPage={props.setPage}
@@ -562,7 +562,7 @@ function CenterPanel(props: Props) {
               {activeBoard && activePage && isEmbedded && boardPageType === 'inline_board' && (
                 <InlineViewTitle
                   key={activePage.id + activePage.title}
-                  board={activeBoard}
+                  pageTitle={activePage.title}
                   readOnly={props.readOnly}
                   setPage={props.setPage}
                 />

--- a/components/common/BoardEditor/focalboard/src/components/viewTitle.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewTitle.tsx
@@ -40,28 +40,28 @@ const InlineBoardTitleEditable = styled(BoardTitleEditable)`
 `;
 
 type ViewTitleInlineProps = {
-  board: Board;
+  pageTitle: string;
   readOnly: boolean;
   setPage: (page: Partial<Page>) => void;
 };
 
 type ViewTitleProps = ViewTitleInlineProps & {
   pageIcon?: string | null;
+  board: Board;
 };
 
 // NOTE: This is actually the title of the board, not a particular view
 function ViewTitle(props: ViewTitleProps) {
-  const { board, pageIcon } = props;
+  const { board, pageTitle, pageIcon } = props;
 
-  const [title, setTitle] = useState(board.title);
+  const [title, setTitle] = useState(pageTitle);
   const onEditTitleSave = useCallback(() => {
-    mutator.changeTitle(board.id, board.title, title);
     props.setPage({ title });
-  }, [board.id, board.title, title]);
+  }, [pageTitle, title]);
   const onEditTitleCancel = useCallback(() => {
-    setTitle(board.title);
-    props.setPage({ title: board.title });
-  }, [board.title]);
+    setTitle(pageTitle);
+    props.setPage({ title: pageTitle });
+  }, [pageTitle]);
   const onDescriptionChange = useCallback(
     (text: PageContent) => mutator.changeDescription(board.id, board.fields.description, text),
     [board.id, board.fields.description]
@@ -69,7 +69,7 @@ function ViewTitle(props: ViewTitleProps) {
   const onAddRandomIcon = useCallback(() => {
     const newIcon = BlockIcons.shared.randomIcon();
     props.setPage({ icon: newIcon });
-  }, [board.id]);
+  }, []);
   const setRandomHeaderImage = useCallback(
     (headerImage?: string | null) => {
       const newHeaderImage = headerImage ?? randomBannerImage();
@@ -180,13 +180,12 @@ function ViewTitle(props: ViewTitleProps) {
 }
 
 export function InlineViewTitle(props: ViewTitleInlineProps) {
-  const { board } = props;
+  const { pageTitle } = props;
 
-  const [title, setTitle] = useState(board.title);
+  const [title, setTitle] = useState(pageTitle);
   const onEditTitleSave = useCallback(() => {
-    mutator.changeTitle(board.id, board.title, title);
     props.setPage({ title });
-  }, [board.id, board.title, title]);
+  }, [title]);
 
   // cancel key events, such as "Delete" or "Backspace" so that prosemiror doesnt pick them up on inline dbs
   function cancelEvent(e: KeyboardEvent<HTMLDivElement>) {

--- a/components/common/BoardEditor/focalboard/src/mutator.ts
+++ b/components/common/BoardEditor/focalboard/src/mutator.ts
@@ -194,6 +194,19 @@ class Mutator {
     );
   }
 
+  async changeTitle(blockId: string, oldTitle: string, newTitle: string, description = 'change title') {
+    await undoManager.perform(
+      async () => {
+        await charmClient.patchBlock(blockId, { title: newTitle }, publishIncrementalUpdate);
+      },
+      async () => {
+        await charmClient.patchBlock(blockId, { title: oldTitle }, publishIncrementalUpdate);
+      },
+      description,
+      this.undoGroupId
+    );
+  }
+
   async setDefaultTemplate(
     blockId: string,
     oldTemplateId: string,

--- a/components/common/BoardEditor/focalboard/src/mutator.ts
+++ b/components/common/BoardEditor/focalboard/src/mutator.ts
@@ -194,19 +194,6 @@ class Mutator {
     );
   }
 
-  async changeTitle(blockId: string, oldTitle: string, newTitle: string, description = 'change title') {
-    await undoManager.perform(
-      async () => {
-        await charmClient.patchBlock(blockId, { title: newTitle }, publishIncrementalUpdate);
-      },
-      async () => {
-        await charmClient.patchBlock(blockId, { title: oldTitle }, publishIncrementalUpdate);
-      },
-      description,
-      this.undoGroupId
-    );
-  }
-
   async setDefaultTemplate(
     blockId: string,
     oldTemplateId: string,

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -113,7 +113,7 @@ export default function DatabaseView({ containerWidth, readOnly: readOnlyOverrid
 
   const { permissions: currentPagePermissions } = usePagePermissions({ pageIdOrPath: pageId });
 
-  const debouncedPageUpdate = useCallback(() => {
+  const debouncedPageUpdate = useMemo(() => {
     return debouncePromise(async (updates: Partial<Page>) => {
       const updatedPage = await updatePage({ id: pageId, ...updates });
 

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -50,11 +50,10 @@ export const PagesContext = createContext<Readonly<PagesContext>>({
 });
 
 export function PagesProvider({ children }: { children: ReactNode }) {
-  const isAdmin = useIsAdmin();
   const currentSpace = useCurrentSpace();
   const currentSpaceId = useRef<undefined | string>();
   const router = useRouter();
-  const { user, isLoaded: isUserLoaded } = useUser();
+  const { user } = useUser();
   const { subscribe } = useWebSocketClient();
 
   const { data, mutate: mutatePagesList } = useSWR(

--- a/lib/pages/server/getAccessiblePages.ts
+++ b/lib/pages/server/getAccessiblePages.ts
@@ -131,7 +131,7 @@ function isAccessible({
   }
 }
 
-export async function getAccessiblePages(input: PagesRequest): Promise<IPageWithPermissions[]> {
+export async function getAccessiblePages(input: PagesRequest): Promise<PageMeta[]> {
   let spaceRole: SpaceRole | null = null;
 
   if (input.userId) {
@@ -215,14 +215,14 @@ export async function getAccessiblePages(input: PagesRequest): Promise<IPageWith
   }
 
   if (spaceRole?.isAdmin) {
-    const pagesWithoutPermissions = pages.map((p) => {
+    const pagesWithoutPermissions: PageMeta[] = pages.map((p) => {
       delete (p as any).permissions;
       return p;
     });
-    return pagesWithoutPermissions as IPageWithPermissions[];
+    return pagesWithoutPermissions;
   }
 
-  const filteredPages = pages
+  const filteredPages: PageMeta[] = pages
     .filter((page) => {
       if (spaceRole && (page.type === 'proposal_template' || page.type === 'proposal')) {
         return true;
@@ -241,5 +241,5 @@ export async function getAccessiblePages(input: PagesRequest): Promise<IPageWith
       return p;
     });
 
-  return filteredPages as IPageWithPermissions[];
+  return filteredPages;
 }

--- a/pages/api/spaces/[id]/pages.ts
+++ b/pages/api/spaces/[id]/pages.ts
@@ -3,9 +3,10 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
 import { prisma } from 'db';
+import log from 'lib/log';
 import { onError, onNoMatch } from 'lib/middleware';
-import type { IPageWithPermissions } from 'lib/pages/server';
-import { getAccessiblePages, includePagePermissionsMeta } from 'lib/pages/server';
+import type { PageMeta } from 'lib/pages/server';
+import { getAccessiblePages } from 'lib/pages/server';
 import { createPage } from 'lib/pages/server/createPage';
 import { untitledPage } from 'lib/pages/untitledPage';
 import { setupPermissionsAfterPageCreated } from 'lib/permissions/pages';
@@ -15,7 +16,7 @@ const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler.get(getPages);
 
-async function getPages(req: NextApiRequest, res: NextApiResponse<IPageWithPermissions[]>) {
+async function getPages(req: NextApiRequest, res: NextApiResponse<PageMeta[]>) {
   const spaceId = req.query.id as string;
   const archived = req.query.archived === 'true';
   const userId = req.session?.user?.id;
@@ -30,7 +31,7 @@ async function getPages(req: NextApiRequest, res: NextApiResponse<IPageWithPermi
     search
   });
 
-  const createdPages: IPageWithPermissions[] = [];
+  const createdPages: PageMeta[] = [];
 
   if (accessiblePages.length === 0 && !search) {
     const totalPages = await prisma.page.count({
@@ -40,18 +41,16 @@ async function getPages(req: NextApiRequest, res: NextApiResponse<IPageWithPermi
     });
 
     if (totalPages === 0) {
-      const createdPage = (await createPage({
+      const createdPage = await createPage({
         data: untitledPage({
           userId,
           spaceId
-        }) as Prisma.PageUncheckedCreateInput,
-        include: {
-          ...includePagePermissionsMeta()
-        }
-      })) as IPageWithPermissions;
+        }) as Prisma.PageUncheckedCreateInput
+      });
 
       await setupPermissionsAfterPageCreated(createdPage.id);
       createdPages.push(createdPage);
+      log.warn(`Created default first page for space ${spaceId}`, { spaceId, userId });
     }
   }
 

--- a/scripts/migrations/2023_04_19_set_board_titles.ts
+++ b/scripts/migrations/2023_04_19_set_board_titles.ts
@@ -1,0 +1,43 @@
+import { prisma } from 'db';
+
+async function init() {
+  const inlineBoardPages = await prisma.page.findMany({
+    where : {
+      type: 'inline_board',
+      boardId: {
+        not: null
+      }
+    },
+    select: {
+      id: true,
+      boardId: true,
+      title: true
+    }
+  })
+  console.log('found inline board pages', inlineBoardPages.length);
+  console.log('found inline board pages with title', inlineBoardPages.filter(p => p.title).length);
+
+  let blockTitles = 0;
+  for (const page of inlineBoardPages) {
+    const boardBlock = await prisma.block.findFirst({
+      where: {
+        id: page.boardId as string,
+      }
+    });
+    if (boardBlock?.title) {
+      blockTitles++;
+      // console.log(boardBlock.title)
+      await prisma.page.update({
+        where: {
+          id: page.id
+        },
+        data: {
+          title: boardBlock.title
+        }
+      });
+    }
+  }
+  console.log('found inline board pages with block title', blockTitles);
+}
+
+init();


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e98b70</samp>

This pull request improves the board title display and editing in the `BoardEditor` component, and simplifies the pages API and data fetching in the `usePages` hook. It also refactors some components and functions to use better types and hooks, and removes unused or unnecessary code.

### WHY
Customers were saying that inline boards don't show up, i think it is because they show up as "Untitled" because we were saving the title only to the block, not the page!

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e98b70</samp>

*  Update `ViewTitle` and `InlineViewTitle` components to use `pageTitle` prop instead of `board` prop, and remove unnecessary `changeTitle` function from `Mutator` class ([link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-4861c59cd150d8a9cf079ed0c4e13eddf06ef19ae3cdecdb283d92f2faa012b0L523-R526), [link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-4861c59cd150d8a9cf079ed0c4e13eddf06ef19ae3cdecdb283d92f2faa012b0L565-R565), [link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-d8927c1e6b02d7492987cf4f8fb0a67d2a0471e15845fa0e9f1e0f16c0e4c77dL43-R43), [link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-d8927c1e6b02d7492987cf4f8fb0a67d2a0471e15845fa0e9f1e0f16c0e4c77dL183-R188), [link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-5400c0df3e97462d692451db9864be13fa1c99e967eb2c9c9b662c6063b7fe05L197-L209))
*  Add `board` prop to `ViewTitleProps` type definition and remove `board.id` dependency from `setRandomIcon` function in `viewTitle.tsx` ([link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-d8927c1e6b02d7492987cf4f8fb0a67d2a0471e15845fa0e9f1e0f16c0e4c77dL50-R64), [link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-d8927c1e6b02d7492987cf4f8fb0a67d2a0471e15845fa0e9f1e0f16c0e4c77dL72-R72))
*  Remove empty line of code from `centerPanel.tsx` ([link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-4861c59cd150d8a9cf079ed0c4e13eddf06ef19ae3cdecdb283d92f2faa012b0L499))
*  Use `useMemo` instead of `useCallback` for `debouncedPageUpdate` function in `InlineDatabase.tsx` ([link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-397b36baca9c88cb12f096ef33ff5082f524d47ac386954891a567e0a7cc325cL116-R116))
*  Remove unused variables from `PagesProvider` component in `usePages.tsx` ([link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-e5e8481441b266dbb4f138734e4152f9a8dd7819b2484444b19b372c948e3bf0L53-R56))
*  Update `getAccessiblePages` function and `getPages` handler to return `PageMeta[]` instead of `IPageWithPermissions[]`, and remove unnecessary imports and type assertions from `getAccessiblePages.ts` and `pages/api/spaces/[id]/pages.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-4e6fa4cd8b9c7c7f93c481cc9ed4a8d340cb337966b393b3688e37df056902a8L134-R134), [link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-4e6fa4cd8b9c7c7f93c481cc9ed4a8d340cb337966b393b3688e37df056902a8L218-R225), [link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-4e6fa4cd8b9c7c7f93c481cc9ed4a8d340cb337966b393b3688e37df056902a8L244-R244), [link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-fa6e20a067d740e7760753aa1ac8ffc4f5bfe97ee7621cf3cf8fc6ee0dc950feL6-R9), [link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-fa6e20a067d740e7760753aa1ac8ffc4f5bfe97ee7621cf3cf8fc6ee0dc950feL18-R19), [link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-fa6e20a067d740e7760753aa1ac8ffc4f5bfe97ee7621cf3cf8fc6ee0dc950feL33-R34))
*  Add log warning when a default first page is created for a space, and remove `include` option from `createPage` function call in `pages/api/spaces/[id]/pages.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2044/files?diff=unified&w=0#diff-fa6e20a067d740e7760753aa1ac8ffc4f5bfe97ee7621cf3cf8fc6ee0dc950feL43-R53))
