### PR TITLE
Fix user created another user account when logged in through google after having a verified email

### DIFF
--- a/lib/google/__tests__/loginWithGoogle.spec.ts
+++ b/lib/google/__tests__/loginWithGoogle.spec.ts
@@ -92,4 +92,31 @@ describe('loginWithGoogle', () => {
       })
     ).rejects.toBeInstanceOf(DisabledAccountError);
   });
+
+  it('should pass login if the user has an existing verified email', async () => {
+    const { user } = await generateUserAndSpaceWithApiToken();
+
+    const testEmail = `test-${v4()}@example.com`;
+
+    await prisma.verifiedEmail.create({
+      data: {
+        email: testEmail,
+        name: googleUserName,
+        avatarUrl: googleAvatarUrl,
+        user: {
+          connect: {
+            id: user.id
+          }
+        }
+      }
+    });
+
+    const existingUser = await loginWithGoogle({
+      accessToken: testEmail,
+      avatarUrl: googleAvatarUrl,
+      displayName: googleUserName
+    });
+
+    expect(existingUser.id).toEqual(user.id);
+  });
 });

--- a/lib/google/loginWithGoogle.ts
+++ b/lib/google/loginWithGoogle.ts
@@ -1,3 +1,4 @@
+import { log } from '@charmverse/core/log';
 import { prisma } from '@charmverse/core/prisma-client';
 
 import type { SignupAnalytics } from 'lib/metrics/mixpanel/interfaces/UserEvent';
@@ -82,11 +83,7 @@ export async function loginWithGoogle({
       }
     }
 
-    if (emailAccount) {
-      if (emailAccount.user.deletedAt) {
-        throw new DisabledAccountError(`This account has been disabled`);
-      }
-
+    if (emailAccount && !emailAccount.user.deletedAt) {
       if (emailAccount.name !== displayName || emailAccount.avatarUrl !== avatarUrl) {
         trackUserAction('sign_in', { userId: emailAccount.userId, identityType: 'Google' });
 

--- a/lib/google/loginWithGoogle.ts
+++ b/lib/google/loginWithGoogle.ts
@@ -45,6 +45,19 @@ export async function loginWithGoogle({
       }
     });
 
+    const emailAccount = await prisma.verifiedEmail.findUnique({
+      where: {
+        email
+      },
+      include: {
+        user: {
+          select: {
+            deletedAt: true
+          }
+        }
+      }
+    });
+
     if (googleAccount) {
       if (googleAccount.user.deletedAt) {
         throw new DisabledAccountError(`This account has been disabled`);
@@ -66,6 +79,30 @@ export async function loginWithGoogle({
         return updateUserProfile(googleAccount.userId, { identityType: 'Google', username: displayName });
       } else {
         return getUserProfile('id', googleAccount.userId);
+      }
+    }
+
+    if (emailAccount) {
+      if (emailAccount.user.deletedAt) {
+        throw new DisabledAccountError(`This account has been disabled`);
+      }
+
+      if (emailAccount.name !== displayName || emailAccount.avatarUrl !== avatarUrl) {
+        trackUserAction('sign_in', { userId: emailAccount.userId, identityType: 'Google' });
+
+        await prisma.verifiedEmail.update({
+          where: {
+            id: emailAccount.id
+          },
+          data: {
+            avatarUrl,
+            name: displayName
+          }
+        });
+
+        return updateUserProfile(emailAccount.userId, { identityType: 'Google', username: displayName });
+      } else {
+        return getUserProfile('id', emailAccount.userId);
       }
     }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 863aa15</samp>

This pull request adds support for logging in with Google when the user has an existing verified email in the database. It modifies the `loginWithGoogle` function in `lib/google/loginWithGoogle.ts` and adds a test case in `lib/google/__tests__/loginWithGoogle.spec.ts`.

### WHY
An user lost access to their account by doing:
Create user and space with just their email (verifiedEmail) -> Logout -> Login with Google. 
The app created another user with no space.

[Task item](https://app.charmverse.io/charmverse/page-9248424773658832)


