### PR TITLE
Fix/gnosis payment select wallet

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
@@ -13,7 +13,7 @@ import { useState } from 'react';
 import useSWR from 'swr';
 
 import charmClient from 'charmClient';
-import { useGnosisPayment } from 'hooks/useGnosisPayment';
+import { getPaymentErrorMessage, useGnosisPayment } from 'hooks/useGnosisPayment';
 import { useMultiBountyPayment } from 'hooks/useMultiBountyPayment';
 import useMultiWalletSigs from 'hooks/useMultiWalletSigs';
 import { usePaymentMethods } from 'hooks/usePaymentMethods';
@@ -36,26 +36,6 @@ interface Props {
   onClick?: () => void;
   onError?: (err: string, severity?: AlertColor) => void;
   bounty: BountyWithDetails;
-}
-
-function extractWalletErrorMessage(error: any): string {
-  if (error?.code === 'INSUFFICIENT_FUNDS') {
-    return 'You do not have sufficient funds to perform this transaction';
-  } else if (error?.code === 4001) {
-    return 'You rejected the transaction';
-  } else if (error?.code === -32602) {
-    return 'A valid recipient must be provided';
-  } else if (error?.reason) {
-    return error.reason;
-  } else if (error?.message) {
-    return error.message;
-  } else if (typeof error === 'object') {
-    return JSON.stringify(error);
-  } else if (typeof error === 'string') {
-    return error;
-  } else {
-    return 'An unknown error occurred';
-  }
 }
 
 function SafeMenuItem({
@@ -87,16 +67,7 @@ function SafeMenuItem({
         try {
           await makePayment();
         } catch (error: any) {
-          const errorMessage = extractWalletErrorMessage(error);
-
-          if (errorMessage === 'underlying network changed') {
-            onError(
-              "You've changed your active network.\r\nRe-select 'Make payment' to complete this transaction",
-              'warning'
-            );
-          } else {
-            onError(errorMessage);
-          }
+          onError(getPaymentErrorMessage(error));
         }
       }}
     >
@@ -219,16 +190,7 @@ export default function BountyPaymentButton({
         onError('Please provide a valid contract address');
       }
     } catch (err: any) {
-      const errorMessage = extractWalletErrorMessage(err);
-
-      if (errorMessage === 'underlying network changed') {
-        onError(
-          "You've changed your active network.\r\nRe-select 'Make payment' to complete this transaction",
-          'warning'
-        );
-      } else {
-        onError(errorMessage);
-      }
+      onError(getPaymentErrorMessage(err));
     }
   };
 

--- a/components/bounties/BountiesPage.tsx
+++ b/components/bounties/BountiesPage.tsx
@@ -20,7 +20,7 @@ import { isTruthy } from 'lib/utilities/types';
 
 import BountiesKanbanView from './components/BountiesKanbanView';
 import BountiesGalleryView from './components/BountyGalleryView';
-import MultiPaymentModal from './components/MultiPaymentModal';
+import { MultiPaymentModal } from './components/MultiPaymentModal';
 import { NewBountyButton } from './components/NewBountyButton';
 
 const bountyStatuses: BountyStatus[] = ['open', 'inProgress', 'complete', 'paid', 'suggestion'];

--- a/components/bounties/components/MultiPaymentButton.tsx
+++ b/components/bounties/components/MultiPaymentButton.tsx
@@ -26,7 +26,10 @@ export default function MultiPaymentButton({ isLoading, chainId, safeAddress, tr
   return (
     <Tooltip arrow placement='top' title={!safe ? `Connect your wallet to the Gnosis safe: ${safeAddress}` : ''}>
       <span>
-        <Button disabled={isLoading || !safe || transactions.length === 0} onClick={makePayment}>
+        <Button
+          disabled={isLoading || !safe || transactions.length === 0 || !chainId || !safeAddress}
+          onClick={makePayment}
+        >
           Make Payment ({transactions.length})
         </Button>
       </span>

--- a/components/bounties/components/MultiPaymentButton.tsx
+++ b/components/bounties/components/MultiPaymentButton.tsx
@@ -3,7 +3,8 @@ import Button from '@mui/material/Button';
 import type { MetaTransactionData } from '@safe-global/safe-core-sdk-types';
 
 import type { GnosisPaymentProps } from 'hooks/useGnosisPayment';
-import { useGnosisPayment } from 'hooks/useGnosisPayment';
+import { getPaymentErrorMessage, useGnosisPayment } from 'hooks/useGnosisPayment';
+import { useSnackbar } from 'hooks/useSnackbar';
 
 export interface MultiPaymentResult {
   safeAddress: string;
@@ -23,12 +24,22 @@ export default function MultiPaymentButton({ isLoading, chainId, safeAddress, tr
     transactions
   });
 
+  const { showMessage } = useSnackbar();
+
+  const makeSafePayment = async () => {
+    try {
+      await makePayment();
+    } catch (error: any) {
+      showMessage(getPaymentErrorMessage(error), 'error');
+    }
+  };
+
   return (
     <Tooltip arrow placement='top' title={!safe ? `Connect your wallet to the Gnosis safe: ${safeAddress}` : ''}>
       <span>
         <Button
           disabled={isLoading || !safe || transactions.length === 0 || !chainId || !safeAddress}
-          onClick={makePayment}
+          onClick={makeSafePayment}
         >
           Make Payment ({transactions.length})
         </Button>

--- a/components/bounties/components/MultiPaymentModal.tsx
+++ b/components/bounties/components/MultiPaymentModal.tsx
@@ -17,7 +17,7 @@ import { isTruthy } from 'lib/utilities/types';
 import { BountyAmount } from './BountyStatusBadge';
 import MultiPaymentButton from './MultiPaymentButton';
 
-export default function MultiPaymentModal({ bounties }: { bounties: BountyWithDetails[] }) {
+export function MultiPaymentModal({ bounties }: { bounties: BountyWithDetails[] }) {
   const [selectedApplicationIds, setSelectedApplicationIds] = useState<string[]>([]);
   const popupState = usePopupState({ variant: 'popover', popupId: 'multi-payment-modal' });
   const modalProps = bindPopover(popupState);
@@ -32,9 +32,8 @@ export default function MultiPaymentModal({ bounties }: { bounties: BountyWithDe
       }
     });
 
-  const firstGnosisSafe = gnosisSafes?.[0];
-  const gnosisSafeAddress = firstGnosisSafe?.address;
-  const gnosisSafeChainId = firstGnosisSafe?.chainId;
+  const gnosisSafeAddress = gnosisSafeData?.address;
+  const gnosisSafeChainId = gnosisSafeData?.chainId;
 
   const userGnosisSafeRecord =
     userGnosisSafes?.reduce<Record<string, UserGnosisSafe>>((record, userGnosisSafe) => {
@@ -167,15 +166,13 @@ export default function MultiPaymentModal({ bounties }: { bounties: BountyWithDe
             </List>
           </Box>
           <Box display='flex' gap={2} alignItems='center'>
-            {gnosisSafeChainId && gnosisSafeAddress && (
-              <MultiPaymentButton
-                chainId={gnosisSafeChainId}
-                safeAddress={gnosisSafeAddress}
-                transactions={selectedTransactions}
-                onSuccess={onPaymentSuccess}
-                isLoading={isLoading}
-              />
-            )}
+            <MultiPaymentButton
+              chainId={gnosisSafeChainId}
+              safeAddress={gnosisSafeAddress || ''}
+              transactions={selectedTransactions}
+              onSuccess={onPaymentSuccess}
+              isLoading={isLoading}
+            />
           </Box>
         </Modal>
       )}

--- a/hooks/useGnosisPayment.ts
+++ b/hooks/useGnosisPayment.ts
@@ -66,7 +66,7 @@ export function useGnosisPayment({ chainId, safeAddress, transactions, onSuccess
     } catch (e: any) {
       log.error(e);
 
-      throw new Error(`There was an issue with payment: ${e.message}`);
+      throw new Error(e);
     }
   }
 
@@ -74,4 +74,34 @@ export function useGnosisPayment({ chainId, safeAddress, transactions, onSuccess
     safe,
     makePayment
   };
+}
+
+export function getPaymentErrorMessage(error: any) {
+  const errorMessage = extractWalletErrorMessage(error);
+
+  if (errorMessage.toLowerCase().includes('underlying network changed')) {
+    return "You've changed your active network.\r\nRe-select 'Make payment' to complete this transaction";
+  }
+
+  return errorMessage;
+}
+
+function extractWalletErrorMessage(error: any): string {
+  if (error?.code === 'INSUFFICIENT_FUNDS') {
+    return 'You do not have sufficient funds to perform this transaction';
+  } else if (error?.code === 4001) {
+    return 'You rejected the transaction';
+  } else if (error?.code === -32602) {
+    return 'A valid recipient must be provided';
+  } else if (error?.reason) {
+    return error.reason;
+  } else if (error?.message) {
+    return error.message;
+  } else if (typeof error === 'object') {
+    return JSON.stringify(error);
+  } else if (typeof error === 'string') {
+    return error;
+  } else {
+    return 'An unknown error occurred';
+  }
 }

--- a/hooks/useGnosisPayment.ts
+++ b/hooks/useGnosisPayment.ts
@@ -12,7 +12,7 @@ import { switchActiveNetwork } from 'lib/blockchain/switchNetwork';
 import useGnosisSafes from './useGnosisSafes';
 
 export type GnosisPaymentProps = {
-  chainId: number;
+  chainId?: number;
   onSuccess: (result: MultiPaymentResult) => void;
   safeAddress: string;
   transactions: (MetaTransactionData & { applicationId: string })[];
@@ -22,13 +22,13 @@ export function useGnosisPayment({ chainId, safeAddress, transactions, onSuccess
   const { account, chainId: connectedChainId, library } = useWeb3AuthSig();
 
   const [safe] = useGnosisSafes([safeAddress]);
-  const network = getChainById(chainId);
-  if (!network?.gnosisUrl) {
+  const network = chainId ? getChainById(chainId) : null;
+  if (chainId && !network?.gnosisUrl) {
     throw new Error(`Unsupported Gnosis network: ${chainId}`);
   }
 
   async function makePayment() {
-    if (chainId !== connectedChainId) {
+    if (chainId && chainId !== connectedChainId) {
       await switchActiveNetwork(chainId);
     }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 037b928</samp>

This pull request improves the error handling and UI feedback for payment transactions using Gnosis Safe in the bounties feature. It refactors the `BountyPaymentButton` and `MultiPaymentButton` components to use a common hook and helper functions. It also simplifies the props and exports of the `MultiPaymentModal` component.

### WHY
User in discord mentioned she cannot change gnosis wallet for payment. Turned out the issue was we ALWAYS picked 1st gnosis wallet from the list, even if you selected another one. This issue happens only if you have >1 multisig wallet.
Additionally I added error handling for batch payments.

discord message: https://discord.com/channels/894960387743698944/945679068710469714/1098533786905497631

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 037b928</samp>

*  Simplify and standardize error handling for payment transactions using `getPaymentErrorMessage` function ([link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-0bfc9075f6b1cc3d09d0b7855b1c9e0865f9c3d1ded103a3eecb76748202bb10L16-R16), [link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-0bfc9075f6b1cc3d09d0b7855b1c9e0865f9c3d1ded103a3eecb76748202bb10L90-R70), [link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-0bfc9075f6b1cc3d09d0b7855b1c9e0865f9c3d1ded103a3eecb76748202bb10L222-R193), [link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-156fbd13da95f26d1574cba46988561ce41f1af7f55a87321d423c9527e1a5d9L26-R43), [link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-75ac4225b644e53ff94f295c0722646f234be5fa5818f8374ac75207b638fa0dL69-R69), [link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-75ac4225b644e53ff94f295c0722646f234be5fa5818f8374ac75207b638fa0dR78-R107))
*  Remove unnecessary fetching and state management of safe data from `MultiPaymentModal` component and pass `safeAddress` and `chainId` as props ([link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-0fef58ae2fc6afcbc212ab8e3767ea1670531c114eac3550e5731212aff296e1L35-R36), [link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-0fef58ae2fc6afcbc212ab8e3767ea1670531c114eac3550e5731212aff296e1L170-R175))
*  Change `MultiPaymentModal` and `MultiPaymentButton` components from default exports to named exports to match convention ([link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-c7092ef3afe5be44ff8f0842541692775eef1a1786229797a42c31910f168e0dL23-R23), [link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-0fef58ae2fc6afcbc212ab8e3767ea1670531c114eac3550e5731212aff296e1L20-R20))
*  Make `chainId` prop of `GnosisPaymentProps` type optional and handle null cases in `useGnosisPayment` hook ([link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-75ac4225b644e53ff94f295c0722646f234be5fa5818f8374ac75207b638fa0dL15-R15), [link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-75ac4225b644e53ff94f295c0722646f234be5fa5818f8374ac75207b638fa0dL25-R31), [link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-156fbd13da95f26d1574cba46988561ce41f1af7f55a87321d423c9527e1a5d9L26-R43))
*  Move `extractWalletErrorMessage` function from `BountyPaymentButton` component to `useGnosisPayment` hook ([link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-0bfc9075f6b1cc3d09d0b7855b1c9e0865f9c3d1ded103a3eecb76748202bb10L41-L60), [link](https://github.com/charmverse/app.charmverse.io/pull/2047/files?diff=unified&w=0#diff-75ac4225b644e53ff94f295c0722646f234be5fa5818f8374ac75207b638fa0dR78-R107))
