### PR TITLE
fix dev environment

### DIFF
--- a/next.base.js
+++ b/next.base.js
@@ -28,7 +28,7 @@ const esmModules = [
   'uuid',
   'data-uri-to-buffer',
   'fetch-blob',
-  '@babel/runtime',
+  // '@babel/runtime',
   'formdata-polyfill',
   'jose',
   'nanoid',

--- a/next.base.js
+++ b/next.base.js
@@ -35,4 +35,9 @@ const esmModules = [
   '@charmverse/core'
 ];
 
+// this breaks the dev environment with an error when importing MUI icons: Cannot use 'import.meta' outside a module
+if (process.env.NODE_ENV === 'test') {
+  esmModules.push('@babel/runtime');
+}
+
 exports.esmModules = esmModules;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d10cfa6</samp>

Comment out `@babel/runtime` from `esmModules` in `next.base.js` to fix a build error with `esbuild`. This avoids transpiling a module that already supports ESM.

### WHY
<!-- author to complete -->
