### PR TITLE
Revert hiding linked db pages -> Fix: Show data sources dbs

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -124,9 +124,9 @@ function CenterPanel(props: Props) {
     ? allViews.filter((view) => view.fields.linkedSourceId && pages[view.fields.linkedSourceId])
     : allViews;
 
-  const linksToDeletedDatabasePages = views.length !== allViews.length;
+  const linksToDeletedDatabasePages = props.views.length !== allViews.length;
 
-  const activeView = isLinkedBoardType && views.length === 0 ? null : defaultActiveView;
+  const activeView = isLinkedBoardType && props.views.length === 0 ? null : defaultActiveView;
 
   useEffect(() => {
     if (linksToDeletedDatabasePages) {
@@ -135,12 +135,12 @@ function CenterPanel(props: Props) {
   }, [linksToDeletedDatabasePages]);
 
   useEffect(() => {
-    if ((views.length === 0 && !activeView) || (isLinkedBoardType && views.length === 0)) {
+    if ((props.views.length === 0 && !activeView) || (isLinkedBoardType && props.views.length === 0)) {
       setState((s) => ({ ...s, showSettings: 'create-linked-view' }));
     } else if (activeView) {
       setState((s) => ({ ...s, showSettings: null }));
     }
-  }, [activeView?.id, views.length, isLinkedBoardType]);
+  }, [activeView?.id, props.views.length, isLinkedBoardType]);
 
   // for 'linked' boards, each view has its own board which we use to determine the cards to show
   let activeBoardId: string | undefined = props.board.id;
@@ -558,7 +558,7 @@ function CenterPanel(props: Props) {
             activeView={props.activeView}
             toggleViewOptions={toggleViewOptions}
             cards={cards}
-            views={views}
+            views={props.views}
             dateDisplayProperty={dateDisplayProperty}
             addCard={() => addCard('', true)}
             showCard={showCard}
@@ -623,7 +623,7 @@ function CenterPanel(props: Props) {
                   readOnly={props.readOnly}
                   onSelect={selectViewSource}
                   // if it links to deleted db page then the board can't be inline_board type
-                  onCreate={views.length === 0 && !linksToDeletedDatabasePages ? createDatabase : undefined}
+                  onCreate={props.views.length === 0 && !linksToDeletedDatabasePages ? createDatabase : undefined}
                   onCsvImport={onCsvImport}
                   pageId={props.page?.id}
                 />


### PR DESCRIPTION
### WHY
Revert back a change from this commit => https://github.com/charmverse/app.charmverse.io/pull/2080/files
Because it broke the view of data sources and now we can't see Google forms responses