### PR TITLE
dont throw an error if no api keys exist

### DIFF
--- a/pages/api/api-page-key/index.ts
+++ b/pages/api/api-page-key/index.ts
@@ -36,10 +36,6 @@ async function getApiKeys(req: NextApiRequest, res: NextApiResponse<ApiPageKey[]
     }
   });
 
-  if (apiPageKeys.length === 0) {
-    throw new NotFoundError(`No API keys found for the page ${pageId}`);
-  }
-
   return res.status(200).json(apiPageKeys);
 }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 144888c</samp>

Removed error throw for empty API keys array in `getApiKeys` function. This allows the API to return an empty array instead of an error and lets the front-end handle the no API keys case.

### WHY
- since it returns a list, an empty list should be fine to return
- we should try to design endpoints to return 2xx in normal use. from an ops perspective its confusing if a lot of stuff is returning 4xx for 'normal behavior' 

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 144888c</samp>

*  Remove error throw for empty API keys array in `getApiKeys` function ([link](https://github.com/charmverse/app.charmverse.io/pull/2056/files?diff=unified&w=0#diff-d883a961ff84ad215aa1cbf4e7aa08a50a4b4cc1bf7164449ea13c8eb17b4026L39-L42)) to allow API to return an empty array instead of an error
