### PR TITLE
fix copy link

### DIFF
--- a/components/common/PageActions/components/CopyPageLinkAction.tsx
+++ b/components/common/PageActions/components/CopyPageLinkAction.tsx
@@ -1,11 +1,13 @@
 import LinkIcon from '@mui/icons-material/Link';
 import { MenuItem, ListItemIcon, ListItemText } from '@mui/material';
+import { useRouter } from 'next/router';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
 import { useSnackbar } from 'hooks/useSnackbar';
 
 export function CopyPageLinkAction({ path, onComplete }: { path: string; onComplete?: VoidFunction }) {
   const { showMessage } = useSnackbar();
+  const router = useRouter();
 
   function onClick() {
     showMessage('Link copied to clipboard');
@@ -13,7 +15,7 @@ export function CopyPageLinkAction({ path, onComplete }: { path: string; onCompl
   }
 
   return (
-    <CopyToClipboard text={path} onCopy={onClick}>
+    <CopyToClipboard text={getAbsolutePath(router.query.domain as string | undefined, path)} onCopy={onClick}>
       <MenuItem dense>
         <ListItemIcon>
           <LinkIcon fontSize='small' />
@@ -22,4 +24,12 @@ export function CopyPageLinkAction({ path, onComplete }: { path: string; onCompl
       </MenuItem>
     </CopyToClipboard>
   );
+}
+
+function getAbsolutePath(subdomain: string | undefined, path: string) {
+  const absolutePath = subdomain ? `/${subdomain}${path}` : path;
+  if (typeof window !== 'undefined') {
+    return window.location.origin + absolutePath;
+  }
+  return absolutePath;
 }

--- a/components/common/PageActions/components/DatabasePageActionList.tsx
+++ b/components/common/PageActions/components/DatabasePageActionList.tsx
@@ -207,7 +207,7 @@ export function DatabasePageActionList({ pagePermissions, onComplete, page }: Pr
         pageType={boardPage?.type}
         pagePermissions={pagePermissions}
       />
-      <CopyPageLinkAction path={window.location.href} onComplete={onComplete} />
+      <CopyPageLinkAction path={`/${boardPage?.path}`} onComplete={onComplete} />
       <Divider />
       <Tooltip title={!pagePermissions?.delete ? "You don't have permission to delete this page" : ''}>
         <div>

--- a/components/common/PageActions/components/DocumentPageActionList.tsx
+++ b/components/common/PageActions/components/DocumentPageActionList.tsx
@@ -288,7 +288,7 @@ export function DocumentPageActionList({
           redirect
         />
       )}
-      <CopyPageLinkAction path={router.asPath} onComplete={onComplete} />
+      <CopyPageLinkAction path={`/${page.path}`} onComplete={onComplete} />
 
       <Divider sx={{ my: '0 !important' }} />
       {(page.type === 'card' || page.type === 'card_synced' || page.type === 'page') && (

--- a/components/common/PageActions/components/ForumPostActionList.tsx
+++ b/components/common/PageActions/components/ForumPostActionList.tsx
@@ -81,7 +81,7 @@ export function ForumPostActionList({
 
   return (
     <List data-test='header--forum-post-actions' dense>
-      <CopyPageLinkAction path={router.asPath} onComplete={onComplete} />
+      <CopyPageLinkAction path={`/forum/post/${post?.path}`} onComplete={onComplete} />
       <Divider />
       <DeletePageAction onClick={deletePost} disabled={!postPermissions?.delete_post} />
       <UndoAction onClick={undoEditorChanges} disabled={!postPermissions?.edit_post} />

--- a/components/common/PageActions/components/PageActionsMenu.tsx
+++ b/components/common/PageActions/components/PageActionsMenu.tsx
@@ -97,7 +97,7 @@ export function PageActionsMenu({
           pagePermissions={pagePermissions}
         />
       )}
-      <CopyPageLinkAction path={getPageLink()} />
+      <CopyPageLinkAction path={`/${page.path}`} />
       <MenuItem dense onClick={onClickOpenInNewTab}>
         <LaunchIcon fontSize='small' sx={{ mr: 1 }} />
         <ListItemText>Open in new tab</ListItemText>

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -404,13 +404,6 @@ function PageActionsMenu({ closeMenu, pageId, pagePath }: { closeMenu: () => voi
     }
   }
 
-  function getAbsolutePath() {
-    if (typeof window !== 'undefined') {
-      return window.location.origin + pagePath;
-    }
-    return '';
-  }
-
   return (
     <>
       <Tooltip arrow placement='top' title={deletePageDisabled ? 'You do not have permission to delete this page' : ''}>
@@ -430,7 +423,7 @@ function PageActionsMenu({ closeMenu, pageId, pagePath }: { closeMenu: () => voi
         pagePermissions={pagePermissions}
         onComplete={closeMenu}
       />
-      <CopyPageLinkAction path={getAbsolutePath()} onComplete={closeMenu} />
+      <CopyPageLinkAction path={pagePath} onComplete={closeMenu} />
     </>
   );
 }

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -425,7 +425,7 @@ function PageActionsMenu({ closeMenu, pageId, pagePath }: { closeMenu: () => voi
         pagePermissions={pagePermissions}
         onComplete={closeMenu}
       />
-      <CopyPageLinkAction path={pagePath} onComplete={closeMenu} />
+      <CopyPageLinkAction path={`/${pagePath}`} onComplete={closeMenu} />
     </>
   );
 }

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -47,6 +47,7 @@ interface PageTreeItemProps {
   label: string;
   pageType: PageType;
   pageId: string;
+  pagePath: string;
   hasSelectedChildView: boolean;
   children: React.ReactNode;
   onClick?: () => void;
@@ -297,6 +298,7 @@ const PageTreeItem = forwardRef<any, PageTreeItemProps>((props, ref) => {
     label,
     pageType,
     pageId,
+    pagePath,
     hasSelectedChildView,
     onClick
   } = props;
@@ -373,7 +375,7 @@ const PageTreeItem = forwardRef<any, PageTreeItemProps>((props, ref) => {
         anchorOrigin={anchorOrigin}
         transformOrigin={transformOrigin}
       >
-        {Boolean(anchorEl) && <PageActionsMenu closeMenu={closeMenu} pageId={pageId} pagePath={href} />}
+        {Boolean(anchorEl) && <PageActionsMenu closeMenu={closeMenu} pageId={pageId} pagePath={pagePath} />}
       </Menu>
     </>
   );

--- a/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
@@ -185,6 +185,7 @@ function DraggableTreeNode({
       href={`${pathPrefix}/${item.path}${
         item.type.includes('board') && focalboardViewsRecord[item.id] ? `?viewId=${focalboardViewsRecord[item.id]}` : ''
       }`}
+      pagePath={item.path}
       isActive={isActive}
       isAdjacent={isAdjacentActive}
       isEmptyContent={item.isEmptyContent}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc8cf5a</samp>

Updated the `CopyPageLinkAction` component to use the router query and a helper function to copy the full URL of the page, including the subdomain, to the clipboard. Changed the `path` prop of the component in various page action lists to use the page object instead of the window location or the router path. This improves the usability and accuracy of the copy link feature and simplifies the code.

### WHY
We were just copying the relative path :( I made it so that consumers don't have to pass in a subdomain
