### PR TITLE
Fix create space api template name check

### DIFF
--- a/lib/spaces/config.ts
+++ b/lib/spaces/config.ts
@@ -48,6 +48,7 @@ export const staticSpaceTemplates = [
 const dynamicTemplateIds = ['default', 'importNotion', 'importMarkdown'] as const;
 
 export const spaceTemplateIds = [...staticSpaceTemplates.map((tpl) => tpl.id), ...dynamicTemplateIds];
+export const spaceTemplateApiNames = [...staticSpaceTemplates.map((tpl) => tpl.apiName)];
 
 export type StaticSpaceTemplateType = (typeof staticSpaceTemplates)[number]['id'];
 export type APISpaceTemplateType = (typeof staticSpaceTemplates)[number]['apiName'];

--- a/pages/api/v1/spaces/index.ts
+++ b/pages/api/v1/spaces/index.ts
@@ -5,7 +5,7 @@ import { createWorkspaceApi } from 'lib/public-api/createWorkspaceApi';
 import { superApiHandler } from 'lib/public-api/handler';
 import type { CreateWorkspaceResponseBody, CreateWorkspaceRequestBody } from 'lib/public-api/interfaces';
 import { withSessionRoute } from 'lib/session/withSession';
-import { spaceTemplateIds } from 'lib/spaces/config';
+import { spaceTemplateApiNames, spaceTemplateIds } from 'lib/spaces/config';
 import { InvalidInputError } from 'lib/utilities/errors';
 import { isTruthy } from 'lib/utilities/types';
 
@@ -48,7 +48,7 @@ async function createSpace(req: NextApiRequest, res: NextApiResponse<CreateWorks
     template
   } = req.body as CreateWorkspaceRequestBody;
 
-  if (isTruthy(template) && !spaceTemplateIds.includes(template as any)) {
+  if (isTruthy(template) && !spaceTemplateApiNames.includes(template)) {
     throw new InvalidInputError('Invalid template provided.');
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 506ad9b</samp>

This pull request improves the validation and import of space templates in the create space API endpoint. It introduces a new constant `spaceTemplateApiNames` in `lib/spaces/config.ts` and uses it in `pages/api/v1/spaces/index.ts`.

### WHY
Collabland CV app install does not work, because our API returns invalid template. This is because we verify templateId instead of templateApiName.
