### PR TITLE
increase keepalivetimeout in next.js to support graceful deploys

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ const esmModules = require('./next.base').esmModules;
 const skipCodeChecks = process.env.CI === 'true';
 
 const config = {
+  keepAliveTimeout: 70000, // should be gretaer than AWS load balancer which is 60s. See: https://nextjs.org/docs/api-reference/cli#keep-alive-timeout
   poweredByHeader: false,
   eslint: {
     // add background and serverless to the default list of pages for eslint

--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,7 @@ const esmModules = require('./next.base').esmModules;
 const skipCodeChecks = process.env.CI === 'true';
 
 const config = {
-  keepAliveTimeout: 70000, // should be gretaer than AWS load balancer which is 60s. See: https://nextjs.org/docs/api-reference/cli#keep-alive-timeout
+  keepAliveTimeout: 70000, // should be greater than AWS load balancer which is 60s. See: https://nextjs.org/docs/api-reference/cli#keep-alive-timeout
   poweredByHeader: false,
   eslint: {
     // add background and serverless to the default list of pages for eslint


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
We need to make sure keep alive is greater than the load balancer timeout. [keep alive setting in next.js docs](https://nextjs.org/docs/api-reference/cli#keep-alive-timeout)

### HOW
copilot:walkthrough
