### PR TITLE
remove snapshot id from page meta

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -234,6 +234,7 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
                   containerWidth={containerWidth}
                   pageType={page.type}
                   pagePermissions={pagePermissions ?? undefined}
+                  snapshotProposalId={page.snapshotProposalId}
                   onParticipantUpdate={onParticipantUpdate}
                   style={{
                     minHeight: proposalId ? '100px' : 'unset'
@@ -293,6 +294,7 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
                           pageId={page.id}
                           proposalId={proposalId}
                           pagePermissions={pagePermissions}
+                          snapshotProposalId={page.snapshotProposalId}
                           refreshPagePermissions={refreshPage}
                           readOnly={readonlyProposalProperties}
                           isTemplate={page.type === 'proposal_template'}

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -35,7 +35,7 @@ import PageBanner from './components/PageBanner';
 import PageDeleteBanner from './components/PageDeleteBanner';
 import PageHeader from './components/PageHeader';
 import { PageTemplateBanner } from './components/PageTemplateBanner';
-import ProposalProperties from './components/ProposalProperties';
+import { ProposalProperties } from './components/ProposalProperties';
 
 const CharmEditor = dynamic(() => import('components/common/CharmEditor'), {
   ssr: false

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -31,7 +31,7 @@ interface ProposalPropertiesProps {
   readOnly?: boolean;
   pageId: string;
   proposalId: string;
-  snpashotProposalId: string | null;
+  snapshotProposalId: string | null;
   isTemplate: boolean;
   pagePermissions?: IPagePermissionFlags;
   refreshPagePermissions?: () => void;
@@ -42,7 +42,7 @@ export function ProposalProperties({
   refreshPagePermissions = () => null,
   pageId,
   proposalId,
-  snpashotProposalId,
+  snapshotProposalId,
   readOnly,
   isTemplate
 }: ProposalPropertiesProps) {
@@ -331,7 +331,7 @@ export function ProposalProperties({
         proposalFlowFlags={proposalFlowFlags}
         proposal={proposal}
         pageId={pageId}
-        snapshotProposalId={snpashotProposalId}
+        snapshotProposalId={snapshotProposalId}
         open={isVoteModalOpen}
         onCreateVote={() => {
           setIsVoteModalOpen(false);

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -36,7 +36,7 @@ interface ProposalPropertiesProps {
   refreshPagePermissions?: () => void;
 }
 
-export default function ProposalProperties({
+export function ProposalProperties({
   pagePermissions,
   refreshPagePermissions = () => null,
   pageId,

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -31,6 +31,7 @@ interface ProposalPropertiesProps {
   readOnly?: boolean;
   pageId: string;
   proposalId: string;
+  snpashotProposalId: string | null;
   isTemplate: boolean;
   pagePermissions?: IPagePermissionFlags;
   refreshPagePermissions?: () => void;
@@ -41,6 +42,7 @@ export function ProposalProperties({
   refreshPagePermissions = () => null,
   pageId,
   proposalId,
+  snpashotProposalId,
   readOnly,
   isTemplate
 }: ProposalPropertiesProps) {
@@ -329,6 +331,7 @@ export function ProposalProperties({
         proposalFlowFlags={proposalFlowFlags}
         proposal={proposal}
         pageId={pageId}
+        snapshotProposalId={snpashotProposalId}
         open={isVoteModalOpen}
         onCreateVote={() => {
           setIsVoteModalOpen(false);

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -387,6 +387,7 @@ interface CharmEditorProps {
   postId?: string;
   containerWidth?: number;
   pageType?: PageType | 'post';
+  snapshotProposalId?: string | null;
   pagePermissions?: IPagePermissionFlags;
   onParticipantUpdate?: (participants: FrontendParticipant[]) => void;
   placeholderText?: string;
@@ -412,6 +413,7 @@ function CharmEditor({
   postId,
   containerWidth,
   pageType,
+  snapshotProposalId,
   pagePermissions,
   placeholderText,
   focusOnInit,
@@ -584,6 +586,7 @@ function CharmEditor({
           pageId,
           pagePermissions,
           postId,
+          snapshotProposalId,
           readOnly,
           deleteNode: () => {
             const view = props.view;

--- a/components/common/CharmEditor/components/nodeView/nodeView.ts
+++ b/components/common/CharmEditor/components/nodeView/nodeView.ts
@@ -5,6 +5,7 @@ import type { IPagePermissionFlags } from 'lib/permissions/pages/page-permission
 export type CharmNodeViewProps = {
   pageId?: string;
   postId?: string;
+  snapshotProposalId?: string | null;
   readOnly: boolean;
   pagePermissions?: IPagePermissionFlags;
   deleteNode: () => void;

--- a/components/common/CharmEditor/components/poll/PollComponent.tsx
+++ b/components/common/CharmEditor/components/poll/PollComponent.tsx
@@ -19,6 +19,7 @@ export function PollNodeView({
   readOnly,
   updateAttrs,
   pagePermissions,
+  snapshotProposalId,
   selected,
   deleteNode
 }: CharmNodeViewProps) {
@@ -60,6 +61,7 @@ export function PollNodeView({
           onCreateVote={onCreateVote}
           pageId={pageId}
           postId={postId}
+          snapshotProposalId={snapshotProposalId || null}
         />
         <div
           onClick={(e) => {

--- a/components/common/PageActions/components/DocumentPageActionList.tsx
+++ b/components/common/PageActions/components/DocumentPageActionList.tsx
@@ -48,6 +48,7 @@ export type PageActionMeta = Pick<
   | 'id'
   | 'parentId'
   | 'path'
+  | 'snapshotProposalId'
   | 'title'
   | 'type'
   | 'updatedAt'
@@ -317,6 +318,7 @@ export function DocumentPageActionList({
       <Divider />
       <PublishToSnapshot
         pageId={pageId}
+        snapshotProposalId={page.snapshotProposalId}
         renderContent={({ label, onClick, icon }) => (
           <ListItemButton onClick={onClick}>
             {icon}

--- a/components/common/PageActions/components/DocumentPageActionList.tsx
+++ b/components/common/PageActions/components/DocumentPageActionList.tsx
@@ -20,7 +20,7 @@ import { useMembers } from 'hooks/useMembers';
 import { usePageActionDisplay } from 'hooks/usePageActionDisplay';
 import { usePages } from 'hooks/usePages';
 import { useSnackbar } from 'hooks/useSnackbar';
-import type { PageMeta, PageUpdates } from 'lib/pages';
+import type { PageWithContent, PageUpdates } from 'lib/pages';
 import type { IPagePermissionFlags } from 'lib/permissions/pages';
 import { fontClassName } from 'theme/fonts';
 
@@ -37,7 +37,7 @@ import { PublishToSnapshot } from './SnapshotAction/PublishToSnapshot';
 import { UndoAction } from './UndoAction';
 
 export type PageActionMeta = Pick<
-  PageMeta,
+  PageWithContent,
   | 'convertedProposalId'
   | 'createdAt'
   | 'createdBy'

--- a/components/common/PageActions/components/SnapshotAction/PublishToSnapshot.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishToSnapshot.tsx
@@ -16,7 +16,7 @@ import { PublishingForm } from './PublishingForm';
 
 interface Props {
   pageId: string;
-  snapshotProposalId?: string;
+  snapshotProposalId: string | null;
   renderContent: (props: { onClick?: () => void; label: string; icon: ReactNode }) => ReactNode;
   onPublish?: () => void;
 }

--- a/components/common/PageActions/components/SnapshotAction/PublishToSnapshot.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishToSnapshot.tsx
@@ -9,23 +9,20 @@ import Link from 'components/common/Link';
 import { LoadingIcon } from 'components/common/LoadingComponent';
 import { Modal } from 'components/common/Modal';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import { usePages } from 'hooks/usePages';
 import type { SnapshotProposal } from 'lib/snapshot';
 import { getSnapshotProposal } from 'lib/snapshot';
 
-import PublishingForm from './PublishingForm';
+import { PublishingForm } from './PublishingForm';
 
 interface Props {
   pageId: string;
+  snapshotProposalId?: string;
   renderContent: (props: { onClick?: () => void; label: string; icon: ReactNode }) => ReactNode;
   onPublish?: () => void;
 }
 
-export function PublishToSnapshot({ pageId, renderContent, onPublish = () => null }: Props) {
-  const { pages, mutatePage } = usePages();
-  const page = pages[pageId];
-
-  const [checkingProposal, setCheckingProposal] = useState(!!page?.snapshotProposalId);
+export function PublishToSnapshot({ pageId, snapshotProposalId, renderContent, onPublish = () => null }: Props) {
+  const [checkingProposal, setCheckingProposal] = useState(!!snapshotProposalId);
   const [proposal, setProposal] = useState<SnapshotProposal | null>(null);
   const currentSpace = useCurrentSpace();
 
@@ -33,23 +30,24 @@ export function PublishToSnapshot({ pageId, renderContent, onPublish = () => nul
 
   async function verifyProposal(proposalId: string) {
     const snapshotProposal = await getSnapshotProposal(proposalId);
-
     if (!snapshotProposal) {
-      const pageWithoutSnapshotId = await charmClient.updatePageSnapshotData(pageId, { snapshotProposalId: null });
-      mutatePage(pageWithoutSnapshotId);
+      await charmClient.updatePageSnapshotData(pageId, { snapshotProposalId: null });
     }
-
-    setProposal(snapshotProposal);
-    setCheckingProposal(false);
+    return snapshotProposal;
   }
 
   useEffect(() => {
-    if (page?.snapshotProposalId) {
-      verifyProposal(page?.snapshotProposalId);
-    } else {
-      setProposal(null);
+    async function init() {
+      if (snapshotProposalId) {
+        const _proposal = await verifyProposal(snapshotProposalId);
+        setProposal(_proposal);
+      } else {
+        setProposal(null);
+      }
+      setCheckingProposal(false);
     }
-  }, [page, page?.snapshotProposalId]);
+    init();
+  }, [snapshotProposalId]);
 
   return (
     <>
@@ -70,7 +68,7 @@ export function PublishToSnapshot({ pageId, renderContent, onPublish = () => nul
           })}
           <Modal
             size='large'
-            open={isOpen && !!page}
+            open={isOpen && !!pageId}
             onClose={close}
             title={`Publish to Snapshot ${currentSpace?.snapshotDomain ? `(${currentSpace.snapshotDomain})` : ''}`}
           >
@@ -79,7 +77,7 @@ export function PublishToSnapshot({ pageId, renderContent, onPublish = () => nul
                 close();
                 onPublish();
               }}
-              page={page!}
+              pageId={pageId}
             />
           </Modal>
         </>

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -10,7 +10,9 @@ import { memo } from 'react';
 import { documentTypes } from 'components/common/PageActions/components/DocumentPageActionList';
 import { FullPageActionsMenuButton } from 'components/common/PageActions/FullPageActionsMenuButton';
 import { usePostByPath } from 'components/forum/hooks/usePostByPath';
-import { usePageFromPath } from 'hooks/usePageFromPath';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import { usePage } from 'hooks/usePage';
+import { usePageIdFromPath } from 'hooks/usePageFromPath';
 import { useUser } from 'hooks/useUser';
 
 import BountyShareButton from './components/BountyShareButton/BountyShareButton';
@@ -36,13 +38,17 @@ type HeaderProps = {
 function HeaderComponent({ open, openSidebar }: HeaderProps) {
   const router = useRouter();
   const { user } = useUser();
+  const basePageId = usePageIdFromPath();
+  const currentSpace = useCurrentSpace();
+  const { page: basePage } = usePage({
+    pageIdOrPath: currentSpace ? basePageId : undefined,
+    spaceId: currentSpace?.id
+  });
 
-  const basePage = usePageFromPath();
   // Post permissions hook will not make an API call if post ID is null. Since we can't conditionally render hooks, we pass null as the post ID. This is the reason for the 'null as any' statement
   const forumPostInfo = usePostByPath();
   const isBountyBoard = router.route === '/[domain]/bounties';
   const isBasePageDocument = documentTypes.includes(basePage?.type as PageType);
-
   return (
     <StyledToolbar variant='dense'>
       <IconButton
@@ -69,7 +75,11 @@ function HeaderComponent({ open, openSidebar }: HeaderProps) {
         }}
       >
         <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-          <PageTitleWithBreadcrumbs pageId={basePage?.id} pageType={basePage?.type} />
+          <PageTitleWithBreadcrumbs
+            pageId={basePage?.id}
+            pageType={basePage?.type}
+            spaceDomain={currentSpace?.domain}
+          />
         </div>
 
         <Box display='flex' alignItems='center' alignSelf='stretch' mr={-1} gap={0.25}>

--- a/components/common/PageLayout/components/Header/components/PageTitleWithBreadcrumbs.tsx
+++ b/components/common/PageLayout/components/Header/components/PageTitleWithBreadcrumbs.tsx
@@ -179,9 +179,16 @@ function EmptyPageTitle() {
   return <div></div>;
 }
 
-export default function PageTitleWithBreadcrumbs({ pageId, pageType }: { pageId?: string; pageType?: PageType }) {
+export default function PageTitleWithBreadcrumbs({
+  pageId,
+  pageType,
+  spaceDomain
+}: {
+  pageId?: string;
+  pageType?: PageType;
+  spaceDomain?: string;
+}) {
   const router = useRouter();
-  const space = useCurrentSpace();
 
   if (router.route === '/share/[...pageId]' && router.query?.pageId?.[1] === 'bounties') {
     return <PublicBountyPageTitle />;
@@ -190,11 +197,11 @@ export default function PageTitleWithBreadcrumbs({ pageId, pageType }: { pageId?
   } else if (pageType === 'proposal') {
     return <ProposalPageTitle basePath={`/${router.query.domain}`} />;
   } else if (router.route === '/[domain]/[pageId]') {
-    return <DocumentPageTitle basePath={`/${space?.domain}`} pageId={pageId} />;
+    return <DocumentPageTitle basePath={`/${spaceDomain}`} pageId={pageId} />;
   } else if (router.route.includes('/[domain]/forum')) {
     return <ForumPostTitle basePath={`/${router.query.domain}`} pathName={router.pathname} />;
   } else if (router.route === '/share/[...pageId]') {
-    return <DocumentPageTitle basePath={`/share/${space?.domain}`} pageId={pageId} />;
+    return <DocumentPageTitle basePath={`/share/${spaceDomain}`} pageId={pageId} />;
   } else if (router.route.startsWith('/u/')) {
     return <EmptyPageTitle />;
   } else {

--- a/components/votes/components/CreateVoteModal.tsx
+++ b/components/votes/components/CreateVoteModal.tsx
@@ -97,6 +97,7 @@ interface CreateVoteModalProps {
   open?: boolean;
   pageId?: string;
   postId?: string;
+  snapshotProposalId?: string;
   proposal?: ProposalWithUsers;
   proposalFlowFlags?: ProposalFlowFlags;
 }
@@ -108,6 +109,7 @@ export function CreateVoteModal({
   onPublishToSnapshot = () => null,
   pageId,
   postId,
+  snapshotProposalId,
   proposal,
   proposalFlowFlags
 }: CreateVoteModalProps) {
@@ -307,6 +309,7 @@ export function CreateVoteModal({
                     )}
                     onPublish={onPublishToSnapshot}
                     pageId={proposal.id}
+                    snapshotProposalId={snapshotProposalId}
                   />
                 </div>
               </Tooltip>

--- a/components/votes/components/CreateVoteModal.tsx
+++ b/components/votes/components/CreateVoteModal.tsx
@@ -97,7 +97,7 @@ interface CreateVoteModalProps {
   open?: boolean;
   pageId?: string;
   postId?: string;
-  snapshotProposalId?: string;
+  snapshotProposalId: string | null;
   proposal?: ProposalWithUsers;
   proposalFlowFlags?: ProposalFlowFlags;
 }

--- a/lib/pages/interfaces.ts
+++ b/lib/pages/interfaces.ts
@@ -107,7 +107,7 @@ export type PageMeta = Pick<
   | 'index'
   | 'cardId'
   | 'proposalId'
-  | 'snapshotProposalId'
+  // | 'snapshotProposalId'
   | 'fullWidth'
   | 'bountyId'
   | 'hasContent'

--- a/lib/pages/interfaces.ts
+++ b/lib/pages/interfaces.ts
@@ -107,7 +107,6 @@ export type PageMeta = Pick<
   | 'index'
   | 'cardId'
   | 'proposalId'
-  // | 'snapshotProposalId'
   | 'fullWidth'
   | 'bountyId'
   | 'hasContent'

--- a/lib/pages/server/getAccessiblePages.ts
+++ b/lib/pages/server/getAccessiblePages.ts
@@ -78,7 +78,6 @@ function selectPageFields() {
       index: true,
       cardId: true,
       proposalId: true,
-      snapshotProposalId: true,
       fullWidth: true,
       bountyId: true,
       hasContent: true,

--- a/lib/pages/server/getPageMeta.ts
+++ b/lib/pages/server/getPageMeta.ts
@@ -26,7 +26,6 @@ export function pageMetaSelect() {
     parentId: true,
     path: true,
     proposalId: true,
-    snapshotProposalId: true,
     title: true,
     spaceId: true,
     updatedAt: true,

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -1,5 +1,7 @@
 // import type { Block } from '@charmverse/core/prisma';
 
+import type { Page } from '@charmverse/core/prisma';
+
 import type { Block } from 'lib/focalboard/block';
 import type { PageMeta } from 'lib/pages';
 import type { ExtendedVote, VoteTask } from 'lib/votes/interfaces';
@@ -32,7 +34,8 @@ type BlocksDeleted = {
 
 type PagesMetaUpdated = {
   type: 'pages_meta_updated';
-  payload: (Partial<PageMeta> & ResourceWithSpaceId)[];
+  // we use the full Page interface so that we can pass other fields for individual page views
+  payload: (Partial<Page> & ResourceWithSpaceId)[];
 };
 
 type PagesCreated = {

--- a/pages/api/pages/[id]/snapshot.ts
+++ b/pages/api/pages/[id]/snapshot.ts
@@ -9,6 +9,7 @@ import { getPage } from 'lib/pages/server';
 import { withSessionRoute } from 'lib/session/withSession';
 import { hasAccessToSpace } from 'lib/users/hasAccessToSpace';
 import { DataNotFoundError } from 'lib/utilities/errors';
+import { relay } from 'lib/websockets/relay';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
@@ -37,7 +38,7 @@ async function recordSnapshotInfo(req: NextApiRequest, res: NextApiResponse<IPag
     throw error;
   }
 
-  const updatedPage = await prisma.page.update({
+  await prisma.page.update({
     where: {
       id: pageId
     },
@@ -53,7 +54,16 @@ async function recordSnapshotInfo(req: NextApiRequest, res: NextApiResponse<IPag
     }
   });
 
-  res.status(200).json(updatedPage);
+  // update the UI
+  relay.broadcast(
+    {
+      type: 'pages_meta_updated',
+      payload: [{ snapshotProposalId, spaceId: page.spaceId, id: pageId }]
+    },
+    page.spaceId
+  );
+
+  res.status(200).end();
 }
 
 export default withSessionRoute(handler);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d2a9c7</samp>

This pull request refactors the snapshot feature to improve performance and reduce data duplication. It changes how the `PublishingForm` and `PublishToSnapshot` components receive and use the page data, how the `CreateVoteModal` component handles snapshot proposals, how the websockets interface and the `snapshot.ts` API endpoint broadcast page meta updates, and how the `snapshotProposalId` is stored and fetched in the database. It also fixes some minor inconsistencies in the component exports and imports.

### WHY
This is a small step towards removing some unnecessary reliance on usePages()
