### PR TITLE
Fix mobile action bar UI, fix inline palette

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -173,7 +173,7 @@
     "react/self-closing-comp": "off",
     "react/state-in-constructor": "off",
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
+    "react-hooks/exhaustive-deps": "off",
     "prefer-spread": "off",
     "no-bitwise": "warn",
     "no-undef": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -173,7 +173,7 @@
     "react/self-closing-comp": "off",
     "react/state-in-constructor": "off",
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "off",
+    "react-hooks/exhaustive-deps": "warn",
     "prefer-spread": "off",
     "no-bitwise": "warn",
     "no-undef": "off",

--- a/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
@@ -1,20 +1,14 @@
 /* eslint-disable react/no-unused-prop-types */
-import { usePluginState, useEditorViewContext } from '@bangle.dev/react';
-import { selectionTooltip } from '@bangle.dev/tooltip';
-import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
-import Tooltip from '@mui/material/Tooltip';
-import Typography from '@mui/material/Typography';
-import { bindTrigger } from 'material-ui-popup-state';
+import { usePluginState } from '@bangle.dev/react';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import type { PluginKey } from 'prosemirror-state';
 import { useState } from 'react';
 import reactDOM from 'react-dom';
 
-import Button from 'components/common/Button';
+import { InlinePalletteFloatingMenu } from 'components/common/CharmEditor/components/inlinePalette/inlinePalletteFloatingMenu';
 import type { IPagePermissionFlags } from 'lib/permissions/pages';
 
 import { InlineCommentSubMenu } from '../inlineComment/inlineComment.components';
-import InlineCommandPalette from '../inlinePalette/components/InlineCommandPalette';
 import { TextColorMenuDropdown } from '../textColor/ColorMenuDropdown';
 
 import type { SubMenu } from './floating-menu';
@@ -66,12 +60,8 @@ function MenuByType(props: MenuProps) {
     disableNestedPage,
     pageId
   } = props;
-  const { type } = usePluginState(props.pluginKey) as { type: SubMenu };
-
-  const popupState = usePopupState({ variant: 'popover', popupId: 'commands-menu' });
+  const { type } = usePluginState(props.pluginKey) as { type: SubMenu; show: boolean };
   const displayInlineCommentButton = !inline && pagePermissions?.comment && enableComments;
-  const [activeItem, setActiveItem] = useState('Text');
-  const handleActiveItem = (item: string) => setActiveItem(item);
 
   if ((type as FloatingMenuVariant) === 'commentOnlyMenu' && pagePermissions?.comment) {
     return (
@@ -86,28 +76,12 @@ function MenuByType(props: MenuProps) {
       <Menu type={type} inline={inline}>
         {!inline && palettePluginKey && (
           <MenuGroup>
-            <Tooltip title={<Typography component='div'>Turn into</Typography>}>
-              <Button
-                {...bindTrigger(popupState)}
-                endIcon={<KeyboardArrowDown sx={{ marginLeft: '-4px' }} />}
-                disableElevation
-                variant='text'
-                color='inherit'
-                sx={{ padding: 0 }}
-              >
-                {activeItem}
-              </Button>
-            </Tooltip>
-            <InlineCommandPalette
+            <InlinePalletteFloatingMenu
               palettePluginKey={palettePluginKey}
-              menuKey={pluginKey}
               nestedPagePluginKey={nestedPagePluginKey}
+              pageId={pageId}
+              pluginKey={pluginKey}
               disableNestedPage={disableNestedPage}
-              externalPopupState={popupState}
-              filterItem={(item) => !!item.showInFloatingMenu}
-              isFloatingMenuList={true}
-              handleActiveItem={handleActiveItem}
-              pageId={props.pageId}
             />
           </MenuGroup>
         )}

--- a/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/FloatingMenu.tsx
@@ -1,11 +1,9 @@
 /* eslint-disable react/no-unused-prop-types */
 import { usePluginState } from '@bangle.dev/react';
-import { usePopupState } from 'material-ui-popup-state/hooks';
 import type { PluginKey } from 'prosemirror-state';
-import { useState } from 'react';
 import reactDOM from 'react-dom';
 
-import { InlinePalletteFloatingMenu } from 'components/common/CharmEditor/components/inlinePalette/inlinePalletteFloatingMenu';
+import { InlinePalletteFloatingMenu } from 'components/common/CharmEditor/components/inlinePalette/InlinePalletteFloatingMenu';
 import type { IPagePermissionFlags } from 'lib/permissions/pages';
 
 import { InlineCommentSubMenu } from '../inlineComment/inlineComment.components';

--- a/components/common/CharmEditor/components/floatingMenu/Icon.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/Icon.tsx
@@ -29,8 +29,8 @@ const StyledMenuButton = styled(ListItemButton, { shouldForwardProp: (prop) => p
   }
 
   ${(props) => props.theme.breakpoints.down('md')} {
-    min-width: 38px;
-    min-height: 40px;
+    min-width: 40px;
+    min-height: 46px;
     justify-content: center;
   }
 `;

--- a/components/common/CharmEditor/components/floatingMenu/Menu.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/Menu.tsx
@@ -15,7 +15,7 @@ const StyledMenu = styled(Paper, { shouldForwardProp: (prop: string) => prop !==
   ${({ theme, type }) =>
     type && ['defaultMenu', 'inlineCommentSubMenu'].includes(type) && theme.breakpoints.down('sm')} {
     ${({ inline, theme }) => !inline && `width: calc(100vw - ${theme.spacing(1)})`};
-    margin: ${({ theme }) => theme.spacing(2)} ${({ theme }) => theme.spacing(0.5)};
+    margin: ${({ theme }) => theme.spacing(2, 0.5)};
     ${({ noScroll }) => (noScroll ? '' : 'overflow-x: auto')};
   }
 `;

--- a/components/common/CharmEditor/components/floatingMenu/Menu.tsx
+++ b/components/common/CharmEditor/components/floatingMenu/Menu.tsx
@@ -15,7 +15,7 @@ const StyledMenu = styled(Paper, { shouldForwardProp: (prop: string) => prop !==
   ${({ theme, type }) =>
     type && ['defaultMenu', 'inlineCommentSubMenu'].includes(type) && theme.breakpoints.down('sm')} {
     ${({ inline, theme }) => !inline && `width: calc(100vw - ${theme.spacing(1)})`};
-    margin: 0 ${({ theme }) => theme.spacing(0.5)};
+    margin: ${({ theme }) => theme.spacing(2)} ${({ theme }) => theme.spacing(0.5)};
     ${({ noScroll }) => (noScroll ? '' : 'overflow-x: auto')};
   }
 `;

--- a/components/common/CharmEditor/components/inlinePalette/InlinePalletteFloatingMenu.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/InlinePalletteFloatingMenu.tsx
@@ -1,0 +1,55 @@
+import type { PluginKey } from '@bangle.dev/pm';
+import { KeyboardArrowDown } from '@mui/icons-material';
+import { Stack, Typography } from '@mui/material';
+import { bindTrigger } from 'material-ui-popup-state';
+import { usePopupState } from 'material-ui-popup-state/hooks';
+import { useState } from 'react';
+
+import { MenuButton } from 'components/common/CharmEditor/components/floatingMenu/Icon';
+
+import InlineCommandPalette from '../inlinePalette/components/InlineCommandPalette';
+
+type Props = {
+  pluginKey: PluginKey;
+  palettePluginKey: PluginKey;
+  nestedPagePluginKey?: PluginKey;
+  disableNestedPage?: boolean;
+  pageId?: string;
+};
+
+export function InlinePalletteFloatingMenu({
+  pluginKey,
+  palettePluginKey,
+  nestedPagePluginKey,
+  disableNestedPage,
+  pageId
+}: Props) {
+  const popupState = usePopupState({ variant: 'popover', popupId: 'commands-menu' });
+  const [activeItem, setActiveItem] = useState('Text');
+  const handleActiveItem = (item: string) => setActiveItem(item);
+
+  return (
+    <>
+      <div {...bindTrigger(popupState)}>
+        <MenuButton hints={['Turn into']}>
+          <Stack mx={0.5} direction='row' alignItems='center' gap={1}>
+            <Typography variant='subtitle1'>{activeItem}</Typography>
+            <KeyboardArrowDown sx={{ fontSize: 16 }} />
+          </Stack>
+        </MenuButton>
+      </div>
+
+      <InlineCommandPalette
+        palettePluginKey={palettePluginKey}
+        menuKey={pluginKey}
+        nestedPagePluginKey={nestedPagePluginKey}
+        disableNestedPage={disableNestedPage}
+        externalPopupState={popupState}
+        filterItem={(item) => !!item.showInFloatingMenu}
+        isFloatingMenuList={true}
+        handleActiveItem={handleActiveItem}
+        pageId={pageId}
+      />
+    </>
+  );
+}

--- a/scripts/importGitCoinProjects.ts
+++ b/scripts/importGitCoinProjects.ts
@@ -18,7 +18,7 @@ import { getFilenameWithExtension } from 'lib/utilities/getFilenameWithExtension
  * It also updates mixpanel profiles so make sure to have prod mixpanel api key set in .env
  */
 
-const START_ID = 500;
+const START_ID = 100;
 const CHAIN_ID = 1;
 
 const provider = new AlchemyProvider(CHAIN_ID, process.env.ALCHEMY_API_KEY);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e38e05</samp>

Refactored and improved the floating menu component in `CharmEditor` by removing unused code, using a new reusable component, and adjusting the styles for smaller screens. Added a new component for the inline command palette that can be triggered from the floating menu. Changed the `START_ID` constant in `importGitCoinProjects.ts` for testing purposes.

### WHY
- opening inline palette on mobile
- fix palette state after toolbar is being closed
- change mobile UI a bit.

NOTE: InlineCommandPalette component uses Popper instead of Menu and it acts widely sometimes. For some reason ClickAwayListener is not working properly there and I think long-term this component should be refactored.
