### PR TITLE
Bug/page search

### DIFF
--- a/lib/pages/createFormResponseCard.ts
+++ b/lib/pages/createFormResponseCard.ts
@@ -29,10 +29,6 @@ export async function createFormResponseCard({
 
   const board = await getDatabaseDetails({ spaceId, idOrPath: databaseIdorPath });
 
-  if (!board) {
-    throw new InvalidInputError('Database not found');
-  }
-
   const fields = (board.fields as any) || {};
   const cardProperties = fields?.cardProperties || [];
   const existingResponseProperties: FormResponseProperty[] =

--- a/lib/pages/getDatabaseDetails.ts
+++ b/lib/pages/getDatabaseDetails.ts
@@ -1,22 +1,29 @@
 import { prisma } from '@charmverse/core';
+import type { Block } from '@charmverse/core/dist/prisma';
 
+import { DatabasePageNotFoundError } from 'lib/public-api';
 import { isUUID } from 'lib/utilities/strings';
 
-export async function getDatabaseDetails({ idOrPath, spaceId }: { idOrPath: string; spaceId?: string }) {
+import { generatePageQuery } from './server/generatePageQuery';
+
+export async function getDatabaseDetails({
+  idOrPath,
+  spaceId
+}: {
+  idOrPath: string;
+  spaceId?: string;
+}): Promise<Block> {
   let dbId: string | null | undefined = isUUID(idOrPath) ? idOrPath : null;
 
-  // We need a spaceId if looking up by path
-  if (!dbId && !spaceId) {
-    return null;
-  }
+  const searchQuery = generatePageQuery({
+    pageIdOrPath: idOrPath,
+    spaceIdOrDomain: spaceId
+  });
 
   if (!dbId) {
     // Get the database ID from the page
     const page = await prisma.page.findFirst({
-      where: {
-        path: idOrPath,
-        spaceId
-      },
+      where: searchQuery,
       select: {
         boardId: true
       }
@@ -26,13 +33,19 @@ export async function getDatabaseDetails({ idOrPath, spaceId }: { idOrPath: stri
   }
 
   if (!dbId) {
-    return null;
+    throw new DatabasePageNotFoundError(idOrPath);
   }
-  return prisma.block.findFirst({
+  const block = await prisma.block.findFirst({
     where: {
       type: 'board',
       id: dbId,
       spaceId
     }
   });
+
+  if (!block) {
+    throw new DatabasePageNotFoundError(idOrPath);
+  }
+
+  return block;
 }

--- a/lib/pages/server/__tests__/generatePageQuery.spec.ts
+++ b/lib/pages/server/__tests__/generatePageQuery.spec.ts
@@ -1,0 +1,123 @@
+import { ExpectedAnError, InvalidInputError } from '@charmverse/core';
+import type { Page, Space, User } from '@charmverse/core/dist/prisma';
+import { v4 } from 'uuid';
+
+import { createPage, generateUserAndSpace } from 'testing/setupDatabase';
+
+import { generatePageQuery } from '../generatePageQuery';
+
+let space: Space;
+let page: Page;
+let pageWithUuidPath: Page;
+let user: User;
+
+beforeAll(async () => {
+  const generated = await generateUserAndSpace();
+  space = generated.space;
+  user = generated.user;
+  const createdPage = await createPage({
+    createdBy: user.id,
+    spaceId: space.id
+  });
+  const createdUuidPage = await createPage({
+    createdBy: user.id,
+    spaceId: space.id,
+    path: v4()
+  });
+  const { permissions: ignored1, ...normalPage } = createdPage;
+  const { permissions: ignored2, ...normalUuidPage } = createdUuidPage;
+
+  // Get only a normal page since that's what we're testing
+  page = normalPage;
+  pageWithUuidPath = normalUuidPage;
+});
+
+describe('generatePageQuery', () => {
+  it('should return correct query for searching a page by ID', async () => {
+    const query = generatePageQuery({ pageIdOrPath: page.id });
+
+    const found = await prisma.page.findFirst({
+      where: query
+    });
+
+    expect(found).toMatchObject(page);
+  });
+
+  it('should return correct query for searching a page by ID + spaceID', async () => {
+    const query = generatePageQuery({ pageIdOrPath: page.id, spaceIdOrDomain: space.id });
+
+    const found = await prisma.page.findFirst({
+      where: query
+    });
+
+    expect(found).toMatchObject(page);
+  });
+
+  it('should return correct query for searching a page by page path where path is a UUID + spaceID', async () => {
+    const query = generatePageQuery({ pageIdOrPath: pageWithUuidPath.id, spaceIdOrDomain: space.id });
+
+    const found = await prisma.page.findFirst({
+      where: query
+    });
+
+    expect(found).toMatchObject(pageWithUuidPath);
+  });
+
+  it('should return correct query for searching a page by page path and space domain', async () => {
+    const query = generatePageQuery({ pageIdOrPath: page.path, spaceIdOrDomain: space.domain });
+
+    const found = await prisma.page.findFirst({
+      where: query
+    });
+
+    expect(found).toMatchObject(page);
+  });
+
+  it('should return correct query for searching a page by page path and space ID', async () => {
+    const query = generatePageQuery({ pageIdOrPath: page.path, spaceIdOrDomain: space.id });
+
+    const found = await prisma.page.findFirst({
+      where: query
+    });
+
+    expect(found).toMatchObject(page);
+  });
+
+  it('should return correct query for searching a page by page path where path is a UUID and space domain', async () => {
+    const query = generatePageQuery({ pageIdOrPath: pageWithUuidPath.path, spaceIdOrDomain: space.domain });
+
+    const found = await prisma.page.findFirst({
+      where: query
+    });
+
+    expect(found).toMatchObject(pageWithUuidPath);
+  });
+
+  it('should return correct query for searching a page by page ID and space domain', async () => {
+    const query = generatePageQuery({ pageIdOrPath: page.id, spaceIdOrDomain: space.domain });
+
+    const found = await prisma.page.findFirst({
+      where: query
+    });
+
+    expect(found).toMatchObject(page);
+  });
+
+  it('should throw an error if no pageID is provided', async () => {
+    try {
+      generatePageQuery({ pageIdOrPath: undefined as any });
+      throw new ExpectedAnError();
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidInputError);
+    }
+  });
+
+  it('should throw an error if a page path is provided without a spaceDomain', async () => {
+    try {
+      generatePageQuery({ pageIdOrPath: page.path });
+      throw new ExpectedAnError();
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidInputError);
+    }
+  });
+});

--- a/lib/pages/server/generatePageQuery.ts
+++ b/lib/pages/server/generatePageQuery.ts
@@ -1,0 +1,78 @@
+import { InvalidInputError, stringUtils } from '@charmverse/core';
+import type { Prisma } from '@charmverse/core/dist/prisma';
+
+type PageQuery = {
+  pageIdOrPath: string;
+  spaceIdOrDomain?: string;
+};
+
+/**
+ * Lookup pages with different types of query
+ * Solves an issue where pagePath might actually be a UUID
+ */
+export function generatePageQuery({ pageIdOrPath, spaceIdOrDomain }: PageQuery): Prisma.PageWhereInput {
+  const pageIdOrPathIsValidUUid = stringUtils.isUUID(pageIdOrPath);
+  const spaceIdOrDomainIsValidUUid = !!spaceIdOrDomain && stringUtils.isUUID(spaceIdOrDomain);
+
+  let searchQuery: Prisma.PageWhereInput = {};
+
+  if (!pageIdOrPath) {
+    throw new InvalidInputError(`You must provide a page id or path to fetch a page.`);
+  } else if (!spaceIdOrDomain && !pageIdOrPathIsValidUUid) {
+    throw new InvalidInputError(`To fetch a page by path, you must also provide a spaceIdOrDomain.`);
+  }
+
+  // Handle searching by page id only
+  if (!spaceIdOrDomain && pageIdOrPathIsValidUUid) {
+    searchQuery = {
+      id: pageIdOrPath
+    };
+    // Handle searching by page path where page path might have been generated as a UUID
+  } else if (spaceIdOrDomainIsValidUUid && pageIdOrPathIsValidUUid) {
+    searchQuery = {
+      spaceId: spaceIdOrDomain,
+      OR: [
+        {
+          path: pageIdOrPath
+        },
+        {
+          id: pageIdOrPath
+        }
+      ]
+    };
+    // Classic space domain + page path search
+  } else if (!spaceIdOrDomainIsValidUUid && !pageIdOrPathIsValidUUid) {
+    searchQuery = {
+      space: {
+        domain: spaceIdOrDomain
+      },
+      path: pageIdOrPath
+    };
+    // Space ID + page path search
+  } else if (spaceIdOrDomainIsValidUUid && !pageIdOrPathIsValidUUid) {
+    searchQuery = {
+      spaceId: spaceIdOrDomain,
+      path: pageIdOrPath
+    };
+    // Space domain received along with a UUID
+  } else if (!spaceIdOrDomainIsValidUUid && pageIdOrPathIsValidUUid) {
+    searchQuery = {
+      space: {
+        domain: spaceIdOrDomain
+      },
+      OR: [
+        {
+          path: pageIdOrPath
+        },
+        {
+          id: pageIdOrPath
+        }
+      ]
+    };
+  } else {
+    // This should never happen
+    throw new InvalidInputError(`Invalid page id or path: ${pageIdOrPath} ${spaceIdOrDomain}`);
+  }
+
+  return searchQuery;
+}

--- a/lib/public-api/getPageInBoard.ts
+++ b/lib/public-api/getPageInBoard.ts
@@ -1,13 +1,12 @@
 import { prisma } from '@charmverse/core';
 import type { Block } from '@charmverse/core/dist/prisma';
-import { validate } from 'uuid';
 
+import { generatePageQuery } from 'lib/pages/server/generatePageQuery';
 import { generateMarkdown } from 'lib/prosemirror/plugins/markdown/generateMarkdown';
-import { InvalidInputError } from 'lib/utilities/errors';
 import { filterObjectKeys } from 'lib/utilities/objects';
 
 import { DatabasePageNotFoundError, PageNotFoundError, SpaceNotFoundError } from './errors';
-import type { DatabasePage, CardPage, PageProperty } from './interfaces';
+import type { CardPage, DatabasePage, PageProperty } from './interfaces';
 import { PageFromBlock } from './pageFromBlock.class';
 
 export async function getPageInBoard(pageId: string): Promise<CardPage> {
@@ -62,25 +61,16 @@ export async function getPageInBoard(pageId: string): Promise<CardPage> {
  * @param spaceId If searching by database path, you must provide the spaceId to avoid conflicts
  */
 export async function getDatabaseRoot(id: string, spaceId?: string): Promise<DatabasePage> {
-  const isValidUuid = validate(id as string);
-
-  if (!isValidUuid && !spaceId) {
-    throw new InvalidInputError('Please provide a spaceID in order to search pages by path');
-  }
-
+  const searchQuery = generatePageQuery({
+    pageIdOrPath: id,
+    spaceIdOrDomain: spaceId
+  });
   // eslint-disable-next-line prefer-const
   const database = await prisma.page.findFirst({
-    where: isValidUuid
-      ? {
-          type: 'board',
-          boardId: id as string,
-          spaceId
-        }
-      : {
-          type: 'board',
-          path: id as string,
-          spaceId
-        }
+    where: {
+      ...searchQuery,
+      type: 'board'
+    }
   });
 
   if (!database) {

--- a/lib/zapier/validateFormRequestInput.ts
+++ b/lib/zapier/validateFormRequestInput.ts
@@ -27,11 +27,8 @@ export async function validateFormRequestInput({
     throw new InvalidInputError(`Invalid input data`);
   }
 
-  const board = await getDatabaseDetails({ spaceId, idOrPath: databaseIdOrPath });
-
-  if (!board) {
-    throw new DatabasePageNotFoundError(databaseIdOrPath);
-  }
+  // Check if database exists
+  await getDatabaseDetails({ spaceId, idOrPath: databaseIdOrPath });
 
   return true;
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "sockets:dev": "PORT=3001 npx dotenv -e .env -e .env.local -- node --watch ./.next/server/websockets.js",
     "sockets:prod": "node ./.next/server/websockets.js",
     "sockets:staging": "npx react-env --path .env.staging -- node ./.next/server/websockets.js",
+    "prisma:migrate": "cd node_modules/@charmverse/core && npm run prisma:migrate",
     "prisma:studio": "cd node_modules/@charmverse/core && npm run prisma:studio",
     "prisma:generate": "cd node_modules/@charmverse/core && npm run prisma:generate",
     "prisma:reset": "cd node_modules/@charmverse/core && npm run prisma:reset",

--- a/pages/api/blocks/index.ts
+++ b/pages/api/blocks/index.ts
@@ -2,7 +2,6 @@ import { prisma } from '@charmverse/core';
 import type { Block, Prisma } from '@charmverse/core/dist/prisma';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
-import { validate } from 'uuid';
 
 import { prismaToBlock } from 'lib/focalboard/block';
 import {
@@ -14,6 +13,7 @@ import {
   requireUser
 } from 'lib/middleware';
 import { createPage } from 'lib/pages/server/createPage';
+import { generatePageQuery } from 'lib/pages/server/generatePageQuery';
 import { getPageMetaList } from 'lib/pages/server/getPageMetaList';
 import { getPagePath } from 'lib/pages/utils';
 import { computeUserPagePermissions } from 'lib/permissions/pages';
@@ -47,10 +47,11 @@ async function getBlocks(req: NextApiRequest, res: NextApiResponse<Block[] | { e
     if (!pageId) {
       throw new InvalidStateError('invalid referrer url');
     }
-    const pageIdIsUUID = validate(pageId);
-    const page = pageIdIsUUID
-      ? await prisma.page.findUnique({ where: { id: pageId } })
-      : await prisma.page.findFirst({ where: { spaceId: req.query.spaceId as string, path: pageId } });
+    const searchQuery = generatePageQuery({
+      pageIdOrPath: pageId,
+      spaceIdOrDomain: req.query.spaceId as string
+    });
+    const page = await prisma.page.findFirst({ where: searchQuery });
     if (!page) {
       throw new NotFoundError('page not found');
     }

--- a/pages/api/pages/[id]/index.ts
+++ b/pages/api/pages/[id]/index.ts
@@ -1,14 +1,13 @@
 import { prisma } from '@charmverse/core';
-import type { Page, Prisma } from '@charmverse/core/dist/prisma';
+import type { Page } from '@charmverse/core/dist/prisma';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
-import { validate } from 'uuid';
 
 import log from 'lib/log';
 import { trackUserAction } from 'lib/metrics/mixpanel/trackUserAction';
 import { updateTrackPageProfile } from 'lib/metrics/mixpanel/updateTrackPageProfile';
 import { ActionNotPermittedError, NotFoundError, onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
-import type { PageWithContent, ModifyChildPagesResponse } from 'lib/pages';
+import type { ModifyChildPagesResponse, PageWithContent } from 'lib/pages';
 import { modifyChildPages } from 'lib/pages/modifyChildPages';
 import { resolvePageTree } from 'lib/pages/server';
 import { generatePageQuery } from 'lib/pages/server/generatePageQuery';
@@ -32,11 +31,12 @@ handler
 async function getPageRoute(req: NextApiRequest, res: NextApiResponse<PageWithContent>) {
   const { id: pageIdOrPath, spaceId: spaceIdOrDomain } = req.query as { id: string; spaceId: string };
   const userId = req.session?.user?.id;
+  const searchQuery = generatePageQuery({
+    pageIdOrPath,
+    spaceIdOrDomain
+  });
   const page = await prisma.page.findFirst({
-    where: generatePageQuery({
-      pageIdOrPath,
-      spaceIdOrDomain
-    })
+    where: searchQuery
   });
 
   if (!page) {

--- a/pages/api/permissions/pages/compute-page-permissions.ts
+++ b/pages/api/permissions/pages/compute-page-permissions.ts
@@ -3,10 +3,11 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
 import { onError, onNoMatch, requireKeys } from 'lib/middleware';
+import { PageNotFoundError } from 'lib/pages/server';
+import { generatePageQuery } from 'lib/pages/server/generatePageQuery';
 import type { PermissionCompute } from 'lib/permissions/interfaces';
 import type { IPagePermissionFlags } from 'lib/permissions/pages';
 import { computeUserPagePermissions } from 'lib/permissions/pages';
-import { ProposalNotFoundError } from 'lib/proposal/errors';
 import { withSessionRoute } from 'lib/session/withSession';
 import { InvalidInputError } from 'lib/utilities/errors';
 import { isUUID } from 'lib/utilities/strings';
@@ -20,28 +21,28 @@ async function computePagePermissions(req: NextApiRequest, res: NextApiResponse<
 
   let resourceId = input.resourceId;
 
-  if (!isUUID(input.resourceId)) {
-    const [spaceDomain, proposalPath] = resourceId.split('/');
-    if (!spaceDomain || !proposalPath) {
-      throw new InvalidInputError(`Invalid proposal path and space domain`);
+  if (!isUUID(resourceId)) {
+    const [spaceDomain, pagePath] = resourceId.split('/');
+    if (!spaceDomain || !pagePath) {
+      throw new InvalidInputError(`Invalid page path and space domain`);
     }
 
-    const proposal = await prisma.page.findFirst({
-      where: {
-        path: proposalPath,
-        space: {
-          domain: spaceDomain
-        }
-      },
+    const searchQuery = generatePageQuery({
+      pageIdOrPath: pagePath,
+      spaceIdOrDomain: spaceDomain
+    });
+
+    const page = await prisma.page.findFirst({
+      where: searchQuery,
       select: {
         id: true
       }
     });
 
-    if (!proposal) {
-      throw new ProposalNotFoundError(resourceId);
+    if (!page) {
+      throw new PageNotFoundError(resourceId);
     } else {
-      resourceId = proposal.id;
+      resourceId = page.id;
     }
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a4f58f</samp>

This pull request refactors and improves some functions related to getting and querying page and database details in `lib/pages` and `pages/api/pages`. It also adds a new function `generatePageQuery` in `lib/pages/server` that handles different cases of page and space identifiers. It removes some redundant checks for board existence that are already done by `getDatabaseDetails`. It also adds unit tests for the new function in `lib/pages/server/__tests__`.

### WHY
Clean up logic on resolving pages. We use pageId or pagePath in a number of places. This adds a more resilient unit tested query in those places

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a4f58f</samp>

*  Simplify and generalize page query logic by adding a new function `generatePageQuery` that handles different cases of page id or path and space id or domain ([link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-4d2ed461e382ad0e4d5a50dfc39357fa486bcc8de3716953fe45c810075b7521R1-R78), [link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-05b543b36b090e7f0b325686705b3adcb8d400a48d2731bc359d4d93e2e082e1R1-R123))
*  Use `generatePageQuery` function in `getPageDetails` and `getPageRoute` functions to replace previous logic that only handled UUIDs or not ([link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-f7e39a7fee08baad83c497aaea0a9a5833898e935348320b3d59dca0229d3b0bL2-R14), [link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-d62eee397cd615c1da35a46fe643ecca74f15806132126da1b790e928d5ac1abR14), [link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-d62eee397cd615c1da35a46fe643ecca74f15806132126da1b790e928d5ac1abL32-R39))
*  Add error handling for page and board not found cases in `getDatabaseDetails` and `getPageDetails` functions by throwing custom errors instead of returning null ([link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-f9456d2cc61f2a00f3826fda79e7892f55737cc6e8b68d40193b1133af5523a1L29-R38), [link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-f9456d2cc61f2a00f3826fda79e7892f55737cc6e8b68d40193b1133af5523a1R45-R50), [link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-f7e39a7fee08baad83c497aaea0a9a5833898e935348320b3d59dca0229d3b0bR23-R27))
*  Remove redundant checks for board existence and public page permission in `createFormResponseCard`, `validateFormRequestInput`, and `getPageRoute` functions, since they are already done by `getDatabaseDetails` and `getPageDetails` functions ([link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-24e74d4fe4285c8b8c9445d3d5136732bf87d5b37712200b85dde281f8849461L32-L35), [link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-06619e5e50616076c77f780fc3f322aa97764c198c422509efd6656330da4745L30-R32), [link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-d62eee397cd615c1da35a46fe643ecca74f15806132126da1b790e928d5ac1abL58-L69))
*  Move `getDatabaseDetails` function from `lib/pages/getDatabaseDetails.ts` to `lib/pages/createFormResponseCard.ts`, since it is only used by the latter ([link](https://github.com/charmverse/app.charmverse.io/pull/2096/files?diff=unified&w=0#diff-f9456d2cc61f2a00f3826fda79e7892f55737cc6e8b68d40193b1133af5523a1L2-R26))
