### PR TITLE
Re-order board view tabs

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/addViewMenu.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/addViewMenu.tsx
@@ -13,6 +13,8 @@ import { injectIntl } from 'react-intl';
 import type { IntlShape } from 'react-intl';
 import { v4 as uuid } from 'uuid';
 
+import charmClient from 'charmClient';
+import { publishIncrementalUpdate } from 'components/common/BoardEditor/publisher';
 import Button from 'components/common/Button';
 import type { Block } from 'lib/focalboard/block';
 import type { Board, IPropertyTemplate } from 'lib/focalboard/board';
@@ -45,6 +47,10 @@ function AddViewMenu(props: AddViewProps) {
   const intl = props.intl;
   const showView = props.showView;
 
+  const views = props.views.filter((view) => !view.fields.inline);
+  const viewIds =
+    props.board.fields.viewIds.length === views.length ? props.board.fields.viewIds : views.map((view) => view.id);
+
   const popupState = usePopupState({ variant: 'popover', popupId: 'add-view-menu' });
 
   const boardText = intl.formatMessage({
@@ -60,7 +66,7 @@ function AddViewMenu(props: AddViewProps) {
     defaultMessage: 'Gallery'
   });
 
-  const handleAddViewBoard = useCallback(() => {
+  const handleAddViewBoard = useCallback(async () => {
     const { board, activeView } = props;
     Utils.log('addview-board');
     // TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.CreateBoardView, {board: board.id, view: activeView.id})
@@ -73,7 +79,7 @@ function AddViewMenu(props: AddViewProps) {
 
     const oldViewId = activeView?.id;
 
-    mutator.insertBlock(
+    await mutator.insertBlock(
       view,
       'add view',
       async (block: Block) => {
@@ -88,10 +94,16 @@ function AddViewMenu(props: AddViewProps) {
         oldViewId && showView(oldViewId);
       }
     );
-    closePopup();
-  }, [props.activeView, props.board, props.intl, showView]);
 
-  const handleAddViewTable = useCallback(() => {
+    await charmClient.patchBlock(
+      board.id,
+      { updatedFields: { viewIds: [...viewIds, view.id] } },
+      publishIncrementalUpdate
+    );
+    closePopup();
+  }, [viewIds, props.activeView, props.board, props.intl, showView]);
+
+  const handleAddViewTable = useCallback(async () => {
     const { board, activeView } = props;
 
     Utils.log('addview-table');
@@ -100,7 +112,7 @@ function AddViewMenu(props: AddViewProps) {
 
     const oldViewId = activeView?.id;
 
-    mutator.insertBlock(
+    await mutator.insertBlock(
       view,
       'add view',
       async (block: Block) => {
@@ -115,10 +127,17 @@ function AddViewMenu(props: AddViewProps) {
         oldViewId && showView(oldViewId);
       }
     );
-    closePopup();
-  }, [props.activeView, props.board, props.intl, showView]);
 
-  const handleAddViewGallery = useCallback(() => {
+    await charmClient.patchBlock(
+      board.id,
+      { updatedFields: { viewIds: [...viewIds, view.id] } },
+      publishIncrementalUpdate
+    );
+
+    closePopup();
+  }, [viewIds, props.activeView, props.board, props.intl, showView]);
+
+  const handleAddViewGallery = useCallback(async () => {
     const { board, activeView } = props;
 
     Utils.log('addview-gallery');
@@ -132,7 +151,7 @@ function AddViewMenu(props: AddViewProps) {
 
     const oldViewId = activeView?.id;
 
-    mutator.insertBlock(
+    await mutator.insertBlock(
       view,
       'add view',
       async (block: Block) => {
@@ -146,10 +165,15 @@ function AddViewMenu(props: AddViewProps) {
         oldViewId && showView(oldViewId);
       }
     );
+    await charmClient.patchBlock(
+      board.id,
+      { updatedFields: { viewIds: [...viewIds, view.id] } },
+      publishIncrementalUpdate
+    );
     closePopup();
-  }, [props.board, props.activeView, props.intl, showView]);
+  }, [viewIds, props.board, props.activeView, props.intl, showView]);
 
-  const handleAddViewCalendar = useCallback(() => {
+  const handleAddViewCalendar = useCallback(async () => {
     const { board, activeView } = props;
 
     Utils.log('addview-calendar');
@@ -180,7 +204,7 @@ function AddViewMenu(props: AddViewProps) {
       view.fields.dateDisplayPropertyId = template.id;
     }
 
-    mutator.insertBlock(
+    await mutator.insertBlock(
       view,
       'add view',
       async (block: Block) => {
@@ -194,8 +218,15 @@ function AddViewMenu(props: AddViewProps) {
         oldViewId && showView(oldViewId);
       }
     );
+
+    await charmClient.patchBlock(
+      board.id,
+      { updatedFields: { viewIds: [...viewIds, view.id] } },
+      publishIncrementalUpdate
+    );
+
     closePopup();
-  }, [props.board, props.activeView, props.intl, showView]);
+  }, [viewIds, props.board, props.activeView, props.intl, showView]);
 
   function onClickIcon(e: MouseEvent) {
     if (props.onClickIcon) {

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
@@ -110,6 +110,7 @@ function ViewHeader(props: Props) {
         disableUpdatingUrl={props.disableUpdatingUrl}
         maxTabsShown={maxTabsShown}
         openViewOptions={() => toggleViewOptions(true)}
+        viewIds={activeBoard?.fields.viewIds ?? []}
       />
 
       {/* add a view */}

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
@@ -6,7 +6,8 @@ import {
   ContentCopy as DuplicateIcon,
   Refresh as RefreshIcon
 } from '@mui/icons-material';
-import { Typography, Box } from '@mui/material';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import { Typography, Box, Stack } from '@mui/material';
 import type { ButtonProps } from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -33,6 +34,7 @@ import type { Board } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';
 import { formatViewTitle, createBoardView } from 'lib/focalboard/boardView';
 
+import { useSortable } from '../../hooks/sortable';
 import mutator from '../../mutator';
 import { IDType, Utils } from '../../utils';
 import AddViewMenu from '../addViewMenu';
@@ -70,6 +72,38 @@ interface ViewTabsProps {
   disableUpdatingUrl?: boolean;
   maxTabsShown: number;
   openViewOptions: () => void;
+}
+
+function ViewMenuItem({
+  view,
+  onClick,
+  onDrop,
+  href
+}: {
+  href: string;
+  onDrop: (currentView: BoardView, droppedView: BoardView) => void;
+  view: BoardView;
+  onClick: VoidFunction;
+}) {
+  const [isDragging, isOver, columnRef] = useSortable('view', view, true, onDrop);
+  return (
+    <Stack
+      ref={columnRef}
+      sx={{
+        overflow: 'unset',
+        opacity: isDragging ? 0.5 : 1,
+        transition: `background-color 150ms ease-in-out`,
+        backgroundColor: isOver ? 'var(--charmeditor-active)' : 'initial',
+        flexDirection: 'row'
+      }}
+    >
+      <MenuItem onClick={onClick} href={href} component={Link} key={view.id} dense className={isOver ? 'dragover' : ''}>
+        <DragIndicatorIcon color='secondary' fontSize='small' sx={{ mr: 1 }} />
+        <ListItemIcon>{iconForViewType(view.fields.viewType)}</ListItemIcon>
+        <ListItemText>{view.title || formatViewTitle(view)}</ListItemText>
+      </MenuItem>
+    </Stack>
+  );
 }
 
 function ViewTabs(props: ViewTabsProps) {
@@ -319,20 +353,17 @@ function ViewTabs(props: ViewTabsProps) {
       </Menu>
 
       <Menu {...showViewsMenuState}>
-        {restViews.map((view) => (
-          <MenuItem
+        {views.map((view) => (
+          <ViewMenuItem
+            view={view}
+            key={view.id}
+            href={disableUpdatingUrl ? '' : getViewUrl(view.id)}
             onClick={() => {
               showView(view.id);
               showViewsMenuState.onClose();
             }}
-            href={disableUpdatingUrl ? '' : getViewUrl(view.id)}
-            component={Link}
-            key={view.id}
-            dense
-          >
-            <ListItemIcon>{iconForViewType(view.fields.viewType)}</ListItemIcon>
-            <ListItemText>{view.title || formatViewTitle(view)}</ListItemText>
-          </MenuItem>
+            onDrop={(currentView, droppedView) => {}}
+          />
         ))}
         <Divider sx={{ my: 1 }} />
         <Box pl='14px'>

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
@@ -27,6 +27,8 @@ import { useForm } from 'react-hook-form';
 import type { IntlShape } from 'react-intl';
 import { injectIntl } from 'react-intl';
 
+import charmClient from 'charmClient';
+import { publishIncrementalUpdate } from 'components/common/BoardEditor/publisher';
 import Button from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
@@ -228,11 +230,16 @@ function ViewTabs(props: ViewTabsProps) {
     setViewMenuAnchorEl(null);
     const nextViewId = viewIds.find((viewId) => viewId !== dropdownView.id);
     await mutator.deleteBlock(dropdownView, 'delete view');
+    await charmClient.patchBlock(
+      board.id,
+      { updatedFields: { viewIds: viewIds.filter((viewId) => viewId !== dropdownView.id) } },
+      publishIncrementalUpdate
+    );
     onDeleteView?.(dropdownView.id);
     if (nextViewId) {
       showView(nextViewId);
     }
-  }, [viewIds, dropdownView, showView]);
+  }, [viewIds, dropdownView, showView, board.id]);
 
   function resyncGoogleFormData() {
     if (dropdownView) {

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import {
   Edit as EditIcon,
@@ -119,6 +120,60 @@ function ViewMenuItem({
         <ListItemText>{view.title || formatViewTitle(view)}</ListItemText>
       </MenuItem>
     </Stack>
+  );
+}
+
+function ShownViewMenuItem({
+  view,
+  onClick,
+  onDrop,
+  href,
+  isActive
+}: {
+  isActive: boolean;
+  href?: string;
+  onDrop: (currentView: BoardView, dropzoneView: BoardView) => void;
+  view: BoardView;
+  onClick: (event: MouseEvent<HTMLElement>) => void;
+}) {
+  const theme = useTheme();
+  const [isDragging, isOver, columnRef] = useSortable<BoardView, HTMLButtonElement>('view', view, true, onDrop);
+  return (
+    <TabButton
+      ref={columnRef as any}
+      disableRipple
+      href={href}
+      onClick={onClick}
+      variant='text'
+      size='small'
+      id={view.id}
+      sx={{
+        p: 0,
+        overflow: 'unset',
+        opacity: isDragging ? 0.5 : 1,
+        transition: `background-color 150ms ease-in-out`,
+        backgroundColor: isOver ? 'var(--charmeditor-active)' : 'initial',
+        flexDirection: 'row',
+        // The tab indicator is not shown anymore since its located in a separate component
+        borderBottom: isActive ? `1.5px solid ${theme.palette.text.primary}` : ''
+      }}
+      value={view.id}
+      label={
+        <StyledTabContent
+          color={isActive ? 'textPrimary' : 'secondary'}
+          display='flex'
+          alignItems='center'
+          fontSize='small'
+          fontWeight={500}
+          gap={1}
+        >
+          <span>
+            {iconForViewType(view.fields.viewType)}
+            {view.title || formatViewTitle(view)}
+          </span>
+        </StyledTabContent>
+      }
+    />
   );
 }
 
@@ -310,31 +365,13 @@ function ViewTabs(props: ViewTabsProps) {
           .map((viewId) => {
             const view = viewsRecord[viewId];
             return view ? (
-              <TabButton
-                disableRipple
-                key={viewId}
-                href={activeView?.id === view.id ? undefined : getViewUrl(view.id)}
+              <ShownViewMenuItem
                 onClick={handleViewClick}
-                variant='text'
-                size='small'
-                id={view.id}
-                sx={{ p: 0 }}
-                value={view.id}
-                label={
-                  <StyledTabContent
-                    color={activeView?.id === view.id ? 'textPrimary' : 'secondary'}
-                    display='flex'
-                    alignItems='center'
-                    fontSize='small'
-                    fontWeight={500}
-                    gap={1}
-                  >
-                    <span>
-                      {iconForViewType(view.fields.viewType)}
-                      {view.title || formatViewTitle(view)}
-                    </span>
-                  </StyledTabContent>
-                }
+                onDrop={reorderViews}
+                view={view}
+                isActive={activeView?.id === view.id}
+                key={view.id}
+                href={activeView?.id === view.id ? undefined : getViewUrl(view.id)}
               />
             ) : null;
           })

--- a/components/common/BoardEditor/focalboard/src/hooks/sortable.tsx
+++ b/components/common/BoardEditor/focalboard/src/hooks/sortable.tsx
@@ -43,13 +43,13 @@ function useSortableBase<T>(
   return [isDragging, isOver, drag, drop, preview];
 }
 
-export function useSortable<T>(
+export function useSortable<T, E = HTMLDivElement>(
   itemType: string,
   item: T,
   enabled: boolean,
   handler: (src: T, st: T) => void
-): [boolean, boolean, React.RefObject<HTMLDivElement>] {
-  const ref = useRef<HTMLDivElement>(null);
+): [boolean, boolean, React.RefObject<E>] {
+  const ref = useRef<E>(null);
   const [isDragging, isOver, drag, drop] = useSortableBase(itemType, item, enabled, handler);
   drop(drag(ref));
   return [isDragging, isOver, ref];

--- a/components/common/BoardEditor/focalboard/src/mutator.ts
+++ b/components/common/BoardEditor/focalboard/src/mutator.ts
@@ -763,6 +763,32 @@ class Mutator {
     );
   }
 
+  async changeBoardViewsOrder(
+    boardId: string,
+    currentViewIds: string[],
+    droppedView: BoardView,
+    dropzoneView: BoardView
+  ) {
+    const tempViewIds = [...currentViewIds];
+    const droppedViewIndex = tempViewIds.indexOf(droppedView.id);
+    const dropzoneViewIndex = tempViewIds.indexOf(dropzoneView.id);
+    tempViewIds.splice(dropzoneViewIndex, 0, tempViewIds.splice(droppedViewIndex, 1)[0]);
+
+    await undoManager.perform(
+      async () => {
+        await charmClient.patchBlock(boardId, { updatedFields: { viewIds: tempViewIds } }, publishIncrementalUpdate);
+      },
+      async () => {
+        await charmClient.patchBlock(
+          boardId,
+          { updatedFields: { visiblePropertyIds: currentViewIds } },
+          publishIncrementalUpdate
+        );
+      },
+      "change board's views order"
+    );
+  }
+
   async changeViewVisiblePropertiesOrder(
     viewId: string,
     visiblePropertyIds: string[],

--- a/components/common/BoardEditor/focalboard/src/store/views.ts
+++ b/components/common/BoardEditor/focalboard/src/store/views.ts
@@ -4,7 +4,6 @@ import { createSelector, createSlice } from '@reduxjs/toolkit';
 import type { BoardView } from 'lib/focalboard/boardView';
 import { createBoardView } from 'lib/focalboard/boardView';
 
-import { getCurrentBoard } from './boards';
 import { initialLoad, initialReadOnlyLoad } from './initialLoad';
 
 import type { RootState } from './index';

--- a/lib/focalboard/board.ts
+++ b/lib/focalboard/board.ts
@@ -45,6 +45,7 @@ export type BoardFields = {
   isTemplate?: boolean;
   cardProperties: IPropertyTemplate[];
   columnCalculations: Record<string, string>;
+  viewIds: string[];
 };
 
 type Board = Block & {
@@ -101,6 +102,7 @@ function createBoard({
       isTemplate: block?.fields?.isTemplate ?? false,
       columnCalculations: block?.fields?.columnCalculations ?? [],
       headerImage: block?.fields?.headerImage ?? null,
+      viewIds: block?.fields?.viewIds ?? [],
       ...block?.fields,
       cardProperties
     }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7886b55</samp>

This pull request enhances the board editor component of the app by adding real-time collaboration and synchronization of board views, drag and drop functionality for reordering the views, and undo/redo functionality for the view actions. It modifies several files in the `components/common/BoardEditor/focalboard/src` folder, such as `addViewMenu.tsx`, `viewTabs.tsx`, `mutator.ts`, and `views.ts`, and adds a new field `viewIds` to the board type in the `lib/focalboard/board.ts` file.

### WHY
<!-- author to complete -->
