### PR TITLE
Wrap person and multi-select properties

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -91,11 +91,10 @@ function PropertyValueElement(props: Props) {
   };
 
   let propertyValueElement: ReactNode = null;
-
   if (propertyTemplate.type === 'select' || propertyTemplate.type === 'multiSelect') {
     propertyValueElement = (
       <SelectProperty
-        wrapColumn={displayType === 'details' ? true : props.wrapColumn ?? false}
+        wrapColumn={displayType !== 'table' ? true : props.wrapColumn ?? false}
         multiselect={propertyTemplate.type === 'multiSelect'}
         readOnly={readOnly || !board}
         propertyValue={propertyValue as string}
@@ -124,7 +123,7 @@ function PropertyValueElement(props: Props) {
         onChange={(newValue) => {
           mutator.changePropertyValue(card, propertyTemplate.id, newValue);
         }}
-        wrapColumn={displayType === 'details' ? true : props.wrapColumn ?? false}
+        wrapColumn={displayType !== 'table' ? true : props.wrapColumn ?? false}
         showEmptyPlaceholder={displayType === 'details'}
       />
     );

--- a/components/members/components/MemberDirectoryGalleryView.tsx
+++ b/components/members/components/MemberDirectoryGalleryView.tsx
@@ -190,6 +190,7 @@ function MemberDirectoryGalleryCard({ member }: { member: Member }) {
               return memberProperty ? (
                 <SelectPreview
                   size='small'
+                  wrapColumn
                   options={property.options as SelectOptionType[]}
                   value={memberProperty.value as string | string[]}
                   name={property.name}

--- a/components/members/components/MemberDirectoryTableView.tsx
+++ b/components/members/components/MemberDirectoryTableView.tsx
@@ -215,6 +215,7 @@ function MemberDirectoryTableRow({ member }: { member: Member }) {
                 >
                   {memberProperty.value ? (
                     <SelectPreview
+                      wrapColumn
                       size='small'
                       options={property.options as SelectOptionType[]}
                       value={memberProperty.value as string | string[]}

--- a/components/profile/components/SpacesMemberDetails/components/MemberPropertiesRenderer.tsx
+++ b/components/profile/components/SpacesMemberDetails/components/MemberPropertiesRenderer.tsx
@@ -45,6 +45,7 @@ export function MemberPropertiesRenderer({ properties }: { properties: PropertyV
             }
             return (
               <SelectPreview
+                wrapColumn
                 key={property.memberPropertyId}
                 value={propertyValue}
                 name={property.name}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49568,7 +49568,7 @@
       "dev": true,
       "requires": {
         "@types/mdx": "^2.0.0",
-        "@types/react": ">=16"
+        "@types/react": "^18.0.26"
       }
     },
     "@metamask/onboarding": {
@@ -54238,7 +54238,7 @@
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
       "requires": {
-        "@types/react": "*",
+        "@types/react": "^18.0.26",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -54673,7 +54673,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.5.tgz",
       "integrity": "sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==",
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^18.0.26"
       }
     },
     "@types/redux-mock-store": {
@@ -68534,7 +68534,7 @@
       "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.1.1.tgz",
       "integrity": "sha512-GDh/XOp6AP14MGPEMpKXrRBPPcsFd3kwFqorl/EUH/1RrbLPSog+E5vyyb8BU5YTwq9BBjQd6ixOS2I8XXC1Vg==",
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^18.0.26"
       }
     },
     "merge-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49568,7 +49568,7 @@
       "dev": true,
       "requires": {
         "@types/mdx": "^2.0.0",
-        "@types/react": "^18.0.26"
+        "@types/react": ">=16"
       }
     },
     "@metamask/onboarding": {
@@ -54238,7 +54238,7 @@
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
       "requires": {
-        "@types/react": "^18.0.26",
+        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -54673,7 +54673,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.5.tgz",
       "integrity": "sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==",
       "requires": {
-        "@types/react": "^18.0.26"
+        "@types/react": "*"
       }
     },
     "@types/redux-mock-store": {
@@ -68534,7 +68534,7 @@
       "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.1.1.tgz",
       "integrity": "sha512-GDh/XOp6AP14MGPEMpKXrRBPPcsFd3kwFqorl/EUH/1RrbLPSog+E5vyyb8BU5YTwq9BBjQd6ixOS2I8XXC1Vg==",
       "requires": {
-        "@types/react": "^18.0.26"
+        "@types/react": "*"
       }
     },
     "merge-stream": {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23a0151</samp>

Added a `wrapColumn` prop to the `propertyValueElement` component and used it in various places to improve the layout of the board editor, member directory, and member properties. This prop controls whether the property value element should wrap the column based on the display type.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23a0151</samp>

*  Make select and date property elements wrap the column when the display type is not 'table' for better responsiveness and consistency in the board editor ([link](https://github.com/charmverse/app.charmverse.io/pull/2084/files?diff=unified&w=0#diff-5c7511c9b39c0b6d64a4c1acc78372600d6d48186c4ecf17c25b800442f6082dL94-R97), [link](https://github.com/charmverse/app.charmverse.io/pull/2084/files?diff=unified&w=0#diff-5c7511c9b39c0b6d64a4c1acc78372600d6d48186c4ecf17c25b800442f6082dL127-R126)) in `propertyValueElement.tsx`
