### PR TITLE
set custom health check for staging

### DIFF
--- a/.cdk/staging-stack.ts
+++ b/.cdk/staging-stack.ts
@@ -94,6 +94,12 @@ export class CdkDeployStack extends Stack {
         value: 't3.micro'
       },
       {
+        // ALB health check
+        namespace: 'aws:elasticbeanstalk:application',
+        optionName: 'Application Healthcheck URL',
+        value: '/api/health'
+      }
+      {
         namespace: 'aws:elasticbeanstalk:application:environment',
         optionName: 'DOMAIN',
         value: 'https://' + deploymentDomain

--- a/.cdk/staging-stack.ts
+++ b/.cdk/staging-stack.ts
@@ -98,7 +98,7 @@ export class CdkDeployStack extends Stack {
         namespace: 'aws:elasticbeanstalk:application',
         optionName: 'Application Healthcheck URL',
         value: '/api/health'
-      }
+      },
       {
         namespace: 'aws:elasticbeanstalk:application:environment',
         optionName: 'DOMAIN',


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55b0608</samp>

Update CDK stack for staging environment of app.charmverse.io. Add ALB health check option setting to Elastic Beanstalk environment.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55b0608</samp>

*  Add health check option setting to Elastic Beanstalk environment (.cdk/staging-stack.ts, [link](https://github.com/charmverse/app.charmverse.io/pull/2045/files?diff=unified&w=0#diff-fb87490e71a48b41874f197eedee75e8699c30f1acedf7b29e6d8ee8affbe467R97-R102))
*  Specify '/api/health' as the URL path for the ALB health check ([link](https://github.com/charmverse/app.charmverse.io/pull/2045/files?diff=unified&w=0#diff-fb87490e71a48b41874f197eedee75e8699c30f1acedf7b29e6d8ee8affbe467R97-R102))
