### PR TITLE
Fix edge case for assigning proposal reviewers

### DIFF
--- a/__integration-tests__/server/pages/api/proposals/[id]/index.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/[id]/index.spec.ts
@@ -234,6 +234,11 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
         {
           group: 'user',
           id: userWithRole.id
+        },
+        // New valid reviewer being adding in, admins can always be reviewers
+        {
+          group: 'user',
+          id: adminUser.id
         }
       ]
     };

--- a/pages/api/proposals/[id]/index.ts
+++ b/pages/api/proposals/[id]/index.ts
@@ -115,7 +115,7 @@ async function updateProposalController(req: NextApiRequest, res: NextApiRespons
       const reviewerPool = await req.basePermissionsClient.proposals.getProposalReviewerPool({
         resourceId: proposal.id
       });
-      for (const reviewer of reviewers) {
+      for (const reviewer of newReviewers) {
         if (reviewer.group === 'role' && !reviewerPool.roleIds.includes(reviewer.id)) {
           const role = await prisma.role.findUnique({
             where: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d04dc02</samp>

Fix a bug in the `updateProposalController` function and add a test case for it. The bug prevented adding an admin user as a reviewer to a proposal. The test case verifies that the bug is fixed.

### WHY
This fixes a retro-compatibility edge case.

If user / reviewer was already assigned to a proposal, you should continue to be able to update the proposal as normal, but not add new banned reviewers.

This fixes a case where adding a new authorized reviewer when there is an unauthorized reviewer would fail (we exepect this to work)