### PR TITLE
Add tests

### DIFF
--- a/lib/token-gates/__tests__/verifyTokenGateMemberships.spec.ts
+++ b/lib/token-gates/__tests__/verifyTokenGateMemberships.spec.ts
@@ -1,0 +1,157 @@
+import type { Space } from '@prisma/client';
+import * as litSDK from 'lit-js-sdk';
+
+import { prisma } from 'db';
+import { applyTokenGates } from 'lib/token-gates/applyTokenGates';
+import { verifyTokenGateMemberships } from 'lib/token-gates/verifyTokenGateMemberships';
+import type { LoggedInUser } from 'models';
+import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+import { verifiedJWTResponse } from 'testing/utils/litProtocol';
+import { deleteTokenGate, generateTokenGate } from 'testing/utils/tokenGates';
+
+jest.mock('lit-js-sdk');
+
+// @ts-ignore
+const mockedLitSDK: jest.Mocked<typeof litSDK> = litSDK;
+
+async function getSpaceUser({ spaceId, userId }: { spaceId: string; userId: string }) {
+  return prisma.spaceRole.findUnique({
+    where: {
+      spaceUser: {
+        spaceId,
+        userId
+      }
+    }
+  });
+}
+
+describe('verifyTokenGateMemberships', () => {
+  let user: LoggedInUser;
+  let user2: LoggedInUser;
+  let space: Space;
+  let space2: Space;
+
+  beforeEach(async () => {
+    const { user: u, space: s } = await generateUserAndSpaceWithApiToken(undefined, false);
+    const { user: u2, space: s2 } = await generateUserAndSpaceWithApiToken(undefined, false);
+    user = u;
+    space = s;
+    user2 = u2;
+    space2 = s2;
+  });
+
+  afterEach(() => {
+    mockedLitSDK.verifyJwt.mockClear();
+    // jest.unmock('lit-js-sdk');
+    jest.resetModules();
+  });
+
+  it('should not remove users without token gates', async () => {
+    const res = await verifyTokenGateMemberships();
+
+    const spaceUser1 = await getSpaceUser({ spaceId: space.id, userId: user.id });
+    const spaceUser2 = await getSpaceUser({ spaceId: space2.id, userId: user2.id });
+
+    expect(res).toEqual({ removedRoles: 0, removedMembers: 0 });
+    expect(spaceUser1).not.toBeNull();
+    expect(spaceUser2).not.toBeNull();
+  });
+
+  it('should not verify and remove user connected via deleted token gate', async () => {
+    const tokenGate = await generateTokenGate({ userId: user.id, spaceId: space.id });
+
+    mockedLitSDK.verifyJwt.mockResolvedValue(
+      verifiedJWTResponse({
+        verified: true,
+        payload: {
+          orgId: space.id,
+          extraData: `{ "tokenGateId": "${tokenGate.id}" }`
+        }
+      })
+    );
+
+    await applyTokenGates({
+      spaceId: space.id,
+      userId: user.id,
+      commit: true,
+      tokens: [{ tokenGateId: tokenGate.id, signedToken: 'jwt1' }]
+    });
+    await deleteTokenGate(tokenGate.id);
+
+    const tokenGate2 = await generateTokenGate({ userId: user2.id, spaceId: space2.id });
+    mockedLitSDK.verifyJwt.mockResolvedValue(
+      verifiedJWTResponse({
+        verified: true,
+        payload: {
+          orgId: space2.id,
+          extraData: `{ "tokenGateId": "${tokenGate2.id}" }`
+        }
+      })
+    );
+
+    await applyTokenGates({
+      spaceId: space2.id,
+      userId: user2.id,
+      commit: true,
+      tokens: [{ tokenGateId: tokenGate2.id, signedToken: 'jwt2' }]
+    });
+
+    const res = await verifyTokenGateMemberships();
+
+    const spaceUser1 = await getSpaceUser({ spaceId: space.id, userId: user.id });
+    const spaceUser2 = await getSpaceUser({ spaceId: space2.id, userId: user2.id });
+
+    expect(res).toEqual({ removedRoles: 0, removedMembers: 1 });
+    expect(spaceUser1).toBeNull();
+    expect(spaceUser2).not.toBeNull();
+  });
+
+  it('should remove multi-space user from a proper space', async () => {
+    const tokenGate = await generateTokenGate({ userId: user.id, spaceId: space.id });
+
+    mockedLitSDK.verifyJwt.mockResolvedValue(
+      verifiedJWTResponse({
+        verified: true,
+        payload: {
+          orgId: space.id,
+          extraData: `{ "tokenGateId": "${tokenGate.id}" }`
+        }
+      })
+    );
+
+    await applyTokenGates({
+      spaceId: space.id,
+      userId: user.id,
+      commit: true,
+      tokens: [{ tokenGateId: tokenGate.id, signedToken: 'jwt1' }]
+    });
+    await deleteTokenGate(tokenGate.id);
+
+    const tokenGate2 = await generateTokenGate({ userId: user.id, spaceId: space2.id });
+    mockedLitSDK.verifyJwt.mockResolvedValue(
+      verifiedJWTResponse({
+        verified: true,
+        payload: {
+          orgId: space2.id,
+          extraData: `{ "tokenGateId": "${tokenGate2.id}" }`
+        }
+      })
+    );
+
+    await applyTokenGates({
+      spaceId: space2.id,
+      userId: user.id,
+      commit: true,
+      tokens: [{ tokenGateId: tokenGate2.id, signedToken: 'jwt2' }]
+    });
+
+    const res = await verifyTokenGateMemberships();
+
+    const spaceUser1 = await getSpaceUser({ spaceId: space.id, userId: user.id });
+    const spaceUser2 = await getSpaceUser({ spaceId: space2.id, userId: user.id });
+
+    expect(res).toEqual({ removedRoles: 0, removedMembers: 1 });
+    expect(spaceUser1).toBeNull();
+    expect(spaceUser2).not.toBeNull();
+  });
+});

--- a/lib/token-gates/verifyTokenGateMemberships.ts
+++ b/lib/token-gates/verifyTokenGateMemberships.ts
@@ -21,15 +21,33 @@ export type UserToVerifyMembership = SpaceRole & {
 };
 
 export async function verifyTokenGateMemberships() {
+  const userTokenGates = await prisma.userTokenGate.findMany({
+    include: {
+      tokenGate: {
+        include: {
+          tokenGateToRoles: {
+            include: {
+              role: true
+            }
+          }
+        }
+      },
+      space: true,
+      user: true
+    }
+  });
+
+  const spaceRoleQuery = userTokenGates.map((userTokenGate) => ({
+    userId: userTokenGate.userId,
+    spaceId: userTokenGate.spaceId
+  }));
+
   const usersWithTokenGates = await prisma.spaceRole.findMany({
     where: {
       // We do not want to delete admins
       isAdmin: false,
-      user: {
-        userTokenGates: {
-          some: {}
-        }
-      }
+      // match userId / spaceId pairs
+      OR: spaceRoleQuery
     },
     include: {
       user: {
@@ -61,8 +79,11 @@ export async function verifyTokenGateMemberships() {
   let removedRoles = 0;
 
   for (const spaceRole of usersWithTokenGates) {
+    // filter token gates related to the space
+    const spaceUserTokenGates = spaceRole.user.userTokenGates.filter((utg) => utg.spaceId === spaceRole.spaceId);
+
     const res = await verifyTokenGateMembership({
-      userTokenGates: spaceRole.user.userTokenGates,
+      userTokenGates: spaceUserTokenGates,
       userId: spaceRole.user.id,
       spaceId: spaceRole.spaceId,
       userSpaceRoles: spaceRole.spaceRoleToRole,


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
This pr will reenable removing userv with invalid token gates. It fixes the issue that caused removing incorrect users in the past + adds test

### HOW
copilot:walkthrough
