### PR TITLE
pass domain in when setting cookies on server

### DIFF
--- a/pages/api/discord/callback.ts
+++ b/pages/api/discord/callback.ts
@@ -31,17 +31,18 @@ handler.get(async (req, res) => {
   const redirect = subdomain ? redirectPath : redirectUrl.pathname + redirectUrl.search;
 
   const tempAuthCode = req.query.code;
+  const domain = isLocalhostAlias(req.headers.host) ? undefined : getAppApexDomain();
   if (req.query.error || typeof tempAuthCode !== 'string') {
     log.warn('Error importing from notion', req.query);
     cookies.set(AUTH_ERROR_COOKIE, 'There was an error from Discord. Please try again', {
       httpOnly: false,
-      sameSite: 'strict'
+      sameSite: 'strict',
+      domain
     });
     res.redirect(`${redirect}?discord=2&type=${type}`);
     return;
   }
 
-  const domain = isLocalhostAlias(req.headers.host) ? undefined : getAppApexDomain();
   cookies.set(AUTH_CODE_COOKIE, tempAuthCode, { httpOnly: false, sameSite: 'strict', domain });
 
   if (type === 'login') {

--- a/pages/api/notion/callback.ts
+++ b/pages/api/notion/callback.ts
@@ -4,6 +4,8 @@ import nc from 'next-connect';
 
 import { onError, onNoMatch } from 'lib/middleware';
 import { AUTH_CODE_COOKIE, AUTH_ERROR_COOKIE } from 'lib/notion/constants';
+import { getAppApexDomain } from 'lib/utilities/domains/getAppApexDomain';
+import { isLocalhostAlias } from 'lib/utilities/domains/isLocalhostAlias';
 
 const handler = nc({
   onError,
@@ -24,15 +26,17 @@ handler.get(async (req, res) => {
   }
 
   // use cookies to pass response to frontend because they're easier to delete than query params
+  const domain = isLocalhostAlias(req.headers.host) ? undefined : getAppApexDomain();
   const cookies = new Cookies(req, res);
 
   if (typeof tempAuthCode === 'string') {
-    cookies.set(AUTH_CODE_COOKIE, tempAuthCode, { httpOnly: false, sameSite: 'strict' });
+    cookies.set(AUTH_CODE_COOKIE, tempAuthCode, { httpOnly: false, sameSite: 'strict', domain });
   } else {
     log.warn('Error importing from notion', req.query);
     cookies.set(AUTH_ERROR_COOKIE, 'There was an error from Notion. Please try again', {
       httpOnly: false,
-      sameSite: 'strict'
+      sameSite: 'strict',
+      domain
     });
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f6f0b77</samp>

The pull request enhances the app's cross-subdomain authentication with Discord and Notion by setting the `domain` option for cookies in the respective API callbacks. This allows the app to work with different domains and deployment scenarios.

### WHY
Set the domain on cookies so they  are deleted properly in the frontend
