### PR TITLE
Toggle: unable to shift / return down to the next row from the first toggle line

### DIFF
--- a/components/common/CharmEditor/components/disclosure/commands.ts
+++ b/components/common/CharmEditor/components/disclosure/commands.ts
@@ -48,16 +48,16 @@ export const backspaceCmd: Command = (state, dispatch) => {
   return false;
 };
 
-// TODO: we should move cursor to the content section when hitting Enter
-
-export const moveDownCmd: Command = (state, dispatch) => {
+export const moveDownCmd: Command = (state, dispatch, view) => {
   let { tr } = state;
   // @ts-ignore types package is missing $cursor property as of 1.2.8
   const { $cursor } = state.selection;
   const summaryNode = findParentNodeOfTypeClosestToPos($cursor, state.schema.nodes.disclosureSummary);
   const detailsNode = findParentNodeOfTypeClosestToPos($cursor, state.schema.nodes.disclosureDetails);
   // Must be in summary node for enter to take effect
-  if (detailsNode && summaryNode) {
+  if (detailsNode && summaryNode && view) {
+    const summaryDomNode = view.domAtPos(summaryNode.pos).node as HTMLDivElement;
+    summaryDomNode.setAttribute('open', '');
     const emptyParagraphNode = state.schema.nodes.paragraph.create();
     const summaryNodePosition = tr.doc.resolve(detailsNode.pos + summaryNode.node.nodeSize);
     tr = tr.setSelection(new TextSelection(summaryNodePosition)).replaceSelectionWith(emptyParagraphNode, false);

--- a/components/common/CharmEditor/components/disclosure/commands.ts
+++ b/components/common/CharmEditor/components/disclosure/commands.ts
@@ -50,19 +50,22 @@ export const backspaceCmd: Command = (state, dispatch) => {
 
 // TODO: we should move cursor to the content section when hitting Enter
 
-// export const moveDownCmd: Command = (state, dispatch) => {
-//   const { tr } = state;
-//   // @ts-ignore types package is missing $cursor property as of 1.2.8
-//   const { $cursor } = state.selection;
-//   const summaryNode = findParentNodeOfTypeClosestToPos($cursor, state.schema.nodes.disclosureSummary);
-//   console.log('hit enter', !!summaryNode);
-//   if (summaryNode) {
-//     console.log('move cursor down', tr.doc.resolve(summaryNode.pos + summaryNode.node.nodeSize + 1));
-//     tr.setSelection(new TextSelection(tr.doc.resolve(summaryNode.pos + summaryNode.node.nodeSize + 1)));
-//     if (dispatch) {
-//       dispatch(tr);
-//     }
-//     return true;
-//   }
-//   return false;
-// };
+export const moveDownCmd: Command = (state, dispatch) => {
+  let { tr } = state;
+  // @ts-ignore types package is missing $cursor property as of 1.2.8
+  const { $cursor } = state.selection;
+  const summaryNode = findParentNodeOfTypeClosestToPos($cursor, state.schema.nodes.disclosureSummary);
+  const detailsNode = findParentNodeOfTypeClosestToPos($cursor, state.schema.nodes.disclosureDetails);
+  // Must be in summary node for enter to take effect
+  if (detailsNode && summaryNode) {
+    const emptyParagraphNode = state.schema.nodes.paragraph.create();
+    const summaryNodePosition = tr.doc.resolve(detailsNode.pos + summaryNode.node.nodeSize);
+    tr = tr.setSelection(new TextSelection(summaryNodePosition)).replaceSelectionWith(emptyParagraphNode, false);
+    tr.setSelection(new TextSelection(tr.doc.resolve(detailsNode.pos + summaryNode.node.nodeSize)));
+    if (dispatch) {
+      dispatch(tr);
+    }
+    return true;
+  }
+  return false;
+};

--- a/components/common/CharmEditor/components/disclosure/disclosure.ts
+++ b/components/common/CharmEditor/components/disclosure/disclosure.ts
@@ -3,7 +3,7 @@ import { createElement } from '@bangle.dev/core';
 import type { DOMOutputSpec } from '@bangle.dev/pm';
 import { Plugin, PluginKey, keymap } from '@bangle.dev/pm';
 
-import { backspaceCmd } from './commands';
+import { backspaceCmd, moveDownCmd } from './commands';
 
 export function spec() {
   return [summarySpec(), detailsSpec()];
@@ -50,8 +50,8 @@ export function plugins(): RawPlugins {
   return () => {
     return [
       keymap({
-        Backspace: backspaceCmd
-        // Enter: moveDownCmd
+        Backspace: backspaceCmd,
+        Enter: moveDownCmd
       }),
       ContainerPlugin({ type: 'disclosureSummary', contentDOM: ['summary'] }),
       ContainerPlugin({ type: 'disclosureDetails', contentDOM: ['div', { class: 'disclosure-details' }] })


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d199856</samp>

This pull request enhances the `CharmEditor` component by adding keyboard support for the disclosure node. It allows the user to move the cursor to the content section of a disclosure node with the Enter key and automatically opens the summary node and inserts an empty paragraph node.

### WHY
1. Inside toggle heading, press enter to insert a new paragraph at the top of the content
2. If the toggle is close, open the toggle

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d199856</samp>

*  Implement a function to move the cursor to the content section of a disclosure node on Enter key ([link](https://github.com/charmverse/app.charmverse.io/pull/2066/files?diff=unified&w=0#diff-39d3fa539197235f6f13580c41ceb437bb665ae2f5ed4dd76e83d9daf0f881b8L51-R71))
*  Import and use the function in the keymap plugin for the disclosure node ([link](https://github.com/charmverse/app.charmverse.io/pull/2066/files?diff=unified&w=0#diff-d2016fa25b268d7af494011c3837b0ab16cd7b8519999a60eff69290da18f0b1L6-R6), [link](https://github.com/charmverse/app.charmverse.io/pull/2066/files?diff=unified&w=0#diff-d2016fa25b268d7af494011c3837b0ab16cd7b8519999a60eff69290da18f0b1L53-R54))
