### PR TITLE
Add rate limiting to notification task

### DIFF
--- a/background/tasks/sendNotifications/sendNotifications.ts
+++ b/background/tasks/sendNotifications/sendNotifications.ts
@@ -11,7 +11,7 @@ import * as mailer from 'lib/mailer';
 import { getProposalTasksFromWorkspaceEvents } from 'lib/proposal/getProposalTasksFromWorkspaceEvents';
 import { getVoteTasks } from 'lib/votes/getVoteTasks';
 
-const notificationTaskLimiter = RateLimit(50);
+const notificationTaskLimiter = RateLimit(100);
 
 export async function sendUserNotifications(): Promise<number> {
   const notificationsToSend = await getNotifications();

--- a/background/tasks/sendNotifications/sendNotifications.ts
+++ b/background/tasks/sendNotifications/sendNotifications.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@charmverse/core';
 import { log } from '@charmverse/core/log';
+import { RateLimit } from 'async-sema';
 
 import { getBountyTasks } from 'lib/bounties/getBountyTasks';
 import { getDiscussionTasks } from 'lib/discussion/getDiscussionTasks';
@@ -9,6 +10,8 @@ import { getForumNotifications } from 'lib/forums/getForumNotifications/getForum
 import * as mailer from 'lib/mailer';
 import { getProposalTasksFromWorkspaceEvents } from 'lib/proposal/getProposalTasksFromWorkspaceEvents';
 import { getVoteTasks } from 'lib/votes/getVoteTasks';
+
+const notificationTaskLimiter = RateLimit(50);
 
 export async function sendUserNotifications(): Promise<number> {
   const notificationsToSend = await getNotifications();
@@ -56,6 +59,9 @@ export async function getNotifications(): Promise<(PendingTasksProps & { unmarke
 
   // Because we have a large number of queries in parallel we need to avoid Promise.all and chain them one by one
   const notifications = await activeUsersWithSafes.reduce(async (acc, user) => {
+    // Since we will be calling permissions API, we want to ensure we don't flood it with requests
+    await notificationTaskLimiter();
+
     const accPromise = await acc;
     const discussionTasks = await getDiscussionTasks(user.id);
     const voteTasks = await getVoteTasks(user.id);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 848d26f</samp>

Added rate-limiting to the `sendNotifications` background task to avoid overloading the permissions API. Used the `async-sema` package to implement the rate-limiting logic.

### WHY
Include rate limiting in the notification tasks
