### PR TITLE
add more log data to web sockets and bump buffer size to 10MiB

### DIFF
--- a/background/websockets.ts
+++ b/background/websockets.ts
@@ -4,6 +4,7 @@ import { log } from '@charmverse/core/log';
 import { Server } from 'socket.io';
 
 import { appEnv, isDevEnv } from 'config/constants';
+import { config } from 'lib/websockets/config';
 import { relay } from 'lib/websockets/relay';
 
 import app from './server/app';
@@ -13,6 +14,7 @@ const port = process.env.PORT || 3001;
 const server = createServer(app.callback());
 
 const io = new Server(server, {
+  ...config,
   cors: {
     allowedHeaders: ['authorization'],
     credentials: true,

--- a/lib/pages/restoreDocument.ts
+++ b/lib/pages/restoreDocument.ts
@@ -92,7 +92,7 @@ export async function restoreDocument({ pageId, version }: RestoreInput): Promis
     return updated;
   });
 
-  log.debug(`Rebuilt document with ${pageWithDiffs.diffs} steps`);
+  log.debug(`Rebuilt document with ${pageWithDiffs.diffs.length} steps`);
 
   return pageAfterUpdate;
 }

--- a/lib/websockets/broadcaster.ts
+++ b/lib/websockets/broadcaster.ts
@@ -6,17 +6,18 @@ import { Server } from 'socket.io';
 
 import { redisClient } from 'adapters/redis/redisClient';
 import { SpaceMembershipRequiredError } from 'lib/permissions/errors';
-import { authOnConnect } from 'lib/websockets/authentication';
-import { DocumentEventHandler } from 'lib/websockets/documentEvents';
-import { SpaceEventHandler } from 'lib/websockets/spaceEvents';
 
+import { authOnConnect } from './authentication';
+import { config } from './config';
+import { DocumentEventHandler } from './documentEvents';
 import type { ServerMessage } from './interfaces';
+import { SpaceEventHandler } from './spaceEvents';
 
 export class WebsocketBroadcaster {
   sockets: Record<string, Socket> = {};
 
   // Server will be set after the first request
-  private io: Server = new Server();
+  private io: Server = new Server(config);
 
   // Only called once in the app lifecycle once the server is initialised
   async bindServer(io: Server): Promise<void> {
@@ -63,7 +64,7 @@ export class WebsocketBroadcaster {
     io.of('/ceditor')
       .use(authOnConnect)
       .on('connect', (socket) => {
-        log.debug('[ws] Web socket namepsace /editor connected');
+        log.debug('[ws] Web socket namepsace /editor connected', { userId: socket.data.user.id });
         new DocumentEventHandler(socket).init();
       });
   }

--- a/lib/websockets/config.ts
+++ b/lib/websockets/config.ts
@@ -1,0 +1,4 @@
+export const config = {
+  // increase the amount of data that can be sent to the server
+  maxHttpBufferSize: 1e7 // set from 1e6 (1MB) to 1e7 (10Mb)
+};

--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -75,10 +75,14 @@ export class DocumentEventHandler {
   }
 
   getSessionMeta() {
-    const session = this.socket.data as SocketSessionData;
+    const session = this.getSession();
+    const docRoom = docRooms.get(session.documentId);
     return {
       userId: session.user?.id,
-      pageId: session.documentId
+      pageId: session.documentId,
+      pageVersion: docRoom?.doc.version,
+      serverMessages: this.messages.server,
+      clientMessages: this.messages.client
     };
   }
 
@@ -136,26 +140,35 @@ export class DocumentEventHandler {
     // log.debug('Received message:', { message, messages: this.messages });
 
     if (message.type === 'request_resend') {
+      log.debug('Client requested to resend messages', logData);
       await this.resendMessages(message.from);
       return;
     }
 
+    // Verify the order of the message
     if (!('c' in message) || !('s' in message)) {
+      log.warn(`Received invalid message`, { message, ...this.getSessionMeta() });
       this.sendError('Received invalid message');
       return;
     } else if (message.c < this.messages.client + 1) {
       // Receive a message already received at least once. Ignore.
-      log.debug(`Ignore duplicate ${message.type} message from client`, logData);
+      log.debug(`Ignore duplicate ${message.type} message from client`, {
+        ...logData,
+        message
+      });
       return;
     } else if (message.c > this.messages.client + 1) {
-      log.debug('Request resent of lost messages from client', logData);
+      log.warn('Request resent of lost messages from client', {
+        ...logData,
+        message
+      });
       this.sendMessage({ type: 'request_resend', from: this.messages.client });
       return;
     } else if (message.s < this.messages.server) {
       /* Message was sent either simultaneously with message from server
          or a message from the server previously sent never arrived.
          Resend the messages the client missed. */
-      log.debug('Resend messages to client', logData);
+      log.warn('Resend messages to client', { message, ...logData });
       this.messages.client += 1;
       await this.resendMessages(message.s);
       await this.rejectMessage(message);
@@ -168,7 +181,7 @@ export class DocumentEventHandler {
       await this.handleMessage(message);
     } catch (error) {
       log.error('Error handling socket message', {
-        error: (error as any).stack || error,
+        error,
         message,
         ...logData
       });
@@ -180,6 +193,7 @@ export class DocumentEventHandler {
 
     // handle subscription to document
     if (message.type === 'subscribe') {
+      log.debug('Received subscribe event', { pageId: message.roomId, userId: session.user.id });
       await this.subscribeToDoc({ pageId: message.roomId, connectionCount: message.connection });
       return;
     }
@@ -190,7 +204,7 @@ export class DocumentEventHandler {
     }
 
     if (!docRooms.has(session.documentId)) {
-      log.debug('Ignore message from closed document', { pageId: session.documentId, userId: session.user.id });
+      log.warn('Ignore message from closed document', { pageId: session.documentId, userId: session.user.id });
       return;
     }
 
@@ -214,14 +228,17 @@ export class DocumentEventHandler {
         break;
 
       default:
-        log.debug(`Unhandled socket message type: "${message.type}"`, message);
+        log.warn(`Unhandled socket message type: "${message.type}"`, {
+          message,
+          pageId: session.documentId,
+          userId: session.user.id
+        });
     }
   }
 
   async subscribeToDoc({ pageId, connectionCount = 0 }: { pageId: string; connectionCount?: number }) {
     try {
       const userId = this.getSession().user.id;
-      log.debug('subscribe event', { pageId, userId });
 
       const isValidPageId = validate(pageId);
       if (!isValidPageId) {
@@ -233,6 +250,7 @@ export class DocumentEventHandler {
       });
 
       if (permissions.edit_content !== true && permissions.comment !== true) {
+        log.warn('Denied permission to user', { permissions, pageId, userId });
         this.sendError('You do not have permission to edit this page');
         return;
       }
@@ -272,11 +290,15 @@ export class DocumentEventHandler {
       // console.log('connection count on subscription', connectionCount);
       if (connectionCount < 1) {
         await this.sendDocument();
-        log.debug('Sent document to new subscriber', { pageId, userId });
+        log.debug('Sent document to new subscriber', {
+          pageId,
+          userId,
+          pageVersion: docRooms.get(pageId)?.doc.version
+        });
       }
       this.handleParticipantUpdate();
     } catch (error) {
-      log.error('Error subscribing user to page', { error });
+      log.error('Error subscribing user to page', { error, pageId, userId: this.getSession().user.id });
       this.sendError('There was an error loading the page! Please try again later.');
     }
   }
@@ -325,7 +347,17 @@ export class DocumentEventHandler {
     const room = this.getDocumentRoomOrThrow();
     const clientV = message.v;
     const serverV = room.doc.version;
-    log.debug('Handling change event', { userId: this.getSession().user.id, pageId: room.doc.id, clientV, serverV });
+    const logMeta = {
+      userId: this.getSession().user.id,
+      pageId: room.doc.id,
+      v: clientV,
+      c: message.c,
+      s: message.s,
+      serverV,
+      serverC: this.messages.client,
+      serverS: this.messages.server
+    };
+    log.debug('Handling change event', logMeta);
     if (clientV === serverV) {
       if (message.ds) {
         // do some pre-processing on the diffs
@@ -336,6 +368,7 @@ export class DocumentEventHandler {
           room.node = updatedNode;
           room.doc.content = updatedNode.toJSON();
         } catch (error) {
+          log.error('Error applying steps to node', { error, ds: message.ds, ...logMeta });
           this.unfixable();
           const patchError = { type: 'patch_error' } as const;
           this.sendMessage(patchError);
@@ -355,19 +388,23 @@ export class DocumentEventHandler {
       this.sendUpdatesToOthers(message);
     } else if (clientV < serverV) {
       if (clientV + room.doc.diffs.length >= serverV) {
-        const numberDiffs = clientV - serverV;
-        log.debug('Client is behind. Resend document diffs', { numberDiffs });
-        const messages = room.doc.diffs.slice(numberDiffs);
+        const diffsToSend = clientV - serverV;
+        log.debug('Client is behind. Resend document diffs', {
+          ...logMeta,
+          roomDiffs: room.doc.diffs.length,
+          diffsToSend
+        });
+        const messages = room.doc.diffs.slice(diffsToSend);
         for (const m of messages) {
           const newMessage = { ...m, server_fix: true };
           await this.sendMessage(newMessage);
         }
       } else {
-        log.debug('Client is too far behind. Resend document');
+        log.debug('Client is too far behind. Resend document', logMeta);
         await this.unfixable();
       }
     } else {
-      log.debug('Ignore message from user with higher document version than server');
+      log.debug('Ignore message from user with higher document version than server', logMeta);
     }
   }
 
@@ -376,16 +413,17 @@ export class DocumentEventHandler {
     const room = this.getDocumentRoomOrThrow();
     const clientV = message.v;
     const serverV = room?.doc.version;
-    log.debug('Check version of document', { clientV, serverV, userId: session.user.id });
+    const logData = { clientV, serverV, pageId: room?.doc.id, userId: session.user.id };
+    log.debug('Check version of document', logData);
     if (clientV === serverV) {
       this.sendMessage({ type: 'confirm_version', v: clientV });
     } else if (clientV + room.doc.diffs.length >= serverV) {
       const numberDiffs = clientV - serverV;
-      log.debug('Resending document diffs', { numberDiffs, userId: session.user.id });
+      log.debug('Resending document diffs', { numberDiffs, ...logData });
       const messages = room?.doc.diffs.slice(numberDiffs);
       this.sendDocument(messages);
     } else {
-      log.debug('User is on a very old version of the document');
+      log.warn('User is on a very old version of the document', logData);
       this.unfixable();
     }
   }
@@ -396,10 +434,9 @@ export class DocumentEventHandler {
 
   resendMessages(from: number) {
     const toSend = this.messages.server - from;
-    log.debug('Resending messages to user');
     this.messages.server -= toSend;
     if (toSend > this.messages.lastTen.length) {
-      log.debug('Too many messages to resend. Send full document');
+      log.warn('Too many messages to resend. Send full document', this.getSessionMeta());
       this.unfixable();
     } else {
       for (const message of this.messages.lastTen.slice(-toSend)) {
@@ -412,7 +449,7 @@ export class DocumentEventHandler {
     const session = this.getSession();
 
     if (!session.documentId) {
-      log.error('Cannot send document - session is missing documentId', { session });
+      log.error('Cannot send document - session is missing documentId', { session, userId: session.user.id });
       return;
     }
 
@@ -468,10 +505,13 @@ export class DocumentEventHandler {
   }
 
   async resetCollaboration(message: ServerMessage) {
-    log.debug('Resetting collaboration');
     const room = this.getDocumentRoomOrThrow();
+
+    log.debug('Resetting collaboration', this.getSessionMeta());
+
     for (const participant of Object.values(room.participants)) {
       if (participant.id !== this.id) {
+        log.warn('Resetting document for client', participant.getSessionMeta());
         await participant.unfixable();
         participant.sendMessage(message);
       }
@@ -494,7 +534,7 @@ export class DocumentEventHandler {
   }
 
   onClose() {
-    log.debug('Closing collaboration session');
+    log.debug('Closing collaboration session', this.getSessionMeta());
     const room = this.getDocumentRoom();
     if (room) {
       delete room.participants[this.id];

--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -78,6 +78,7 @@ export class DocumentEventHandler {
     const session = this.getSession();
     const docRoom = docRooms.get(session.documentId);
     return {
+      socketId: this.id,
       userId: session.user?.id,
       pageId: session.documentId,
       pageVersion: docRoom?.doc.version,

--- a/pages/api/socket/index.ts
+++ b/pages/api/socket/index.ts
@@ -8,6 +8,7 @@ import { Server } from 'socket.io';
 import { onError, onNoMatch, requireUser } from 'lib/middleware';
 import { authSecret } from 'lib/session/config';
 import { withSessionRoute } from 'lib/session/withSession';
+import { config } from 'lib/websockets/config';
 import type { SealedUserId, SocketAuthReponse } from 'lib/websockets/interfaces';
 import { relay } from 'lib/websockets/relay';
 
@@ -48,7 +49,7 @@ async function socketHandler(req: NextApiRequest, res: NextApiReponseWithSocketS
     res.send({ authToken: sealedUserId });
     return;
   }
-  const io = new Server(res.socket.server);
+  const io = new Server(res.socket.server, config);
   res.socket.server.io = io;
   relay.bindServer(io);
   log.info('Web socket server instantiated');


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f483c3</samp>

This pull request improves the websocket server functionality and performance for the app.charmverse.io application. It adds a custom config file for the server, refactors some server modules, enhances the logging and debugging features, fixes a bug in the restoreDocument function, and increases the maxHttpBufferSize option. These changes aim to enable more flexible and reliable document collaboration and communication over the websocket.

### WHY
This should make it even easier to correlate logs by userId or pageId. I also increased the max payload size the server will accept just so it's less likely to be a single point of failure, but I'll admit this won't solve teh issue and might hide what happened for a longer period...