### PR TITLE
Hide deleted db page linked views

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -98,7 +98,7 @@ type State = {
 };
 
 function CenterPanel(props: Props) {
-  const { activeView, board, pageIcon, showView, views } = props;
+  const { activeView: defaultActiveView, board, pageIcon, showView, views: allViews } = props;
 
   const [state, setState] = useState<State>({
     cardIdToFocusOnRender: '',
@@ -117,17 +117,23 @@ function CenterPanel(props: Props) {
   const { user } = useUser();
   const { keys } = useApiPageKeys();
 
+  const isEmbedded = !!props.embeddedBoardPath;
+  const boardPage = pages[board.id] ?? props.page;
+  const boardPageType = boardPage?.type;
+  const isLinkedBoardType = boardPageType === 'linked_board' || boardPageType === 'inline_linked_board';
+  const views = isLinkedBoardType
+    ? allViews.filter((view) => view.fields.linkedSourceId && pages[view.fields.linkedSourceId])
+    : allViews;
+
+  const activeView = isLinkedBoardType && views.length === 0 ? null : defaultActiveView;
+
   useEffect(() => {
-    if (views.length === 0 && !activeView) {
+    if ((views.length === 0 && !activeView) || (isLinkedBoardType && views.length === 0)) {
       setState((s) => ({ ...s, showSettings: 'create-linked-view' }));
     } else if (activeView) {
       setState((s) => ({ ...s, showSettings: null }));
     }
-  }, [activeView?.id, views.length]);
-
-  const isEmbedded = !!props.embeddedBoardPath;
-  const boardPage = pages[board.id] ?? props.page;
-  const boardPageType = boardPage?.type;
+  }, [activeView?.id, views.length, isLinkedBoardType]);
 
   // for 'linked' boards, each view has its own board which we use to determine the cards to show
   let activeBoardId: string | undefined = props.board.id;
@@ -552,7 +558,7 @@ function CenterPanel(props: Props) {
             activeView={props.activeView}
             toggleViewOptions={toggleViewOptions}
             cards={cards}
-            views={props.views}
+            views={views}
             dateDisplayProperty={dateDisplayProperty}
             addCard={() => addCard('', true)}
             showCard={showCard}
@@ -616,7 +622,8 @@ function CenterPanel(props: Props) {
                 <CreateLinkedView
                   readOnly={props.readOnly}
                   onSelect={selectViewSource}
-                  onCreate={views.length === 0 ? createDatabase : undefined}
+                  // defaultActiveView indicates that there was a view which was linked to a deleted database page
+                  onCreate={views.length === 0 && !defaultActiveView ? createDatabase : undefined}
                   onCsvImport={onCsvImport}
                 />
               )}

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -125,7 +125,15 @@ function CenterPanel(props: Props) {
     ? allViews.filter((view) => view.fields.linkedSourceId && pages[view.fields.linkedSourceId])
     : allViews;
 
+  const linksToDeletedDatabasePages = views.length !== allViews.length;
+
   const activeView = isLinkedBoardType && views.length === 0 ? null : defaultActiveView;
+
+  useEffect(() => {
+    if (linksToDeletedDatabasePages) {
+      showView('');
+    }
+  }, [linksToDeletedDatabasePages]);
 
   useEffect(() => {
     if ((views.length === 0 && !activeView) || (isLinkedBoardType && views.length === 0)) {
@@ -622,8 +630,8 @@ function CenterPanel(props: Props) {
                 <CreateLinkedView
                   readOnly={props.readOnly}
                   onSelect={selectViewSource}
-                  // defaultActiveView indicates that there was a view which was linked to a deleted database page
-                  onCreate={views.length === 0 && !defaultActiveView ? createDatabase : undefined}
+                  // if it links to deleted db page then the board can't be inline_board type
+                  onCreate={views.length === 0 && !linksToDeletedDatabasePages ? createDatabase : undefined}
                   onCsvImport={onCsvImport}
                 />
               )}


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
1. For a `inline_linked_board` or `linked_board` if any of the source id of the view is deleted filter it out
2. If there are no views after filtering show the "Select source" menu
3. Hide the "New Database" option since it can never be a `board` or `inline_board`

### HOW
copilot:walkthrough
