### PR TITLE
Only load the guilds the user is already a member of

### DIFF
--- a/components/settings/roles/components/GuildsAutocomplete.tsx
+++ b/components/settings/roles/components/GuildsAutocomplete.tsx
@@ -1,4 +1,5 @@
-import type { GetGuildsResponse } from '@guildxyz/sdk';
+import { stringUtils } from '@charmverse/core/shared';
+import type { GetGuildResponse } from '@guildxyz/sdk';
 import { Avatar, Box, ListItem, ListItemIcon, ListItemText, MenuItem } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
@@ -8,7 +9,7 @@ import { VariableSizeList } from 'react-window';
 
 const LISTBOX_PADDING = 8;
 
-type ItemData = [React.HTMLAttributes<HTMLLIElement>, GetGuildsResponse[0]];
+type ItemData = [React.HTMLAttributes<HTMLLIElement>, GetGuildResponse];
 
 function renderRow(props: { data: ItemData[]; index: number; style: React.CSSProperties }) {
   const { data, index, style } = props;
@@ -63,10 +64,7 @@ function renderRow(props: { data: ItemData[]; index: number; style: React.CSSPro
           </Box>
           <Box display='flex' gap={1}>
             <Typography variant='subtitle2' color='secondary'>
-              {guild.memberCount} Members(s)
-            </Typography>
-            <Typography variant='subtitle2' color='secondary'>
-              {guild.roles.length} Role(s)
+              {guild.roles.length} {stringUtils.conditionalPlural({ count: guild.roles.length, word: 'Role' })}
             </Typography>
           </Box>
         </MenuItem>
@@ -137,10 +135,10 @@ export default function GuildsAutocomplete({
   disabled: boolean;
   onChange: (guildIds: number[]) => void;
   selectedGuildIds: number[];
-  guilds: GetGuildsResponse;
+  guilds: GetGuildResponse[];
 }) {
   const guildRecord = React.useMemo(() => {
-    return guilds.reduce<Record<string, GetGuildsResponse[0]>>(
+    return guilds.reduce<Record<string, GetGuildResponse>>(
       (record, guild) => ({
         ...record,
         [guild.name]: guild,

--- a/components/settings/roles/components/ImportGuildRolesMenuItem.tsx
+++ b/components/settings/roles/components/ImportGuildRolesMenuItem.tsx
@@ -1,5 +1,5 @@
-import type { GetGuildsResponse } from '@guildxyz/sdk';
-import { guild, user } from '@guildxyz/sdk';
+import type { GetGuildResponse, GetGuildsResponse } from '@guildxyz/sdk';
+import { guild, user as guildUser } from '@guildxyz/sdk';
 import { Box, MenuItem, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { mutate } from 'swr';
@@ -17,7 +17,7 @@ import GuildsAutocomplete from './GuildsAutocomplete';
 
 export default function ImportGuildRolesMenuItem({ onClose }: { onClose: () => void }) {
   const [showImportedRolesModal, setShowImportedRolesModal] = useState(false);
-  const [guilds, setGuilds] = useState<GetGuildsResponse>([]);
+  const [guilds, setGuilds] = useState<GetGuildResponse[]>([]);
   const [fetchingGuilds, setFetchingGuilds] = useState(false);
   const [importingRoles, setImportingRoles] = useState(false);
   const [selectedGuildIds, setSelectedGuildIds] = useState<number[]>([]);
@@ -30,7 +30,9 @@ export default function ImportGuildRolesMenuItem({ onClose }: { onClose: () => v
     async function main() {
       if (showImportedRolesModal) {
         setFetchingGuilds(true);
-        const guildMembershipsResponses = await Promise.all(addresses.map((address) => user.getMemberships(address)));
+        const guildMembershipsResponses = await Promise.all(
+          addresses.map((address) => guildUser.getMemberships(address))
+        );
         const userGuildIds: number[] = [];
 
         guildMembershipsResponses.forEach((guildMembershipsResponse) => {
@@ -38,7 +40,7 @@ export default function ImportGuildRolesMenuItem({ onClose }: { onClose: () => v
             userGuildIds.push(...guildMembershipsResponse.map((guildMembership) => guildMembership.guildId));
           }
         });
-        const allGuilds = await guild.getAll();
+        const allGuilds = await Promise.all(userGuildIds.map((id) => guild.get(id)));
         setSelectedGuildIds(userGuildIds);
         setGuilds(allGuilds);
         setFetchingGuilds(false);


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
Guild XYZ was stuck on hanging. The issue was due to GuildAutocomplete taking 38 seconds to render, and the API taking another 10 seconds.

This update only loads the guilds the user is a member of.

An alternative fix would be to embed pagination inside the guild autocomplete so that it is responsible for querying guild.xyz for data