### PR TITLE
make error in Notion import a warning

### DIFF
--- a/lib/notion/NotionImporter/NotionBlock.ts
+++ b/lib/notion/NotionImporter/NotionBlock.ts
@@ -167,7 +167,9 @@ export class NotionBlock {
         }
       } catch (err) {
         if (block) {
-          log.error(`[notion] Failed to convert notion ${block.type}:${block.id} block to charmverse block`);
+          log.warn(`[notion] Failed to convert notion ${block.type}:${block.id} block to charmverse block`, {
+            spaceId: this.notionPage.spaceId
+          });
           const notionPage = this.notionPage.cache.notionPagesRecord[
             this.charmversePage.notionPageId
           ] as PageObjectResponse;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 893a403</samp>

Reduced the log level for non-critical errors when importing notion blocks to charmverse blocks. Added `spaceId` to the log metadata for easier debugging.

### WHY
we dont have bandwidth do respond to these, so it can just be a warning in case someone asks about an issue

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 893a403</samp>

* Lowered the log level for notion block conversion errors and added `spaceId` to log metadata ([link](https://github.com/charmverse/app.charmverse.io/pull/2069/files?diff=unified&w=0#diff-e32e241a14fc33d159723e4dd1cf32e6cd745c44ad996d4455693b1b28d9b794L170-R172))
