### PR TITLE
fixes premature quitting of pull secrets script

### DIFF
--- a/.platform/hooks/predeploy/01_pull_secrets.sh
+++ b/.platform/hooks/predeploy/01_pull_secrets.sh
@@ -24,7 +24,8 @@ if [[ $env_file_grep =~ ^EBSTALK_ENV_FILE=(.+)$ ]]; then
 
     # before we process the secrets, 
     # lets get any non-secret env variables from ebstalk_env_file and append it to the $APP_STAGING_DIR/.env file
-    grep -v -e "^\s*$" -e "^#" -e "pull:secretsmanager" $ebstalk_env_file >> $APP_STAGING_DIR/.env
+    #   returns true when there are no non-mustached lines so the script doesn't quit with -e option set
+    grep -v -e "^\s*$" -e "^#" -e "pull:secretsmanager" $ebstalk_env_file >> $APP_STAGING_DIR/.env || true
 
     # Now start processing secrets
     secrets_pattern='^(.+)=.*pull:secretsmanager:(.*):SecretString:([^:]+):?(.*)}}'


### PR DESCRIPTION
with -e set on pull secret script, when there are no bare stringed lines in the app.env file, grep fails and it'll quit out of the script prematurely. setting that line to return true when failed to grep resolves the situation

### WHAT
copilot:summary

### WHY
pull secrets script quits too prematurely with an empty grep.
