### PR TITLE
Fixed table row handles in wrong position

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
@@ -144,7 +144,7 @@ function TableRow(props: Props) {
       style={{ opacity: isDragging ? 0.5 : 1 }}
     >
       {/* Columns, one per property */}
-      {visiblePropertyTemplates.map((template) => {
+      {visiblePropertyTemplates.map((template, templateIndex) => {
         if (template.id === Constants.titleColumnId) {
           return (
             <Box
@@ -161,7 +161,7 @@ function TableRow(props: Props) {
               key={template.id}
               onPaste={(e) => e.stopPropagation()}
             >
-              {!props.readOnly && (
+              {!props.readOnly && templateIndex === 0 && (
                 <IconButton className='icons' onClick={handleClick} size='small'>
                   <DragIndicatorIcon color='secondary' />
                 </IconButton>
@@ -190,6 +190,11 @@ function TableRow(props: Props) {
             ref={columnRefs.get(template.id)}
             onPaste={(e) => e.stopPropagation()}
           >
+            {!props.readOnly && templateIndex === 0 && (
+              <IconButton className='icons' onClick={handleClick} size='small'>
+                <DragIndicatorIcon color='secondary' />
+              </IconButton>
+            )}
             <PropertyValueElement
               readOnly={props.readOnly}
               card={card}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 24a5633</samp>

Improved table UI and UX for reordering rows by showing drag indicator icon only for title column and moving it to the end. Modified `tableRow.tsx` component.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 24a5633</samp>

*  Add `templateIndex` parameter to `map` callback function to access property template index ([link](https://github.com/charmverse/app.charmverse.io/pull/2059/files?diff=unified&w=0#diff-7fd599d595110955b7bd18282192c5d28baa165986452170924a819ec148c040L147-R147))
*  Render drag indicator icon only for the first column of the table, which is the title column ([link](https://github.com/charmverse/app.charmverse.io/pull/2059/files?diff=unified&w=0#diff-7fd599d595110955b7bd18282192c5d28baa165986452170924a819ec148c040L164-R164), [link](https://github.com/charmverse/app.charmverse.io/pull/2059/files?diff=unified&w=0#diff-7fd599d595110955b7bd18282192c5d28baa165986452170924a819ec148c040R193-R197))
*  Duplicate drag indicator icon and move it to the end of the title column for better visibility and accessibility ([link](https://github.com/charmverse/app.charmverse.io/pull/2059/files?diff=unified&w=0#diff-7fd599d595110955b7bd18282192c5d28baa165986452170924a819ec148c040R193-R197))
