### PR TITLE
add default payment tokens for Arbitrum and Optimism

### DIFF
--- a/lib/payment-methods/defaultPaymentMethods.ts
+++ b/lib/payment-methods/defaultPaymentMethods.ts
@@ -43,6 +43,16 @@ const defaultPaymentMethods: Pick<
     tokenSymbol: 'OP',
     // tokenLogo: '/images/cryptoLogos/optimism.svg',
     tokenLogo: 'https://optimistic.etherscan.io/token/images/optimism_32.png'
+  },
+  // arbitrum
+  {
+    chainId: 42161,
+    contractAddress: '0x912CE59144191C1204E64559FE8253a0e49E6548',
+    tokenDecimals: 18,
+    tokenName: 'Arbitrum',
+    tokenSymbol: 'ARB',
+    // tokenLogo: '/images/cryptoLogos/optimism.svg',
+    tokenLogo: 'https://static.alchemyapi.io/images/assets/11841.png'
   }
 ];
 

--- a/lib/payment-methods/defaultPaymentMethods.ts
+++ b/lib/payment-methods/defaultPaymentMethods.ts
@@ -41,7 +41,6 @@ const defaultPaymentMethods: Pick<
     tokenDecimals: 18,
     tokenName: 'Optimism',
     tokenSymbol: 'OP',
-    // tokenLogo: '/images/cryptoLogos/optimism.svg',
     tokenLogo: 'https://optimistic.etherscan.io/token/images/optimism_32.png'
   },
   // arbitrum
@@ -51,7 +50,6 @@ const defaultPaymentMethods: Pick<
     tokenDecimals: 18,
     tokenName: 'Arbitrum',
     tokenSymbol: 'ARB',
-    // tokenLogo: '/images/cryptoLogos/optimism.svg',
     tokenLogo: 'https://static.alchemyapi.io/images/assets/11841.png'
   }
 ];

--- a/scripts/migrations/2023_05_10_addDefaultPaymentMethods.ts
+++ b/scripts/migrations/2023_05_10_addDefaultPaymentMethods.ts
@@ -27,6 +27,8 @@ async function init() {
 
   let newTokens = 0;
 
+  console.log('found', spaces.length, spaces);
+
   for (let space of spaces) {
     const methods = paymentMethods.filter((method) => method.spaceId === space.id);
     const transactions: any = [];
@@ -57,6 +59,9 @@ async function init() {
     if (transactions.length) {
       await prisma.$transaction(transactions);
       newTokens += transactions.length;
+    }
+    if ((newTokens / 2) % 100 === 0) {
+      console.log('added tokens', newTokens);
     }
   }
   console.log('added tokens', newTokens);

--- a/scripts/migrations/2023_05_10_addDefaultPaymentMethods.ts
+++ b/scripts/migrations/2023_05_10_addDefaultPaymentMethods.ts
@@ -1,0 +1,65 @@
+import { prisma } from '@charmverse/core';
+
+const opToken = {
+  chainId: 10,
+  contractAddress: '0x4200000000000000000000000000000000000042',
+  tokenDecimals: 18,
+  tokenName: 'Optimism',
+  tokenSymbol: 'OP',
+  // tokenLogo: '/images/cryptoLogos/optimism.svg',
+  tokenLogo: 'https://optimistic.etherscan.io/token/images/optimism_32.png'
+};
+
+const arbToken = {
+  chainId: 42161,
+  contractAddress: '0x912CE59144191C1204E64559FE8253a0e49E6548',
+  tokenDecimals: 18,
+  tokenName: 'Arbitrum',
+  tokenSymbol: 'ARB',
+  // tokenLogo: '/images/cryptoLogos/optimism.svg',
+  tokenLogo: 'https://static.alchemyapi.io/images/assets/11841.png'
+};
+
+// a function that adds OP token as a default payment for all spaces in the database
+async function init() {
+  const spaces = await prisma.space.findMany();
+  const paymentMethods = await prisma.paymentMethod.findMany();
+
+  let newTokens = 0;
+
+  for (let space of spaces) {
+    const methods = paymentMethods.filter((method) => method.spaceId === space.id);
+    const transactions: any = [];
+    if (!methods.find((method) => method.chainId === opToken.chainId)) {
+      transactions.push(
+        prisma.paymentMethod.create({
+          data: {
+            ...opToken,
+            spaceId: space.id,
+            createdBy: space.createdBy,
+            walletType: 'metamask'
+          }
+        })
+      );
+    }
+    if (!methods.find((method) => method.chainId === arbToken.chainId)) {
+      transactions.push(
+        prisma.paymentMethod.create({
+          data: {
+            ...arbToken,
+            spaceId: space.id,
+            createdBy: space.createdBy,
+            walletType: 'metamask'
+          }
+        })
+      );
+    }
+    if (transactions.length) {
+      await prisma.$transaction(transactions);
+      newTokens += transactions.length;
+    }
+  }
+  console.log('added tokens', newTokens);
+}
+
+init();

--- a/scripts/migrations/2023_05_10_addDefaultPaymentMethods.ts
+++ b/scripts/migrations/2023_05_10_addDefaultPaymentMethods.ts
@@ -27,7 +27,7 @@ async function init() {
 
   let newTokens = 0;
 
-  console.log('found', spaces.length, spaces);
+  console.log('found', spaces.length, 'spaces and', paymentMethods.length, 'payment methods');
 
   for (let space of spaces) {
     const methods = paymentMethods.filter((method) => method.spaceId === space.id);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6131ea</samp>

This pull request adds support for two new default payment methods, OP and ARB tokens, for the Charmverse platform. It defines the token properties in `lib/payment-methods/defaultPaymentMethods.ts` and inserts them into the database for all existing spaces using a migration script in `scripts/migrations/2023_05_10_addDefaultPaymentMethods.ts`.

### WHY
<!-- author to complete -->
