### PR TITLE
Show empty placeholder for person property

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/properties/user/user.tsx
@@ -163,13 +163,24 @@ function UserProperty(props: Props): JSX.Element | null {
             : undefined
         }
       >
-        <MembersDisplay
-          wrapColumn={props.wrapColumn ?? false}
-          readOnly={props.readOnly}
-          clicked={clicked}
-          memberIds={memberIds}
-          setMemberIds={updateMemberIds}
-        />
+        {props.displayType === 'details' && memberIds.length === 0 ? (
+          <div
+            className='octo-propertyvalue'
+            style={{
+              color: 'var(--text-gray)'
+            }}
+          >
+            Empty
+          </div>
+        ) : (
+          <MembersDisplay
+            wrapColumn={props.wrapColumn ?? false}
+            readOnly={props.readOnly}
+            clicked={clicked}
+            memberIds={memberIds}
+            setMemberIds={updateMemberIds}
+          />
+        )}
       </div>
     );
   }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ac8c7b</samp>

Improve user property rendering in board editor. Add a condition to show 'Empty' text for user properties with no members in 'details' display type in `user.tsx`.

### WHY
<!-- author to complete -->
