### PR TITLE
try fixing flaky onboarding modal

### DIFF
--- a/components/common/UserProfile/components/CurrentUserProfile.tsx
+++ b/components/common/UserProfile/components/CurrentUserProfile.tsx
@@ -43,7 +43,7 @@ export function CurrentUserProfile({
     if (currentStep === 'email_step') {
       title = 'Welcome to CharmVerse';
     } else if (currentStep === 'profile_step') {
-      title = `Welcome to ${currentSpace.domain}! Set up your profile`;
+      title = `Welcome to ${currentSpace.name}! Set up your profile`;
     }
   }
 

--- a/components/common/UserProfile/hooks/useOnboarding.tsx
+++ b/components/common/UserProfile/hooks/useOnboarding.tsx
@@ -21,11 +21,9 @@ export function useOnboarding({ spaceId, user }: { spaceId?: string; user: Logge
   }
 
   const userIsCurrentSpaceMember = !!user?.spaceRoles.some((sr) => sr.spaceId === spaceId);
+  const spaceMember = members.find((member) => member.id === userId);
   const showOnboardingFlow =
-    userIsCurrentSpaceMember &&
-    !isValidating &&
-    members.length > 0 &&
-    !members.find((member) => member.id === userId)?.onboarded;
+    userIsCurrentSpaceMember && !isValidating && members.length > 0 && !!spaceMember && !spaceMember.onboarded;
 
   return {
     showOnboardingFlow,

--- a/lib/members/interfaces.ts
+++ b/lib/members/interfaces.ts
@@ -44,7 +44,7 @@ export type Member = Pick<User, 'id' | 'createdAt' | 'updatedAt' | 'username'> &
   profile?: UserDetails;
   properties: PropertyValueWithDetails[];
   roles: Pick<Role, 'name' | 'id'>[];
-  onboarded?: boolean;
+  onboarded: boolean;
   searchValue: string;
 };
 

--- a/pages/api/spaces/[id]/members/index.ts
+++ b/pages/api/spaces/[id]/members/index.ts
@@ -39,6 +39,7 @@ async function getMembers(req: NextApiRequest, res: NextApiResponse<Member[]>) {
       id: sr.user.id,
       createdAt: new Date(),
       updatedAt: new Date(),
+      onboarded: true,
       path: 'not-found',
       joinDate: new Date().toISOString(),
       properties: [],


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
Xandra says after working on the app for a few minutes, she gets the onboarding modal: https://www.loom.com/share/e09e5835504c446cbcec059d7d46f868. Based on the screenshot which includes "Welcome to charmverse", it looks like useOnboarding() has to be returning true for `showOnboardingFlow`. I am wondering if we have some mutation in useMembers() where we override the 'onboarded' flag but couldn't find any. I verified in the DB that she is marked 'onboarded'