### PR TITLE
Fixed next node calculation from current cursor

### DIFF
--- a/components/common/CharmEditor/components/disclosure/commands.ts
+++ b/components/common/CharmEditor/components/disclosure/commands.ts
@@ -16,10 +16,10 @@ export const backspaceCmd: Command = (state, dispatch) => {
 
   const summaryNode = findParentNodeOfTypeClosestToPos($cursor, state.schema.nodes.disclosureSummary);
   const disclosureNode = findParentNodeOfTypeClosestToPos($cursor, state.schema.nodes.disclosureDetails);
-
-  const nextNode = tr.doc.resolve($cursor.pos + $cursor.node().nodeSize).node();
+  const nextNodePos = $cursor.after();
+  const nextNode = state.doc.nodeAt(nextNodePos);
   // If the cursor is at the paragraph (#) node and the next sibling is a disclosureDetails node
-  if (nextNode.type === state.schema.nodes.disclosureDetails) {
+  if (nextNode && nextNode.type === state.schema.nodes.disclosureDetails) {
     const paragraphNode = $cursor.parent;
     const paragraphIsEmpty = paragraphNode.textContent.length === 0;
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0bd587</samp>

Fixed a bug in the `disclosure` commands of the `CharmEditor` component that could cause incorrect node positions and null pointer exceptions. Improved the logic to use the `after` method and check for node existence.

### WHY
This was throwing index out of range when trying to delete any text in the editor. Weird that I didn't see it locally. And more weirdly it works correctly if you're deleting an empty line.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a0bd587</samp>

* Fix bug in disclosure commands to use `after` method and check for next node existence ([link](https://github.com/charmverse/app.charmverse.io/pull/2075/files?diff=unified&w=0#diff-39d3fa539197235f6f13580c41ceb437bb665ae2f5ed4dd76e83d9daf0f881b8L19-R22))
