### PR TITLE
fix closing rooms too early

### DIFF
--- a/components/common/CharmEditor/components/fiduswriter/collab/doc.ts
+++ b/components/common/CharmEditor/components/fiduswriter/collab/doc.ts
@@ -88,7 +88,11 @@ export class ModCollabDoc {
   receiveDocument(data: ServerDocDataMessage) {
     this.cancelCurrentlyCheckingVersion();
     if (this.mod.editor.docInfo.confirmedDoc) {
-      log.debug('merge document updates', { pageId: this.mod.editor.docInfo.id });
+      log.debug('merge document updates', {
+        clientPageVersion: this.mod.editor.docInfo.version,
+        pageId: this.mod.editor.docInfo.id,
+        serverPageVersion: data.doc.v
+      });
       this.merge.adjustDocument(data);
     } else {
       this.loadDocument(data);

--- a/components/common/CharmEditor/components/fiduswriter/collab/merge/index.ts
+++ b/components/common/CharmEditor/components/fiduswriter/collab/merge/index.ts
@@ -34,8 +34,8 @@ export class Merge {
     if (this.mod.editor.docInfo.version < data.doc.v && sendableSteps(this.mod.editor.view.state)) {
       log.debug('Update document with server changes', {
         messages: data.m?.length,
-        version: data.doc.v,
-        clientVersion: this.mod.editor.docInfo.version
+        serverPageVersion: data.doc.v,
+        clientPageVersion: this.mod.editor.docInfo.version
       });
       this.mod.doc.receiving = true;
       const confirmedState = EditorState.create({ doc: this.mod.editor.docInfo.confirmedDoc || undefined });

--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -125,8 +125,8 @@ export class DocumentEventHandler {
     });
 
     this.socket.on('disconnect', (...args) => {
-      // console.log('disconnect', args);
       try {
+        log.debug('Closing collaboration session', { args, ...this.getSessionMeta() });
         this.onClose();
       } catch (error) {
         const logData = this.getSessionMeta();
@@ -195,18 +195,23 @@ export class DocumentEventHandler {
 
     // handle subscription to document
     if (message.type === 'subscribe') {
-      log.debug('Received subscribe event', { pageId: message.roomId, userId: session.user.id });
+      log.debug('Received subscribe event', { socketId: this.id, pageId: message.roomId, userId: session.user.id });
       await this.subscribeToDoc({ pageId: message.roomId, connectionCount: message.connection });
       return;
     }
 
     if (!session.documentId) {
-      log.warn('Ignore message because session is missing document', { userId: session.user.id });
+      log.warn('Ignore message because session is missing document', { socketId: this.id, userId: session.user.id });
       return;
     }
 
     if (!docRooms.has(session.documentId)) {
-      log.warn('Ignore message from closed document', { message, pageId: session.documentId, userId: session.user.id });
+      log.warn('Ignore message from closed document', {
+        socketId: this.id,
+        message,
+        pageId: session.documentId,
+        userId: session.user.id
+      });
       return;
     }
 
@@ -261,10 +266,16 @@ export class DocumentEventHandler {
 
       const docRoom = docRooms.get(pageId);
       if (docRoom && docRoom.participants.size > 0) {
-        log.debug('Join existing document room', { pageId, userId, connectionCount });
+        log.debug('Join existing document room', {
+          pageId,
+          userId,
+          connectionCount,
+          socketId: this.id,
+          participants: docRoom.participants.size
+        });
         docRoom.participants.set(this.id, this);
       } else {
-        log.debug('Opening new document room', { pageId, userId, connectionCount });
+        log.debug('Opening new document room', { socketId: this.id, pageId, userId, connectionCount });
         const page = await prisma.page.findUniqueOrThrow({
           where: { id: pageId },
           include: {
@@ -297,6 +308,7 @@ export class DocumentEventHandler {
       if (connectionCount < 1) {
         await this.sendDocument();
         log.debug('Sent document to new subscriber', {
+          socketId: this.id,
           pageId,
           userId,
           pageVersion: docRooms.get(pageId)?.doc.version
@@ -304,7 +316,12 @@ export class DocumentEventHandler {
       }
       this.handleParticipantUpdate();
     } catch (error) {
-      log.error('Error subscribing user to page', { error, pageId, userId: this.getSession().user.id });
+      log.error('Error subscribing user to page', {
+        error,
+        socketId: this.id,
+        pageId,
+        userId: this.getSession().user.id
+      });
       this.sendError('There was an error loading the page! Please try again later.');
     }
   }
@@ -354,6 +371,7 @@ export class DocumentEventHandler {
     const clientV = message.v;
     const serverV = room.doc.version;
     const logMeta = {
+      socketId: this.id,
       userId: this.getSession().user.id,
       pageId: room.doc.id,
       v: clientV,
@@ -537,11 +555,10 @@ export class DocumentEventHandler {
   }
 
   onClose() {
-    log.debug('Closing collaboration session', this.getSessionMeta());
     const room = this.getDocumentRoom();
     if (room) {
       room.participants.delete(this.id);
-      if (Object.keys(room.participants).length === 0) {
+      if (room.participants.size === 0) {
         docRooms.delete(room.doc.id);
       } else {
         this.sendParticipantList();


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at abacfa4</samp>

This pull request improves the logging functionality of the websocket and collaboration modules of the app. It adds more details and clarity to the log messages, such as socket ids, session meta data, message content, and page versions. The affected files are `lib/websockets/documentEvents/documentEvents.ts`, `components/common/CharmEditor/components/fiduswriter/collab/doc.ts`, and `components/common/CharmEditor/components/fiduswriter/collab/merge/index.ts`.

### WHY
Issue: if two users are connected to a doc, and one leaves, it closes the doc for everyone and no changes can be saved.

I changed 'room.participants' to a Map recently, but there was a line using it as an array. Object.keys(map) always returns an empty array, even if keys are set.
