### PR TITLE
add imagery back for mobile login

### DIFF
--- a/components/login/Footer.tsx
+++ b/components/login/Footer.tsx
@@ -52,6 +52,9 @@ export default function Footer() {
         <Grid container spacing={6}>
           <Grid item xs={12} sm={4}>
             <LinkHeader>Links</LinkHeader>
+            <StyledLink href='https://charmverse.io' target='_blank'>
+              What is CharmVerse?
+            </StyledLink>
             <StyledLink href='https://charmverse.io/privacy-policy' target='_blank'>
               Privacy Policy
             </StyledLink>

--- a/components/login/LoginPageContent.tsx
+++ b/components/login/LoginPageContent.tsx
@@ -63,6 +63,7 @@ export function LoginPageContent({ hideLoginOptions, isLoggingIn }: Props) {
           <Box sx={{ textAlign: { xs: 'center', md: 'left' } }}>
             <Typography
               sx={{
+                display: { xs: 'none', md: 'block' },
                 fontSize: { xs: 30, md: 48 },
                 fontWeight: 'bold',
                 lineHeight: '1.1em',
@@ -73,7 +74,18 @@ export function LoginPageContent({ hideLoginOptions, isLoggingIn }: Props) {
               Powering the Future <br />
               of Work through Web3
             </Typography>
-            <Typography sx={{ fontSize: 20, mb: 6, maxWidth: '520px' }}>
+
+            <Box display={{ xs: 'flex', md: 'none' }} mb={2} mx={2} justifyContent='center'>
+              <Image src={splashImage} maxWidth={400} />
+            </Box>
+            <Typography
+              sx={{
+                display: { xs: 'none', md: 'block' },
+                fontSize: 20,
+                mb: { sm: 2, md: 6 },
+                maxWidth: { md: '520px' }
+              }}
+            >
               The solution for token communities to build relationships, work together and vote
             </Typography>
             <Box
@@ -87,8 +99,8 @@ export function LoginPageContent({ hideLoginOptions, isLoggingIn }: Props) {
             </Box>
           </Box>
         </Grid>
-        <Grid item md={6} alignItems='center'>
-          <Image display={{ xs: 'none', md: 'block' }} px={3} src={splashImage} />
+        <Grid item md={6} display={{ xs: 'none', md: 'block' }} alignItems='center'>
+          <Image px={3} src={splashImage} />
         </Grid>
       </Grid>
       <LoginErrorModal open={(discordLoginError as ErrorType) === 'Disabled account'} onClose={clearError} />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 51bd788</samp>

The pull request enhances the login page of the app by adding responsive design features and a link to the CharmVerse website. It modifies `components/login/LoginPageContent.tsx` and `components/login/Footer.tsx`.

### WHY
Make the mobile login look more friendly. After talking with Chris:
- remove extra copy on mobile and just add a link to the main charmverse site in the footer
- bring back planet image

![image](https://github.com/charmverse/app.charmverse.io/assets/305398/bdb52ef3-61e7-4a18-9d50-e779a4a5e1ec)
