### PR TITLE
fix wrapping of card properties on mobile

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
@@ -91,8 +91,9 @@ function CardDetailProperty({
         flexDirection: 'row',
         // Allow dragging past left border
         paddingLeft: '150px',
-        position: 'relative',
-        right: '150px'
+        marginLeft: '-150px !important'
+        // position: 'relative',
+        // right: '150px'
       }}
       className='octo-propertyrow'
     >


### PR DESCRIPTION
Fixes this issue:

<img width="380" alt="image" src="https://user-images.githubusercontent.com/305398/233744915-0be0cce8-b389-4e6a-89d2-fed293122884.png">

I have a feeling it might be good to revisit the classes and styles we're using for card properties altogether
