### PR TITLE
Charmeditor lazy

### DIFF
--- a/components/[pageId]/DatabasePage/index.ts
+++ b/components/[pageId]/DatabasePage/index.ts
@@ -1,1 +1,5 @@
-export { DatabasePage } from './DatabasePage';
+import dynamic from 'next/dynamic';
+
+export const DatabasePage = dynamic(() => import('./DatabasePage').then((module) => module.DatabasePage), {
+  ssr: false
+});

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import { useMediaQuery } from '@mui/material';
 import type { Theme } from '@mui/material';
 import Box from '@mui/material/Box';
-import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { memo, useEffect, useRef, useState } from 'react';
 import { useElementSize } from 'usehooks-ts';

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -16,6 +16,7 @@ import CardDetailProperties from 'components/common/BoardEditor/focalboard/src/c
 import CommentsList from 'components/common/BoardEditor/focalboard/src/components/cardDetail/commentsList';
 import { getCardComments } from 'components/common/BoardEditor/focalboard/src/store/comments';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
+import { CharmEditor } from 'components/common/CharmEditor';
 import type { FrontendParticipant } from 'components/common/CharmEditor/components/fiduswriter/collab';
 import { SnapshotVoteDetails } from 'components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails';
 import { VoteDetail } from 'components/common/CharmEditor/components/inlineVote/components/VoteDetail';
@@ -36,10 +37,6 @@ import PageDeleteBanner from './components/PageDeleteBanner';
 import PageHeader from './components/PageHeader';
 import { PageTemplateBanner } from './components/PageTemplateBanner';
 import ProposalProperties from './components/ProposalProperties';
-
-const CharmEditor = dynamic(() => import('components/common/CharmEditor'), {
-  ssr: false
-});
 
 export const Container = styled(({ fullWidth, ...props }: any) => <Box {...props} />)<{
   top: number;

--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -4,7 +4,6 @@ import ArrowSquareOut from '@mui/icons-material/Launch';
 import { Grid, IconButton, Typography } from '@mui/material';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import Alert from '@mui/material/Alert';
-import UAuth from '@uauth/js';
 import type { AbstractConnector } from '@web3-react/abstract-connector';
 import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
@@ -88,6 +87,7 @@ export function WalletSelector({ loginSuccess, onError = () => null }: Props) {
   const redirectUri = typeof window === 'undefined' ? '' : window.location.origin;
 
   async function handleUnstoppableDomainsLogin() {
+    const UAuth = (await import('@uauth/js')).default;
     const uauth = new UAuth({
       clientID,
       redirectUri,

--- a/components/common/BoardEditor/focalboard/src/components/viewTitle.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewTitle.tsx
@@ -6,12 +6,12 @@ import ImageIcon from '@mui/icons-material/Image';
 import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import { Box } from '@mui/material';
-import dynamic from 'next/dynamic';
 import type { KeyboardEvent } from 'react';
 import React, { useCallback, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { randomBannerImage } from 'components/[pageId]/DocumentPage/components/PageBanner';
+import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
 import type { Board } from 'lib/focalboard/board';
 import type { PageContent } from 'lib/prosemirror/interfaces';
@@ -22,10 +22,6 @@ import Button from '../widgets/buttons/button';
 import Editable from '../widgets/editable';
 
 import BlockIconSelector from './blockIconSelector';
-
-const CharmEditor = dynamic(() => import('components/common/CharmEditor'), {
-  ssr: false
-});
 
 const BoardTitleEditable = styled(Editable)`
   font-size: 32px;

--- a/components/common/CharmEditor/InlineCharmEditor.tsx
+++ b/components/common/CharmEditor/InlineCharmEditor.tsx
@@ -7,11 +7,11 @@ import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 import type { CSSProperties, ReactNode } from 'react';
 
-import { BangleEditor as ReactBangleEditor } from 'components/common/CharmEditor/components/@bangle.dev/react/ReactEditor';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useUser } from 'hooks/useUser';
 import type { PageContent } from 'lib/prosemirror/interfaces';
 
+import { BangleEditor as ReactBangleEditor } from './components/@bangle.dev/react/ReactEditor';
 import { userDataPlugin } from './components/charm/charm.plugins';
 import EmojiSuggest, * as emoji from './components/emojiSuggest';
 import * as floatingMenu from './components/floatingMenu';

--- a/components/common/CharmEditor/index.ts
+++ b/components/common/CharmEditor/index.ts
@@ -1,3 +1,5 @@
-import CharmEditor from './CharmEditor';
+import dynamic from 'next/dynamic';
 
-export default CharmEditor;
+export const CharmEditor = dynamic(() => import('./CharmEditor'), {
+  ssr: false
+});

--- a/components/common/comments/Comment.tsx
+++ b/components/common/comments/Comment.tsx
@@ -8,7 +8,7 @@ import { bindMenu, usePopupState } from 'material-ui-popup-state/hooks';
 import { useMemo, useState } from 'react';
 
 import Button from 'components/common/Button';
-import CharmEditor from 'components/common/CharmEditor/CharmEditor';
+import { CharmEditor } from 'components/common/CharmEditor';
 import InlineCharmEditor from 'components/common/CharmEditor/InlineCharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/InlineCharmEditor';
 import { CommentReply } from 'components/common/comments/CommentReply';

--- a/components/common/comments/CommentForm.tsx
+++ b/components/common/comments/CommentForm.tsx
@@ -2,7 +2,7 @@ import { Stack, Box } from '@mui/material';
 import { useMemo, useState } from 'react';
 
 import Button from 'components/common/Button';
-import CharmEditor from 'components/common/CharmEditor';
+import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/InlineCharmEditor';
 import InlineCharmEditor from 'components/common/CharmEditor/InlineCharmEditor';
 import UserDisplay from 'components/common/UserDisplay';

--- a/components/forum/components/PostList/components/PostSummary.tsx
+++ b/components/forum/components/PostList/components/PostSummary.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import CharmEditor from 'components/common/CharmEditor/CharmEditor';
+import { CharmEditor } from 'components/common/CharmEditor';
 import type { PageContent } from 'lib/prosemirror/interfaces';
 
 const StyledCharmEditor = styled(CharmEditor)`

--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -10,7 +10,7 @@ import { PageTitleInput } from 'components/[pageId]/DocumentPage/components/Page
 import { Container } from 'components/[pageId]/DocumentPage/DocumentPage';
 import { ProposalBanner } from 'components/common/Banners/ProposalBanner';
 import Button from 'components/common/Button';
-import CharmEditor from 'components/common/CharmEditor';
+import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
 import type { CommentSortType } from 'components/common/comments/CommentSort';
 import { CommentSort } from 'components/common/comments/CommentSort';

--- a/jest.setup.browser.ts
+++ b/jest.setup.browser.ts
@@ -4,3 +4,16 @@
 // Used for __tests__/testing-library.js
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+
+// fix dynamic imports in next.js 13: https://github.com/vercel/next.js/issues/41725
+jest.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: (...props: any[]) => {
+    const dynamicModule = jest.requireActual('next/dynamic');
+    const dynamicActualComp = dynamicModule.default;
+    const RequiredComponent = dynamicActualComp(props[0]);
+    // eslint-disable-next-line no-unused-expressions
+    RequiredComponent.preload ? RequiredComponent.preload() : RequiredComponent.render.preload();
+    return RequiredComponent;
+  }
+}));

--- a/lib/aws/uploadToS3Browser.ts
+++ b/lib/aws/uploadToS3Browser.ts
@@ -2,7 +2,6 @@
 // We can replace with the actual library once next-s3-upload updates their AWS-SDK dependency to V3
 // see this issue for more: https://github.com/ryanto/next-s3-upload/issues/15
 import type { PutObjectCommandInput } from '@aws-sdk/client-s3';
-import { S3Client } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { XhrHttpHandler } from '@aws-sdk/xhr-http-handler';
 
@@ -15,6 +14,8 @@ type Config = {
 export async function uploadToS3(file: File, config?: Config) {
   const data = await charmClient.uploadToS3(file);
   const trackProgress = !!config?.onUploadPercentageProgress;
+
+  const { S3Client } = await import('@aws-sdk/client-s3');
 
   const client = new S3Client({
     credentials: {

--- a/lib/aws/uploadToS3Browser.ts
+++ b/lib/aws/uploadToS3Browser.ts
@@ -2,7 +2,6 @@
 // We can replace with the actual library once next-s3-upload updates their AWS-SDK dependency to V3
 // see this issue for more: https://github.com/ryanto/next-s3-upload/issues/15
 import type { PutObjectCommandInput } from '@aws-sdk/client-s3';
-import { Upload } from '@aws-sdk/lib-storage';
 import { XhrHttpHandler } from '@aws-sdk/xhr-http-handler';
 
 import charmClient from 'charmClient';
@@ -16,6 +15,7 @@ export async function uploadToS3(file: File, config?: Config) {
   const trackProgress = !!config?.onUploadPercentageProgress;
 
   const { S3Client } = await import('@aws-sdk/client-s3');
+  const { Upload } = await import('@aws-sdk/lib-storage');
 
   const client = new S3Client({
     credentials: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4336b07</samp>

This pull request improves the performance and code readability of the app by using dynamic imports for the `CharmEditor` and `UAuth` components, simplifying the import paths of some components, and removing unnecessary dynamic imports from the `viewTitle` component. It affects the files `components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx`, `components/[pageId]/DocumentPage/DocumentPage.tsx`, `components/common/BoardEditor/focalboard/src/components/viewTitle.tsx`, `components/[pageId]/DatabasePage/index.ts`, `components/common/CharmEditor/index.ts`, `components/common/CharmEditor/InlineCharmEditor.tsx`, `components/common/comments/Comment.tsx`, `components/common/comments/CommentForm.tsx`, `components/forum/components/PostList/components/PostSummary.tsx`, and `components/forum/components/PostPage/PostPage.tsx`.

### WHY
Reducing size of _app.js by 100KB
