### PR TITLE
Use t3 small for staging instance

### DIFF
--- a/.cdk/staging-stack.ts
+++ b/.cdk/staging-stack.ts
@@ -91,7 +91,7 @@ export class CdkDeployStack extends Stack {
       {
         namespace: 'aws:ec2:instances',
         optionName: 'InstanceTypes',
-        value: 't3.micro'
+        value: 't3.small'
       },
       {
         // ALB health check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       [
         'sh',
         '-c',
-        'npm run prisma:deploy && node --require dd-trace/init node_modules/.bin/next start --keepAliveTimeout 70000'
+        'npm run prisma:deploy && node --max-old-space-size=750 --require dd-trace/init node_modules/.bin/next start --keepAliveTimeout 70000'
       ]
     environment:
       - NEXT_PUBLIC_APP_ENV=staging
@@ -94,7 +94,7 @@ services:
       [
         'sh',
         '-c',
-        'node --experimental-specifier-resolution=node  ./dist/main.js',
+        'node --max-old-space-size=750 --experimental-specifier-resolution=node  ./dist/main.js',
       ]
     env_file:
       - '.env'


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd05609</samp>

Increased the instance type for EC2 instances in the staging stack to `t3.small`. This improves the performance and stability of the staging environment.

### WHY
Use larger instance since we now run permissions API as a sidecar

Default nodeJS max old memory size is 512Mb, so should fit perfectly with this setup which has 2GB ram