### PR TITLE
Simplify rules to switch web3 accounts

### DIFF
--- a/components/_app/hooks/useSpaceGatesReevaluate.ts
+++ b/components/_app/hooks/useSpaceGatesReevaluate.ts
@@ -13,7 +13,7 @@ export function useSpaceGatesReevaluate() {
   useEffect(() => {
     const reevaluateRoles = async () => {
       if (user?.id && currentSpace?.id && account) {
-        const authSig = getStoredSignature();
+        const authSig = getStoredSignature(account);
         if (!authSig) return;
 
         const newRoles = await charmClient.tokenGates.reevaluateRoles({

--- a/components/common/SpaceAccessGate/SpaceAccessGate.tsx
+++ b/components/common/SpaceAccessGate/SpaceAccessGate.tsx
@@ -30,7 +30,7 @@ export function SpaceAccessGate({
   const router = useRouter();
   const { showMessage } = useSnackbar();
   const { user } = useUser();
-  const { loginFromWeb3Account } = useWeb3AuthSig();
+  const { account, loginFromWeb3Account } = useWeb3AuthSig();
 
   const discordGate = useDiscordGate({
     joinType,
@@ -45,6 +45,7 @@ export function SpaceAccessGate({
   });
 
   const tokenGate = useTokenGates({
+    account,
     autoVerify: true,
     joinType,
     space,

--- a/components/common/SpaceAccessGate/components/TokenGate/hooks/useTokenGates.ts
+++ b/components/common/SpaceAccessGate/components/TokenGate/hooks/useTokenGates.ts
@@ -11,7 +11,13 @@ import type { SpaceWithGates } from 'lib/spaces/interfaces';
 import type { TokenGateEvaluationResult, TokenGateJoinType, TokenGateWithRoles } from 'lib/token-gates/interfaces';
 import { lowerCaseEqual } from 'lib/utilities/strings';
 
-type Props = { autoVerify?: boolean; joinType?: TokenGateJoinType; space: SpaceWithGates; onSuccess?: () => void };
+type Props = {
+  account?: string | null;
+  autoVerify?: boolean;
+  joinType?: TokenGateJoinType;
+  space: SpaceWithGates;
+  onSuccess?: () => void;
+};
 
 export type TokenGateState = {
   isEnabled: boolean;
@@ -25,6 +31,7 @@ export type TokenGateState = {
 };
 
 export function useTokenGates({
+  account,
   autoVerify = false,
   space,
   joinType = 'token_gate',
@@ -42,14 +49,14 @@ export function useTokenGates({
   // Token gates with those that succeedeed first
 
   useEffect(() => {
-    if (autoVerify) {
-      const signature = getStoredSignature();
+    if (autoVerify && account) {
+      const signature = getStoredSignature(account);
 
       if (user && !!signature && user.wallets.some((wallet) => lowerCaseEqual(wallet.address, signature.address))) {
         evaluateEligibility(signature);
       }
     }
-  }, [user]);
+  }, [user, account]);
 
   async function evaluateEligibility(authSig: AuthSig) {
     // Reset the current state

--- a/hooks/useWeb3AuthSig.tsx
+++ b/hooks/useWeb3AuthSig.tsx
@@ -29,7 +29,7 @@ type IContext = {
   chainId: any;
   sign: () => Promise<AuthSig>;
   triedEager: boolean;
-  getStoredSignature: () => AuthSig | null;
+  getStoredSignature: (account: string) => AuthSig | null;
   logoutWallet: () => void;
   disconnectWallet: (address: UserWallet['address']) => Promise<void>;
   // Which tool is providing the web3 connection ie. Metamask∂, WalletConnect, etc.
@@ -88,17 +88,13 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
 
   const [, setLitAuthSignature] = useLocalStorage<AuthSig | null>('lit-auth-signature', null, true);
   const [, setLitProvider] = useLocalStorage<string | null>('lit-web3-provider', null, true);
-  const { user, setUser, logoutUser, isLoaded } = useUser();
+  const { user, setUser, logoutUser } = useUser();
 
   const [walletAuthSignature, setWalletAuthSignature] = useState<AuthSig | null>(null);
   const [accountUpdatePaused, setAccountUpdatePaused] = useState(false);
 
-  function getStoredSignature(): AuthSig | null {
-    if (!account) {
-      return null;
-    }
-
-    const stored = window.localStorage.getItem(`${PREFIX}.wallet-auth-sig-${account}`);
+  function getStoredSignature(_account: string): AuthSig | null {
+    const stored = window.localStorage.getItem(`${PREFIX}.wallet-auth-sig-${_account}`);
 
     if (stored) {
       try {
@@ -119,7 +115,7 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
       throw new MissingWeb3AccountError();
     }
 
-    let signature = authSig ?? (getStoredSignature() as AuthSig);
+    let signature = authSig ?? (account ? (getStoredSignature(account) as AuthSig) : null);
 
     if (!signature) {
       signature = await sign();
@@ -157,37 +153,46 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
 
   // Only expose account if current user and account match up
   useEffect(() => {
+    const userOwnsAddress = user?.wallets.some((w) => lowerCaseEqual(w.address, account));
+    // Case 1: user is connecting wallets
     if (isConnectingIdentity) {
       // Don't update new values
-    } else if (account && (user?.wallets.some((w) => lowerCaseEqual(w.address, account)) || accountUpdatePaused)) {
+    }
+    // Case 2: user is logged in and account is linked to user or user is adding a new wallet
+    else if (account && (userOwnsAddress || accountUpdatePaused)) {
       setStoredAccount(account.toLowerCase());
 
-      const storedWalletSignature = getStoredSignature();
+      const storedWalletSignature = getStoredSignature(account);
       setSignature(storedWalletSignature);
-    } else if (
-      isLoaded &&
+    }
+    // Case 3: user is switching wallets
+    else if (
       account &&
+      user &&
       // Only apply the following logic to users that have at least 1 wallet
-      (!user || (!!user?.wallets.length && !user?.wallets.some((w) => lowerCaseEqual(w.address, account))))
+      user?.wallets.length > 0 &&
+      !userOwnsAddress
     ) {
-      const storedSignature = getStoredSignature();
+      const storedSignature = getStoredSignature(account);
 
-      if (storedSignature && storedSignature.address === account) {
-        loginFromWeb3Account(storedSignature).catch((e) => {
+      if (storedSignature) {
+        if (storedSignature.address === account) {
+          log.debug('Logging user in with previous wallet signature');
+          loginFromWeb3Account(storedSignature).catch((e) => {
+            setSignature(null);
+            setStoredAccount(null);
+            logoutUser();
+          });
+          // user is currently signed in to a different wallet, log them out
+        } else if (walletAuthSignature) {
+          log.debug('Logging out user due to wallet switch');
           setSignature(null);
           setStoredAccount(null);
-          logoutUser();
-        });
-      } else {
-        setSignature(null);
-        setStoredAccount(null);
-        // We should only logout if there is a user. The logout function triggers a wipe of the SWR cache, and this was having undesirable effects for people with a connected wallet but no user account
-        if (user) {
           logoutUser();
         }
       }
     }
-  }, [account, user, isConnectingIdentity, isLoaded, accountUpdatePaused]);
+  }, [account, !!user, isConnectingIdentity, accountUpdatePaused]);
 
   async function sign(): Promise<AuthSig> {
     if (!account) {

--- a/hooks/useWeb3AuthSig.tsx
+++ b/hooks/useWeb3AuthSig.tsx
@@ -176,7 +176,7 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
       const storedSignature = getStoredSignature(account);
 
       if (storedSignature) {
-        if (storedSignature.address === account) {
+        if (lowerCaseEqual(storedSignature.address, account)) {
           log.debug('Logging user in with previous wallet signature');
           loginFromWeb3Account(storedSignature).catch((e) => {
             setSignature(null);

--- a/hooks/useWeb3AuthSig.tsx
+++ b/hooks/useWeb3AuthSig.tsx
@@ -168,6 +168,8 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
     // Case 3: user is switching wallets
     else if (
       account &&
+      // storedAccount means they logged in with a different wallet previously
+      storedAccount &&
       user &&
       // Only apply the following logic to users that have at least 1 wallet
       user?.wallets.length > 0 &&
@@ -176,20 +178,18 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
       const storedSignature = getStoredSignature(account);
 
       if (storedSignature) {
-        if (lowerCaseEqual(storedSignature.address, account)) {
-          log.debug('Logging user in with previous wallet signature');
-          loginFromWeb3Account(storedSignature).catch((e) => {
-            setSignature(null);
-            setStoredAccount(null);
-            logoutUser();
-          });
-          // user is currently signed in to a different wallet, log them out
-        } else if (walletAuthSignature) {
-          log.debug('Logging out user due to wallet switch');
+        log.debug('Logging user in with previous wallet signature');
+        loginFromWeb3Account(storedSignature).catch((e) => {
           setSignature(null);
           setStoredAccount(null);
           logoutUser();
-        }
+        });
+        // user is currently signed in to a different wallet, log them out
+      } else {
+        log.debug('Logging out user due to wallet switch');
+        setSignature(null);
+        setStoredAccount(null);
+        logoutUser();
       }
     }
   }, [account, !!user, isConnectingIdentity, accountUpdatePaused]);

--- a/scripts/getPageHistory.ts
+++ b/scripts/getPageHistory.ts
@@ -1,11 +1,10 @@
 import { prisma } from '@charmverse/core/prisma-client';
 import { fancyTrim } from 'lib/utilities/strings';
 
-const spaceDomain = 'superseed-test-5';
-const pagePath = 'page-8649583367437599';
+const spaceDomain = 'charmverse';
+const pagePath = 'page-24404801619516814';
 const maxContentSize = 150;
-const maxRows = 300;
-const minVersion = 1700;
+const maxRows = 200;
 
 // Restrict results to a specific date range, or leave empty to get the entire history
 const minimumDiffDate: Date | null = null;
@@ -47,7 +46,7 @@ async function exec() {
   });
 
   const sortedDiffs = page.diffs
-    .filter((diff) => diff.createdAt >= startDate && diff.createdAt <= endDate && diff.version >= minVersion)
+    .filter((diff) => diff.createdAt >= startDate && diff.createdAt <= endDate)
     .sort((a, b) => a.version - b.version)
     .slice(0, maxRows);
   const dateRange = `${page.diffs[0].createdAt.toLocaleString()} to ${page.diffs[
@@ -58,7 +57,6 @@ async function exec() {
   console.log('Page History');
   console.log('Page Title: ' + page.title);
   console.log('Page Id: ' + page.id);
-  console.log('Latest version: ' + page.version);
   console.log('Date Range: ' + dateRange);
   console.log('------------------------------------');
   const tableData = sortedDiffs

--- a/scripts/getPageHistory.ts
+++ b/scripts/getPageHistory.ts
@@ -1,10 +1,11 @@
 import { prisma } from '@charmverse/core/prisma-client';
 import { fancyTrim } from 'lib/utilities/strings';
 
-const spaceDomain = 'charmverse';
-const pagePath = 'page-24404801619516814';
+const spaceDomain = 'superseed-test-5';
+const pagePath = 'page-8649583367437599';
 const maxContentSize = 150;
-const maxRows = 200;
+const maxRows = 300;
+const minVersion = 1700;
 
 // Restrict results to a specific date range, or leave empty to get the entire history
 const minimumDiffDate: Date | null = null;
@@ -46,7 +47,7 @@ async function exec() {
   });
 
   const sortedDiffs = page.diffs
-    .filter((diff) => diff.createdAt >= startDate && diff.createdAt <= endDate)
+    .filter((diff) => diff.createdAt >= startDate && diff.createdAt <= endDate && diff.version >= minVersion)
     .sort((a, b) => a.version - b.version)
     .slice(0, maxRows);
   const dateRange = `${page.diffs[0].createdAt.toLocaleString()} to ${page.diffs[
@@ -57,6 +58,7 @@ async function exec() {
   console.log('Page History');
   console.log('Page Title: ' + page.title);
   console.log('Page Id: ' + page.id);
+  console.log('Latest version: ' + page.version);
   console.log('Date Range: ' + dateRange);
   console.log('------------------------------------');
   const tableData = sortedDiffs


### PR DESCRIPTION
### WHAT
The change is that we will only respond to changes in the connected address if you logged in thru Metamask.

### WHY

We've had a couple cases in the past including this one where we inadvertently log a user out at the wrong time. We can  simplify the logic by reducing the variables in play when we allow users to switch wallets.  

- assumes that the existence of wallet signature means a user logged in via wallet (we remove it when you log out). 

Flows that may no longer work:
- Log in thru Oauth, then connect thru Metamask expecting to be logged out and go to the login page