### PR TITLE
Fix udpating erc20 gnosis tx status

### DIFF
--- a/lib/gnosis/__tests__/getSafeTxStatus.spec.ts
+++ b/lib/gnosis/__tests__/getSafeTxStatus.spec.ts
@@ -1,12 +1,15 @@
 describe('getGnosisTransactionQueueUrl', () => {
   let getTransactionMock: jest.Mock;
+  let getAllTransactionsMock: jest.Mock;
 
   beforeAll(() => {
     getTransactionMock = jest.fn();
+    getAllTransactionsMock = jest.fn();
 
     jest.mock('../gnosis.ts', () => ({
       getGnosisService: () => ({
-        getTransaction: getTransactionMock
+        getTransaction: getTransactionMock,
+        getAllTransactions: getAllTransactionsMock
       })
     }));
   });
@@ -29,13 +32,14 @@ describe('getGnosisTransactionQueueUrl', () => {
       isSuccessful: false,
       transactionHash: '0x456'
     });
+    getAllTransactionsMock.mockResolvedValue({ results: [] });
 
     const { getSafeTxStatus } = await import('lib/gnosis/getSafeTxStatus');
 
     const status = await getSafeTxStatus({ safeTxHash: '0x123', chainId: 1 });
     expect(status?.status).toBe('processing');
 
-    getTransactionMock.mockResolvedValue({ value: '1', isExecuted: true, isSuccessful: false });
+    getTransactionMock.mockResolvedValue({ value: '1', isExecuted: false, isSuccessful: false });
 
     const status2 = await getSafeTxStatus({ safeTxHash: '0x123', chainId: 1 });
     expect(status2?.status).toBe('processing');
@@ -43,34 +47,13 @@ describe('getGnosisTransactionQueueUrl', () => {
     expect(status?.safeTxHash).toBe('0x123');
   });
 
-  it('should return processing status when tx was found, but not yet executed', async () => {
-    getTransactionMock.mockResolvedValue({
-      value: '1',
-      isExecuted: false,
-      isSuccessful: false,
-      transactionHash: '0x456'
-    });
-
-    const { getSafeTxStatus } = await import('lib/gnosis/getSafeTxStatus');
-
-    const status = await getSafeTxStatus({ safeTxHash: '0x123', chainId: 1 });
-
-    expect(status?.status).toBe('processing');
-    expect(status?.chainTxHash).toBe('0x456');
-    expect(status?.safeTxHash).toBe('0x123');
-
-    getTransactionMock.mockResolvedValue({ value: '1', isExecuted: true, isSuccessful: false });
-
-    const status2 = await getSafeTxStatus({ safeTxHash: '0x123', chainId: 1 });
-    expect(status2?.status).toBe('processing');
-  });
-
-  it('should return cancelled status when tx was executed with no value', async () => {
+  it('should return cancelled status when tx was executed with no value and no data', async () => {
     getTransactionMock.mockResolvedValue({
       value: '0',
       isExecuted: true,
       isSuccessful: true,
-      transactionHash: '0x456'
+      transactionHash: '0x456',
+      data: null
     });
 
     const { getSafeTxStatus } = await import('lib/gnosis/getSafeTxStatus');
@@ -81,12 +64,55 @@ describe('getGnosisTransactionQueueUrl', () => {
     expect(status?.safeTxHash).toBe('0x123');
   });
 
+  it('should return cancelled status when tx was not executed, but replaced with another tx with the same nonce', async () => {
+    getTransactionMock.mockResolvedValue({
+      value: '1',
+      isExecuted: false,
+      isSuccessful: false,
+      transactionHash: '0x456',
+      data: null,
+      nonce: 1
+    });
+    getAllTransactionsMock.mockResolvedValue({
+      results: [
+        {
+          nonce: 1,
+          transactionHash: '0x789'
+        }
+      ]
+    });
+
+    const { getSafeTxStatus } = await import('lib/gnosis/getSafeTxStatus');
+
+    const status = await getSafeTxStatus({ safeTxHash: '0x123', chainId: 1 });
+    expect(status?.status).toBe('cancelled');
+    expect(status?.chainTxHash).toBe('0x789');
+    expect(status?.safeTxHash).toBe('0x123');
+  });
+
   it('should return paid status when tx was executed with value', async () => {
     getTransactionMock.mockResolvedValue({
       value: '1',
       isExecuted: true,
       isSuccessful: true,
       transactionHash: '0x456'
+    });
+
+    const { getSafeTxStatus } = await import('lib/gnosis/getSafeTxStatus');
+
+    const status = await getSafeTxStatus({ safeTxHash: '0x123', chainId: 1 });
+    expect(status?.status).toBe('paid');
+    expect(status?.chainTxHash).toBe('0x456');
+    expect(status?.safeTxHash).toBe('0x123');
+  });
+
+  it('should return paid status when tx was executed with custom transfer data', async () => {
+    getTransactionMock.mockResolvedValue({
+      value: '0',
+      isExecuted: true,
+      isSuccessful: true,
+      transactionHash: '0x456',
+      data: '0xa9059cbb00000000000000000000000012345678901234567890123456789012345678900000000000'
     });
 
     const { getSafeTxStatus } = await import('lib/gnosis/getSafeTxStatus');

--- a/lib/gnosis/getSafeTxStatus.ts
+++ b/lib/gnosis/getSafeTxStatus.ts
@@ -1,6 +1,7 @@
 import { log } from '@charmverse/core/log';
 import { ApplicationStatus } from '@charmverse/core/prisma';
 import { AlchemyProvider } from '@ethersproject/providers';
+import type { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types';
 import { BigNumber } from 'ethers';
 
 import { getGnosisService } from 'lib/gnosis/gnosis';
@@ -27,14 +28,24 @@ export async function getSafeTxStatus({
 
   try {
     const safeTx = await safeService.getTransaction(safeTxHash);
-    const hasValue = BigNumber.from(safeTx.value || '0').gt(0);
-    const { isExecuted, isSuccessful, transactionHash: chainTxHash } = safeTx;
+
+    const { isExecuted, isSuccessful, transactionHash: chainTxHash, nonce } = safeTx;
 
     if (isExecuted && isSuccessful) {
       // if safe tx was executed without value, it is considered as cancelled
-      const status = hasValue ? ApplicationStatus.paid : ApplicationStatus.cancelled;
+      const status = hasValue(safeTx) ? ApplicationStatus.paid : ApplicationStatus.cancelled;
 
       return { status, chainTxHash, safeTxHash };
+    }
+
+    // check if tx was replaced with other tx with the same nonce
+    const executedTxs = await safeService.getAllTransactions(safeTx.safe, { executed: true });
+    const replacedTx = executedTxs.results.find((tx) => 'nonce' in tx && tx.nonce === nonce);
+
+    // orginal tx was replaced with other tx
+    if (replacedTx) {
+      const replacedChainTxHash = 'transactionHash' in replacedTx ? replacedTx.transactionHash : undefined;
+      return { status: ApplicationStatus.cancelled, chainTxHash: replacedChainTxHash, safeTxHash };
     }
 
     return { status: ApplicationStatus.processing, chainTxHash, safeTxHash };
@@ -43,4 +54,8 @@ export async function getSafeTxStatus({
 
     return null;
   }
+}
+
+function hasValue(safeTx: SafeMultisigTransactionResponse): boolean {
+  return BigNumber.from(safeTx.value || '0').gt(0) || !!safeTx.data;
 }

--- a/scripts/testTx.ts
+++ b/scripts/testTx.ts
@@ -1,9 +1,0 @@
-import { getSafeTxStatus } from "lib/gnosis/getSafeTxStatus";
-
-async function test(){
-  const res = await getSafeTxStatus({safeTxHash: '0xfe0df7ccebdfa7bcd1eae5ec80382a7c5d77a0d299e4ef9ba804ff44495e27b1', chainId: 137});
-  console.log('🔥', res);
-}
-
-test();
-

--- a/scripts/testTx.ts
+++ b/scripts/testTx.ts
@@ -1,0 +1,9 @@
+import { getSafeTxStatus } from "lib/gnosis/getSafeTxStatus";
+
+async function test(){
+  const res = await getSafeTxStatus({safeTxHash: '0xfe0df7ccebdfa7bcd1eae5ec80382a7c5d77a0d299e4ef9ba804ff44495e27b1', chainId: 137});
+  console.log('🔥', res);
+}
+
+test();
+


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dc9d3ce</samp>

This pull request improves the `getSafeTxStatus` function to handle safe transaction replacement scenarios and adds tests and a script to verify its functionality. It updates the test file `lib/gnosis/__tests__/getSafeTxStatus.spec.ts`, the function file `lib/gnosis/getSafeTxStatus.ts`, and adds a new script file `scripts/testTx.ts`.

### WHY
Gnosis status update logic was incorrect for erc20 token transfers. Current solution of detecting tx as cancelled it based on: https://ethereum.stackexchange.com/questions/119564/how-can-you-identify-if-a-transaction-has-been-rejected-on-the-gnosis-safe-trans
