### PR TITLE
apply font styles to sidebar

### DIFF
--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -41,6 +41,7 @@ import { useSnackbar } from 'hooks/useSnackbar';
 import { useToggleFavorite } from 'hooks/useToggleFavorite';
 import { useUser } from 'hooks/useUser';
 import type { PageUpdates } from 'lib/pages';
+import { monoFont, serifFont } from 'theme/fonts';
 
 import { BountyActions } from './components/BountyActions';
 import BountyShareButton from './components/BountyShareButton/BountyShareButton';
@@ -383,7 +384,7 @@ function HeaderComponent({ open, openSidebar }: HeaderProps) {
     <List data-test='header--page-actions' dense>
       <Box px={2.5} mb={1}>
         <Typography variant='caption'>Style</Typography>
-        <Box display='flex' mt={0.5}>
+        <Box display='flex' mt={0.5} className={`${serifFont.variable} ${monoFont.variable}`}>
           <StyledFontButton
             size='small'
             color={basePage?.fontFamily === 'default' ? 'primary' : 'secondary'}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce9dce3</samp>

Add font switcher feature to `Header` component. This allows the user to change the font of the app content between `monoFont` and `serifFont`.

### WHY
It didn't work because Popover creates itself as a child outside the span tag in _app which assigns the font variable. Next.js requires us to use it in _app and not _document, so to add it to the 'body' tag I'd have to do it in a useEffect()

![image](https://user-images.githubusercontent.com/305398/234416254-bab7032a-4873-4c09-9df5-2df5f5e6fb29.png)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce9dce3</samp>

*  Import and apply font variables from `theme/fonts` module to enable font switching feature ([link](https://github.com/charmverse/app.charmverse.io/pull/2070/files?diff=unified&w=0#diff-97400afdebf25587839de062948405ef1a7258a6ede291863ed9dd8b2ce2ba5eR44), [link](https://github.com/charmverse/app.charmverse.io/pull/2070/files?diff=unified&w=0#diff-97400afdebf25587839de062948405ef1a7258a6ede291863ed9dd8b2ce2ba5eL386-R387))
