### PR TITLE
Add chain explorer url for optimism

### DIFF
--- a/connectors.ts
+++ b/connectors.ts
@@ -412,6 +412,9 @@ export function getChainExplorerLink(
     case '80001':
       return `https://mumbai.polygonscan.com/${path}/${transactionOrContractId}`;
 
+    case '10':
+      return `https://optimistic.etherscan.io/${path}/${transactionOrContractId}`;
+
     default:
       return '';
   }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 701a988</samp>

Add support for Optimistic Ethereum network in `getChainExplorerLink` function. This enables users to view their transactions and contracts on Etherscan for this network.

### WHY
Just noticed during the demo - Bounty paid via optimism chain does not have transaciton url - that is because we did not support optimism chain in `getChainExplorerLink` function
