### PR TITLE
Script to sync collabland roles

### DIFF
--- a/lib/collabland/collablandClient.ts
+++ b/lib/collabland/collablandClient.ts
@@ -109,7 +109,7 @@ export function createCredential<T = BountyEventSubject>({ subject }: { subject:
   });
 }
 
-export async function canJoinSpaceViaDiscord({
+export async function getDiscordUserState({
   discordServerId,
   discordUserId
 }: {

--- a/lib/discord/__tests__/checkDiscordGate.spec.ts
+++ b/lib/discord/__tests__/checkDiscordGate.spec.ts
@@ -26,7 +26,7 @@ describe('checkDiscordGate', () => {
 
     const canJoinSpaceMock = jest.fn().mockResolvedValue({ isVerified: true, roles: [] });
     jest.mock('lib/collabland/collablandClient', () => ({
-      canJoinSpaceViaDiscord: canJoinSpaceMock
+      getDiscordUserState: canJoinSpaceMock
     }));
 
     const { checkDiscordGate } = await import('lib/discord/checkDiscordGate');
@@ -43,7 +43,7 @@ describe('checkDiscordGate', () => {
 
     const canJoinSpaceMock = jest.fn().mockResolvedValueOnce({ isVerified: true, roles: [] });
     jest.mock('lib/collabland/collablandClient', () => ({
-      canJoinSpaceViaDiscord: canJoinSpaceMock
+      getDiscordUserState: canJoinSpaceMock
     }));
 
     const { checkDiscordGate } = await import('lib/discord/checkDiscordGate');
@@ -67,7 +67,7 @@ describe('checkDiscordGate', () => {
 
     const canJoinSpaceMock = jest.fn().mockResolvedValueOnce({ isVerified: true, roles: [] });
     jest.mock('lib/collabland/collablandClient', () => ({
-      canJoinSpaceViaDiscord: canJoinSpaceMock
+      getDiscordUserState: canJoinSpaceMock
     }));
 
     const { checkDiscordGate } = await import('lib/discord/checkDiscordGate');

--- a/lib/discord/syncDiscorRoles.ts
+++ b/lib/discord/syncDiscorRoles.ts
@@ -2,11 +2,14 @@ import { log } from '@charmverse/core/log';
 import { prisma } from '@charmverse/core/prisma-client';
 
 import { getGuildRoles } from 'lib/collabland/collablandClient';
+import type { ExternalRole } from 'lib/roles';
 import { findOrCreateRoles } from 'lib/roles/createRoles';
 
 type Props = {
   spaceId: string;
 };
+
+const rolePromises: Record<string, Promise<ExternalRole[]> | null> = {};
 
 export async function syncDiscordRoles({ spaceId }: Props) {
   const space = await prisma.space.findFirst({ where: { id: spaceId } });
@@ -30,7 +33,14 @@ export async function syncDiscordRoles({ spaceId }: Props) {
   }
 
   try {
-    const roles = await getGuildRoles(space.discordServerId);
+    // reuse existing promise if it exists to avoid spamming collabland
+    const existingPromise = rolePromises[spaceId];
+    const rolesPromise = existingPromise !== null ? existingPromise : getGuildRoles(space.discordServerId);
+    rolePromises[spaceId] = rolesPromise;
+
+    const roles = await rolesPromise;
+    rolePromises[spaceId] = null;
+
     await findOrCreateRoles(roles, space.id, botUser?.userId, {
       source: 'collabland',
       createRoles: true

--- a/lib/discord/verifyDiscordGateForSpace.tsx
+++ b/lib/discord/verifyDiscordGateForSpace.tsx
@@ -1,6 +1,6 @@
 import type { Space } from '@charmverse/core/prisma';
 
-import { canJoinSpaceViaDiscord } from 'lib/collabland/collablandClient';
+import { getDiscordUserState } from 'lib/collabland/collablandClient';
 
 type Props = {
   discordUserId?: string;
@@ -19,7 +19,7 @@ export async function verifyDiscordGateForSpace({ discordUserId, space }: Props)
     };
   }
 
-  const { roles, isVerified } = await canJoinSpaceViaDiscord({ discordServerId, discordUserId });
+  const { roles, isVerified } = await getDiscordUserState({ discordServerId, discordUserId });
 
   return {
     isVerified,

--- a/scripts/syncCollablandSpaces.ts
+++ b/scripts/syncCollablandSpaces.ts
@@ -1,0 +1,88 @@
+import { DiscordUser, Role, Space, User, prisma } from '@charmverse/core/prisma-client';
+import { assignRolesCollabland } from 'lib/collabland/assignRolesCollabland';
+import { getDiscordUserState } from 'lib/collabland/collablandClient';
+import { unassignRolesDiscord } from 'lib/discord/unassignRolesDiscord';
+
+export async function syncCollablandSpaces() {
+  const usersToSync = await prisma.spaceRole.findMany({
+    where: {
+      // only spaces with discord servers
+      space: {
+        discordServerId: { not: null }
+      },
+      user: {
+        // only users connected to discord
+        discordUser: { is: {} }
+      }
+    },
+    include: {
+      space: true,
+      user: {
+        include: {
+          discordUser: true
+        }
+      },
+      spaceRoleToRole: {
+        include: {
+          role: true
+        }
+      }
+    }
+  });
+
+  console.log('🔥 number of users to sync:', usersToSync.length);
+
+  for (const syncUser of usersToSync) {
+    const currentRoles = syncUser.spaceRoleToRole.map((r) => r.role);
+    // await syncDiscordUser({ currentRoles, space: syncUser.space, user: syncUser.user });
+  }
+}
+
+async function syncDiscordUser({
+  currentRoles,
+  space,
+  user
+}: {
+  space: Space;
+  currentRoles: Role[];
+  user: User & { discordUser: DiscordUser | null };
+}) {
+  if (!space.discordServerId || user.discordUser === null) {
+    return;
+  }
+  const {
+    discordUser: { discordId: discordUserId }
+  } = user;
+  const { discordServerId } = space;
+
+  // consider only roles in CV that ocmes from collabland
+  const oldRoles = currentRoles
+    .filter((r) => r.source === 'collabland')
+    .map((r) => r.externalId)
+    .filter((r): r is string => r !== null);
+
+  const { roles: updatedRoles } = await getDiscordUserState({
+    discordServerId: space.discordServerId,
+    discordUserId: user.discordUser.discordId
+  });
+
+  const newRoles = updatedRoles.map((r) => String(r.id));
+
+  const rolesAdded = newRoles.filter((role) => !oldRoles.includes(role));
+  const rolesRemoved = oldRoles.filter((role) => !newRoles.includes(role));
+
+  if (rolesAdded.length) {
+    await assignRolesCollabland({ discordUserId, discordServerId, roles: rolesAdded });
+  }
+
+  if (rolesRemoved.length) {
+    await unassignRolesDiscord({ discordUserId, discordServerId, roles: rolesRemoved });
+  }
+
+  console.log('🔥 user:', user.id);
+  console.log('🔥 added roles:', rolesAdded.length);
+  console.log('🔥 removed roles:', rolesRemoved.length);
+  console.log('🔥 ---');
+}
+
+syncCollablandSpaces();


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
Due to collabland webhook API issues we lost track of syncing space users and roles. This script will sync all the roles for existing users. That means it will add missing roles and remove invalid ones (NOTE: it consider only roles from collabland to be removed, so it will not mess up roles manually added in charmverse)
