### PR TITLE
Trigger logout from web3AuthSig only if user can only connect via wallet

### DIFF
--- a/hooks/useWeb3AuthSig.tsx
+++ b/hooks/useWeb3AuthSig.tsx
@@ -184,7 +184,7 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
         setStoredAccount(null);
         // We should only logout if there is a user. The logout function triggers a wipe of the SWR cache, and this was having undesirable effects for people with a connected wallet but no user account
         // Also only trigger logout from web3AuthSig if wallet is the only way of connecting
-        if (user && account && user.wallets.length > 0 && countConnectableIdentities(user) === 1) {
+        if (user && account && user.wallets.length > 0 && countConnectableIdentities(user) === user.wallets.length) {
           logoutUser();
         }
       }

--- a/hooks/useWeb3AuthSig.tsx
+++ b/hooks/useWeb3AuthSig.tsx
@@ -13,6 +13,7 @@ import useSWRMutation from 'swr/mutation';
 import charmClient from 'charmClient';
 import { useWeb3ConnectionManager } from 'components/_app/Web3ConnectionManager/Web3ConnectionManager';
 import type { AuthSig } from 'lib/blockchain/interfaces';
+import { countConnectableIdentities } from 'lib/users/countConnectableIdentities';
 import type { SystemError } from 'lib/utilities/errors';
 import { ExternalServiceError, MissingWeb3AccountError } from 'lib/utilities/errors';
 import { lowerCaseEqual } from 'lib/utilities/strings';
@@ -182,7 +183,8 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
         setSignature(null);
         setStoredAccount(null);
         // We should only logout if there is a user. The logout function triggers a wipe of the SWR cache, and this was having undesirable effects for people with a connected wallet but no user account
-        if (user) {
+        // Also only trigger logout from web3AuthSig if wallet is the only way of connecting
+        if (user && account && user.wallets.length > 0 && countConnectableIdentities(user) === 1) {
           logoutUser();
         }
       }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6448d7</samp>

The pull request enhances the web3 authentication feature by adding a function to `hooks/useWeb3AuthSig.tsx` that counts the user's connectable identities and by fixing the logout logic to prevent session loss.

### WHY
More conservative approach to auto-logout