### PR TITLE
only load stripe on checkout

### DIFF
--- a/components/subscription/SubscriptionSettings.tsx
+++ b/components/subscription/SubscriptionSettings.tsx
@@ -3,7 +3,6 @@ import { useTheme } from '@emotion/react';
 import { Divider, InputLabel, Skeleton, Tooltip, Typography } from '@mui/material';
 import { Stack } from '@mui/system';
 import { Elements } from '@stripe/react-stripe-js';
-import { loadStripe } from '@stripe/stripe-js';
 import { capitalize } from 'lodash';
 import { useEffect, useState } from 'react';
 import useSWR from 'swr';
@@ -15,13 +14,10 @@ import Legend from 'components/settings/Legend';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useMembers } from 'hooks/useMembers';
 import { SUBSCRIPTION_PRODUCTS_RECORD } from 'lib/subscription/constants';
-import { inputBackground, inputBackgroundDarkMode } from 'theme/colors';
+import { inputBackground } from 'theme/colors';
 
 import { CheckoutForm } from './CheckoutForm';
-
-const stripePublicKey = process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY as string;
-
-const stripePromise = loadStripe(stripePublicKey);
+import { loadStripe } from './loadStripe';
 
 export function SubscriptionSettings({ space }: { space: Space }) {
   const {
@@ -59,6 +55,8 @@ export function SubscriptionSettings({ space }: { space: Space }) {
   }
 
   const theme = useTheme();
+
+  const stripePromise = loadStripe();
 
   return (
     <Stack>

--- a/components/subscription/loadStripe.ts
+++ b/components/subscription/loadStripe.ts
@@ -1,0 +1,13 @@
+import type { Stripe } from '@stripe/stripe-js';
+import { loadStripe as _loadStripe } from '@stripe/stripe-js';
+
+const stripePublicKey = process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY as string;
+
+let stripePromise: Promise<Stripe | null>;
+
+export function loadStripe() {
+  if (!stripePromise) {
+    stripePromise = _loadStripe(stripePublicKey);
+  }
+  return stripePromise;
+}

--- a/scripts/getPageHistory.ts
+++ b/scripts/getPageHistory.ts
@@ -1,9 +1,9 @@
 import { prisma } from '@charmverse/core/prisma-client';
 import { fancyTrim } from 'lib/utilities/strings';
 
-const spaceDomain = 'tame-fomo-duck';
-const pagePath = 'page-8649583367437599-restored-1684821513609';
-const maxContentSize = 150;
+const spaceDomain = 'myosinxyz';
+const pagePath = 'page-012379792069703965';
+const maxContentSize = 750;
 const maxRows = 300;
 const minVersion = 0;
 

--- a/scripts/query.ts
+++ b/scripts/query.ts
@@ -2,34 +2,24 @@ import { prisma } from '@charmverse/core/prisma-client';
 import { customAlphabet } from 'nanoid';
 import fs from 'node:fs/promises';
 
-import * as opts from 'nanoid-dictionary';
-console.log(opts);
-function uid() {
-  return Math.round(Date.now() + Math.random() * 1000).toString(36);
-}
-function uid2() {
-  return customAlphabet(opts.lowercase + opts.numbers, 8)();
-}
+import { getDiscussionTasks } from 'lib/discussion/getDiscussionTasks';
+
+/**
+
+  userId: cb9a5ede-6ff7-4eaa-9c23-91e684e23aed
+  spaceId: 33918abc-f753-4a3d-858d-63c3fa36fa15
+
+  kameil userId: f7d47848-f993-4d16-8008-e1f5b23b8ad3 or 356af4f7-cbd1-4350-b046-9f55da500fec
+*/
+
 /**
  * Use this script to perform database searches.
  */
 
 async function search() {
-  const page = await prisma.page.findFirst({
-    where: {
-      path: `page-12890905063646585`
-    },
-    include: {
-      author: true,
-      diffs: {
-        orderBy: {
-          version: 'asc'
-        }
-      }
-    }
-  });
-
-  await fs.writeFile(`${__dirname}/out.json`, JSON.stringify(page, null, 2));
+  const tasks = await getDiscussionTasks('cb9a5ede-6ff7-4eaa-9c23-91e684e23aed');
+  console.log('tasks', tasks);
+  // await fs.writeFile(`${__dirname}/out.json`, JSON.stringify(page, null, 2));
 }
 
 search().then(() => console.log('Done'));


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14b2c0d</samp>

This pull request refactors the `SubscriptionSettings` component to use a custom `loadStripe` function and module. It also updates some scripts for testing and querying the database, using the `getDiscussionTasks` function and a different page history.

### WHY
So we reduce resources overhead and unecessary logs.. example from https://vercel.com/guides/getting-started-with-nextjs-typescript-stripe
