### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/__e2e__/po/signup.po.ts
+++ b/__e2e__/po/signup.po.ts
@@ -25,9 +25,7 @@ export class SignUpPage {
 
   async waitForWorkspaceLoaded({ domain }: { domain: string }) {
     await this.page.waitForURL(`**/${domain}`);
-    await this.page.locator('text=[Your DAO] Home').first().waitFor({
-      timeout: 60000
-    });
+    await this.page.locator('text=[Your DAO] Home').first().waitFor();
   }
 
   async submitWorkspaceForm(): Promise<Space> {

--- a/__e2e__/sessions/signup.spec.ts
+++ b/__e2e__/sessions/signup.spec.ts
@@ -1,13 +1,11 @@
 import type { Page } from '@playwright/test';
 import { test as base } from '@playwright/test';
 import { TokenGatePage } from '__e2e__/po/tokenGate.po';
-
-import { baseUrl } from 'config/constants';
+import { Wallet } from 'ethers';
 
 import { LoginPage } from '../po/login.po';
 import { SignUpPage } from '../po/signup.po';
-import { createUser, generateUser, generateUserAndSpace } from '../utils/mocks';
-import { login } from '../utils/session';
+import { createUser } from '../utils/mocks';
 import { mockWeb3 } from '../utils/web3';
 
 type Fixtures = {
@@ -33,12 +31,12 @@ test('signup - allows user to sign up and create a workspace using Metamask wall
   loginPage,
   signupPage
 }) => {
-  let address: string = '';
+  const wallet = Wallet.createRandom();
+  const address = wallet.address;
 
   await mockWeb3({
     page: sandboxPage,
     init: ({ Web3Mock, context }) => {
-      address = context.address;
       Web3Mock.mock({
         blockchain: 'ethereum',
         accounts: {

--- a/__e2e__/utils/mocks.ts
+++ b/__e2e__/utils/mocks.ts
@@ -35,6 +35,7 @@ export async function logoutBrowserUser({ browserPage }: { browserPage: BrowserP
   await browserPage.request.post(`${baseUrl}/api/session/logout`);
 }
 
+// Note: the endpoint creates a user when wallet address is provided
 export async function createUser({
   browserPage,
   address

--- a/__e2e__/utils/web3.ts
+++ b/__e2e__/utils/web3.ts
@@ -56,6 +56,7 @@ type InitParams<T> = {
 
 type MockWeb3Options<T> = {
   page: BrowserPage;
+  wallet?: Wallet;
   context?: Partial<T>;
   init(params: InitParams<T>): void;
 };
@@ -63,8 +64,12 @@ type MockWeb3Options<T> = {
 type MockContext = { address: string; chainId?: number; privateKey: string | false };
 
 // load web3 mock library https:// massimilianomirra.com/notes/mocking-window-ethereum-in-playwright-for-end-to-end-dapp-testing
-export async function mockWeb3<T extends MockContext>({ page, context, init }: MockWeb3Options<T>) {
-  const wallet = Wallet.createRandom();
+export async function mockWeb3<T extends MockContext>({
+  page,
+  wallet = Wallet.createRandom(),
+  context,
+  init
+}: MockWeb3Options<T>) {
   context ||= {} as T;
   context.address ||= wallet.address;
   context.privateKey ??= wallet.privateKey; // allow setting to false to skip signing

--- a/components/common/UserProfile/components/MemberPropertiesForm.tsx
+++ b/components/common/UserProfile/components/MemberPropertiesForm.tsx
@@ -28,22 +28,12 @@ export function MemberPropertiesForm({
   showBlockchainData = false,
   userId
 }: Props) {
-  const { data: properties = [], mutate } = useSWR(
+  const { data: properties, mutate } = useSWR(
     spaceId ? `members/${userId}/values/${spaceId}` : null,
     () => charmClient.members.getSpacePropertyValues(userId, spaceId || ''),
     { revalidateOnMount: true }
   );
   const { createOption, deleteOption, updateOption } = useMutateMemberPropertyValues(mutate);
-
-  const defaultValues = useMemo(
-    () =>
-      properties?.reduce<Record<string, MemberPropertyValueType>>((acc, prop) => {
-        acc[prop.memberPropertyId] = prop.value;
-        return acc;
-      }, {}),
-    [properties]
-  );
-
   const {
     control,
     formState: { errors, isDirty },
@@ -75,17 +65,21 @@ export function MemberPropertiesForm({
   );
 
   useEffect(() => {
-    if (defaultValues && isDirty) {
+    if (!properties || isDirty) {
       return;
     }
+    const defaultValues = properties.reduce<Record<string, MemberPropertyValueType>>((acc, prop) => {
+      acc[prop.memberPropertyId] = prop.value;
+      return acc;
+    }, {});
 
     reset(defaultValues);
-  }, [defaultValues, isDirty]);
+  }, [properties, isDirty]);
 
   return (
     <Box>
       <Box display='flex' flexDirection='column'>
-        {properties.map((property) => (
+        {properties?.map((property) => (
           <Controller
             key={property.memberPropertyId}
             name={property.memberPropertyId}

--- a/hooks/useWeb3AuthSig.tsx
+++ b/hooks/useWeb3AuthSig.tsx
@@ -94,7 +94,7 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
   const [accountUpdatePaused, setAccountUpdatePaused] = useState(false);
 
   function getStoredSignature(_account: string): AuthSig | null {
-    const stored = window.localStorage.getItem(`${PREFIX}.wallet-auth-sig-${_account}`);
+    const stored = window.localStorage.getItem(`${PREFIX}.wallet-auth-sig-${getAddress(_account)}`);
 
     if (stored) {
       try {
@@ -115,7 +115,7 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
       throw new MissingWeb3AccountError();
     }
 
-    let signature = authSig ?? (account ? (getStoredSignature(account) as AuthSig) : null);
+    let signature = authSig ?? (account ? getStoredSignature(account) : null);
 
     if (!signature) {
       signature = await sign();
@@ -176,7 +176,6 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
       !userOwnsAddress
     ) {
       const storedSignature = getStoredSignature(account);
-
       if (storedSignature) {
         log.debug('Logging user in with previous wallet signature');
         loginFromWeb3Account(storedSignature).catch((e) => {

--- a/pages/join.tsx
+++ b/pages/join.tsx
@@ -2,7 +2,7 @@ import NavigateNextIcon from '@mui/icons-material/ArrowRightAlt';
 import { Alert, Box, Card, Divider } from '@mui/material';
 import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import useSWR from 'swr';
 
 import charmClient from 'charmClient';
@@ -35,6 +35,7 @@ export default function JoinWorkspace() {
   const router = useRouter();
   const domain = router.query.domain as string;
   const { spaces } = useSpaces();
+  const [isRouterReady, setRouterReady] = useState(false);
   const {
     data: spaceFromPath,
     isLoading: isSpaceLoading,
@@ -48,6 +49,13 @@ export default function JoinWorkspace() {
     }
   }, [spaces]);
 
+  useEffect(() => {
+    // isReady should only be used conditionally inside a useEffect()
+    if (router.isReady) {
+      setRouterReady(true);
+    }
+  }, [router.isReady]);
+
   const spaceFromPathNotFound = domain && !isSpaceLoading && !spaceFromPath;
 
   return (
@@ -58,7 +66,7 @@ export default function JoinWorkspace() {
         {domain && isSpaceLoading && <LoadingComponent height='80px' isLoading={true} />}
         {domain && !isSpaceLoading && spaceError && <Alert severity='error'>No space found</Alert>}
         {domain && spaceFromPath && <SpaceAccessGate space={spaceFromPath} />}
-        {router.isReady && (spaceFromPathNotFound || !domain) && <SpaceAccessGateWithSearch defaultValue={domain} />}
+        {isRouterReady && (spaceFromPathNotFound || !domain) && <SpaceAccessGateWithSearch defaultValue={domain} />}
       </Card>
       <AlternateRouteButton href='/createSpace'>Create a space</AlternateRouteButton>
     </Box>


### PR DESCRIPTION
## signup test
I noticed that sometimes, when opening the member profile form or running the test locally, my console would show a  "maximum depth exceeded" error inside this component. With logging, I Could see that the useEffect() that watches `defaultValues` was being called over and over. My hypothesis is that the default array `[]` supplied for `properties` was causing the issue.

## token gates test
This must have broken in my update to simplify token gates, we were not picking up the signature from local storage because I was mixing up the casing of wallet address :/