### PR TITLE
disable long-polling in sockets client + other cleanup

### DIFF
--- a/components/common/CharmEditor/components/fiduswriter/ws.ts
+++ b/components/common/CharmEditor/components/fiduswriter/ws.ts
@@ -104,7 +104,8 @@ export class WebSocketConnector {
       withCredentials: true,
       auth: {
         authToken
-      }
+      },
+      transports: ['websocket'] // skip long-polling
     });
     this.createWSConnection();
   }

--- a/lib/focalboard/cardFilter.ts
+++ b/lib/focalboard/cardFilter.ts
@@ -95,7 +95,7 @@ class CardFilter {
             return sourceValue !== '';
           }
           default: {
-            Utils.assertFailure(`Invalid filter condition ${filter.condition}`);
+            Utils.assertFailure(`Invalid filter condition: ${filter.condition} for type ${filterPropertyDataType}`);
           }
         }
       } else if (filterPropertyDataType === 'boolean') {
@@ -109,7 +109,7 @@ class CardFilter {
             return sourceValue !== (filter.values[0] || 'false');
           }
           default: {
-            Utils.assertFailure(`Invalid filter condition ${filter.condition}`);
+            Utils.assertFailure(`Invalid filter condition: ${filter.condition} for type ${filterPropertyDataType}`);
           }
         }
       } else if (filterPropertyDataType === 'number') {
@@ -141,7 +141,7 @@ class CardFilter {
             return Number(sourceValue) !== Number(filterValue);
           }
           default: {
-            Utils.assertFailure(`Invalid filter condition ${filter.condition}`);
+            Utils.assertFailure(`Invalid filter condition: ${filter.condition} for type ${filterPropertyDataType}`);
           }
         }
       } else if (filterPropertyDataType === 'multi_select') {
@@ -162,7 +162,7 @@ class CardFilter {
             return valueArray.length > 0;
           }
           default: {
-            Utils.assertFailure(`Invalid filter condition ${filter.condition}`);
+            Utils.assertFailure(`Invalid filter condition: ${filter.condition} for type ${filterPropertyDataType}`);
           }
         }
       } else if (filterPropertyDataType === 'select') {
@@ -182,7 +182,7 @@ class CardFilter {
             return sourceValue !== '';
           }
           default: {
-            Utils.assertFailure(`Invalid filter condition ${filter.condition}`);
+            Utils.assertFailure(`Invalid filter condition: ${filter.condition} for type ${filterPropertyDataType}`);
           }
         }
       } else if (filterPropertyDataType === 'date') {
@@ -238,7 +238,7 @@ class CardFilter {
             );
           }
           default: {
-            Utils.assertFailure(`Invalid filter condition ${filter.condition}`);
+            Utils.assertFailure(`Invalid filter condition: ${filter.condition} for type ${filterPropertyDataType}`);
           }
         }
       }


### PR DESCRIPTION
Long-polling is not a great experience for typing, and socket.io always starts with it by default. This might help reduce latency that people experience.

AFAICT, long-polling is just needed for really old versions of IE.