### PR TITLE
restrict duplication rules to users with create page

### DIFF
--- a/__integration-tests__/server/pages/api/pages/[id]/duplicate.spec.ts
+++ b/__integration-tests__/server/pages/api/pages/[id]/duplicate.spec.ts
@@ -1,0 +1,35 @@
+import { testUtilsPages, testUtilsUser } from '@charmverse/core/test';
+import request from 'supertest';
+
+import { addSpaceOperations } from 'lib/permissions/spaces';
+import { baseUrl, loginUser } from 'testing/mockApiCall';
+
+describe('POST /api/pages/{id}/duplicate - Duplicate a page', () => {
+  it('should allow a user to duplicate the page if they have access to create pages', async () => {
+    const { user, space } = await testUtilsUser.generateUserAndSpace();
+    const userCookie = await loginUser(user.id);
+    const page = await testUtilsPages.generatePage({
+      createdBy: user.id,
+      spaceId: space.id
+    });
+
+    await addSpaceOperations({
+      forSpaceId: space.id,
+      spaceId: space.id,
+      operations: ['createPage']
+    });
+
+    await request(baseUrl).post(`/api/pages/${page.id}/duplicate`).set('Cookie', userCookie).expect(200);
+  });
+
+  it('should not allow a user to duplicate the page if they do not have access to create pages', async () => {
+    const { user, space } = await testUtilsUser.generateUserAndSpace();
+    const userCookie = await loginUser(user.id);
+    const page = await testUtilsPages.generatePage({
+      createdBy: user.id,
+      spaceId: space.id
+    });
+
+    await request(baseUrl).post(`/api/pages/${page.id}/duplicate`).set('Cookie', userCookie).expect(401);
+  });
+});

--- a/components/common/PageActions/components/DuplicatePageAction.tsx
+++ b/components/common/PageActions/components/DuplicatePageAction.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 import charmClient from 'charmClient';
 import { useBounties } from 'hooks/useBounties';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
 
 const excludedPageTypes: (PageType | undefined)[] = ['bounty_template', 'proposal_template'];
 
@@ -24,10 +25,11 @@ export function DuplicatePageAction({
   pagePermissions: PagePermissionFlags | undefined;
 }) {
   const currentSpace = useCurrentSpace();
+  const [userSpacePermissions] = useCurrentSpacePermissions();
   const router = useRouter();
   const { refreshBounty } = useBounties();
 
-  const disabled = !pagePermissions?.read;
+  const disabled = !pagePermissions?.read || !userSpacePermissions?.createPage;
 
   async function duplicatePage() {
     if (currentSpace) {

--- a/pages/api/pages/[id]/duplicate.ts
+++ b/pages/api/pages/[id]/duplicate.ts
@@ -46,12 +46,12 @@ async function duplicatePageRoute(req: NextApiRequest, res: NextApiResponse<Dupl
     throw new PageNotFoundError(pageId);
   }
 
-  const permissions = await req.basePermissionsClient.pages.computePagePermissions({
-    resourceId: pageId,
+  const spacePermissions = await req.basePermissionsClient.spaces.computeSpacePermissions({
+    resourceId: pageToDuplicate.spaceId,
     userId
   });
 
-  if (!permissions.read) {
+  if (!spacePermissions.createPage) {
     throw new ActionNotPermittedError('You are not allowed to duplicate this page.');
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 602a594</samp>

Added a permission check for duplicating a page in the same space. The `DuplicatePageAction` component and the `duplicatePageRoute` function now use the `useCurrentSpacePermissions` hook and the space permission for creating a page.

### WHY
If you can't create a page, you shouldn't be able to duplicate a page in the space - essentially lets you create a page. And as the author, you automatically have write access to it.