### PR TITLE
removed my config change to attempt getting syslogs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,8 +92,6 @@ services:
   datadog-agent:
     image: public.ecr.aws/datadog/agent
     hostname: datadog-agent
-    labels:
-      com.datadoghq.ad.logs: '[{"type":"file", "source": "os", "service": "syslog", "sourcecategory": "${SERVICE_NAME}", "path": "/host/var/log/messages"}]'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /proc/:/host/proc/:ro


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e414e6f</samp>

Removed `labels` from `syslog` service in `docker-compose.yml` to prevent duplicate logging. This improves the logging configuration of the app.charmverse.io application.

### WHY
label was meant to forward syslog to datadog. It doesn't work yet but is generating tons of unless datadog logs. So going to remove this. 
