### PR TITLE
Fixed snapshot proposal with voting delay

### DIFF
--- a/components/common/PageLayout/components/Header/components/Snapshot/PublishingForm.tsx
+++ b/components/common/PageLayout/components/Header/components/Snapshot/PublishingForm.tsx
@@ -227,20 +227,22 @@ export default function PublishingForm({ onSubmit, page }: Props) {
 
       const client = await getSnapshotClient();
 
+      const start = Math.round(startDate.toSeconds());
       const proposalParams: any = {
         space: space?.snapshotDomain as any,
         type: snapshotVoteMode,
         title: page.title,
         body: content,
         choices: votingOptions,
-        start: Math.round(startDate.toSeconds()),
+        start,
         end: Math.round(endDate.toSeconds()),
         snapshot: snapshotBlockNumber,
         network: snapshotSpace?.network,
         strategies: JSON.stringify(selectedVotingStrategies),
         plugins: JSON.stringify({}),
         metadata: JSON.stringify({}),
-        app: ''
+        app: '',
+        timestamp: start - (snapshotSpace?.voting.delay ?? 0)
       };
 
       const receipt: SnapshotReceipt = (await client.proposal(

--- a/components/common/PageLayout/components/Header/components/Snapshot/PublishingForm.tsx
+++ b/components/common/PageLayout/components/Header/components/Snapshot/PublishingForm.tsx
@@ -228,6 +228,7 @@ export default function PublishingForm({ onSubmit, page }: Props) {
       const client = await getSnapshotClient();
 
       const start = Math.round(startDate.toSeconds());
+      const timestampWithVotingDelay = start - (snapshotSpace?.voting.delay ?? 0);
       const proposalParams: any = {
         space: space?.snapshotDomain as any,
         type: snapshotVoteMode,
@@ -242,7 +243,7 @@ export default function PublishingForm({ onSubmit, page }: Props) {
         plugins: JSON.stringify({}),
         metadata: JSON.stringify({}),
         app: '',
-        timestamp: start - (snapshotSpace?.voting.delay ?? 0)
+        timestamp: timestampWithVotingDelay
       };
 
       const receipt: SnapshotReceipt = (await client.proposal(

--- a/components/common/PageLayout/components/Header/components/Snapshot/PublishingForm.tsx
+++ b/components/common/PageLayout/components/Header/components/Snapshot/PublishingForm.tsx
@@ -228,7 +228,6 @@ export default function PublishingForm({ onSubmit, page }: Props) {
       const client = await getSnapshotClient();
 
       const start = Math.round(startDate.toSeconds());
-      const timestampWithVotingDelay = start - (snapshotSpace?.voting.delay ?? 0);
       const proposalParams: any = {
         space: space?.snapshotDomain as any,
         type: snapshotVoteMode,
@@ -242,9 +241,13 @@ export default function PublishingForm({ onSubmit, page }: Props) {
         strategies: JSON.stringify(selectedVotingStrategies),
         plugins: JSON.stringify({}),
         metadata: JSON.stringify({}),
-        app: '',
-        timestamp: timestampWithVotingDelay
+        app: ''
       };
+
+      if (snapshotSpace?.voting.delay) {
+        const timestampWithVotingDelay = start - snapshotSpace.voting.delay;
+        proposalParams.timestamp = timestampWithVotingDelay;
+      }
 
       const receipt: SnapshotReceipt = (await client.proposal(
         library,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa6370d</samp>

Add `timestamp` field to proposal data and refactor start time calculation in `PublishingForm.tsx`. This enables delayed voting periods for proposals in the app.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aa6370d</samp>

*  Add `timestamp` field to proposal data to support delayed voting period ([link](https://github.com/charmverse/app.charmverse.io/pull/2054/files?diff=unified&w=0#diff-9c30a48f33f5e0473a9fee36d20df8a6957799870f1742a5e04d4ab24ec07207R230), [link](https://github.com/charmverse/app.charmverse.io/pull/2054/files?diff=unified&w=0#diff-9c30a48f33f5e0473a9fee36d20df8a6957799870f1742a5e04d4ab24ec07207L236-R237), [link](https://github.com/charmverse/app.charmverse.io/pull/2054/files?diff=unified&w=0#diff-9c30a48f33f5e0473a9fee36d20df8a6957799870f1742a5e04d4ab24ec07207L243-R245))
