### PR TITLE
add metrics and logging for public api endpoints

### DIFF
--- a/lib/public-api/handler.ts
+++ b/lib/public-api/handler.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
+
+import log from 'lib/log';
+import { count } from 'lib/metrics';
+import { onError, onNoMatch } from 'lib/middleware';
+import { requireApiKey } from 'lib/middleware/requireApiKey';
+import { requireSuperApiKey } from 'lib/middleware/requireSuperApiKey';
+
+export function defaultHandler() {
+  return nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch }).use(logApiRequest);
+}
+
+export function apiHandler() {
+  return nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch }).use(requireApiKey).use(logApiRequest);
+}
+
+export function superApiHandler() {
+  return nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch }).use(requireSuperApiKey).use(logApiRequest);
+}
+
+async function logApiRequest(req: NextApiRequest, res: NextApiResponse, next: VoidFunction) {
+  const path = req.url?.split('?')[0];
+
+  log.debug(`[public-api] Request: ${req.method} ${req.url}`, {
+    query: req.query,
+    body: req.body,
+    spaceId: req.authorizedSpaceId,
+    superApiTokenName: req.superApiToken?.name,
+    path
+  });
+
+  count(`public-api.${path}.${req.method?.toLowerCase()}`, 1);
+
+  next();
+}

--- a/pages/api/v1/bounties/index.ts
+++ b/pages/api/v1/bounties/index.ts
@@ -1,14 +1,13 @@
 import { prisma } from '@charmverse/core';
 import type { BountyStatus } from '@charmverse/core/dist/prisma';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { onError, onNoMatch, requireApiKey } from 'lib/middleware';
 import { generateMarkdown } from 'lib/prosemirror/plugins/markdown/generateMarkdown';
+import { apiHandler } from 'lib/public-api/handler';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = apiHandler();
 
-handler.use(requireApiKey).get(getBounties);
+handler.get(getBounties);
 
 /**
  * @swagger

--- a/pages/api/v1/cards/[cardId].ts
+++ b/pages/api/v1/cards/[cardId].ts
@@ -1,16 +1,16 @@
 import { prisma } from '@charmverse/core';
 import type { Prisma } from '@charmverse/core/dist/prisma';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { onError, onNoMatch, requireApiKey, SpaceAccessDeniedError } from 'lib/middleware';
+import { SpaceAccessDeniedError } from 'lib/middleware';
 import { generateMarkdown } from 'lib/prosemirror/plugins/markdown/generateMarkdown';
 import type { CardPage, PageProperty } from 'lib/public-api';
 import { getPageInBoard, mapProperties, PageFromBlock, validateUpdateData } from 'lib/public-api';
+import { apiHandler } from 'lib/public-api/handler';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = apiHandler();
 
-handler.use(requireApiKey).get(getCard).patch(updateCard);
+handler.get(getCard).patch(updateCard);
 
 /**
  * @swagger

--- a/pages/api/v1/databases/[id]/cards.ts
+++ b/pages/api/v1/databases/[id]/cards.ts
@@ -1,18 +1,15 @@
 import { prisma } from '@charmverse/core';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { onError, onNoMatch, requireApiKey, requireKeys } from 'lib/middleware';
+import { requireKeys } from 'lib/middleware';
 import { setupPermissionsAfterPageCreated } from 'lib/permissions/pages';
 import type { CardPage } from 'lib/public-api';
 import { validateCreationData, DatabasePageNotFoundError, createDatabaseCardPage } from 'lib/public-api';
+import { apiHandler } from 'lib/public-api/handler';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = apiHandler();
 
-handler
-  .use(requireApiKey)
-  .use(requireKeys<CardPage>(['title'], 'body'))
-  .post(createCard);
+handler.use(requireKeys<CardPage>(['title'], 'body')).post(createCard);
 
 /**
  * @swagger

--- a/pages/api/v1/databases/[id]/form.ts
+++ b/pages/api/v1/databases/[id]/form.ts
@@ -1,14 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { onError, onNoMatch, requireApiKey } from 'lib/middleware';
 import { createFormResponseCard } from 'lib/pages/createFormResponseCard';
+import { apiHandler } from 'lib/public-api/handler';
 import type { AddFormResponseInput } from 'lib/zapier/interfaces';
 import { validateFormRequestInput } from 'lib/zapier/validateFormRequestInput';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = apiHandler();
 
-handler.use(requireApiKey).post(createFormResponse);
+handler.post(createFormResponse);
 
 /**
  * @swagger

--- a/pages/api/v1/databases/[id]/index.ts
+++ b/pages/api/v1/databases/[id]/index.ts
@@ -1,17 +1,16 @@
 import { prisma } from '@charmverse/core';
 import type { Block } from '@charmverse/core/dist/prisma';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 import { validate } from 'uuid';
 
-import { onError, onNoMatch, requireApiKey } from 'lib/middleware';
 import type { DatabasePage } from 'lib/public-api';
 import { DatabasePageNotFoundError } from 'lib/public-api';
+import { apiHandler } from 'lib/public-api/handler';
 import { filterObjectKeys } from 'lib/utilities/objects';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = apiHandler();
 
-handler.use(requireApiKey).get(getDatabase);
+handler.get(getDatabase);
 
 /**
  * @swagger

--- a/pages/api/v1/databases/[id]/search.ts
+++ b/pages/api/v1/databases/[id]/search.ts
@@ -1,9 +1,7 @@
 import { prisma } from '@charmverse/core';
 import type { Page as PrismaPage, Prisma } from '@charmverse/core/dist/prisma';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { onError, onNoMatch, requireApiKey } from 'lib/middleware';
 import type { CardPage, PageProperty, CardPageQuery, PaginatedQuery, PaginatedResponse } from 'lib/public-api';
 import {
   DatabasePageNotFoundError,
@@ -12,10 +10,11 @@ import {
   validatePageQuery,
   validatePaginationQuery
 } from 'lib/public-api';
+import { apiHandler } from 'lib/public-api/handler';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = apiHandler();
 
-handler.use(requireApiKey).post(searchDatabase);
+handler.post(searchDatabase);
 
 // Limit the maximum size of a search query's results
 const maxRecordsPerQuery = 100;

--- a/pages/api/v1/pages/[pageIdOrPath].ts
+++ b/pages/api/v1/pages/[pageIdOrPath].ts
@@ -1,13 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { onError, onNoMatch, requireApiKey } from 'lib/middleware';
 import type { PublicApiPage } from 'lib/public-api/getPageApi';
 import { getPageApi } from 'lib/public-api/getPageApi';
+import { apiHandler } from 'lib/public-api/handler';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = apiHandler();
 
-handler.use(requireApiKey).get(getPageHandler);
+handler.get(getPageHandler);
 
 /**
  * @swagger

--- a/pages/api/v1/proposals/index.ts
+++ b/pages/api/v1/proposals/index.ts
@@ -1,13 +1,14 @@
 import { prisma } from '@charmverse/core';
 import type { ProposalStatus } from '@charmverse/core/dist/prisma';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { InvalidStateError, onError, onNoMatch, requireApiKey } from 'lib/middleware';
+import { InvalidStateError } from 'lib/middleware';
 import { generateMarkdown } from 'lib/prosemirror/plugins/markdown/generateMarkdown';
+import { apiHandler } from 'lib/public-api/handler';
 import { withSessionRoute } from 'lib/session/withSession';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = apiHandler();
+
 type ProposalAuthor = {
   userId: string;
   address?: string;
@@ -104,7 +105,7 @@ export interface PublicApiProposal {
   url: string;
 }
 
-handler.use(requireApiKey).get(listProposals);
+handler.get(listProposals);
 
 /**
  * @swagger

--- a/pages/api/v1/proposals/vote.ts
+++ b/pages/api/v1/proposals/vote.ts
@@ -1,15 +1,14 @@
 import type { UserVote } from '@charmverse/core/dist/prisma';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { onError, onNoMatch, requireKeys, requireApiKey } from 'lib/middleware';
+import { requireKeys } from 'lib/middleware';
 import { castProposalVote } from 'lib/public-api/castProposalVote';
+import { apiHandler } from 'lib/public-api/handler';
 import { withSessionRoute } from 'lib/session/withSession';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = apiHandler();
 
 handler
-  .use(requireApiKey)
   .use(
     requireKeys(
       [

--- a/pages/api/v1/spaces/index.ts
+++ b/pages/api/v1/spaces/index.ts
@@ -1,20 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { onError, onNoMatch, requireSuperApiKey, requireKeys } from 'lib/middleware';
+import { requireKeys } from 'lib/middleware';
 import { createWorkspaceApi } from 'lib/public-api/createWorkspaceApi';
+import { superApiHandler } from 'lib/public-api/handler';
 import type { CreateWorkspaceResponseBody, CreateWorkspaceRequestBody } from 'lib/public-api/interfaces';
 import { withSessionRoute } from 'lib/session/withSession';
 import { spaceInternalTemplateMapping } from 'lib/spaces/config';
 import { InvalidInputError } from 'lib/utilities/errors';
 import { isTruthy } from 'lib/utilities/types';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = superApiHandler();
 
-handler
-  .use(requireSuperApiKey)
-  .use(requireKeys([{ key: 'name', truthy: true }], 'body'))
-  .post(createSpace);
+handler.use(requireKeys([{ key: 'name', truthy: true }], 'body')).post(createSpace);
 
 /**
  * @swagger

--- a/pages/api/v1/users/search.ts
+++ b/pages/api/v1/users/search.ts
@@ -1,14 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { InvalidStateError, onError, onNoMatch, requireSuperApiKey } from 'lib/middleware';
+import { InvalidStateError } from 'lib/middleware';
+import { superApiHandler } from 'lib/public-api/handler';
 import type { UserProfile } from 'lib/public-api/interfaces';
 import { searchUserProfile } from 'lib/public-api/searchUserProfile';
 import { withSessionRoute } from 'lib/session/withSession';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = superApiHandler();
 
-handler.use(requireSuperApiKey).get(searchUser);
+handler.get(searchUser);
 
 /**
  * @example https://github.com/jellydn/next-swagger-doc/blob/main/example/models/organization.ts

--- a/pages/api/v1/webhooks/addToDatabase/[key]/index.ts
+++ b/pages/api/v1/webhooks/addToDatabase/[key]/index.ts
@@ -1,16 +1,16 @@
 import { prisma } from '@charmverse/core';
 import type { Typeform } from '@typeform/api-client';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
 
-import { onError, onNoMatch, requireKeys } from 'lib/middleware';
+import { requireKeys } from 'lib/middleware';
 import { createFormResponseCard } from 'lib/pages/createFormResponseCard';
+import { defaultHandler } from 'lib/public-api/handler';
 import { simplifyTypeformResponse } from 'lib/typeform/simplifyTypeformResponse';
 import { DataNotFoundError } from 'lib/utilities/errors';
 import type { AddFormResponseInput } from 'lib/zapier/interfaces';
 import { validateFormRequestInput } from 'lib/zapier/validateFormRequestInput';
 
-const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+const handler = defaultHandler();
 
 handler.use(requireKeys(['key'], 'query')).post(createFormResponse);
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08be3c7</samp>

This pull request refactors several API route files to use common handler functions from `lib/public-api/handler.ts` that wrap the `nc` function from `next-connect` and apply common middleware logic. This improves code quality and consistency and reduces code duplication and complexity.

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08be3c7</samp>

*  Add a new file `lib/public-api/handler.ts` that exports three functions for creating API handlers with common middleware and authorization logic ([link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-ca6550f4d004a8c0dc134b8e6858dc31e9e913131522bceabfb216b10219abf1R1-R36))
*  Replace the creation of `nc` instances and the application of `requireApiKey` middleware with the use of `apiHandler` function from `lib/public-api/handler.ts` in the following files: `pages/api/v1/bounties/index.ts`, `pages/api/v1/cards/[cardId].ts`, `pages/api/v1/databases/[id]/cards.ts`, `pages/api/v1/databases/[id]/form.ts`, `pages/api/v1/databases/[id]/index.ts`, `pages/api/v1/pages/[pageIdOrPath].ts`, `pages/api/v1/proposals/index.ts`, and `pages/api/v1/proposals/vote.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-10e62139deb179054dd7a01c4587c9eb82229d460fbbcecaae4c9c96279a4405L4-R10), [link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-5b910fc1abe7230b6d39e2720f83b1bda9317504cff610c74bf72848ece53c2cL4-R13), [link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-cb8b02add092024889c13fe2d225439e6be0ecbbcbb39b514c82535d24717538L3-R12), [link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-c6a31a4a02cf6613b8ce54e0539437d88e14f00b08e10e0e22b9d035076a129fL2-R10), [link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-07b3b3b1ec8394fe874999011a365f2756cdc28772dbe9fd40f5d0aeb596c49dL4-R13), [link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-7d7cb2b3a73c27bbc8d6b414bde07e83bc4711d98e0a2b2025a769063c111a8fL2-R9), [link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-b368354aa44923724289d5c2dafa2f59f94e6e34f0e4494ef9e74af3ea02d9a4L107-R108), [link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-a4bd346c9cdbda8f01c09a483de03a766b31285ed29e54b85ae2307f3dbb71f1L3-R11))
*  Remove the unnecessary imports of `requireApiKey` middleware in the following files: `pages/api/v1/databases/[id]/search.ts` and `pages/api/v1/proposals/index.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-b1c49169ee2cfd1cda74b5a486b0a3d1bc4d038a24240dce53501d4c5fd4691bL4-R4), [link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-b368354aa44923724289d5c2dafa2f59f94e6e34f0e4494ef9e74af3ea02d9a4L4-R11))
*  Replace the creation of `nc` instances and the application of `requireSuperApiKey` middleware with the use of `superApiHandler` function from `lib/public-api/handler.ts` in the following files: `pages/api/v1/spaces/index.ts` and `pages/api/v1/users/search.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-96b97a15d2a756e6071248818e3ed40a477da7b19c6e6f8fc6d9c18bd67c5f12L12-R14), [link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-c21ccfe1afd1b49b925628dfc0f7d5db13e6bfe209f6bc6b618be9bb9d7d9f11L2-R11))
*  Remove the unnecessary import of `requireSuperApiKey` middleware in `pages/api/v1/spaces/index.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-96b97a15d2a756e6071248818e3ed40a477da7b19c6e6f8fc6d9c18bd67c5f12L2-R5))
*  Replace the creation of `nc` instance with the use of `defaultHandler` function from `lib/public-api/handler.ts` in `pages/api/v1/webhooks/addToDatabase/[key]/index.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-399785d82f32529459154d8f5d7d6edc3c26c08c8dd870fb8822862e33ecf2d6L13-R13))
*  Remove the unnecessary import of `requireApiKey` middleware in `pages/api/v1/webhooks/addToDatabase/[key]/index.ts` ([link](https://github.com/charmverse/app.charmverse.io/pull/2093/files?diff=unified&w=0#diff-399785d82f32529459154d8f5d7d6edc3c26c08c8dd870fb8822862e33ecf2d6L4-R7))
