### PR TITLE
Fix uploading files from url without extension

### DIFF
--- a/lib/aws/uploadToS3Server.ts
+++ b/lib/aws/uploadToS3Server.ts
@@ -12,12 +12,13 @@ const bucket = process.env.S3_UPLOAD_BUCKET;
 
 const client = new S3Client(getS3ClientConfig());
 
-export async function uploadFileToS3(file: { pathInS3: string; content: Buffer }) {
+export async function uploadFileToS3(file: { pathInS3: string; content: Buffer; contentType?: string }) {
   const params: PutObjectCommandInput = {
     ACL: 'public-read',
     Bucket: bucket,
     Key: file.pathInS3,
-    Body: file.content
+    Body: file.content,
+    ContentType: file.contentType
   };
 
   const s3Upload = new Upload({
@@ -39,8 +40,10 @@ export async function uploadUrlToS3({ pathInS3, url }: { pathInS3: string; url: 
 
   const { fileUrl } = await uploadFileToS3({
     pathInS3,
-    content: blob
+    content: blob,
+    contentType: data.headers.get('content-type') || undefined
   });
+
   return { url: fileUrl };
 }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbb0863</samp>

Improved file handling for S3 uploads in `lib/aws/uploadToS3Server.ts`. Added `contentType` parameters to preserve MIME types of local and remote files.

### WHY
FIles uploaded from URL without extension did not have proper content type and opened in the browser were downloaded instead of appear in browser. This will pass proper content type from fetch reposonse

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dbb0863</samp>

*  Add optional `contentType` parameter to `uploadFileToS3` function to specify MIME type of file content ([link](https://github.com/charmverse/app.charmverse.io/pull/2049/files?diff=unified&w=0#diff-88814a4650b03dfe55f91c704d7e26a3546270870825e51779d691e080c8bfa8L15-R21))
*  Pass `content-type` header from fetched URL to `uploadFileToS3` function in `uploadUrlToS3` function to preserve original MIME type of URL content ([link](https://github.com/charmverse/app.charmverse.io/pull/2049/files?diff=unified&w=0#diff-88814a4650b03dfe55f91c704d7e26a3546270870825e51779d691e080c8bfa8L42-R46))
