### PR TITLE
dont always scroll into view

### DIFF
--- a/components/common/CharmEditor/components/fiduswriter/track/amendTransaction.ts
+++ b/components/common/CharmEditor/components/fiduswriter/track/amendTransaction.ts
@@ -161,7 +161,6 @@ function markWrapping(
   let blockTrack = track.find((t) => t.type === 'block_change');
 
   const trackBefore = blockTrack?.before as undefined | { type: string; attrs: any };
-
   if (blockTrack) {
     track = track.filter((t: TrackAttribute) => t !== blockTrack);
     if (trackBefore?.type !== newNode.type.name || trackBefore?.attrs.level !== newNode.attrs.level) {
@@ -435,8 +434,6 @@ export function trackedTransaction(
   if (tr.storedMarks && tr.storedMarksSet) {
     newTr.setStoredMarks(tr.storedMarks);
   }
-
-  newTr.scrollIntoView();
 
   return newTr;
 }


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
This fixes https://app.charmverse.io/charmverse/page-49366552253645923?viewId=50d940bb-fdbd-40ba-9816-616d6138a663&cardId=7add3030-eefc-4693-b9f0-b239d69cac75. this call to scrollIntoView was copied over and not necessary, I think.

What is happening is that when a checkbox is toggled and the editor is not focused, something causes the editor to receive focus and put the cursor at the top of the document. I am not sure yet how/why that happens, but it could be an alternative way to address the issue. Since we are also scrolling the doc into view all the time, it makes the page jump.