### PR TITLE
Use page id instead of bounty id when relevant

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
@@ -457,7 +457,7 @@ export default function BountyProperties(props: {
                   await refreshBountyPermissions(currentBounty.id);
                 }
               }}
-              filter={{ mode: 'exclude', userIds: assignedRoleSubmitters }}
+              filterSelectedOptions={true}
               showWarningOnNoRoles={true}
               disabled={readOnly}
               readOnly={readOnly}

--- a/components/bounties/components/BountiesKanbanView.tsx
+++ b/components/bounties/components/BountiesKanbanView.tsx
@@ -91,7 +91,7 @@ export function BountiesKanbanView({ bounties, publicMode }: Props) {
                   bounty={bounty}
                   page={pages[bounty.page.id] as PageMeta}
                   onClick={() => {
-                    openPage(bounty.id);
+                    openPage(bounty.page.id);
                   }}
                 />
               ))}

--- a/components/bounties/components/BountiesKanbanView.tsx
+++ b/components/bounties/components/BountiesKanbanView.tsx
@@ -22,12 +22,12 @@ interface Props {
 export function BountiesKanbanView({ bounties, publicMode }: Props) {
   const { deletePage, pages } = usePages();
   const { showPage } = usePageDialog();
-  const { setBounties, refreshBounty } = useBounties();
+  const { setBounties } = useBounties();
   const router = useRouter();
 
-  function onClickDelete(bountyId: string) {
-    setBounties((_bounties) => _bounties.filter((_bounty) => _bounty.id !== bountyId));
-    deletePage({ pageId: bountyId });
+  function onClickDelete(pageId: string) {
+    setBounties((_bounties) => _bounties.filter((_bounty) => _bounty.page.id !== pageId));
+    deletePage({ pageId });
   }
 
   const bountiesGroupedByStatus = bounties.reduce<Record<BountyStatus, BountyWithDetails[]>>(
@@ -82,7 +82,7 @@ export function BountiesKanbanView({ bounties, publicMode }: Props) {
         {bountyStatuses.map((bountyStatus) => (
           <div className='octo-board-column' key={bountyStatus}>
             {bountiesGroupedByStatus[bountyStatus]
-              .filter((bounty) => Boolean(pages[bounty.page?.id]) && !pages[bounty.page.id]?.deletedAt)
+              .filter((bounty) => Boolean(pages[bounty.page.id]) && !pages[bounty.page.id]?.deletedAt)
               .map((bounty) => (
                 <BountyKanbanCard
                   onDelete={onClickDelete}

--- a/components/bounties/components/BountyGalleryCard.tsx
+++ b/components/bounties/components/BountyGalleryCard.tsx
@@ -45,7 +45,7 @@ export function BountyGalleryCard({ page: bountyPage, bounty, readOnly, onClick,
 
   return bountyPage ? (
     <StyledBox onClick={onClick} className='GalleryCard' data-test={`bounty-card-${bounty.id}`}>
-      {!readOnly && <KanbanPageActionsMenuButton page={bountyPage} onClickDelete={() => onDelete(bounty.id)} />}
+      {!readOnly && <KanbanPageActionsMenuButton page={bountyPage} onClickDelete={() => onDelete(bountyPage.id)} />}
       <div className='gallery-title'>
         {bountyPage?.icon ? (
           <PageIcon isEditorEmpty={!bountyPage?.hasContent} pageType='card' icon={bountyPage.icon} />

--- a/components/bounties/components/BountyGalleryView.tsx
+++ b/components/bounties/components/BountyGalleryView.tsx
@@ -23,9 +23,9 @@ export function BountiesGalleryView({ bounties, publicMode }: Props) {
   const filteredBounties = bounties
     .filter((bounty) => bounty.status === 'open')
     .sort((b1, b2) => (b1.updatedAt > b2.updatedAt ? -1 : 1));
-  function onClickDelete(bountyId: string) {
-    setBounties((_bounties) => _bounties.filter((_bounty) => _bounty.id !== bountyId));
-    deletePage({ pageId: bountyId });
+  function onClickDelete(pageId: string) {
+    setBounties((_bounties) => _bounties.filter((_bounty) => _bounty.page.id !== pageId));
+    deletePage({ pageId });
   }
 
   function onClose() {
@@ -57,7 +57,7 @@ export function BountiesGalleryView({ bounties, publicMode }: Props) {
             key={bounty.id}
             bounty={bounty}
             onClick={() => {
-              openPage(bounty.id);
+              openPage(bounty.page.id);
             }}
             readOnly={!!publicMode}
             page={pages[bounty.page.id] as PageMeta}

--- a/components/bounties/components/BountyKanbanCard.tsx
+++ b/components/bounties/components/BountyKanbanCard.tsx
@@ -55,7 +55,11 @@ function BountyKanbanCard({ onDelete, bounty, page: bountyPage, onClick, readOnl
         </Box>
       </Box>
       {onDelete && (
-        <KanbanPageActionsMenuButton page={bountyPage} readOnly={readOnly} onClickDelete={() => onDelete(bounty.id)} />
+        <KanbanPageActionsMenuButton
+          page={bountyPage}
+          readOnly={readOnly}
+          onClickDelete={() => onDelete(bounty.page.id)}
+        />
       )}
     </StyledBox>
   );

--- a/components/common/PageActions/components/DocumentPageActionList.tsx
+++ b/components/common/PageActions/components/DocumentPageActionList.tsx
@@ -125,7 +125,7 @@ export function DocumentPageActionList({
   const { getCategoriesWithCreatePermission, getDefaultCreateCategory } = useProposalCategories();
   const proposalCategoriesWithCreateAllowed = getCategoriesWithCreatePermission();
   const canCreateProposal = proposalCategoriesWithCreateAllowed.length > 0;
-  const basePageBounty = bounties.find((bounty) => bounty.id === pageId);
+  const basePageBounty = bounties.find((bounty) => bounty.page.id === pageId);
   function setPageProperty(prop: Partial<PageUpdates>) {
     updatePage({
       id: pageId,
@@ -150,7 +150,7 @@ export function DocumentPageActionList({
       pageId
     });
     if (page?.type === 'bounty') {
-      setBounties((_bounties) => _bounties.filter((_bounty) => _bounty.id !== page.id));
+      setBounties((_bounties) => _bounties.filter((_bounty) => _bounty.page.id !== page.id));
     }
     onComplete();
     onDelete?.();

--- a/components/common/form/InputSearchRole.tsx
+++ b/components/common/form/InputSearchRole.tsx
@@ -3,7 +3,6 @@ import { Alert, Autocomplete, TextField } from '@mui/material';
 import type { ComponentProps } from 'react';
 
 import Link from 'components/common/Link';
-import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useRoles } from 'hooks/useRoles';
 import { useSettingsDialog } from 'hooks/useSettingsDialog';
 import type { ListSpaceRolesResponse } from 'pages/api/roles';
@@ -39,9 +38,7 @@ function InputSearchRoleBase({
   ...props
 }: Partial<ComponentProps<typeof Autocomplete>> & { filter?: IRolesFilter } & { showWarningOnNoRoles?: boolean }) {
   const { roles } = useRoles();
-  const space = useCurrentSpace();
   const { onClick } = useSettingsDialog();
-
   const defaultRole =
     typeof defaultValue === 'string'
       ? roles?.find((role) => {
@@ -67,7 +64,7 @@ function InputSearchRoleBase({
 
   return (
     <Autocomplete<ReducedRole>
-      defaultValue={defaultRole as any}
+      value={defaultRole as any}
       loading={!roles}
       sx={{ minWidth: 150 }}
       disableCloseOnSelect={disableCloseOnSelect}

--- a/components/common/form/InputSearchRole.tsx
+++ b/components/common/form/InputSearchRole.tsx
@@ -76,7 +76,7 @@ function InputSearchRoleBase({
       // @ts-ignore - not sure why this fails
       options={filteredRoles}
       autoHighlight
-      getOptionLabel={(role) => role.name}
+      getOptionLabel={(role) => role?.name}
       renderOption={(_props, role) => <li {..._props}>{role.name}</li>}
       renderInput={(params) => (
         <TextField


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1211b4e</samp>

Refactored the `Bounty` type to include a `page` property that references the `PageMeta` type. Updated the components that use the `Bounty` type to use the `page.id` instead of the `bounty.id` for deleting, filtering, and opening bounties. This improves the data consistency and clarity across the app.

### WHY
Most of the bounties in our demo space have different id's than the page id's. When possible, we should never just assume they are the same
