### PR TITLE
show Welcome title when user is onboarding

### DIFF
--- a/components/common/UserProfile/UserProfileDialogGlobal.tsx
+++ b/components/common/UserProfile/UserProfileDialogGlobal.tsx
@@ -32,7 +32,7 @@ export function UserProfileDialogGlobal() {
   if (showOnboardingFlow) {
     return (
       <div data-test='member-onboarding-form'>
-        <CurrentUserProfile key={user.id} isOnboarding={!user.email} currentUser={user} onClose={completeOnboarding} />
+        <CurrentUserProfile key={user.id} isOnboarding currentUser={user} onClose={completeOnboarding} />
       </div>
     );
   }

--- a/components/common/UserProfile/components/CurrentUserProfile.tsx
+++ b/components/common/UserProfile/components/CurrentUserProfile.tsx
@@ -27,7 +27,7 @@ export function CurrentUserProfile({
   const currentSpace = useCurrentSpace();
   const { updateSpaceValues } = useMemberPropertyValues(currentUser.id);
 
-  const [currentStep, setCurrentStep] = useState<Step>(isOnboarding ? 'email_step' : 'profile_step');
+  const [currentStep, setCurrentStep] = useState<Step>(!currentUser.email ? 'email_step' : 'profile_step');
 
   function goNextStep() {
     setCurrentStep('profile_step');
@@ -43,7 +43,7 @@ export function CurrentUserProfile({
     if (currentStep === 'email_step') {
       title = 'Welcome to CharmVerse';
     } else if (currentStep === 'profile_step') {
-      title = `Welcome to ${currentSpace.domain}. Set up your profile`;
+      title = `Welcome to ${currentSpace.domain}! Set up your profile`;
     }
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f882a5</samp>

This pull request enhances the user profile component by streamlining the email verification process and the UI. It removes the `isOnboarding` prop from `CurrentUserProfile` and uses `!user.email` to determine the onboarding step. It also adds punctuation to the profile step title.

### WHY
isOnboarding was relying on user.email, so if you already had an email, we would not change the dialog title.
