### PR TITLE
adding config to collect /var/log/messages from ddagent docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     image: public.ecr.aws/datadog/agent
     hostname: datadog-agent
     labels:
-      com.datadoghq.ad.logs: '[{"type":"file", "source": "os", "service": "syslog", "path": "/host/var/log/messages"}]'
+      com.datadoghq.ad.logs: '[{"type":"file", "source": "os", "service": "syslog", "sourcecategory": "${SERVICE_NAME}", "path": "/host/var/log/messages"}]'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /proc/:/host/proc/:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,11 +44,14 @@ services:
   datadog-agent:
     image: public.ecr.aws/datadog/agent
     hostname: datadog-agent
+    labels:
+      com.datadoghq.ad.logs: '[{"type":"file", "source": "os", "service": "syslog", "path": "/host/var/log/messages"}]'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /proc/:/host/proc/:ro
       - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/log:/host/var/log:ro
       - $PWD/.env:/app/.env
     env_file:
       - '.env'


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea0acdf</samp>

Configure Datadog logging for the `app` service. This allows monitoring and troubleshooting of the application performance and behavior using Datadog.

### WHY
need to collect /var/log/messages

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea0acdf</samp>

*  Configure logging for the `app` service using Datadog ([link](https://github.com/charmverse/app.charmverse.io/pull/2055/files?diff=unified&w=0#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R47-R48), [link](https://github.com/charmverse/app.charmverse.io/pull/2055/files?diff=unified&w=0#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R54))
