### PR TITLE
Update gitcoin space origin

### DIFF
--- a/prisma/migrations/20230428173900_space_origin/migration.sql
+++ b/prisma/migrations/20230428173900_space_origin/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Space" ADD COLUMN     "origin" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -280,6 +280,7 @@ model Space {
   webhookSubscriptionUrl      String?
   webhookSubscriptions        WebhookSubscription[]
   webhookSigningSecret        String?
+  origin                      String?
 
   hiddenFeatures Feature[]
 

--- a/scripts/importGitCoinProjects.ts
+++ b/scripts/importGitCoinProjects.ts
@@ -18,7 +18,7 @@ import { getFilenameWithExtension } from "lib/utilities/getFilenameWithExtension
  * It also updates mixpanel profiles so make sure to have prod mixpanel api key set in .env
  */
 
-const START_ID = 650;
+const START_ID = 600;
 const CHAIN_ID = 1;
 
 const provider = new AlchemyProvider(CHAIN_ID, process.env.ALCHEMY_API_KEY);
@@ -174,26 +174,43 @@ async function createSpaceUsers(owners: string[]) {
 
 }
 
-function getImportedProjcetIds() {
+function getImportedProjectsData() {
   try {
     const content = readFileSync(FILE_PATH).toString();
     const rows = content.split('\n');
 
-
-    const ids = rows.map(row => {
-      const cols = row?.split(';') || [];
-      const projectId = Number(cols[0]) || null;
-      return projectId
-    }).filter(id => id !== null);
-
-    console.log('🔥 imported projects count', ids.length);
-
-    return ids;
+    return rows.map(row => row?.split(';') || []);
  } catch (e) {
 
  }
 
  return [];
+}
+
+function getImportedProjcetIds() {
+    const data = getImportedProjectsData();
+    const ids = data.map(cols => {
+      // col 0 - gitcoin project id
+      const projectId = Number(cols[0]) || null;
+      return projectId
+    }).filter((id): id is number => id !== null);
+
+    console.log('🔥 imported projects count', ids.length);
+
+    return ids;
+}
+
+function getImportedProjcetSpaceIds() {
+  const data = getImportedProjectsData();
+  const ids = data.map(cols => {
+    // col 1 - gitcoin project space id
+    const projectId = cols[1] || null;
+    return projectId
+  }).filter((id): id is string => id !== null);
+
+  console.log('🔥 imported projects space ids', ids);
+
+  return ids;
 }
 
 function exportDataToCSV(data: ProjectData[]) {
@@ -226,7 +243,18 @@ function exportDataToCSV(data: ProjectData[]) {
   }
 }
 
+async function updateSpaceOrigins() {
+  const spaceIds = getImportedProjcetSpaceIds();
+  await prisma.space.updateMany({
+    where: { id: { in: spaceIds } },
+    data: { origin: 'gitcoin' }
+  });
+}
+
 // getImportedProjcetIds()
+// getImportedProjcetSpaceIds()
 // getProjectCount();
+
+// updateSpaceOrigins();
 
 // importGitCoinProjects();

--- a/scripts/importGitCoinProjects.ts
+++ b/scripts/importGitCoinProjects.ts
@@ -202,15 +202,12 @@ function getImportedProjcetIds() {
 
 function getImportedProjcetSpaceIds() {
   const data = getImportedProjectsData();
-  const ids = data.map(cols => {
+
+  return data.map(cols => {
     // col 1 - gitcoin project space id
     const projectId = cols[1] || null;
     return projectId
   }).filter((id): id is string => id !== null);
-
-  console.log('🔥 imported projects space ids', ids);
-
-  return ids;
 }
 
 function exportDataToCSV(data: ProjectData[]) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67acd4d</samp>

This pull request enhances the `importGitCoinProjects` script and adds a new column `origin` to the `Space` table and model. The goal is to track and display the source of the spaces in the Charmverse app.

### WHY
Added `origin` field to space + migration script which will update this value for spaces from gitcoin csv file

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67acd4d</samp>

*  Add `origin` column to `Space` table and model to store the source of the space ([link](https://github.com/charmverse/app.charmverse.io/pull/2088/files?diff=unified&w=0#diff-adf1698de24a3e7a9a928fc28322112732cd2c2b42b38340e4f5ef5fb1470a1aR1-R2), [link](https://github.com/charmverse/app.charmverse.io/pull/2088/files?diff=unified&w=0#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR283))
*  Refactor `importGitCoinProjects` script to use helper functions for reading and parsing CSV file and getting space IDs from imported projects ([link](https://github.com/charmverse/app.charmverse.io/pull/2088/files?diff=unified&w=0#diff-bc0db0c548a7a18098d58e2ad1595d1697c4dde654198ffd57a15cd3c663b837L177-R213), [link](https://github.com/charmverse/app.charmverse.io/pull/2088/files?diff=unified&w=0#diff-bc0db0c548a7a18098d58e2ad1595d1697c4dde654198ffd57a15cd3c663b837L229-R258))
*  Lower `START_ID` constant in `importGitCoinProjects` script to import more projects from GitCoin ([link](https://github.com/charmverse/app.charmverse.io/pull/2088/files?diff=unified&w=0#diff-bc0db0c548a7a18098d58e2ad1595d1697c4dde654198ffd57a15cd3c663b837L21-R21))
*  Update `origin` column of spaces imported from GitCoin using Prisma client in `importGitCoinProjects` script ([link](https://github.com/charmverse/app.charmverse.io/pull/2088/files?diff=unified&w=0#diff-bc0db0c548a7a18098d58e2ad1595d1697c4dde654198ffd57a15cd3c663b837L229-R258))
