### PR TITLE
Bug/wrap columns

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/properties/dateRange/dateRange.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/dateRange/dateRange.tsx
@@ -21,6 +21,7 @@ type Props = {
   value: string;
   showEmptyPlaceholder?: boolean;
   onChange: (value: string) => void;
+  wrapColumn?: boolean;
 };
 
 export type DateProperty = {
@@ -157,7 +158,9 @@ function DateRange(props: Props): JSX.Element {
     <>
       <div className='octo-propertyvalue' data-testid='select-non-editable' {...bindTrigger(popupState)}>
         <Label color={displayValue ? 'propColorDefault' : 'empty'}>
-          <span className='Label-text'>{buttonText}</span>
+          <span style={{ whiteSpace: props.wrapColumn ? 'break-spaces' : undefined }} className='Label-text'>
+            {buttonText}
+          </span>
         </Label>
       </div>
       <Popover {...bindPopover(popupState)} onClose={onClose} PaperProps={{ sx: { p: 2, fontSize: 14 } }}>

--- a/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
@@ -94,7 +94,11 @@ function MembersDisplay({
             flexDirection='row'
             key={user.id}
             gap={0.5}
-            sx={wrapColumn ? { width: '100%', justifyContent: 'space-between' } : { overflowX: 'hidden' }}
+            sx={
+              wrapColumn
+                ? { width: '100%', justifyContent: 'space-between', overflowX: 'hidden' }
+                : { overflowX: 'hidden' }
+            }
             onClick={enableDelete ? () => removeMember(user.id) : undefined}
           >
             <UserDisplay fontSize={14} avatarSize='xSmall' user={user} wrapName={wrapColumn} />

--- a/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
@@ -153,7 +153,7 @@ function UserProperty(props: Props): JSX.Element | null {
   if (props.readOnly || !isOpen) {
     return (
       <div
-        style={{ width: '100%', height: '100%' }}
+        style={{ width: '100%', height: '100%', overflow: 'hidden' }}
         onClick={
           !props.readOnly
             ? () => {
@@ -208,7 +208,7 @@ function UserProperty(props: Props): JSX.Element | null {
           placeholder={props.showEmptyPlaceholder && memberIds.length === 0 ? 'Empty' : ''}
           renderTags={() => (
             <MembersDisplay
-              wrapColumn={props.displayType === 'table' ? true : props.wrapColumn ?? false}
+              wrapColumn={true}
               readOnly={props.readOnly}
               clicked={clicked}
               memberIds={memberIds}

--- a/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import CloseIcon from '@mui/icons-material/Close';
 import { IconButton } from '@mui/material';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
 import { Box, Stack } from '@mui/system';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -72,6 +73,13 @@ function MembersDisplay({
   setMemberIds: (memberIds: string[]) => void;
 }) {
   const { membersRecord } = useMembers();
+
+  const enableDelete = !readOnly && clicked;
+
+  function removeMember(memberId: string) {
+    setMemberIds(memberIds.filter((_memberId) => _memberId !== memberId));
+  }
+
   return memberIds.length === 0 ? null : (
     <Stack flexDirection='row' flexWrap={wrapColumn ? 'wrap' : 'nowrap'} gap={1}>
       {memberIds.map((memberId) => {
@@ -81,9 +89,16 @@ function MembersDisplay({
         }
 
         return (
-          <Stack alignItems='center' flexDirection='row' key={user.id} gap={0.5}>
-            <UserDisplay fontSize={14} avatarSize='xSmall' user={user} />
-            {!readOnly && clicked && (
+          <Stack
+            alignItems='center'
+            flexDirection='row'
+            key={user.id}
+            gap={0.5}
+            sx={wrapColumn ? { width: '100%', justifyContent: 'space-between' } : { overflowX: 'hidden' }}
+            onClick={enableDelete ? () => removeMember(user.id) : undefined}
+          >
+            <UserDisplay fontSize={14} avatarSize='xSmall' user={user} wrapName={wrapColumn} />
+            {enableDelete && (
               <IconButton size='small'>
                 <CloseIcon
                   sx={{
@@ -92,7 +107,7 @@ function MembersDisplay({
                   cursor='pointer'
                   fontSize='small'
                   color='secondary'
-                  onClick={() => setMemberIds(memberIds.filter((_memberId) => _memberId !== user.id))}
+                  onClick={() => removeMember(user.id)}
                 />
               </IconButton>
             )}
@@ -112,6 +127,8 @@ function UserProperty(props: Props): JSX.Element | null {
     [memberIds, membersRecord]
   );
 
+  const [isOpen, setIsOpen] = useState(false);
+
   const updateMemberIds = useCallback(
     (unfilteredIds: string[]) => {
       setMemberIds(getFilteredMemberIds(unfilteredIds, membersRecord));
@@ -123,68 +140,80 @@ function UserProperty(props: Props): JSX.Element | null {
     updateMemberIds(props.memberIds);
   }, [props.memberIds, updateMemberIds]);
 
-  const [isOpen, setIsOpen] = useState(false);
-
-  if (props.readOnly) {
-    return (
-      <MembersDisplay
-        wrapColumn={props.wrapColumn ?? false}
-        readOnly={props.readOnly}
-        clicked={clicked}
-        memberIds={memberIds}
-        setMemberIds={updateMemberIds}
-      />
-    );
+  function saveUsers(_memberIds: string[]) {
+    if (!props.readOnly && !arrayEquals(_memberIds, props.memberIds)) {
+      props.onChange(_memberIds);
+    }
   }
 
-  return (
-    <StyledUserPropertyContainer
-      hideOverflow={props.displayType === 'table'}
-      onClick={() => {
-        // Only register click if display type is details or table
-        if (!props.readOnly) {
-          setIsOpen(true);
-          setClicked(true);
+  if (props.readOnly || !isOpen) {
+    return (
+      <div
+        style={{ width: '100%', height: '100%' }}
+        onClick={
+          !props.readOnly
+            ? () => {
+                setClicked(true);
+                setIsOpen(true);
+              }
+            : undefined
         }
+      >
+        <MembersDisplay
+          wrapColumn={props.wrapColumn ?? false}
+          readOnly={props.readOnly}
+          clicked={clicked}
+          memberIds={memberIds}
+          setMemberIds={updateMemberIds}
+        />
+      </div>
+    );
+  }
+  return (
+    <ClickAwayListener
+      onClickAway={(ev) => {
+        setClicked(false);
+        setIsOpen(false);
+        saveUsers(memberIds);
       }}
-      hideInput={props.readOnly || (props.displayType !== 'details' && !clicked)}
     >
-      <InputSearchMemberMultiple
-        disableClearable
-        open={isOpen}
-        disableCloseOnSelect
-        defaultValue={memberIds}
-        value={membersValue}
-        onChange={(_memberIds, reason) => {
-          if (reason === 'removeOption' && !isOpen) {
-            props.onChange(_memberIds);
-          }
-          updateMemberIds(_memberIds);
-        }}
-        onClose={() => {
-          if (isOpen) {
-            // Reduce flicker in the ui
-            if (!arrayEquals(memberIds, props.memberIds)) {
-              props.onChange(memberIds);
-            }
-            setIsOpen(false);
-            setClicked(false);
+      <StyledUserPropertyContainer
+        hideOverflow={props.displayType === 'table'}
+        onClick={() => {
+          // Only register click if display type is details or table
+          if (!props.readOnly) {
+            setIsOpen(true);
+            setClicked(true);
           }
         }}
-        getOptionLabel={(user) => (typeof user === 'string' ? user : user?.username)}
-        readOnly={props.readOnly}
-        placeholder={props.showEmptyPlaceholder && memberIds.length === 0 ? 'Empty' : ''}
-        renderTags={() => (
-          <MembersDisplay
-            wrapColumn={props.wrapColumn ?? false}
-            readOnly={props.readOnly}
-            clicked={clicked}
-            memberIds={memberIds}
-            setMemberIds={updateMemberIds}
-          />
-        )}
-      />
-    </StyledUserPropertyContainer>
+        hideInput={props.readOnly || (props.displayType !== 'details' && !clicked)}
+      >
+        <InputSearchMemberMultiple
+          // sx={{ '& .MuiAutocomplete-paper': { margin: 0, marginTop: '-20px' } }}
+          disableClearable
+          open={isOpen}
+          openOnFocus
+          disableCloseOnSelect
+          defaultValue={memberIds}
+          value={membersValue}
+          onChange={(_memberIds) => {
+            updateMemberIds(_memberIds);
+          }}
+          getOptionLabel={(user) => (typeof user === 'string' ? user : user?.username)}
+          readOnly={props.readOnly}
+          placeholder={props.showEmptyPlaceholder && memberIds.length === 0 ? 'Empty' : ''}
+          renderTags={() => (
+            <MembersDisplay
+              wrapColumn={props.displayType === 'table' ? true : props.wrapColumn ?? false}
+              readOnly={props.readOnly}
+              clicked={clicked}
+              memberIds={memberIds}
+              setMemberIds={updateMemberIds}
+            />
+          )}
+        />
+      </StyledUserPropertyContainer>
+    </ClickAwayListener>
   );
 }
 

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -5,7 +5,6 @@ import { useIntl } from 'react-intl';
 
 import { SelectProperty } from 'components/common/BoardEditor/components/properties/SelectProperty/SelectProperty';
 import type { PropertyValueDisplayType } from 'components/common/BoardEditor/interfaces';
-import { MountTracker } from 'components/common/Debug/MountTracker';
 import { useDateFormatter } from 'hooks/useDateFormatter';
 import type { Board, IPropertyTemplate, PropertyType } from 'lib/focalboard/board';
 import type { Card } from 'lib/focalboard/card';
@@ -124,7 +123,7 @@ function PropertyValueElement(props: Props) {
         onChange={(newValue) => {
           mutator.changePropertyValue(card, propertyTemplate.id, newValue);
         }}
-        wrapColumn={displayType !== 'table' ? true : props.wrapColumn ?? false}
+        wrapColumn={props.wrapColumn ?? false}
         showEmptyPlaceholder={displayType === 'details'}
       />
     );

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -117,18 +117,16 @@ function PropertyValueElement(props: Props) {
     );
   } else if (propertyTemplate.type === 'person') {
     propertyValueElement = (
-      <MountTracker name='UserProp' countRenders>
-        <UserProperty
-          displayType={displayType}
-          memberIds={typeof propertyValue === 'string' ? [propertyValue] : propertyValue ?? []}
-          readOnly={readOnly || (displayType !== 'details' && displayType !== 'table')}
-          onChange={(newValue) => {
-            mutator.changePropertyValue(card, propertyTemplate.id, newValue);
-          }}
-          wrapColumn={displayType !== 'table' ? true : props.wrapColumn ?? false}
-          showEmptyPlaceholder={displayType === 'details'}
-        />
-      </MountTracker>
+      <UserProperty
+        displayType={displayType}
+        memberIds={typeof propertyValue === 'string' ? [propertyValue] : propertyValue ?? []}
+        readOnly={readOnly || (displayType !== 'details' && displayType !== 'table')}
+        onChange={(newValue) => {
+          mutator.changePropertyValue(card, propertyTemplate.id, newValue);
+        }}
+        wrapColumn={displayType !== 'table' ? true : props.wrapColumn ?? false}
+        showEmptyPlaceholder={displayType === 'details'}
+      />
     );
   } else if (propertyTemplate.type === 'date') {
     if (readOnly) {
@@ -136,6 +134,7 @@ function PropertyValueElement(props: Props) {
     } else {
       propertyValueElement = (
         <DateRange
+          wrapColumn={props.wrapColumn}
           className='octo-propertyvalue'
           value={value.toString()}
           showEmptyPlaceholder={showEmptyPlaceholder}

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 
 import { SelectProperty } from 'components/common/BoardEditor/components/properties/SelectProperty/SelectProperty';
 import type { PropertyValueDisplayType } from 'components/common/BoardEditor/interfaces';
+import { MountTracker } from 'components/common/Debug/MountTracker';
 import { useDateFormatter } from 'hooks/useDateFormatter';
 import type { Board, IPropertyTemplate, PropertyType } from 'lib/focalboard/board';
 import type { Card } from 'lib/focalboard/card';
@@ -116,16 +117,18 @@ function PropertyValueElement(props: Props) {
     );
   } else if (propertyTemplate.type === 'person') {
     propertyValueElement = (
-      <UserProperty
-        displayType={displayType}
-        memberIds={typeof propertyValue === 'string' ? [propertyValue] : propertyValue ?? []}
-        readOnly={readOnly || (displayType !== 'details' && displayType !== 'table')}
-        onChange={(newValue) => {
-          mutator.changePropertyValue(card, propertyTemplate.id, newValue);
-        }}
-        wrapColumn={displayType !== 'table' ? true : props.wrapColumn ?? false}
-        showEmptyPlaceholder={displayType === 'details'}
-      />
+      <MountTracker name='UserProp' countRenders>
+        <UserProperty
+          displayType={displayType}
+          memberIds={typeof propertyValue === 'string' ? [propertyValue] : propertyValue ?? []}
+          readOnly={readOnly || (displayType !== 'details' && displayType !== 'table')}
+          onChange={(newValue) => {
+            mutator.changePropertyValue(card, propertyTemplate.id, newValue);
+          }}
+          wrapColumn={displayType !== 'table' ? true : props.wrapColumn ?? false}
+          showEmptyPlaceholder={displayType === 'details'}
+        />
+      </MountTracker>
     );
   } else if (propertyTemplate.type === 'date') {
     if (readOnly) {

--- a/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
@@ -166,15 +166,17 @@ function TableRow(props: Props) {
                   <DragIndicatorIcon color='secondary' />
                 </IconButton>
               )}
-              <div className='octo-icontitle' style={{ alignSelf: 'flex-start', alignItems: 'flex-start' }}>
-                <PageIcon isEditorEmpty={!hasContent} pageType='page' icon={pageIcon} />
-                <TextInput {...commonProps} multiline={wrapColumn} />
-              </div>
+              <div style={{ display: 'flex' }}>
+                <div className='octo-icontitle' style={{ alignSelf: 'flex-start', alignItems: 'flex-start' }}>
+                  <PageIcon isEditorEmpty={!hasContent} pageType='page' icon={pageIcon} />
+                  <TextInput {...commonProps} multiline={wrapColumn} />
+                </div>
 
-              <div className='open-button'>
-                <Button onClick={() => props.showCard(props.card.id || '')}>
-                  <FormattedMessage id='TableRow.open' defaultMessage='Open' />
-                </Button>
+                <div className='open-button'>
+                  <Button onClick={() => props.showCard(props.card.id || '')}>
+                    <FormattedMessage id='TableRow.open' defaultMessage='Open' />
+                  </Button>
+                </div>
               </div>
             </Box>
           );

--- a/components/common/UserDisplay.tsx
+++ b/components/common/UserDisplay.tsx
@@ -1,4 +1,3 @@
-import type { User } from '@charmverse/core/prisma';
 import type { BoxProps } from '@mui/material';
 import { Box, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
@@ -20,6 +19,7 @@ interface StyleProps extends BoxProps {
   avatarSize?: InitialAvatarProps['size'];
   hideName?: boolean;
   avatarIcon?: ReactNode;
+  wrapName?: boolean;
 }
 
 interface BaseComponentProps extends StyleProps {
@@ -36,6 +36,7 @@ function BaseComponent({
   fontWeight,
   isNft,
   hideName,
+  wrapName,
   ...props
 }: BaseComponentProps) {
   return (
@@ -55,7 +56,7 @@ function BaseComponent({
         <Avatar size={avatarSize} name={username} avatar={avatar} isNft={isNft} />
       )}
       {!hideName && (
-        <Typography whiteSpace='nowrap' fontSize={fontSize} fontWeight={fontWeight}>
+        <Typography whiteSpace={wrapName ? 'break-spaces' : 'nowrap'} fontSize={fontSize} fontWeight={fontWeight}>
           {username}
         </Typography>
       )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 94c50ff</samp>

This pull request enhances the board editor and the user display components in the `app.charmverse.io` repository. It adds features to wrap the labels of date range and user properties to improve the layout and readability. It also improves the user interface and functionality of the user property input. It adds a debugging component and a prop for date range wrapping to the `PropertyValueElement` component.

### WHY
Fix wrapping for User and Date columns

Wrapping implemented for user and date columns.

_Notes:
-- Implemented forced wrapping when selecting values, as otherwise values were off screen
-- Made values deleteable by clicking anywhere on that value (once in input mode). This handles the case where the column might be too small to display the X
_ 
<img width="366" alt="Screenshot 2023-06-01 at 00 14 48" src="https://github.com/charmverse/app.charmverse.io/assets/18669748/78030d62-d9e3-40f8-996e-5fb49759a64e">


When wrapped, the user column does not go beyond the column anymore

<img width="366" alt="Screenshot 2023-06-01 at 00 14 48" src="https://github.com/charmverse/app.charmverse.io/assets/18669748/f61dd0cc-f530-40b4-b03d-791874e62091">
