### PR TITLE
Show link popup

### DIFF
--- a/components/common/CharmEditor/components/inlineComment/inlineComment.plugins.tsx
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.plugins.tsx
@@ -9,6 +9,7 @@ import { extractInlineCommentRows } from 'lib/prosemirror/plugins/inlineComments
 
 import { createTooltipDOM, tooltipPlacement } from '../@bangle.dev/tooltip';
 import { referenceElement } from '../@bangle.dev/tooltip/suggest-tooltip';
+import { getLinkElement } from '../link/getLinkElement';
 
 import RowDecoration from './components/InlineCommentRowDecoration';
 import { markName } from './inlineComment.constants';
@@ -63,6 +64,16 @@ export function plugin({ key }: { key: PluginKey }): RawPlugins {
           const className =
             (event.target as HTMLElement).className +
             ((event.target as HTMLElement).parentNode as HTMLElement).className;
+
+          // Sometimes, inline comments are overlaid on links, which blocks proper behaviour. This allows links to open
+          const href = getLinkElement({
+            htmlElement: event.target as HTMLElement
+          })?.getAttribute('href');
+
+          if (href) {
+            window.open(href, '_blank');
+          }
+
           if (/charm-inline-comment/.test(className)) {
             return highlightMarkedElement({
               view,

--- a/components/common/CharmEditor/components/link/getLinkElement.ts
+++ b/components/common/CharmEditor/components/link/getLinkElement.ts
@@ -1,0 +1,26 @@
+/**
+ * Visit the node and its parents for X amount of ancestors
+ *
+ * Returns the node if it has the target class for links
+ *
+ * Used as sometimes we are in a span which is inside a link
+ */
+export function getLinkElement({
+  htmlElement,
+  ancestors = 2
+}: {
+  htmlElement: HTMLElement;
+  ancestors?: number;
+}): HTMLElement | null {
+  const linkClass = 'charm-link';
+
+  if (htmlElement.classList.contains(linkClass)) {
+    return htmlElement;
+  }
+
+  if (ancestors > 0 && htmlElement.parentElement) {
+    return getLinkElement({ htmlElement: htmlElement.parentElement, ancestors: ancestors - 1 });
+  }
+
+  return null;
+}

--- a/components/common/CharmEditor/components/link/getLinkElement.ts
+++ b/components/common/CharmEditor/components/link/getLinkElement.ts
@@ -12,6 +12,10 @@ export function getLinkElement({
   htmlElement: HTMLElement;
   ancestors?: number;
 }): HTMLElement | null {
+  if (!htmlElement) {
+    return null;
+  }
+
   const linkClass = 'charm-link';
 
   if (htmlElement.classList.contains(linkClass)) {

--- a/components/common/CharmEditor/components/link/link.plugins.ts
+++ b/components/common/CharmEditor/components/link/link.plugins.ts
@@ -9,6 +9,8 @@ import {
   renderSuggestionsTooltip
 } from '../@bangle.dev/tooltip/suggest-tooltip';
 
+import { getLinkElement } from './getLinkElement';
+
 export type LinkPluginState = {
   show: boolean;
   href: string | null;
@@ -82,16 +84,7 @@ export function plugins({ key }: { key: PluginKey }) {
               }, 750);
             }
 
-            const target = event.target as HTMLAnchorElement; // span for link
-            const parentElement = target?.parentElement; // anchor for link
-            const hrefElement = parentElement?.classList.contains('charm-link')
-              ? parentElement
-              : target?.classList.contains('charm-link')
-              ? target
-              : // Sometimes, the link text is nested inside a span
-              parentElement?.parentElement?.classList.contains('charm-link')
-              ? parentElement.parentElement
-              : null;
+            const hrefElement = getLinkElement({ htmlElement: event.target as HTMLElement });
 
             if (hrefElement) {
               const href = hrefElement.getAttribute('href');

--- a/components/common/CharmEditor/components/link/link.plugins.ts
+++ b/components/common/CharmEditor/components/link/link.plugins.ts
@@ -88,6 +88,9 @@ export function plugins({ key }: { key: PluginKey }) {
               ? parentElement
               : target?.classList.contains('charm-link')
               ? target
+              : // Sometimes, the link text is nested inside a span
+              parentElement?.parentElement?.classList.contains('charm-link')
+              ? parentElement.parentElement
               : null;
 
             if (hrefElement) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9254f2</samp>

Fix link plugin to handle formatted link text. Update `link.plugins.ts` to check for span tags inside charm-link elements.

### WHY
Fix link clicking issue
