### PR TITLE
always convert values to string before filtering

### DIFF
--- a/lib/focalboard/cardFilter.ts
+++ b/lib/focalboard/cardFilter.ts
@@ -1,3 +1,5 @@
+import { log } from '@charmverse/core/log';
+
 import { Utils } from 'components/common/BoardEditor/focalboard/src/utils';
 import type { IPropertyTemplate } from 'lib/focalboard/board';
 import type { Card } from 'lib/focalboard/card';
@@ -54,12 +56,13 @@ class CardFilter {
     const value = card.fields.properties[filter.propertyId] ?? [];
     const filterProperty = templates.find((o) => o.id === filter.propertyId);
     const filterValue = filter.values[0]?.toString()?.toLowerCase() ?? '';
+    const valueArray = (Array.isArray(value) ? value : [value]).map((v) => v.toString());
 
     if (filterProperty) {
       const filterPropertyDataType = propertyConfigs[filterProperty.type].datatype;
       if (filterPropertyDataType === 'text') {
         const condition = filter.condition as (typeof TextDataTypeConditions)[number];
-        const sourceValue = (Array.isArray(value) ? value[0] : value)?.toLowerCase() ?? '';
+        const sourceValue = valueArray[0]?.toLowerCase() ?? '';
         switch (condition) {
           case 'contains': {
             if (sourceValue.includes(filterValue)) {
@@ -97,7 +100,7 @@ class CardFilter {
         }
       } else if (filterPropertyDataType === 'boolean') {
         const condition = filter.condition as (typeof BooleanDataTypeConditions)[number];
-        const sourceValue = (Array.isArray(value) ? value[0] : value)?.toLowerCase() ?? 'false';
+        const sourceValue = valueArray[0]?.toLowerCase() ?? 'false';
         switch (condition) {
           case 'is': {
             return sourceValue === (filter.values[0] || 'false');
@@ -111,7 +114,7 @@ class CardFilter {
         }
       } else if (filterPropertyDataType === 'number') {
         const condition = filter.condition as (typeof NumberDataTypeConditions)[number];
-        const sourceValue = (Array.isArray(value) ? value[0] : value)?.toLowerCase() ?? '';
+        const sourceValue = valueArray[0]?.toLowerCase() ?? '';
         switch (condition) {
           case 'equal': {
             return sourceValue.length === 0 ? true : Number(sourceValue) === Number(filterValue);
@@ -143,21 +146,20 @@ class CardFilter {
         }
       } else if (filterPropertyDataType === 'multi_select') {
         const condition = filter.condition as (typeof MultiSelectDataTypeConditions)[number];
-        const sourceValues = Array.isArray(value) ? value : [value];
         switch (condition) {
           case 'contains': {
-            return sourceValues.length !== 0 && sourceValues.some((sourceValue) => filter.values.includes(sourceValue));
+            return valueArray.length !== 0 && valueArray.some((sourceValue) => filter.values.includes(sourceValue));
           }
           case 'does_not_contain': {
-            return sourceValues.length === 0
+            return valueArray.length === 0
               ? true
-              : sourceValues.every((sourceValue) => !filter.values.includes(sourceValue));
+              : valueArray.every((sourceValue) => !filter.values.includes(sourceValue));
           }
           case 'is_empty': {
-            return sourceValues.length === 0;
+            return valueArray.length === 0;
           }
           case 'is_not_empty': {
-            return sourceValues.length > 0;
+            return valueArray.length > 0;
           }
           default: {
             Utils.assertFailure(`Invalid filter condition ${filter.condition}`);
@@ -165,7 +167,7 @@ class CardFilter {
         }
       } else if (filterPropertyDataType === 'select') {
         const condition = filter.condition as (typeof SelectDataTypeConditions)[number];
-        const sourceValue = (Array.isArray(value) ? value[0] : value)?.toLowerCase() ?? '';
+        const sourceValue = valueArray[0]?.toLowerCase() ?? '';
         switch (condition) {
           case 'is': {
             return sourceValue.length !== 0 && filterValue === sourceValue;
@@ -185,8 +187,13 @@ class CardFilter {
         }
       } else if (filterPropertyDataType === 'date') {
         const condition = filter.condition as (typeof DateDataTypeConditions)[number];
-        const propertyValue = Array.isArray(value) ? value[0] : value;
-        const sourceValue = propertyValue ? (JSON.parse(propertyValue) as { from: number }) : { from: undefined };
+        const propertyValue = valueArray[0];
+        let sourceValue: { from?: number } = {};
+        try {
+          sourceValue = propertyValue ? (JSON.parse(propertyValue) as { from: number }) : { from: undefined };
+        } catch (error) {
+          log.error('Could not parse card property value', { propertyValue, error });
+        }
         switch (condition) {
           case 'is': {
             return (

--- a/lib/focalboard/cardFilter.ts
+++ b/lib/focalboard/cardFilter.ts
@@ -53,7 +53,7 @@ class CardFilter {
   static isClauseMet(filter: FilterClause, templates: readonly IPropertyTemplate[], card: Card): boolean {
     const value = card.fields.properties[filter.propertyId] ?? [];
     const filterProperty = templates.find((o) => o.id === filter.propertyId);
-    const filterValue = filter.values[0]?.toLowerCase() ?? '';
+    const filterValue = filter.values[0]?.toString()?.toLowerCase() ?? '';
 
     if (filterProperty) {
       const filterPropertyDataType = propertyConfigs[filterProperty.type].datatype;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c63e03</samp>

Fixed a bug in `cardFilter.ts` that caused the app to crash when filtering by a number property. Added `toString()` to the `filterValue` variable to handle non-string values.

### WHY
It looks like when you use "number" input type in our UI, numbers get saved as strings for some reason. But there is a table in production whose cards are all numbers. They look like they may have been imported from somewhere.