### PR TITLE
Fixed inline palette suggestions

### DIFF
--- a/components/common/CharmEditor/components/@bangle.dev/tooltip/suggest-tooltip.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/tooltip/suggest-tooltip.ts
@@ -34,8 +34,10 @@ export const defaultKeys = {
 function specFactory({
   markName,
   trigger,
-  markColor
+  markColor,
+  excludes
 }: {
+  excludes?: string;
   markName: string;
   trigger?: string;
   markColor?: string;
@@ -44,6 +46,7 @@ function specFactory({
     name: markName,
     type: 'mark',
     schema: {
+      excludes,
       inclusive: true,
       group: 'suggestTriggerMarks',
       parseDOM: [{ tag: `span[data-${markName}]` }],

--- a/components/common/CharmEditor/components/ResizableImage.tsx
+++ b/components/common/CharmEditor/components/ResizableImage.tsx
@@ -239,7 +239,7 @@ function getFileBinary(src: string): File | null {
 
 export function spec() {
   // this is a dummy marker to let us know to show the image selector
-  const tooltipSpec = suggestTooltip.spec({ markName: 'tooltip-marker', trigger: 'image' });
+  const tooltipSpec = suggestTooltip.spec({ markName: 'tooltip-marker', trigger: 'image', excludes: '_' });
   tooltipSpec.schema.inclusive = false;
   return [tooltipSpec, imageSpec()];
 }

--- a/components/common/CharmEditor/components/inlinePalette/inlinePalette.ts
+++ b/components/common/CharmEditor/components/inlinePalette/inlinePalette.ts
@@ -20,7 +20,7 @@ export const plugins = pluginsFactory;
 export const commands = {};
 
 function specFactory(): BaseRawMarkSpec {
-  const _spec = suggestTooltip.spec({ markName: paletteMarkName, trigger });
+  const _spec = suggestTooltip.spec({ markName: paletteMarkName, trigger, excludes: '_' });
 
   return {
     ..._spec,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 988def1</samp>

Added a new option to customize the tooltip trigger characters for different marks in the `CharmEditor` component. This prevents the tooltips from interfering with the placeholders for the inline palette and the image selector.

### WHY
<!-- author to complete -->
