### PR TITLE
Update UX and permission compute for bounty permissions

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
@@ -20,6 +20,7 @@ import { InputSearchReviewers } from 'components/common/form/InputSearchReviewer
 import { InputSearchRoleMultiple } from 'components/common/form/InputSearchRole';
 import { useBounties } from 'hooks/useBounties';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import { useIsPublicSpace } from 'hooks/useIsPublicSpace';
 import { useIsSpaceMember } from 'hooks/useIsSpaceMember';
 import { usePagePermissionsList } from 'hooks/usePagePermissionsList';
 import { usePaymentMethods } from 'hooks/usePaymentMethods';
@@ -62,6 +63,9 @@ export default function BountyProperties(props: {
   const [isAmountInputEmpty, setIsAmountInputEmpty] = useState<boolean>(false);
   const [capSubmissions, setCapSubmissions] = useState(false);
   const space = useCurrentSpace();
+
+  const { isPublicSpace } = useIsPublicSpace();
+
   const { user } = useUser();
   const isRewardAmountInvalid = useMemo(
     () => isAmountInputEmpty || Number(currentBounty?.rewardAmount) <= 0,
@@ -426,53 +430,56 @@ export default function BountyProperties(props: {
             readOnly={readOnly}
           />
         </div>
-        <div
-          className='octo-propertyrow'
-          style={{
-            height: 'fit-content'
-          }}
-        >
+        {!isPublicSpace && (
           <div
-            className='octo-propertyname octo-propertyname--readonly'
-            style={{ alignSelf: 'baseline', paddingTop: 8 }}
+            className='octo-propertyrow'
+            style={{
+              height: 'fit-content'
+            }}
           >
-            <Button>Applicant role(s)</Button>
-          </div>
-          <div style={{ width: '100%' }}>
-            <InputSearchRoleMultiple
-              disableCloseOnSelect={true}
-              fullWidth
-              defaultValue={assignedRoleSubmitters}
-              onChange={async (roleIds) => {
-                await applyBountyUpdates({
-                  permissions: rollupPermissions({
-                    assignedRoleSubmitters: roleIds,
-                    selectedReviewerRoles,
-                    selectedReviewerUsers,
-                    spaceId: space!.id
-                  })
-                });
-                if (currentBounty?.id) {
-                  await refreshBountyPermissions(currentBounty.id);
-                }
-              }}
-              filterSelectedOptions={true}
-              showWarningOnNoRoles={true}
-              disabled={readOnly}
-              readOnly={readOnly}
-              sx={{
-                width: '100%'
-              }}
-            />
-            {bountyPagePermissions && bountyPermissions && (
-              <MissingPagePermissions
-                target='submitter'
-                bountyPermissions={bountyPermissions}
-                pagePermissions={bountyPagePermissions}
+            <div
+              className='octo-propertyname octo-propertyname--readonly'
+              style={{ alignSelf: 'baseline', paddingTop: 8 }}
+            >
+              <Button>Applicant role(s)</Button>
+            </div>
+            <div style={{ width: '100%' }}>
+              <InputSearchRoleMultiple
+                disableCloseOnSelect={true}
+                fullWidth
+                defaultValue={assignedRoleSubmitters}
+                onChange={async (roleIds) => {
+                  await applyBountyUpdates({
+                    permissions: rollupPermissions({
+                      assignedRoleSubmitters: roleIds,
+                      selectedReviewerRoles,
+                      selectedReviewerUsers,
+                      spaceId: space!.id
+                    })
+                  });
+                  if (currentBounty?.id) {
+                    await refreshBountyPermissions(currentBounty.id);
+                  }
+                }}
+                filterSelectedOptions={true}
+                showWarningOnNoRoles={true}
+                disabled={readOnly}
+                readOnly={readOnly}
+                sx={{
+                  width: '100%'
+                }}
               />
-            )}
+              {bountyPagePermissions && bountyPermissions && (
+                <MissingPagePermissions
+                  target='submitter'
+                  bountyPermissions={bountyPermissions}
+                  pagePermissions={bountyPagePermissions}
+                />
+              )}
+            </div>
           </div>
-        </div>
+        )}
+
         <div
           className='octo-propertyrow'
           style={{

--- a/lib/permissions/bounties/__tests__/computeBountyPermissions.public.spec.ts
+++ b/lib/permissions/bounties/__tests__/computeBountyPermissions.public.spec.ts
@@ -202,7 +202,7 @@ describe('computeBountyPermissions - public space', () => {
       mark_paid: true,
       review: true,
       // Everything except working on their own bounty
-      work: true
+      work: false
     });
   });
 });

--- a/lib/permissions/bounties/__tests__/computeBountyPermissions.public.spec.ts
+++ b/lib/permissions/bounties/__tests__/computeBountyPermissions.public.spec.ts
@@ -1,0 +1,208 @@
+import { prisma } from '@charmverse/core/prisma-client';
+
+import { generateBounty, generateRole, generateSpaceUser, generateUserAndSpace } from 'testing/setupDatabase';
+
+import { computeBountyPermissionsPublic } from '../computeBountyPermissions.public';
+import type { BountyPermissionFlags } from '../interfaces';
+
+describe('computeBountyPermissions - public space', () => {
+  it('should provide creator permissions to the bounty creator', async () => {
+    const { space, user } = await generateUserAndSpace({
+      isAdmin: false,
+      // We don't need the paid tier to be set for this test, since we are directly calling the free space implementation
+      paidTier: 'free'
+    });
+
+    const bounty = await generateBounty({
+      approveSubmitters: false,
+      createdBy: user.id,
+      spaceId: space.id,
+      status: 'open'
+    });
+
+    const bountyData = await prisma.bounty.findUniqueOrThrow({
+      where: {
+        id: bounty.id
+      },
+      include: {
+        permissions: true
+      }
+    });
+
+    const creatorPermissions = await computeBountyPermissionsPublic({
+      bounty: bountyData,
+      userId: user.id
+    });
+
+    expect(creatorPermissions).toMatchObject<BountyPermissionFlags>({
+      approve_applications: true,
+      grant_permissions: true,
+      lock: true,
+      mark_paid: true,
+      review: true,
+      work: false
+    });
+  });
+
+  it('should always allow space members to work on the bounty (except the creator)', async () => {
+    const { space, user } = await generateUserAndSpace({ isAdmin: false });
+    const spaceMember = await generateSpaceUser({
+      spaceId: space.id,
+      isAdmin: false
+    });
+
+    const bounty = await generateBounty({
+      approveSubmitters: false,
+      createdBy: user.id,
+      spaceId: space.id,
+      status: 'open'
+    });
+
+    const bountyData = await prisma.bounty.findUniqueOrThrow({
+      where: {
+        id: bounty.id
+      },
+      include: {
+        permissions: true
+      }
+    });
+
+    const memberPermissions = await computeBountyPermissionsPublic({
+      bounty: bountyData,
+      userId: spaceMember.id
+    });
+
+    expect(memberPermissions).toMatchObject<BountyPermissionFlags>({
+      approve_applications: false,
+      grant_permissions: false,
+      lock: false,
+      mark_paid: false,
+      review: false,
+      work: true
+    });
+  });
+
+  it('should assign reviewer permissions to selected users', async () => {
+    const { space, user } = await generateUserAndSpace({ isAdmin: false });
+    const reviewerUser = await generateSpaceUser({
+      spaceId: space.id,
+      isAdmin: false
+    });
+
+    const reviewerUserByRole = await generateSpaceUser({
+      spaceId: space.id,
+      isAdmin: false
+    });
+
+    const role = await generateRole({
+      createdBy: user.id,
+      spaceId: space.id,
+      assigneeUserIds: [reviewerUserByRole.id]
+    });
+
+    const bounty = await generateBounty({
+      approveSubmitters: false,
+      createdBy: user.id,
+      spaceId: space.id,
+      status: 'open',
+      bountyPermissions: {
+        reviewer: [
+          { group: 'role', id: role.id },
+          { group: 'user', id: reviewerUser.id }
+        ]
+      }
+    });
+
+    const bountyData = await prisma.bounty.findUniqueOrThrow({
+      where: {
+        id: bounty.id
+      },
+      include: {
+        permissions: true
+      }
+    });
+
+    const reviewerUserPermissions = await computeBountyPermissionsPublic({
+      bounty: bountyData,
+      userId: reviewerUser.id
+    });
+
+    // In free space mode, we do not want role-based permissions to be assigned
+    const reviewerUserByRolePermissions = await computeBountyPermissionsPublic({
+      bounty: bountyData,
+      userId: reviewerUserByRole.id
+    });
+
+    expect(reviewerUserPermissions.review).toBe(true);
+    expect(reviewerUserByRolePermissions.review).toBe(false);
+  });
+
+  it('should always return full permissions for the space admin, except working on their own bounty', async () => {
+    const { space, user: adminUser } = await generateUserAndSpace({ isAdmin: true });
+    const user = await generateSpaceUser({
+      spaceId: space.id,
+      isAdmin: false
+    });
+    const memberBounty = await generateBounty({
+      approveSubmitters: false,
+      createdBy: user.id,
+      spaceId: space.id,
+      status: 'open'
+    });
+
+    const adminBounty = await generateBounty({
+      approveSubmitters: false,
+      createdBy: adminUser.id,
+      spaceId: space.id,
+      status: 'open'
+    });
+
+    const [memberBountyData, adminBountyData] = await Promise.all([
+      prisma.bounty.findUniqueOrThrow({
+        where: {
+          id: memberBounty.id
+        },
+        include: {
+          permissions: true
+        }
+      }),
+      prisma.bounty.findUniqueOrThrow({
+        where: {
+          id: adminBounty.id
+        },
+        include: {
+          permissions: true
+        }
+      })
+    ]);
+
+    const memberBountyPermissions = await computeBountyPermissionsPublic({
+      bounty: memberBountyData,
+      userId: adminUser.id
+    });
+
+    expect(memberBountyPermissions).toMatchObject<BountyPermissionFlags>({
+      approve_applications: true,
+      grant_permissions: true,
+      lock: true,
+      mark_paid: true,
+      review: true,
+      work: true
+    });
+
+    const adminBountyPermissions = await computeBountyPermissionsPublic({
+      bounty: adminBountyData,
+      userId: adminUser.id
+    });
+
+    expect(adminBountyPermissions).toMatchObject<BountyPermissionFlags>({
+      approve_applications: true,
+      grant_permissions: true,
+      lock: true,
+      mark_paid: true,
+      review: true,
+      // Everything except working on their own bounty
+      work: true
+    });
+  });
+});

--- a/lib/permissions/bounties/__tests__/computeBountyPermissions.spec.ts
+++ b/lib/permissions/bounties/__tests__/computeBountyPermissions.spec.ts
@@ -3,12 +3,7 @@ import { v4 } from 'uuid';
 
 import { assignRole } from 'lib/roles';
 import { typedKeys } from 'lib/utilities/objects';
-import {
-  generateBounty,
-  generateRole,
-  generateSpaceUser,
-  generateUserAndSpaceWithApiToken
-} from 'testing/setupDatabase';
+import { generateBounty, generateRole, generateSpaceUser, generateUserAndSpace } from 'testing/setupDatabase';
 
 import { addBountyPermissionGroup } from '../addBountyPermissionGroup';
 import { computeBountyPermissions } from '../computeBountyPermissions';
@@ -16,7 +11,7 @@ import { bountyPermissionMapping } from '../mapping';
 
 describe('computeBountyPermissions', () => {
   it('should combine permissions from user, role assignments and space membership', async () => {
-    const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);
+    const { space, user } = await generateUserAndSpace({ isAdmin: false });
     const otherUser = await generateSpaceUser({ spaceId: space.id, isAdmin: false });
 
     const bounty = await generateBounty({
@@ -83,7 +78,7 @@ describe('computeBountyPermissions', () => {
   });
 
   it('should give user space permissions via their role', async () => {
-    const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);
+    const { space, user } = await generateUserAndSpace({ isAdmin: false });
     const otherUser = await generateSpaceUser({ spaceId: space.id, isAdmin: false });
 
     const bounty = await generateBounty({
@@ -130,7 +125,7 @@ describe('computeBountyPermissions', () => {
   });
 
   it('should give user space permissions via their space membership', async () => {
-    const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);
+    const { space, user } = await generateUserAndSpace({ isAdmin: false });
     const otherUser = await generateSpaceUser({ spaceId: space.id, isAdmin: false });
 
     const bounty = await generateBounty({
@@ -167,7 +162,7 @@ describe('computeBountyPermissions', () => {
   });
 
   it('should always give creator permissions to the bounty creator, even if this is not explicitly assigned', async () => {
-    const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);
+    const { space, user } = await generateUserAndSpace({ isAdmin: false });
 
     const bounty = await generateBounty({
       createdBy: user.id,
@@ -194,7 +189,7 @@ describe('computeBountyPermissions', () => {
   });
 
   it('should give user space permissions as an individual', async () => {
-    const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);
+    const { space, user } = await generateUserAndSpace({ isAdmin: false });
     const otherUser = await generateSpaceUser({ spaceId: space.id, isAdmin: false });
 
     const bounty = await generateBounty({
@@ -231,7 +226,7 @@ describe('computeBountyPermissions', () => {
   });
 
   it('should return true to all operations if user is a space admin and admin bypass was enabled, except [allowing an admin to apply to their own bounty]', async () => {
-    const { space, user } = await generateUserAndSpaceWithApiToken(undefined, true);
+    const { space, user } = await generateUserAndSpace({ isAdmin: true });
 
     const bounty = await generateBounty({
       createdBy: user.id,
@@ -256,7 +251,7 @@ describe('computeBountyPermissions', () => {
   });
 
   it('should return true only for operations the user has access to if they are a space admin and admin bypass was disabled', async () => {
-    const { space, user } = await generateUserAndSpaceWithApiToken(undefined, true);
+    const { space, user } = await generateUserAndSpace({ isAdmin: true });
 
     const otherUser = await generateSpaceUser({ spaceId: space.id, isAdmin: false });
 
@@ -279,7 +274,7 @@ describe('computeBountyPermissions', () => {
   });
 
   it('should contain all Bounty Operations as keys, with no additional or missing properties', async () => {
-    const { space, user } = await generateUserAndSpaceWithApiToken(undefined, false);
+    const { space, user } = await generateUserAndSpace({ isAdmin: false });
 
     const bounty = await generateBounty({
       createdBy: user.id,
@@ -306,9 +301,9 @@ describe('computeBountyPermissions', () => {
   });
 
   it('should return false for all bounty operations if the the user is not a member of the space', async () => {
-    const { user, space } = await generateUserAndSpaceWithApiToken(undefined, true);
+    const { user, space } = await generateUserAndSpace({ isAdmin: true });
 
-    const { user: externalUser } = await generateUserAndSpaceWithApiToken(undefined, true);
+    const { user: externalUser } = await generateUserAndSpace({ isAdmin: true });
 
     // Create a permission for the non space member which computeBountyPermissions should ignore
     const bounty = await generateBounty({
@@ -336,6 +331,36 @@ describe('computeBountyPermissions', () => {
     typedKeys(BountyOperation).forEach((op) => {
       expect(computedPermissions[op]).toBe(false);
     });
+  });
+
+  it('should delegate the bounty permissions calculation to the public version if the space is a free space', async () => {
+    const { space, user } = await generateUserAndSpace({ isAdmin: false, paidTier: 'free' });
+    const userWithRole = await generateSpaceUser({ spaceId: space.id, isAdmin: false });
+
+    const role = await generateRole({
+      createdBy: user.id,
+      spaceId: space.id,
+      assigneeUserIds: [userWithRole.id]
+    });
+
+    const bounty = await generateBounty({
+      createdBy: user.id,
+      approveSubmitters: true,
+      spaceId: space.id,
+      status: 'open',
+      bountyPermissions: {
+        reviewer: [{ group: 'role', id: role.id }]
+      }
+    });
+
+    const userWithRolePermissions = await computeBountyPermissions({
+      allowAdminBypass: false,
+      resourceId: bounty.id,
+      userId: userWithRole.id
+    });
+
+    // Simple way to check for behaviour, as in public mode, custom role permissions are ignored
+    expect(userWithRolePermissions.review).toBe(false);
   });
 
   it('should return empty permissions if the bounty does not exist', async () => {

--- a/lib/permissions/bounties/computeBountyPermissions.public.ts
+++ b/lib/permissions/bounties/computeBountyPermissions.public.ts
@@ -1,0 +1,49 @@
+import type { Bounty, BountyPermission } from '@charmverse/core/prisma-client';
+
+import { hasAccessToSpace } from 'lib/users/hasAccessToSpace';
+
+import { AvailableBountyPermissions } from './availableBountyPermissions';
+import type { BountyPermissionFlags } from './interfaces';
+import { bountyPermissionMapping } from './mapping';
+
+export async function computeBountyPermissionsPublic({
+  userId,
+  bounty
+}: {
+  userId: string;
+  bounty: Pick<Bounty, 'createdBy' | 'spaceId'> & { permissions: BountyPermission[] };
+}): Promise<BountyPermissionFlags> {
+  const { spaceRole } = await hasAccessToSpace({
+    spaceId: bounty.spaceId,
+    userId
+  });
+
+  const allowedOperations = new AvailableBountyPermissions();
+
+  if (!spaceRole) {
+    return allowedOperations.empty;
+  }
+
+  if (spaceRole?.isAdmin) {
+    return allowedOperations.full;
+  }
+
+  // Creator-level permission is mutually exclusive with any other type of permissions
+  if (
+    bounty.createdBy === userId ||
+    bounty.permissions.some((p) => p.permissionLevel === 'creator' && p.userId === userId)
+  ) {
+    allowedOperations.addPermissions(bountyPermissionMapping.creator.slice());
+    return allowedOperations.operationFlags;
+  }
+
+  // Add reviewer permissions
+  if (bounty.permissions.some((p) => p.permissionLevel === 'reviewer' && p.userId === userId)) {
+    allowedOperations.addPermissions(bountyPermissionMapping.reviewer.slice());
+  }
+
+  // Always allow space members to submit work to the bounty
+  allowedOperations.addPermissions(bountyPermissionMapping.submitter.slice());
+
+  return allowedOperations.operationFlags;
+}

--- a/lib/permissions/bounties/computeBountyPermissions.public.ts
+++ b/lib/permissions/bounties/computeBountyPermissions.public.ts
@@ -25,6 +25,12 @@ export async function computeBountyPermissionsPublic({
   }
 
   if (spaceRole?.isAdmin) {
+    if (
+      bounty.createdBy === userId ||
+      bounty.permissions.some((p) => p.permissionLevel === 'creator' && p.userId === userId)
+    ) {
+      return { ...allowedOperations.full, work: false };
+    }
     return allowedOperations.full;
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7dd891</samp>

This pull request adds support for bounties in public (free) spaces, which have different features and logic than private (paid) spaces. It adds a new function `computeBountyPermissionsPublic` and its tests to calculate the bounty permissions for public spaces. It also modifies the existing function `computeBountyPermissions` and its tests to handle both public and private spaces. It also updates the UI components `BountyProperties` and `InputSearchReviewers` to conditionally render the role selection and filter the reviewers options based on the space type.

### WHY
Provide a computeBountyPermissions alternative for public spaces