### PR TITLE
adding in permissions api to run alongside webapp

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       ]
     environment:
       - NEXT_PUBLIC_APP_ENV=staging
+      - PERMISSIONS_API_URL="http://permissions-api"
     profiles:
       - stg-webapp
 
@@ -92,8 +93,6 @@ services:
 
   permissions-api:
     image: '310849459438.dkr.ecr.us-east-1.amazonaws.com/charmverse-permissions-api:${PERMISSION_IMGTAG:-latest}'
-    ports:
-      - '80:3001'
     command:
       [
         'sh',
@@ -104,6 +103,9 @@ services:
       - $PWD/.env:/app/.env
     env_file:
       - '.env'
+    environment:
+      - HOST=permissions-api
+      - PORT=80
     profiles:
       - stg-webapp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       ]
     environment:
       - NEXT_PUBLIC_APP_ENV=staging
-      - PERMISSIONS_API_URL="http://permissions-api"
+      - PERMISSIONS_API_URL="http://permissions-api:3001"
     profiles:
       - stg-webapp
 
@@ -105,7 +105,6 @@ services:
       - '.env'
     environment:
       - HOST=permissions-api
-      - PORT=80
     profiles:
       - stg-webapp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       ]
     environment:
       - NEXT_PUBLIC_APP_ENV=staging
-      - PERMISSIONS_API_URL="http://permissions-api:3001"
+      - PERMISSIONS_API_URL=http://permissions-api:3001
     profiles:
       - stg-webapp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,23 @@ services:
     profiles:
       - dev
 
+  permissions-api:
+    image: '310849459438.dkr.ecr.us-east-1.amazonaws.com/charmverse-permissions-api:${PERMISSION_IMGTAG:-latest}'
+    ports:
+      - '80:3001'
+    command:
+      [
+        'sh',
+        '-c',
+        'node --experimental-specifier-resolution=node ./dist/main.js',
+      ]
+    volumes:
+      - $PWD/.env:/app/.env
+    env_file:
+      - '.env'
+    profiles:
+      - stg-webapp
+
   localpostgres:
     image: postgres
     ports:


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9fad1e1</samp>

Added a new `permissions-api` service to `docker-compose.yml` for staging the web application. The service runs a node application from a private AWS ECR image and uses the host `.env` file.

### WHY
adding permissions api as sidecar to the staging webapp environment
