### PR TITLE
use light mode by default

### DIFF
--- a/theme/AppThemeProvider.tsx
+++ b/theme/AppThemeProvider.tsx
@@ -11,10 +11,12 @@ import cssVariables from 'theme/cssVariables';
 import { setDarkMode } from 'theme/darkMode';
 import { monoFont, serifFont } from 'theme/fonts';
 
+const defaultMode: PaletteMode = 'light';
+
 export function AppThemeProvider({ children, forceTheme }: { children: React.ReactNode; forceTheme?: PaletteMode }) {
   // dark mode: https://mui.com/customization/dark-mode/
-  const [savedDarkMode, setSavedDarkMode] = useLocalStorage<PaletteMode | null>('dark', null);
-  const [mode, setMode] = useState<PaletteMode>('dark');
+  const [savedDarkMode, setSavedDarkMode] = useLocalStorage<PaletteMode | null>(defaultMode, null);
+  const [mode, setMode] = useState<PaletteMode>(defaultMode);
 
   const toggleColorMode = useCallback(() => {
     setMode((prevMode: PaletteMode) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5eef5f2</samp>

Refactor default palette mode for app theme in `theme/AppThemeProvider.tsx`. Use a constant `defaultMode` instead of hard-coded values to initialize theme state.

### WHY
An ask from user, they don't feel as comfortable sharing pages in dark mode.
