### PR TITLE
dont refresh page meta when permissions change

### DIFF
--- a/components/common/PageLayout/components/Header/components/ShareButton/ShareButton.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/ShareButton.tsx
@@ -3,10 +3,8 @@ import { IosShare } from '@mui/icons-material';
 import type { Theme } from '@mui/material';
 import { Box, Divider, IconButton, Popover, Tooltip, useMediaQuery } from '@mui/material';
 import { bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
-import { memo, useEffect } from 'react';
-import useSWRImmutable from 'swr/immutable';
+import { memo } from 'react';
 
-import charmClient from 'charmClient';
 import Button from 'components/common/Button';
 import Loader from 'components/common/Loader';
 import { usePagePermissionsList } from 'hooks/usePagePermissionsList';
@@ -17,18 +15,12 @@ import { ProposalPagePermissions } from './components/PagePermissions/ProposalPa
 import ShareToWeb from './components/ShareToWeb';
 
 function ShareButton({ headerHeight, pageId }: { headerHeight: number; pageId: string }) {
-  const { refreshPage, pages } = usePages();
+  const { pages } = usePages();
   const popupState = usePopupState({ variant: 'popover', popupId: 'share-menu' });
   const { pagePermissions, refreshPermissions } = usePagePermissionsList({
     pageId
   });
   const isLargeScreen = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
-  // watch changes to the page in case permissions get updated
-  useEffect(() => {
-    if (pageId) {
-      refreshPage(pageId);
-    }
-  }, [pageId, pagePermissions]);
 
   return (
     <>


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
I think this may no longer be necessary since we dont get permissiosn from usePages?