### PR TITLE
dont import log lib, which breaks next.js middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-import { log } from '@charmverse/core/log';
+/* eslint-disable no-console */
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
@@ -36,7 +36,7 @@ export async function middleware(req: NextRequest) {
   if (subdomain && spaceDomainFromPath && spaceDomainFromPath === subdomain) {
     // We are on url with subdomain AND domain in path - redirect to url without domain in path
     const pathWithourSpaceDomain = url.pathname.replace(`/${spaceDomainFromPath}`, '') || '/';
-    log.info(`>>> Redirecting: ${url.pathname} to ${pathWithourSpaceDomain}`);
+    console.debug(`>>> Redirecting: ${url.pathname} to ${pathWithourSpaceDomain}`);
     url.pathname = pathWithourSpaceDomain;
 
     return NextResponse.redirect(url);
@@ -45,7 +45,8 @@ export async function middleware(req: NextRequest) {
   const rewriteDomain = customDomain || subdomain;
   if (rewriteDomain) {
     // Subdomain available, rewriting
-    log.info(`>>> Rewriting: ${url.pathname} to /${rewriteDomain}${url.pathname}`);
+
+    console.debug(`>>> Rewriting: ${url.pathname} to /${rewriteDomain}${url.pathname}`);
     url.pathname = `/${rewriteDomain}${url.pathname}`;
     return NextResponse.rewrite(url);
   }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7fa6eef</samp>

Simplified logging in `middleware.ts` by replacing an external module with native methods and adjusting the verbosity.

### WHY
You can't import anything that uses the nodejs runtime in Next middleware. Our log library imports async-sema which relies on `events` module. This is to reduce rate limiting from Discord, but I can't think of a clean fix in core right now, so decided at least for now it's fine if we just use raw console logs.. maybe we'd want to have a standard bare-bones log in the future.

One mystery is when did this actually start to break, and why is production working?