### PR TITLE
Increase jest test timeout

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -33,7 +33,7 @@ export const jestConfig: JestConfigWithTsJest = {
   // This is needed so CI environment does not attempt to run tests in the permissions_api folder
   testPathIgnorePatterns: ['<rootDir>/permissions_api'],
 
-  testTimeout: 120000
+  testTimeout: 240000
 };
 
 export default createJestConfig(jestConfig);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0aa8578</samp>

Increased the `testTimeout` value in `jest.config.ts` to prevent integration test failures. This was part of a pull request to improve test reliability and stability.

### WHY
Some our tests timeout. After reviewing docs, this seems to be linked to Github actions resources, since they are shared machines.

For now, I extended the jest test timeout