### PR TITLE
dont update page every time metadata is updated

### DIFF
--- a/hooks/usePage.ts
+++ b/hooks/usePage.ts
@@ -39,19 +39,24 @@ export function usePage({ spaceId, pageIdOrPath }: Props): PageResult {
 
   useEffect(() => {
     function handleUpdateEvent(value: WebSocketPayload<'pages_meta_updated'>) {
-      mutate((_page): PageWithContent | undefined => {
-        if (_page) {
-          for (let i = 0; i < value.length; i++) {
-            if (value[i].id === pageWithContent?.id) {
-              return {
-                ..._page,
-                ...(value[i] as PageMeta)
-              };
+      mutate(
+        (_page): PageWithContent | undefined => {
+          if (_page) {
+            for (let i = 0; i < value.length; i++) {
+              if (value[i].id === pageWithContent?.id) {
+                return {
+                  ..._page,
+                  ...(value[i] as PageMeta)
+                };
+              }
             }
           }
+          return _page;
+        },
+        {
+          revalidate: false
         }
-        return _page;
-      });
+      );
     }
     const unsubscribeFromPageUpdates = subscribe('pages_meta_updated', handleUpdateEvent);
 

--- a/hooks/usePage.ts
+++ b/hooks/usePage.ts
@@ -43,7 +43,7 @@ export function usePage({ spaceId, pageIdOrPath }: Props): PageResult {
         (_page): PageWithContent | undefined => {
           if (_page) {
             for (let i = 0; i < value.length; i++) {
-              if (value[i].id === pageWithContent?.id) {
+              if (value[i].id === _page.id) {
                 return {
                   ..._page,
                   ...(value[i] as PageMeta)
@@ -63,7 +63,7 @@ export function usePage({ spaceId, pageIdOrPath }: Props): PageResult {
     return () => {
       unsubscribeFromPageUpdates();
     };
-  }, []);
+  }, [mutate]);
 
   if (pageWithContent) {
     return {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb88123</samp>

Modified `mutate` call in `usePage` hook to avoid revalidation. This improves performance by reducing network requests when the page metadata changes.

### WHY
Every time i receive any type of "page_meta_update", we were re-querying the page and re-rendering the whole React component :/
