### PR TITLE
adding datadog telemetry label for service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     command: ['npm', 'run', '${NPM_SCRIPT}']
     labels:
       com.datadoghq.ad.logs: '[{"source": "nodejs", "service": "${SERVICE_NAME}"}]'
+      com.datadoghq.tags.service: "${SERVICE_NAME}"
     volumes:
       - $PWD/.env:/app/.env
     env_file:


### PR DESCRIPTION
This is to separate webapp service from the websockets

### WHAT
copilot:summary

### WHY
To differentiate webapp from websocket service 

### HOW
copilot:walkthrough
