### PR TITLE
Remove bg for inline dbs with apikeys

### DIFF
--- a/components/common/Banners/Banner.tsx
+++ b/components/common/Banners/Banner.tsx
@@ -1,13 +1,12 @@
 import styled from '@emotion/styled';
 import Box from '@mui/material/Box';
 
-export const StyledBanner = styled(Box, { shouldForwardProp: (prop: string) => prop !== 'noBg' })<{ noBg?: boolean }>`
+export const StyledBanner = styled(Box)`
   width: 100%;
   z-index: var(--z-index-appBar);
   display: flex;
   justify-content: center;
   color: ${({ theme }) => theme.palette.text.primary};
-  background-color: ${({ noBg }) => (noBg ? 'none' : 'var(--bg-blue)')};
-  border: ${({ theme, noBg }) => (noBg ? `2px solid ${theme.palette.text.primary}` : '0')};
+  background-color: var(--bg-blue);
   padding: ${({ theme }) => theme.spacing(1.4)};
 `;

--- a/components/common/Banners/Banner.tsx
+++ b/components/common/Banners/Banner.tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled';
 import Box from '@mui/material/Box';
 
-export const StyledBanner = styled(Box)`
+export const StyledBanner = styled(Box, { shouldForwardProp: (prop: string) => prop !== 'noBg' })<{ noBg?: boolean }>`
   width: 100%;
   z-index: var(--z-index-appBar);
   display: flex;
   justify-content: center;
   color: ${({ theme }) => theme.palette.text.primary};
-  background-color: var(--bg-blue);
+  background-color: ${({ noBg }) => (noBg ? 'none' : 'var(--bg-blue)')};
+  border: ${({ theme, noBg }) => (noBg ? `2px solid ${theme.palette.text.primary}` : '0')};
   padding: ${({ theme }) => theme.spacing(1.4)};
 `;

--- a/components/common/Banners/PageWebhookBanner.tsx
+++ b/components/common/Banners/PageWebhookBanner.tsx
@@ -3,9 +3,9 @@ import Typography from '@mui/material/Typography';
 
 import { StyledBanner } from './Banner';
 
-export function PageWebhookBanner({ type, url }: { type: string; url: string }) {
+export function PageWebhookBanner({ type, url, noBg = false }: { type: string; url: string; noBg?: boolean }) {
   return (
-    <StyledBanner data-test='page-webhook-banner'>
+    <StyledBanner data-test='page-webhook-banner' noBg={noBg}>
       <Stack gap={0.5} flexDirection='column' alignItems='center' display='inline-flex'>
         <Typography>This database is receiving responses from {type} via this webhook URL</Typography>
         <Typography>

--- a/components/common/Banners/PageWebhookBanner.tsx
+++ b/components/common/Banners/PageWebhookBanner.tsx
@@ -1,11 +1,12 @@
+import type { BoxProps } from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
 import { StyledBanner } from './Banner';
 
-export function PageWebhookBanner({ type, url, noBg = false }: { type: string; url: string; noBg?: boolean }) {
+export function PageWebhookBanner({ type, url, ...restProps }: BoxProps & { type: string; url: string }) {
   return (
-    <StyledBanner data-test='page-webhook-banner' noBg={noBg}>
+    <StyledBanner data-test='page-webhook-banner' {...restProps}>
       <Stack gap={0.5} flexDirection='column' alignItems='center' display='inline-flex'>
         <Typography>This database is receiving responses from {type} via this webhook URL</Typography>
         <Typography>

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -503,7 +503,12 @@ function CenterPanel(props: Props) {
             key={key.apiKey}
             type={key.type}
             url={`${webhookBaseUrl}/${key?.apiKey}`}
-            noBg={isEmbedded}
+            sx={{
+              ...(isEmbedded && {
+                border: (theme) => `2px solid ${theme.palette.text.primary}`,
+                backgroundColor: 'transparent !important'
+              })
+            }}
           />
         ) : null
       )}

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -499,7 +499,12 @@ function CenterPanel(props: Props) {
       {!!boardPage?.deletedAt && <PageDeleteBanner pageId={boardPage.id} />}
       {keys?.map((key) =>
         activeBoardId === key.pageId ? (
-          <PageWebhookBanner key={key.apiKey} type={key.type} url={`${webhookBaseUrl}/${key?.apiKey}`} />
+          <PageWebhookBanner
+            key={key.apiKey}
+            type={key.type}
+            url={`${webhookBaseUrl}/${key?.apiKey}`}
+            noBg={isEmbedded}
+          />
         ) : null
       )}
       <div


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 645be19</samp>

Added a `noBg` prop to the `Banner` and `PageWebhookBanner` components to control their background and border styles. Used this prop in the `CenterPanel` component to adjust the banner appearance based on the `isEmbedded` prop.

### WHY
Leftover for Typeform implementation:
After feedback from demo day we decided to remove the background and add a simple border for databases that have a banner. 
