### PR TITLE
Fixed showing visible board view properties value

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/calendar/fullCalendar.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/calendar/fullCalendar.tsx
@@ -158,6 +158,7 @@ function CalendarFullView(props: Props): JSX.Element | null {
             propertyTemplate={template}
             showEmptyPlaceholder={true}
             showTooltip
+            displayType='calendar'
           />
         ))}
       </div>

--- a/components/common/BoardEditor/focalboard/src/components/gallery/galleryCard.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/gallery/galleryCard.tsx
@@ -93,6 +93,7 @@ const GalleryCard = React.memo((props: Props) => {
               propertyTemplate={template}
               showEmptyPlaceholder={false}
               showTooltip
+              displayType='gallery'
             />
           ))}
         </div>

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.scss
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.scss
@@ -60,10 +60,6 @@
       padding: 0;
       margin: 0;
     }
-
-    &:empty {
-      display: none;
-    }
   }
 
   .octo-icontitle {

--- a/components/common/BoardEditor/focalboard/src/components/properties/link/link.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/link/link.tsx
@@ -8,7 +8,7 @@ import { TextInput } from '../../../widgets/TextInput';
 type Props = {
   value: string;
   readOnly?: boolean;
-  placeholder?: string;
+  placeholderText?: string;
   multiline?: boolean;
   onChange: (value: string) => void;
   onSave: () => void;
@@ -35,7 +35,7 @@ function URLProperty(props: Props): JSX.Element {
 
   const commonProps = {
     className: 'octo-propertyvalue',
-    placeholderText: props.placeholder,
+    placeholderText: props.placeholderText,
     readOnly: props.readOnly,
     value: props.value,
     autoExpand: false,

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -194,7 +194,7 @@ function PropertyValueElement(props: Props) {
 
   const hasValue = !!value && (typeof value === 'string' || Array.isArray(value) ? value.length !== 0 : value);
 
-  if (!hasValue && props.readOnly && displayType !== 'details' && !propertyValueElement) {
+  if (!hasValue && props.readOnly && displayType !== 'details') {
     return null;
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6aacd7f</samp>

This pull request adds a new `displayType` prop to the `BoardView` and its subcomponents, which allows rendering different views of the board data, such as calendar, gallery, and kanban. It also fixes some minor issues with the `Link` and `KanbanCard` components, and simplifies the `PropertyValueElement` component.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6aacd7f</samp>

*  Add `displayType` prop to `BoardView` and `GalleryCard` components to render different types of views for the board data ([link](https://github.com/charmverse/app.charmverse.io/pull/2085/files?diff=unified&w=0#diff-444936aeb431360f1e5143be05e47e8c867cabaea8c6bc5ce8c5cd8387af7f7cR161), [link](https://github.com/charmverse/app.charmverse.io/pull/2085/files?diff=unified&w=0#diff-33c90cfbefc82bf2d8b217c0592d6d31bd69e29537f6c32dc64d03dffbfa8039R96))
*  Remove CSS rule that hides empty kanban cards to fix drag and drop issues in kanban view ([link](https://github.com/charmverse/app.charmverse.io/pull/2085/files?diff=unified&w=0#diff-7406c8b4e8c60a562194f47acd90a78609ef2e6d894ff9a9a1f22d8a443cbf03L63-L66))
*  Rename `placeholder` prop of `Link` component to `placeholderText` to avoid confusion with HTML attribute ([link](https://github.com/charmverse/app.charmverse.io/pull/2085/files?diff=unified&w=0#diff-64ada2882f4d70b59abf22f497a99acecdfd073b7d86fe9fe0519e33af6f7027L11-R11), [link](https://github.com/charmverse/app.charmverse.io/pull/2085/files?diff=unified&w=0#diff-64ada2882f4d70b59abf22f497a99acecdfd073b7d86fe9fe0519e33af6f7027L38-R38))
*  Simplify logic of `PropertyValueElement` component by removing redundant condition ([link](https://github.com/charmverse/app.charmverse.io/pull/2085/files?diff=unified&w=0#diff-5c7511c9b39c0b6d64a4c1acc78372600d6d48186c4ecf17c25b800442f6082dL197-R197))
