### PR TITLE
add script to import a single page and its history to local dev

### DIFF
--- a/scripts/exportData/importPageToDev.ts
+++ b/scripts/exportData/importPageToDev.ts
@@ -1,0 +1,104 @@
+import { prisma } from '@charmverse/core/prisma-client';
+import { Prisma } from '@charmverse/core/prisma';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { v4 as uuid } from 'uuid';
+
+/**
+ * Download page from production and load it into a space inside your local database
+ *
+ */
+
+const originalPageId = '0c3fb05f-c701-4daa-a0d5-649915f88c2f';
+const destinationSpaceDomain = 'tame-fomo-duck';
+const destinationUserName = '0x1bd0…07f4';
+
+const fileName = `./page-backup-05-22.json`;
+const pathName = path.join(process.cwd(), fileName);
+
+type RestoreData = Awaited<ReturnType<typeof queryData>>;
+
+async function queryData() {
+  const page = await prisma.page.findFirstOrThrow({
+    where: {
+      id: originalPageId
+    },
+    include: { diffs: true }
+  });
+  return { page };
+}
+
+async function importData(data: RestoreData) {
+  const newPageId = uuid();
+
+  const space = await prisma.space.findUniqueOrThrow({
+    where: {
+      domain: destinationSpaceDomain
+    }
+  });
+  const user = await prisma.user.findFirstOrThrow({
+    where: {
+      username: destinationUserName
+    }
+  });
+
+  const pageDiffs: Prisma.PageDiffCreateManyInput[] = data.page.diffs.map((diff) => {
+    return {
+      ...diff,
+      pageId: newPageId,
+      createdBy: user.id
+    } as Prisma.PageDiffCreateManyInput;
+  });
+
+  const pageToRestore = {
+    ...data.page,
+    diffs: undefined,
+    id: newPageId,
+    path: data.page.path + '-restored-' + Date.now(),
+    spaceId: space.id,
+    createdBy: user.id,
+    updatedBy: user.id
+  };
+
+  await prisma.$transaction([
+    prisma.page.createMany({
+      // @ts-ignore
+      data: pageToRestore
+    }),
+    prisma.pagePermission.create({
+      data: {
+        pageId: newPageId,
+        permissionLevel: 'full_access'
+      }
+    }),
+    prisma.pageDiff.createMany({
+      data: pageDiffs
+    })
+  ]);
+}
+
+function readJson(): Promise<RestoreData> {
+  return fs.readFile(pathName).then((file) => JSON.parse(file.toString()));
+}
+
+function writeJson(data: RestoreData) {
+  return fs.writeFile(pathName, JSON.stringify(data, null, 2)).then(() => data);
+}
+
+// run this while pointed at a backup database
+function download() {
+  return queryData()
+    .then(writeJson)
+    .then((r) => {
+      console.log('Saved data to: ', pathName);
+    });
+}
+
+// run this while pointed at target database
+function upload() {
+  return readJson()
+    .then(importData)
+    .then((r) => console.log('Uploaded records'));
+}
+
+upload();

--- a/scripts/getPageHistory.ts
+++ b/scripts/getPageHistory.ts
@@ -1,10 +1,11 @@
 import { prisma } from '@charmverse/core/prisma-client';
 import { fancyTrim } from 'lib/utilities/strings';
 
-const spaceDomain = 'charmverse';
-const pagePath = 'page-24404801619516814';
+const spaceDomain = 'tame-fomo-duck';
+const pagePath = 'page-8649583367437599-restored-1684821513609';
 const maxContentSize = 150;
-const maxRows = 200;
+const maxRows = 300;
+const minVersion = 0;
 
 // Restrict results to a specific date range, or leave empty to get the entire history
 const minimumDiffDate: Date | null = null;
@@ -46,7 +47,7 @@ async function exec() {
   });
 
   const sortedDiffs = page.diffs
-    .filter((diff) => diff.createdAt >= startDate && diff.createdAt <= endDate)
+    .filter((diff) => diff.createdAt >= startDate && diff.createdAt <= endDate && diff.version >= minVersion)
     .sort((a, b) => a.version - b.version)
     .slice(0, maxRows);
   const dateRange = `${page.diffs[0].createdAt.toLocaleString()} to ${page.diffs[


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb45f32</samp>

The pull request adds a new script `scripts/exportData/importPageToDev.ts` that can import specific versions of page history from a space domain to a local development environment. It also renames and modifies the previous script `scripts/getPageHistory.ts` to use the new script as a helper function. The purpose of these changes is to facilitate data transfer and testing for development.

### WHY
This allows dev to pull in a document to an existing local space and user
