### PR TITLE
Bug/save permissions error

### DIFF
--- a/lib/permissions/spaces/__tests__/saveRoleAndSpacePermissions.spec.ts
+++ b/lib/permissions/spaces/__tests__/saveRoleAndSpacePermissions.spec.ts
@@ -1,0 +1,193 @@
+import type { PostCategoryPermission } from '@prisma/client';
+import { v4 as uuid } from 'uuid';
+
+import { prisma } from 'db';
+import { MissingDataError } from 'lib/utilities/errors';
+import { generateRole, generateUserAndSpace } from 'testing/setupDatabase';
+import { generatePostCategory } from 'testing/utils/forums';
+import { generateProposalCategory } from 'testing/utils/proposals';
+
+import { AvailableSpacePermissions } from '../availableSpacePermissions';
+import { saveRoleAndSpacePermissions } from '../saveRoleAndSpacePermissions';
+
+describe('saveRoleAndSpacePermissions', () => {
+  it('should replace the existing permissions assigned to a space or role for the SpacePermission, ProposalCategoryPermission and PostCategoryPermission entities without affecting public permissions', async () => {
+    const { space, user } = await generateUserAndSpace({});
+    const role = await generateRole({ spaceId: space.id, createdBy: user.id, assigneeUserIds: [user.id] });
+
+    const proposalCategory = await generateProposalCategory({
+      spaceId: space.id
+    });
+
+    const postCategory = await generatePostCategory({
+      spaceId: space.id
+    });
+    const secondPostCategory = await generatePostCategory({
+      spaceId: space.id
+    });
+
+    const thirdPostCategory = await generatePostCategory({
+      spaceId: space.id
+    });
+
+    const permissions = await prisma.$transaction([
+      prisma.spacePermission.create({
+        data: {
+          forSpaceId: space.id,
+          spaceId: space.id,
+          operations: ['createPage']
+        }
+      }),
+      prisma.proposalCategoryPermission.create({
+        data: {
+          proposalCategoryId: proposalCategory.id,
+          permissionLevel: 'full_access',
+          spaceId: space.id
+        }
+      }),
+      prisma.postCategoryPermission.create({
+        data: {
+          postCategoryId: postCategory.id,
+          permissionLevel: 'full_access',
+          spaceId: space.id
+        }
+      }),
+      prisma.postCategoryPermission.create({
+        data: {
+          postCategoryId: postCategory.id,
+          permissionLevel: 'view',
+          public: true
+        }
+      }),
+      // We will try passing this existing permission in the following update. This checks for a bug where an error would be thrown, since the public permission was not deleted, but we tried to create a new one with the same ID
+      prisma.postCategoryPermission.create({
+        data: {
+          postCategoryId: thirdPostCategory.id,
+          permissionLevel: 'view',
+          public: true
+        }
+      })
+    ]);
+
+    await saveRoleAndSpacePermissions(space.id, {
+      space: [
+        {
+          operations: {
+            ...new AvailableSpacePermissions().empty,
+            createPage: true
+          },
+          assignee: {
+            group: 'space',
+            id: space.id
+          }
+        }
+      ],
+      proposalCategories: [],
+      forumCategories: [
+        {
+          id: uuid(),
+          permissionLevel: 'full_access',
+          postCategoryId: postCategory.id,
+          assignee: {
+            group: 'role',
+            id: role.id
+          }
+        },
+        // No public permission for postCategory, and creating a new permission for secondPostCategory
+        // We expect both these updates to be ignored
+        {
+          id: uuid(),
+          permissionLevel: 'view',
+          postCategoryId: secondPostCategory.id,
+          assignee: {
+            group: 'public'
+          }
+        },
+        {
+          id: uuid(),
+          permissionLevel: 'view',
+          postCategoryId: thirdPostCategory.id,
+          assignee: {
+            group: 'public'
+          }
+        }
+      ]
+    });
+
+    const [
+      spacePermissions,
+      proposalCategoryPermissions,
+      postCategoryPermissions,
+      secondPostCategoryPermissions,
+      thirdPostCategoryPermissions
+    ] = await Promise.all([
+      prisma.spacePermission.findMany({
+        where: {
+          forSpaceId: space.id
+        }
+      }),
+      prisma.proposalCategoryPermission.findMany({
+        where: {
+          proposalCategoryId: proposalCategory.id
+        }
+      }),
+      prisma.postCategoryPermission.findMany({
+        where: {
+          postCategoryId: postCategory.id
+        }
+      }),
+      prisma.postCategoryPermission.findMany({
+        where: {
+          postCategoryId: secondPostCategory.id
+        }
+      }),
+      prisma.postCategoryPermission.findMany({
+        where: {
+          postCategoryId: thirdPostCategory.id
+        }
+      })
+    ]);
+
+    expect(spacePermissions).toHaveLength(1);
+    expect(proposalCategoryPermissions).toHaveLength(0);
+    // We expect the old space permission to have been dropped since it was not included in the new permission set
+    expect(postCategoryPermissions).toHaveLength(2);
+    expect(postCategoryPermissions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining<Partial<PostCategoryPermission>>({
+          roleId: role.id,
+          permissionLevel: 'full_access'
+        })
+      ])
+    );
+    // Existing public permission should not have been affected
+    expect(postCategoryPermissions).toContainEqual(
+      expect.objectContaining<Partial<PostCategoryPermission>>({
+        public: true,
+        permissionLevel: 'view'
+      })
+    );
+    // Attempt to add a new public permission should have been ignored
+    expect(secondPostCategoryPermissions).toHaveLength(0);
+
+    expect(thirdPostCategoryPermissions).toHaveLength(1);
+    expect(thirdPostCategoryPermissions).toContainEqual(
+      expect.objectContaining<Partial<PostCategoryPermission>>({
+        public: true,
+        permissionLevel: 'view'
+      })
+    );
+  });
+
+  it('should throw an error if no space permissions are provided for the default role of the space', async () => {
+    const { space } = await generateUserAndSpace({});
+
+    await expect(
+      saveRoleAndSpacePermissions(space.id, {
+        space: [],
+        forumCategories: [],
+        proposalCategories: []
+      })
+    ).rejects.toBeInstanceOf(MissingDataError);
+  });
+});

--- a/lib/permissions/spaces/savePermissions.ts
+++ b/lib/permissions/spaces/savePermissions.ts
@@ -37,28 +37,40 @@ export async function savePermissions(spaceId: string, permissions: SpacePermiss
         }
       });
     }),
-    ...permissions.proposalCategories.map((permission) =>
-      prisma.proposalCategoryPermission.create({
-        data: {
-          id: permission.id,
-          proposalCategoryId: permission.proposalCategoryId,
-          permissionLevel: permission.permissionLevel,
-          roleId: permission.assignee.group === 'role' ? permission.assignee.id : undefined,
-          spaceId: permission.assignee.group === 'space' ? permission.assignee.id : undefined
-        }
-      })
-    ),
-    ...permissions.forumCategories.map((permission) =>
-      prisma.postCategoryPermission.create({
-        data: {
-          id: permission.id,
-          postCategoryId: permission.postCategoryId,
-          permissionLevel: permission.permissionLevel,
-          roleId: permission.assignee.group === 'role' ? permission.assignee.id : undefined,
-          spaceId: permission.assignee.group === 'space' ? permission.assignee.id : undefined
-        }
-      })
-    )
+    ...permissions.proposalCategories
+      .filter(
+        // Since we delete role and space permissions only, we should also only recreate role and space permissions
+        (categoryPermission) =>
+          categoryPermission.assignee.group === 'role' || categoryPermission.assignee.group === 'space'
+      )
+      .map((permission) =>
+        prisma.proposalCategoryPermission.create({
+          data: {
+            id: permission.id,
+            proposalCategoryId: permission.proposalCategoryId,
+            permissionLevel: permission.permissionLevel,
+            roleId: permission.assignee.group === 'role' ? permission.assignee.id : undefined,
+            spaceId: permission.assignee.group === 'space' ? permission.assignee.id : undefined
+          }
+        })
+      ),
+    ...permissions.forumCategories
+      // Since we delete role and space permissions only, we should also only recreate role and space permissions
+      .filter(
+        (categoryPermission) =>
+          categoryPermission.assignee.group === 'role' || categoryPermission.assignee.group === 'space'
+      )
+      .map((permission) =>
+        prisma.postCategoryPermission.create({
+          data: {
+            id: permission.id,
+            postCategoryId: permission.postCategoryId,
+            permissionLevel: permission.permissionLevel,
+            roleId: permission.assignee.group === 'role' ? permission.assignee.id : undefined,
+            spaceId: permission.assignee.group === 'space' ? permission.assignee.id : undefined
+          }
+        })
+      )
   ];
 
   return prisma.$transaction([...deleteOps, ...createOps]);

--- a/lib/permissions/spaces/saveRoleAndSpacePermissions.ts
+++ b/lib/permissions/spaces/saveRoleAndSpacePermissions.ts
@@ -1,11 +1,12 @@
 import type { SpaceOperation } from '@prisma/client';
+import { v4 as uuid } from 'uuid';
 
 import { prisma } from 'db';
 import { InvalidInputError, MissingDataError } from 'lib/utilities/errors';
 
 import type { SpacePermissions } from './listPermissions';
 
-export async function savePermissions(spaceId: string, permissions: SpacePermissions) {
+export async function saveRoleAndSpacePermissions(spaceId: string, permissions: SpacePermissions) {
   const memberPermissions = permissions.space.filter((p) => p.assignee.group === 'space');
 
   // make sure we always define member/default permissions
@@ -46,7 +47,7 @@ export async function savePermissions(spaceId: string, permissions: SpacePermiss
       .map((permission) =>
         prisma.proposalCategoryPermission.create({
           data: {
-            id: permission.id,
+            id: permission.id ?? uuid,
             proposalCategoryId: permission.proposalCategoryId,
             permissionLevel: permission.permissionLevel,
             roleId: permission.assignee.group === 'role' ? permission.assignee.id : undefined,
@@ -63,7 +64,7 @@ export async function savePermissions(spaceId: string, permissions: SpacePermiss
       .map((permission) =>
         prisma.postCategoryPermission.create({
           data: {
-            id: permission.id,
+            id: permission.id ?? uuid(),
             postCategoryId: permission.postCategoryId,
             permissionLevel: permission.permissionLevel,
             roleId: permission.assignee.group === 'role' ? permission.assignee.id : undefined,

--- a/pages/api/permissions/space/[spaceId]/settings.ts
+++ b/pages/api/permissions/space/[spaceId]/settings.ts
@@ -6,7 +6,7 @@ import { trackUserAction } from 'lib/metrics/mixpanel/trackUserAction';
 import { onError, onNoMatch, requireSpaceMembership } from 'lib/middleware';
 import type { SpacePermissions } from 'lib/permissions/spaces/listPermissions';
 import { listPermissions } from 'lib/permissions/spaces/listPermissions';
-import { savePermissions } from 'lib/permissions/spaces/savePermissions';
+import { saveRoleAndSpacePermissions } from 'lib/permissions/spaces/saveRoleAndSpacePermissions';
 import { withSessionRoute } from 'lib/session/withSession';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
@@ -29,7 +29,7 @@ async function updateSpacePermissionsController(req: NextApiRequest, res: NextAp
   const { spaceId } = req.query as { spaceId: string };
   const { roleIdToTrack, ...permissions } = req.body as SpacePermissions & { roleIdToTrack?: string };
 
-  await savePermissions(spaceId, permissions);
+  await saveRoleAndSpacePermissions(spaceId, permissions);
 
   // tracking
   if (roleIdToTrack) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f3530f</samp>

This pull request refactors and tests the logic for saving role and space permissions in the app. It splits the `savePermissions` function into two functions: `saveRoleAndSpacePermissions` and `saveUserPermissions`. It also moves the `saveRoleAndSpacePermissions` function to a separate file under `lib/permissions/spaces`, and adds a test file for it. The API route handler for updating space permissions is updated accordingly.

### WHY
I was getting a 500 error in space / role settings config when saving.

After investigation, this would only happen if you had a public permission for a forum category, since we tried to recreate it.

Updated underlying method to just target space and role permissions on create, since we were already doing this.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9f3530f</samp>

*  Rename and modify `savePermissions` function to `saveRoleAndSpacePermissions`, which only handles the permissions assigned to roles and spaces, and ignores the public permissions ([link](https://github.com/charmverse/app.charmverse.io/pull/2064/files?diff=unified&w=0#diff-fbc353181489be8641810c48964d79db610d5f87b17f7d762d0afd00b667988dL8-R9), [link](https://github.com/charmverse/app.charmverse.io/pull/2064/files?diff=unified&w=0#diff-fbc353181489be8641810c48964d79db610d5f87b17f7d762d0afd00b667988dL40-R74))
*  Add `uuid` module to generate unique ids for the permissions entities in `saveRoleAndSpacePermissions` ([link](https://github.com/charmverse/app.charmverse.io/pull/2064/files?diff=unified&w=0#diff-fbc353181489be8641810c48964d79db610d5f87b17f7d762d0afd00b667988dR2))
*  Update import and function call for `saveRoleAndSpacePermissions` in the API route handler for updating the space permissions in `pages/api/permissions/space/[spaceId]/settings.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2064/files?diff=unified&w=0#diff-ab897c5e4a010d485e405b85ca6d762cf0634f45bb5b674f7f6bf6d8969f60afL9-R9), [link](https://github.com/charmverse/app.charmverse.io/pull/2064/files?diff=unified&w=0#diff-ab897c5e4a010d485e405b85ca6d762cf0634f45bb5b674f7f6bf6d8969f60afL32-R32))
*  Add test file for `saveRoleAndSpacePermissions` in `lib/permissions/spaces/__tests__/saveRoleAndSpacePermissions.spec.ts`, which imports the necessary types, modules, and utilities for testing the function's behavior and logic ([link](https://github.com/charmverse/app.charmverse.io/pull/2064/files?diff=unified&w=0#diff-03ba8757c71b196bed4875a9a818312ce5b4e0fbf9509905249570f91f6301f9R1-R193))
