### PR TITLE
Fix for list item delete indent issue

### DIFF
--- a/components/common/CharmEditor/components/listItem/commands.ts
+++ b/components/common/CharmEditor/components/listItem/commands.ts
@@ -525,10 +525,9 @@ export const backspaceKeyCommand =
           isEmptySelectionAtStart,
 
           // list items might have multiple paragraphs; only do this at the first one
-          isFirstChildOfParent,
-          canOutdent(type)
+          isFirstChildOfParent
         ],
-        chainCommands(deletePreviousEmptyListItem(type), outdentList(type))
+        deletePreviousEmptyListItem(type)
       ),
 
       // if we're just inside a paragraph node (or gapcursor is shown) and backspace, then try to join


### PR DESCRIPTION
delete issue

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d19174f</samp>

Fixed a list outdenting bug in `CharmEditor` by simplifying the `backspaceKeyCommand` function. Removed unnecessary and redundant commands from `components/common/CharmEditor/components/listItem/commands.ts`.

### WHY
<!-- author to complete -->
