### PR TITLE
removing mounting .env as an app volume in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,10 @@ services:
     labels:
       com.datadoghq.ad.logs: '[{"source": "nodejs", "service": "${SERVICE_NAME}"}]'
       com.datadoghq.tags.service: '${SERVICE_NAME}'
-    volumes:
-      - $PWD/.env:/app/.env
     ports:
       - '80:3000'
     env_file:
       - '.env'
-
     environment:
       - NODE_ENV=production
     profiles:
@@ -99,8 +96,6 @@ services:
         '-c',
         'node --experimental-specifier-resolution=node ./dist/main.js',
       ]
-    volumes:
-      - $PWD/.env:/app/.env
     env_file:
       - '.env'
     environment:
@@ -126,7 +121,6 @@ services:
       - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/log:/host/var/log:ro
-      - $PWD/.env:/app/.env
     env_file:
       - '.env'
     environment:


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
The app only uses env variables to get settings and secrets. No need for .env file
