### PR TITLE
Fix mobile action buttons not clickable

### DIFF
--- a/components/common/CharmEditor/components/floatingMenu/Icon.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/Icon.tsx
@@ -27,6 +27,12 @@ const StyledMenuButton = styled(ListItemButton, { shouldForwardProp: (prop) => p
     width: 1.25em;
     fill: currentcolor;
   }
+
+  ${(props) => props.theme.breakpoints.down('md')} {
+    min-width: 38px;
+    min-height: 40px;
+    justify-content: center;
+  }
 `;
 
 export function MenuButton({ children, isActive = false, isDisabled, hints, onClick }: MenuButtonProps) {
@@ -59,10 +65,12 @@ export function MenuButton({ children, isActive = false, isDisabled, hints, onCl
       <ListItem disablePadding component='div'>
         <StyledMenuButton
           disabled={isDisabled}
-          sx={{ pointerEvents: isDisabled ? 'none' : 'initial' }}
+          sx={{
+            pointerEvents: isDisabled ? 'none' : 'initial'
+          }}
           aria-label={hints.join('\n')}
           active={isActive}
-          onMouseDown={onClick}
+          onClick={onClick}
         >
           {children}
         </StyledMenuButton>

--- a/components/common/CharmEditor/components/floatingMenu/MenuButtons.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/MenuButtons.tsx
@@ -265,7 +265,7 @@ export function UndoButton({ hints = ['Undo', historyKeys.undo], children = <Und
 
 export function CodeButton({
   hints = ['Code', codeKeys.toggleCode],
-  children = <CodeIcon fontSize={16} />
+  children = <CodeIcon fontSize={{ xs: 20, md: 16 }} />
 }: ButtonProps) {
   const view = useEditorViewContext();
   const onSelect = useCallback(


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79d67bc</samp>

This pull request enhances the user experience of the `CharmEditor` component on mobile devices by resizing and handling the icon buttons in the floating menu. It affects the files `Icon.tsx` and `MenuButtons.tsx` in the `components/common/CharmEditor/components/floatingMenu` folder.

### WHY
- fixed `onClick` on button prop
- changed menu style to be a bit bigger on mobile
