### PR TITLE
Bug/fix create post

### DIFF
--- a/components/forum/ForumFeedPage.tsx
+++ b/components/forum/ForumFeedPage.tsx
@@ -44,7 +44,7 @@ export function ForumPage() {
 
   if (getPostableCategories().length === 0) {
     disableCreatePost = true;
-    disabledCreatePostTooltip = 'You do not have permission to create posts in any category';
+    disabledCreatePostTooltip = 'You cannot create posts in this space';
   } else if (currentCategory && currentCategoryPermissions?.create_post === false) {
     disableCreatePost = true;
     disabledCreatePostTooltip = `You do not have permission to create posts in the ${currentCategory.name} category`;

--- a/components/forum/ForumFeedPage.tsx
+++ b/components/forum/ForumFeedPage.tsx
@@ -16,6 +16,7 @@ import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useForumCategories } from 'hooks/useForumCategories';
 import { usePageTitle } from 'hooks/usePageTitle';
 import type { PostSortOption } from 'lib/forums/posts/constants';
+import log from 'lib/log';
 import { setUrlWithoutRerender } from 'lib/utilities/browser';
 
 import { CategoryMenu } from './components/CategoryMenu';
@@ -128,9 +129,11 @@ export function ForumPage() {
 
   useEffect(() => {
     if (currentSpace) {
-      charmClient.track.trackAction('main_feed_page_load', {
-        spaceId: currentSpace.id
-      });
+      charmClient.track
+        .trackAction('main_feed_page_load', {
+          spaceId: currentSpace.id
+        })
+        .catch((err) => log.debug(err));
     }
   }, [Boolean(currentSpace)]);
 

--- a/components/forum/components/CreateForumPost.tsx
+++ b/components/forum/components/CreateForumPost.tsx
@@ -3,42 +3,58 @@ import Card from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
 import CardContent from '@mui/material/CardContent';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
 
 import Button from 'components/common/Button';
 import UserDisplay from 'components/common/UserDisplay';
-import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
-import { useForumCategories } from 'hooks/useForumCategories';
 import { useUser } from 'hooks/useUser';
 
-export function CreateForumPost({ onClick }: { onClick: () => void }) {
+export function CreateForumPost({
+  onClick,
+  disabled,
+  disabledTooltip = ''
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  disabledTooltip?: string;
+}) {
   const { user } = useUser();
-  const [userSpacePermissions] = useCurrentSpacePermissions();
-  const { getPostableCategories } = useForumCategories();
-  const canPost = getPostableCategories().length > 0;
 
   function clickHandler() {
-    if (canPost) {
+    if (!disabled) {
       onClick();
     }
   }
+
   return (
-    <Card variant='outlined' sx={{ mb: '15px' }} onClick={clickHandler}>
-      <CardActionArea disabled={!userSpacePermissions?.createPage}>
-        <CardContent>
-          <Box display='flex' flexDirection='row' justifyContent='space-between' alignItems='center' gap={1}>
-            <UserDisplay user={user} avatarSize='medium' hideName mr='10px' />
-            <TextField variant='outlined' placeholder='Create Post' fullWidth sx={{ pointerEvents: 'none' }} disabled />
-            <Button
-              disabledTooltip='There are no categories in which you can create a post.'
-              disabled={!canPost}
-              component='div'
-              float='right'
-            >
-              Create Post
-            </Button>
-          </Box>
-        </CardContent>
-      </CardActionArea>
-    </Card>
+    <Tooltip title={disabled ? disabledTooltip : ''} placement='top-end'>
+      <Card variant='outlined' sx={{ mb: '15px' }} onClick={clickHandler}>
+        <CardActionArea
+          sx={
+            !disabled
+              ? undefined
+              : {
+                  color: 'rgba(255, 255, 255, 0)'
+                }
+          }
+        >
+          <CardContent>
+            <Box display='flex' flexDirection='row' justifyContent='space-between' alignItems='center' gap={1}>
+              <UserDisplay user={user} avatarSize='medium' hideName mr='10px' />
+              <TextField
+                variant='outlined'
+                placeholder='Create Post'
+                fullWidth
+                sx={{ pointerEvents: 'none' }}
+                disabled
+              />
+              <Button disabled={disabled} component='div' float='right'>
+                Create Post
+              </Button>
+            </Box>
+          </CardContent>
+        </CardActionArea>
+      </Card>
+    </Tooltip>
   );
 }

--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -20,11 +20,13 @@ import LoadingComponent from 'components/common/LoadingComponent';
 import { ScrollableWindow } from 'components/common/PageLayout';
 import UserDisplay from 'components/common/UserDisplay';
 import { PostCommentForm } from 'components/forum/components/PostPage/components/PostCommentForm';
+import { usePostCategoryPermissions } from 'components/forum/hooks/usePostCategoryPermissions';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useForumCategories } from 'hooks/useForumCategories';
 import { useMembers } from 'hooks/useMembers';
 import { usePostPermissions } from 'hooks/usePostPermissions';
 import { usePreventReload } from 'hooks/usePreventReload';
+import { useSnackbar } from 'hooks/useSnackbar';
 import { useUser } from 'hooks/useUser';
 import type { PostCommentWithVoteAndChildren } from 'lib/forums/comments/interface';
 import { checkIsContentEmpty } from 'lib/prosemirror/checkIsContentEmpty';
@@ -67,6 +69,7 @@ export function PostPage({
   const currentSpace = useCurrentSpace();
   const { user } = useUser();
   const { categories, getForumCategoryById } = useForumCategories();
+  const { showMessage } = useSnackbar();
   const { showPost } = usePostDialog();
   const [isPublishingDraftPost, setIsPublishingDraftPost] = useState(false);
   // We should only set writeable categories for new post
@@ -86,6 +89,9 @@ export function PostPage({
       }
     })()
   );
+
+  const { permissions: categoryPermissions } = usePostCategoryPermissions(categoryId as string);
+
   const { getMemberById } = useMembers();
   const router = useRouter();
   const {
@@ -130,14 +136,19 @@ export function PostPage({
       });
       setContentUpdated(false);
     } else {
-      const newPost = await charmClient.forum.createForumPost({
-        categoryId,
-        content: formInputs.content,
-        contentText: formInputs.contentText ?? '',
-        spaceId,
-        title: formInputs.title,
-        isDraft
-      });
+      const newPost = await charmClient.forum
+        .createForumPost({
+          categoryId,
+          content: formInputs.content,
+          contentText: formInputs.contentText ?? '',
+          spaceId,
+          title: formInputs.title,
+          isDraft
+        })
+        .catch((err) => {
+          showMessage(err.message ?? 'Something went wrong', 'error');
+          throw err;
+        });
       if (!isDraft) {
         router.push(`/${router.query.domain}/forum/post/${newPost.path}`);
       } else {
@@ -184,6 +195,8 @@ export function PostPage({
     disabledTooltip = 'Category is required';
   } else if (isPublishingDraftPost) {
     disabledTooltip = 'Publishing draft post';
+  } else if (!post && categoryPermissions?.create_post === false) {
+    disabledTooltip = 'You do not have permission to create posts in this category';
   }
 
   const topLevelComments: PostCommentWithVoteAndChildren[] = useMemo(() => {
@@ -249,7 +262,9 @@ export function PostPage({
                   )}
                   {post?.isDraft && (
                     <Button
-                      disabled={Boolean(disabledTooltip) || isPublishingDraftPost}
+                      disabled={
+                        Boolean(disabledTooltip) || isPublishingDraftPost || categoryPermissions?.create_post === false
+                      }
                       disabledTooltip={disabledTooltip}
                       onClick={() => publishDraftPost(post)}
                       loading={isPublishingDraftPost}
@@ -259,7 +274,11 @@ export function PostPage({
                   )}
                   {!post?.isDraft && (
                     <Button
-                      disabled={Boolean(disabledTooltip) || !contentUpdated}
+                      disabled={
+                        Boolean(disabledTooltip) ||
+                        !contentUpdated ||
+                        (!post && categoryPermissions?.create_post === false)
+                      }
                       disabledTooltip={disabledTooltip}
                       onClick={() => createForumPost(false)}
                     >

--- a/components/forum/hooks/usePostCategoryPermissions.ts
+++ b/components/forum/hooks/usePostCategoryPermissions.ts
@@ -1,6 +1,6 @@
 import { useForumCategories } from 'hooks/useForumCategories';
 
-export function usePostCategoryPermissions(postCategoryId: string) {
+export function usePostCategoryPermissions(postCategoryId?: string | null) {
   const { getForumCategoryById } = useForumCategories();
 
   const permissions = getForumCategoryById(postCategoryId)?.permissions;

--- a/hooks/useForumCategories.tsx
+++ b/hooks/useForumCategories.tsx
@@ -1,6 +1,6 @@
 import type { PostCategory } from '@prisma/client';
 import type { ReactNode } from 'react';
-import { useContext, createContext, useMemo } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 import useSWR from 'swr/immutable';
 
 import charmClient from 'charmClient';
@@ -8,13 +8,14 @@ import type { PostCategoryWithPermissions } from 'lib/permissions/forum/interfac
 
 import { useCurrentSpace } from './useCurrentSpace';
 import { useSpaces } from './useSpaces';
+import { useUser } from './useUser';
 
 type IContext = {
   createForumCategory: (categoryName: string) => Promise<void>;
   deleteForumCategory: (option: PostCategory) => Promise<void>;
   updateForumCategory: (option: PostCategory) => Promise<PostCategoryWithPermissions | undefined>;
   setDefaultPostCategory: (option: PostCategory) => Promise<void>;
-  getForumCategoryById: (id: string) => PostCategoryWithPermissions | undefined;
+  getForumCategoryById: (id?: string | null) => PostCategoryWithPermissions | undefined;
   getPostableCategories: () => PostCategoryWithPermissions[];
   isCategoriesLoaded: boolean;
   categories: PostCategoryWithPermissions[];
@@ -39,12 +40,13 @@ export function PostCategoriesProvider({ children }: { children: ReactNode }) {
   const currentSpace = useCurrentSpace();
   const { setSpace } = useSpaces();
 
+  const { user } = useUser();
   const {
     data: categories,
     error,
     isValidating,
     mutate: mutateForumCategories
-  } = useSWR(currentSpace ? `spaces/${currentSpace.id}/post-categories` : null, () =>
+  } = useSWR(currentSpace ? `spaces/${currentSpace.id}/post-categories/${user?.id ?? 'anonymous'}` : null, () =>
     charmClient.forum.listPostCategories(currentSpace!.id).then((_categories) =>
       _categories.sort((catA, catB) => {
         const first = catA.name.toLowerCase();
@@ -119,7 +121,10 @@ export function PostCategoriesProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  function getForumCategoryById(id: string) {
+  function getForumCategoryById(id?: string | null) {
+    if (!id) {
+      return undefined;
+    }
     return categories?.find((category) => category.id === id);
   }
 

--- a/hooks/useRoles.ts
+++ b/hooks/useRoles.ts
@@ -12,7 +12,7 @@ export function useRoles() {
 
   const { data: roles } = useSWR(
     () => (space ? `roles/${space.id}` : null),
-    () => space && charmClient.roles.listRoles(space.id)
+    () => (space ? charmClient.roles.listRoles(space.id) : null)
   );
 
   async function createRole(role: CreateRoleInput): Promise<Role> {

--- a/hooks/useWeb3AuthSig.tsx
+++ b/hooks/useWeb3AuthSig.tsx
@@ -181,7 +181,10 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
       } else {
         setSignature(null);
         setStoredAccount(null);
-        logoutUser();
+        // We should only logout if there is a user. The logout function triggers a wipe of the SWR cache, and this was having undesirable effects for people with a connected wallet but no user account
+        if (user) {
+          logoutUser();
+        }
       }
     }
   }, [account, user, isConnectingIdentity, isLoaded, accountUpdatePaused]);

--- a/lib/permissions/spaces/computeSpacePermissions.ts
+++ b/lib/permissions/spaces/computeSpacePermissions.ts
@@ -2,7 +2,7 @@ import { prisma } from 'db';
 import { hasAccessToSpace } from 'lib/users/hasAccessToSpace';
 
 import { filterApplicablePermissions } from '../filterApplicablePermissions';
-import type { PermissionCompute, PermissionComputeRequest } from '../interfaces';
+import type { PermissionCompute } from '../interfaces';
 
 import { AvailableSpacePermissions } from './availableSpacePermissions';
 import type { SpacePermissionFlags } from './interfaces';

--- a/pages/api/forums/posts/index.ts
+++ b/pages/api/forums/posts/index.ts
@@ -6,7 +6,7 @@ import type { CreateForumPostInput } from 'lib/forums/posts/createForumPost';
 import { createForumPost, trackCreateForumPostEvent } from 'lib/forums/posts/createForumPost';
 import type { ListForumPostsRequest, PaginatedPostList } from 'lib/forums/posts/listForumPosts';
 import { listForumPosts } from 'lib/forums/posts/listForumPosts';
-import { onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
+import { ActionNotPermittedError, onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
 import { mutatePostCategorySearch } from 'lib/permissions/forum/mutatePostCategorySearch';
 import { requestOperations } from 'lib/permissions/requestOperations';
 import { withSessionRoute } from 'lib/session/withSession';
@@ -41,7 +41,8 @@ async function createForumPostController(req: NextApiRequest, res: NextApiRespon
     resourceType: 'post_category',
     resourceId: req.body.categoryId as string,
     userId,
-    operations: ['create_post']
+    operations: ['create_post'],
+    customError: new ActionNotPermittedError('You are not allowed to create a post in this category')
   });
 
   const createdPost = await createForumPost({ ...req.body, createdBy: req.session.user.id });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed21893</samp>

This pull request improves the forum feature by adding permission checks and error handling to the front-end and back-end components. It also enhances the data fetching and caching for the forum categories and the user roles. It fixes some minor bugs and removes some unused code. The main files affected are `components/forum/components/PostPage/PostPage.tsx`, `components/forum/ForumFeedPage.tsx`, `pages/api/forums/posts/index.ts`, and `hooks/useForumCategories.tsx`.

### WHY
This fixes 2 bugs, centring around SWR usage.

1. When switching users, we refresh the forum categories. This also ensures permissions are correct.

2. I noticed that when in the public view of a forum category, with a connected wallet but no user account, categories were not showing. Took ages to solve. In the end, the issue was useWeb3AuthSig always logging out the user, which triggers an SWR cache dump. I've updated this so useWeb3AuthSig only calls logout if there is a user to logout

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed21893</samp>

*  Disable and show tooltip for `CreateForumPost` button if user cannot create posts in current or any category ([link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-1bd0520f055055faf55434a7948abca034156dca6daf9eb854f8e5eb1329fd34L34-R52), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-1bd0520f055055faf55434a7948abca034156dca6daf9eb854f8e5eb1329fd34L176-R198), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-d9498b1c3113d41eb82f6bb381d1c9c9867363dd4846a78bcc5b49bee5c61922L6-R58))
*  Use `usePostCategoryPermissions` hook to check user's permissions to create or update posts in different categories ([link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0R23), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0R92-R94), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0R198-R199), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0L252-R267), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0L262-R281), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-1bd0520f055055faf55434a7948abca034156dca6daf9eb854f8e5eb1329fd34R28), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-6891a723b8e5e3bed3c9bb591cc5373df05eaa72a0f94b37512e2f0b0cb1806bL3-R3), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-d4a47926958a99cac5cf7ff0a71949b97db603622f6f73e136bdc5142b9c55efL17-R18), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-d4a47926958a99cac5cf7ff0a71949b97db603622f6f73e136bdc5142b9c55efL122-R127))
*  Show error message using `useSnackbar` hook if `charmClient.forum.createForumPost` call fails in `PostPage` component ([link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0R29), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0R72), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-87f76330e5f9e224ab67afe03a55d0ca01cdb868546d489a7fc4dba2d64a4de0L133-R151))
*  Add user's id or 'anonymous' to SWR key for `categories` data in `PostCategoriesProvider` function ([link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-d4a47926958a99cac5cf7ff0a71949b97db603622f6f73e136bdc5142b9c55efR11), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-d4a47926958a99cac5cf7ff0a71949b97db603622f6f73e136bdc5142b9c55efR43), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-d4a47926958a99cac5cf7ff0a71949b97db603622f6f73e136bdc5142b9c55efL47-R49))
*  Return null from SWR fetcher function in `useRoles` hook if `space` parameter is falsy ([link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-8dd9df393460fdd22509d33f4cc92c25a89b91d1e9415e0d2cecc89e6bc636f9L15-R15))
*  Check if there is a user before calling `logoutUser` function in `Web3AccountProvider` function ([link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-0d5405560fed1b9944d138ca5f1cdb68e97742c4b4e392f217beb51abffb4a4cL184-R187))
*  Remove unused import of `PermissionComputeRequest` from `lib/permissions/spaces/computeSpacePermissions.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-d1e9480a140062b94e5081d43f00f7a5877024209d44cff66118897ade31342dL5-R5))
*  Pass `customError` option to `requestOperations` function call in `createForumPostController` function to use `ActionNotPermittedError` instance ([link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-9ce89c3f268d8bce2b391f265000d0cb2154f7806aaa99a74af2d1d86cd2f1fcL9-R9), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-9ce89c3f268d8bce2b391f265000d0cb2154f7806aaa99a74af2d1d86cd2f1fcL44-R45))
*  Reorder imports in `hooks/useForumCategories.tsx` to follow convention ([link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-d4a47926958a99cac5cf7ff0a71949b97db603622f6f73e136bdc5142b9c55efL3-R3))
*  Log errors from `charmClient.track.trackAction` call in `ForumPage` component ([link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-1bd0520f055055faf55434a7948abca034156dca6daf9eb854f8e5eb1329fd34R19), [link](https://github.com/charmverse/app.charmverse.io/pull/2072/files?diff=unified&w=0#diff-1bd0520f055055faf55434a7948abca034156dca6daf9eb854f8e5eb1329fd34L116-R136))
