### PR TITLE
Wait to destroy staging env

### DIFF
--- a/.github/workflows/destroy_staging.yml
+++ b/.github/workflows/destroy_staging.yml
@@ -10,7 +10,7 @@ jobs:
       (github.event.action == 'unlabeled' && github.event.label.name == ':rocket: deploy') ||
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, ':rocket: deploy'))
     runs-on: ubuntu-latest
-    # prevent workflows running in parallel
+    # wait until all deploys are complete to destroy the env
     concurrency: deploy-pr-app-${{ github.head_ref }}
     steps:
       - name: configure AWS credentials

--- a/.github/workflows/destroy_staging.yml
+++ b/.github/workflows/destroy_staging.yml
@@ -10,6 +10,8 @@ jobs:
       (github.event.action == 'unlabeled' && github.event.label.name == ':rocket: deploy') ||
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, ':rocket: deploy'))
     runs-on: ubuntu-latest
+    # prevent workflows running in parallel
+    concurrency: deploy-pr-app-${{ github.head_ref }}
     steps:
       - name: configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f718b30</samp>

Add concurrency group to `destroy_staging.yml` workflow. This avoids potential issues when tearing down the staging environment for a pull request branch.

### WHY
If we don't wait, the destroy command fails:
```
 stg-charmverse-pr-2063-next-server: destroy failed Error: Stack [arn:aws:cloudformation:us-east-1:***:stack/stg-charmverse-pr-2063-next-server/bd71e4d0-e320-11ed-8c2d-0af3233c316f] cannot be deleted while in status UPDATE_IN_PROGRESS
 ```

Result:
![image](https://user-images.githubusercontent.com/305398/234418837-c1b293d5-7ff5-40a0-94d1-2015cb156e74.png)


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f718b30</samp>

* Add a concurrency group to the workflow that destroys the staging environment for a pull request ([link](https://github.com/charmverse/app.charmverse.io/pull/2071/files?diff=unified&w=0#diff-b22414912cf00a463dcebcbf2000cff8cdec5c543aab95bc45064386447d1cb4R13-R14)). The concurrency group name is based on the branch name of the pull request and prevents race conditions or conflicts when destroying the staging environment in `.github/workflows/destroy_staging.yml`.
