### PR TITLE
Fix creating a proposal with authors, improve security

### DIFF
--- a/__integration-tests__/server/pages/api/proposals/index.public.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/index.public.spec.ts
@@ -1,0 +1,90 @@
+import type { ProposalWithUsers } from '@charmverse/core/dist/cjs/proposals';
+import type { Space, User } from '@charmverse/core/prisma';
+import type { ProposalCategory } from '@charmverse/core/prisma-client';
+import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
+import request from 'supertest';
+
+import type { CreateProposalInput, CreatedProposal } from 'lib/proposal/createProposal';
+import { emptyDocument } from 'lib/prosemirror/constants';
+import { baseUrl, loginUser } from 'testing/mockApiCall';
+
+let space: Space;
+let user: User;
+let proposalCategory: ProposalCategory;
+
+beforeAll(async () => {
+  const generated = await testUtilsUser.generateUserAndSpace({ isAdmin: false, spacePaidTier: 'free' });
+  space = generated.space;
+  user = generated.user;
+  proposalCategory = await testUtilsProposals.generateProposalCategory({
+    spaceId: space.id
+  });
+});
+
+describe('POST /api/proposals - Create a proposal', () => {
+  it('should allow a space member to create a proposal in a specific category, with page content, reviewers and authors configured and respond with 201', async () => {
+    const userCookie = await loginUser(user.id);
+    const otherUser = await testUtilsUser.generateSpaceUser({
+      spaceId: space.id
+    });
+
+    const input: CreateProposalInput = {
+      categoryId: proposalCategory.id,
+      spaceId: space.id,
+      userId: user.id,
+      authors: [user.id, otherUser.id],
+      reviewers: [{ group: 'user', id: user.id }],
+      pageProps: {
+        title: 'Proposal title',
+        content: { ...emptyDocument },
+        contentText: 'Empty proposal'
+      }
+    };
+
+    const createdProposal = (
+      await request(baseUrl).post('/api/proposals').set('Cookie', userCookie).send(input).expect(201)
+    ).body as CreatedProposal;
+
+    expect(createdProposal.proposal).toMatchObject<Partial<ProposalWithUsers>>({
+      authors: expect.arrayContaining([
+        {
+          proposalId: createdProposal?.proposal.id as string,
+          userId: user.id
+        },
+        {
+          proposalId: createdProposal?.proposal.id as string,
+          userId: otherUser.id
+        }
+      ]),
+      reviewers: expect.arrayContaining([
+        {
+          id: expect.any(String),
+          proposalId: createdProposal?.proposal.id as string,
+          userId: user.id,
+          roleId: null
+        }
+      ])
+    });
+  });
+
+  it('should not allow a user outside the space to create a proposal and respond with 401', async () => {
+    const outsideUser = await testUtilsUser.generateUser();
+
+    const userCookie = await loginUser(outsideUser.id);
+
+    const input: CreateProposalInput = {
+      // This is the important bit
+      categoryId: proposalCategory.id,
+      spaceId: space.id,
+      userId: user.id,
+      authors: [user.id],
+      reviewers: [{ group: 'user', id: outsideUser.id }],
+      pageProps: {
+        title: 'Proposal title',
+        content: { ...emptyDocument },
+        contentText: 'Empty proposal'
+      }
+    };
+    await request(baseUrl).post('/api/proposals').set('Cookie', userCookie).send(input).expect(401);
+  });
+});

--- a/__integration-tests__/server/pages/api/proposals/index.public.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/index.public.spec.ts
@@ -1,6 +1,6 @@
-import type { ProposalWithUsers } from '@charmverse/core/dist/cjs/proposals';
 import type { Space, User } from '@charmverse/core/prisma';
 import type { ProposalCategory } from '@charmverse/core/prisma-client';
+import type { ProposalWithUsers } from '@charmverse/core/proposals';
 import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
 import request from 'supertest';
 
@@ -68,7 +68,7 @@ describe('POST /api/proposals - Create a proposal', () => {
   });
 
   it('should not allow a user outside the space to create a proposal and respond with 401', async () => {
-    const outsideUser = await testUtilsUser.generateUser();
+    const { user: outsideUser } = await testUtilsUser.generateUserAndSpace();
 
     const userCookie = await loginUser(outsideUser.id);
 

--- a/__integration-tests__/server/pages/api/proposals/index.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/index.spec.ts
@@ -1,6 +1,6 @@
-import type { ProposalWithUsers } from '@charmverse/core/dist/cjs/proposals';
 import type { Space, User } from '@charmverse/core/prisma';
 import type { ProposalCategory } from '@charmverse/core/prisma-client';
+import type { ProposalWithUsers } from '@charmverse/core/proposals';
 import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
 import request from 'supertest';
 

--- a/__integration-tests__/server/pages/api/proposals/index.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/index.spec.ts
@@ -1,0 +1,98 @@
+import type { ProposalWithUsers } from '@charmverse/core/dist/cjs/proposals';
+import type { Space, User } from '@charmverse/core/prisma';
+import type { ProposalCategory } from '@charmverse/core/prisma-client';
+import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
+import request from 'supertest';
+
+import type { CreateProposalInput, CreatedProposal } from 'lib/proposal/createProposal';
+import { emptyDocument } from 'lib/prosemirror/constants';
+import { baseUrl, loginUser } from 'testing/mockApiCall';
+
+let space: Space;
+let user: User;
+let proposalCategory: ProposalCategory;
+let readonlyProposalCategory: ProposalCategory;
+
+beforeAll(async () => {
+  const generated = await testUtilsUser.generateUserAndSpace({ isAdmin: false });
+  space = generated.space;
+  user = generated.user;
+  proposalCategory = await testUtilsProposals.generateProposalCategory({
+    spaceId: space.id,
+    proposalCategoryPermissions: [
+      {
+        permissionLevel: 'full_access',
+        assignee: { group: 'space', id: space.id }
+      }
+    ]
+  });
+  readonlyProposalCategory = await testUtilsProposals.generateProposalCategory({
+    spaceId: space.id
+  });
+});
+
+describe('POST /api/proposals - Create a proposal', () => {
+  it('should allow a user to create a proposal in a specific category, with page content, reviewers and authors configured and respond with 201', async () => {
+    const userCookie = await loginUser(user.id);
+    const otherUser = await testUtilsUser.generateSpaceUser({
+      spaceId: space.id
+    });
+
+    const input: CreateProposalInput = {
+      categoryId: proposalCategory.id,
+      spaceId: space.id,
+      userId: user.id,
+      authors: [user.id, otherUser.id],
+      reviewers: [{ group: 'user', id: user.id }],
+      pageProps: {
+        title: 'Proposal title',
+        content: { ...emptyDocument },
+        contentText: 'Empty proposal'
+      }
+    };
+
+    const createdProposal = (
+      await request(baseUrl).post('/api/proposals').set('Cookie', userCookie).send(input).expect(201)
+    ).body as CreatedProposal;
+
+    expect(createdProposal.proposal).toMatchObject<Partial<ProposalWithUsers>>({
+      authors: expect.arrayContaining([
+        {
+          proposalId: createdProposal?.proposal.id as string,
+          userId: user.id
+        },
+        {
+          proposalId: createdProposal?.proposal.id as string,
+          userId: otherUser.id
+        }
+      ]),
+      reviewers: expect.arrayContaining([
+        {
+          id: expect.any(String),
+          proposalId: createdProposal?.proposal.id as string,
+          userId: user.id,
+          roleId: null
+        }
+      ])
+    });
+  });
+
+  it('should fail to create a proposal if the user does not have permissions for the category and respond with 401', async () => {
+    const userCookie = await loginUser(user.id);
+
+    const input: CreateProposalInput = {
+      // This is the important bit
+      categoryId: readonlyProposalCategory.id,
+      spaceId: space.id,
+      userId: user.id,
+      authors: [user.id],
+      reviewers: [{ group: 'user', id: user.id }],
+      pageProps: {
+        title: 'Proposal title',
+        content: { ...emptyDocument },
+        contentText: 'Empty proposal'
+      }
+    };
+    await request(baseUrl).post('/api/proposals').set('Cookie', userCookie).send(input).expect(401);
+  });
+});

--- a/components/proposals/components/ProposalDialog/ProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalPage.tsx
@@ -56,6 +56,7 @@ export function ProposalPage({ setFormInputs, formInputs, contentUpdated, setCon
       setIsCreatingProposal(true);
       const createdProposal = await charmClient.proposals
         .createProposal({
+          authors: formInputs.authors,
           categoryId: formInputs.categoryId,
           pageProps: {
             content: formInputs.content,

--- a/lib/proposal/__tests__/validateProposalAuthorsAndReviewers.spec.ts
+++ b/lib/proposal/__tests__/validateProposalAuthorsAndReviewers.spec.ts
@@ -1,0 +1,77 @@
+import type { TargetPermissionGroup } from '@charmverse/core/permissions';
+import type { Role, Space, User } from '@charmverse/core/src/prisma-client';
+import { testUtilsMembers, testUtilsUser } from '@charmverse/core/test';
+
+import type { ProposalUsersValidationResult } from '../validateProposalAuthorsAndReviewers';
+import { validateProposalAuthorsAndReviewers } from '../validateProposalAuthorsAndReviewers';
+
+// Space we are testing
+let space: Space;
+let user: User;
+let role: Role;
+
+// Outside space
+let outsideSpace: Space;
+let outsideUser: User;
+let outsideRole: Role;
+beforeAll(async () => {
+  const generated = await testUtilsUser.generateUserAndSpace({});
+  user = generated.user;
+  space = generated.space;
+  role = await testUtilsMembers.generateRole({
+    createdBy: user.id,
+    spaceId: space.id
+  });
+
+  const outside = await testUtilsUser.generateUserAndSpace({});
+  outsideUser = outside.user;
+  outsideSpace = outside.space;
+  outsideRole = await testUtilsMembers.generateRole({
+    createdBy: outsideUser.id,
+    spaceId: outsideSpace.id
+  });
+});
+
+describe('validateProposalAuthorsAndReviewers', () => {
+  it('should return valid if all authors and reviewers are valid', async () => {
+    const result = await validateProposalAuthorsAndReviewers({
+      spaceId: space.id,
+      authors: [user.id],
+      reviewers: [
+        { group: 'user', id: user.id },
+        { group: 'role', id: role.id }
+      ]
+    });
+
+    expect(result).toMatchObject<ProposalUsersValidationResult>({
+      valid: true,
+      invalidAuthors: [],
+      invalidReviewers: []
+    });
+  });
+
+  it('should return invalid if some authors and reviewers are invalid as well as their information', async () => {
+    const result = await validateProposalAuthorsAndReviewers({
+      spaceId: space.id,
+      authors: [user.id, outsideUser.id],
+      reviewers: [
+        { group: 'user', id: user.id },
+        { group: 'role', id: role.id },
+        { group: 'user', id: outsideUser.id },
+        { group: 'role', id: outsideRole.id }
+      ]
+    });
+
+    expect(result.invalidAuthors).toHaveLength(1);
+    expect(result.invalidReviewers).toHaveLength(2);
+
+    expect(result).toMatchObject<ProposalUsersValidationResult>({
+      valid: false,
+      invalidAuthors: expect.arrayContaining([outsideUser.id]),
+      invalidReviewers: expect.arrayContaining<TargetPermissionGroup<'role' | 'user'>>([
+        { group: 'user', id: outsideUser.id },
+        { group: 'role', id: outsideRole.id }
+      ])
+    });
+  });
+});

--- a/lib/proposal/__tests__/validateProposalAuthorsAndReviewers.spec.ts
+++ b/lib/proposal/__tests__/validateProposalAuthorsAndReviewers.spec.ts
@@ -1,5 +1,5 @@
 import type { TargetPermissionGroup } from '@charmverse/core/permissions';
-import type { Role, Space, User } from '@charmverse/core/src/prisma-client';
+import type { Role, Space, User } from '@charmverse/core/prisma-client';
 import { testUtilsMembers, testUtilsUser } from '@charmverse/core/test';
 
 import type { ProposalUsersValidationResult } from '../validateProposalAuthorsAndReviewers';

--- a/lib/proposal/validateProposalAuthorsAndReviewers.ts
+++ b/lib/proposal/validateProposalAuthorsAndReviewers.ts
@@ -1,0 +1,91 @@
+import type { TargetPermissionGroup } from '@charmverse/core/permissions';
+import { prisma } from '@charmverse/core/prisma-client';
+
+export type ProposalUsersToValidate = {
+  spaceId: string;
+  authors: string[];
+  reviewers: TargetPermissionGroup<'role' | 'user'>[];
+};
+
+export type ProposalUsersValidationResult = {
+  valid: boolean;
+  invalidAuthors: string[];
+  invalidReviewers: TargetPermissionGroup<'role' | 'user'>[];
+};
+
+export async function validateProposalAuthorsAndReviewers({
+  authors,
+  reviewers,
+  spaceId
+}: ProposalUsersToValidate): Promise<ProposalUsersValidationResult> {
+  const invalidAuthors: string[] = [];
+  const invalidReviewers: TargetPermissionGroup<'role' | 'user'>[] = [];
+
+  // Validate input for security purposes
+  const spaceRoles = await prisma.spaceRole.findMany({
+    where: {
+      spaceId,
+      userId: {
+        in: authors
+      }
+    },
+    select: {
+      userId: true
+    }
+  });
+
+  for (const author of authors) {
+    if (!spaceRoles.some((sr) => sr.userId === author)) {
+      invalidAuthors.push(author);
+    }
+  }
+
+  const userReviewers = reviewers.filter((reviewer) => reviewer.group === 'user');
+
+  if (userReviewers.length > 0) {
+    const userReviewerSpaceRoles = await prisma.spaceRole.findMany({
+      where: {
+        spaceId,
+        userId: {
+          in: userReviewers.map((reviewer) => reviewer.id)
+        }
+      },
+      select: {
+        userId: true
+      }
+    });
+    for (const userReviewer of userReviewers) {
+      if (!userReviewerSpaceRoles.some((sr) => sr.userId === userReviewer.id)) {
+        invalidReviewers.push(userReviewer);
+      }
+    }
+  }
+
+  const roleReviewers = reviewers.filter((reviewer) => reviewer.group === 'role');
+
+  if (roleReviewers.length > 0) {
+    // Double check each reviewer role belongs to space
+    const roles = await prisma.role.findMany({
+      where: {
+        spaceId,
+        id: {
+          in: roleReviewers.map((reviewer) => reviewer.id)
+        }
+      }
+    });
+
+    for (const roleReviewer of roleReviewers) {
+      if (!roles.some((role) => role.id === roleReviewer.id)) {
+        invalidReviewers.push(roleReviewer);
+      }
+    }
+  }
+
+  const isValid = invalidAuthors.length === 0 && invalidReviewers.length === 0;
+
+  return {
+    valid: isValid,
+    invalidAuthors,
+    invalidReviewers
+  };
+}

--- a/lib/subscription/constants.ts
+++ b/lib/subscription/constants.ts
@@ -1,4 +1,4 @@
-import type { SubscriptionTier } from '@charmverse/core/src/prisma-client';
+import type { SubscriptionTier } from '@charmverse/core/prisma-client';
 
 export const SUBSCRIPTION_PRODUCT_IDS = [
   'community_5k',

--- a/pages/api/proposals/index.ts
+++ b/pages/api/proposals/index.ts
@@ -3,19 +3,28 @@ import nc from 'next-connect';
 
 import { ActionNotPermittedError, onError, onNoMatch, requireUser } from 'lib/middleware';
 import type { PageWithProposal } from 'lib/pages';
-import { computeProposalCategoryPermissions } from 'lib/permissions/proposals/computeProposalCategoryPermissions';
+import { providePermissionClients } from 'lib/permissions/api/permissionsClientMiddleware';
 import type { CreateProposalInput } from 'lib/proposal/createProposal';
 import { createProposal } from 'lib/proposal/createProposal';
 import { withSessionRoute } from 'lib/session/withSession';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-handler.use(requireUser).post(createProposalController);
+handler
+  .use(requireUser)
+  .use(
+    providePermissionClients({
+      key: 'categoryId',
+      resourceIdType: 'proposalCategory',
+      location: 'body'
+    })
+  )
+  .post(createProposalController);
 
 async function createProposalController(req: NextApiRequest, res: NextApiResponse<PageWithProposal>) {
   const proposaCreateProps = req.body as CreateProposalInput;
 
-  const permissions = await computeProposalCategoryPermissions({
+  const permissions = await req.basePermissionsClient.proposals.computeProposalCategoryPermissions({
     resourceId: proposaCreateProps.categoryId,
     userId: req.session.user.id
   });
@@ -23,7 +32,6 @@ async function createProposalController(req: NextApiRequest, res: NextApiRespons
   if (!permissions.create_proposal) {
     throw new ActionNotPermittedError('You cannot create new proposals');
   }
-
   const proposalPage = await createProposal({
     ...req.body,
     userId: req.session.user.id

--- a/pages/api/spaces/[id]/proposal-categories/[categoryId].ts
+++ b/pages/api/spaces/[id]/proposal-categories/[categoryId].ts
@@ -2,8 +2,8 @@ import type { ProposalCategoryWithPermissions } from '@charmverse/core/permissio
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
-import { ActionNotPermittedError, onError, onNoMatch, requireSpaceMembership, requireUser } from 'lib/middleware';
-import { computeProposalCategoryPermissions } from 'lib/permissions/proposals/computeProposalCategoryPermissions';
+import { ActionNotPermittedError, onError, onNoMatch, requireUser } from 'lib/middleware';
+import { providePermissionClients } from 'lib/permissions/api/permissionsClientMiddleware';
 import { deleteProposalCategory } from 'lib/proposal/deleteProposalCategory';
 import type { ProposalCategory } from 'lib/proposal/interface';
 import { updateProposalCategory } from 'lib/proposal/updateProposalCategory';
@@ -11,14 +11,24 @@ import { withSessionRoute } from 'lib/session/withSession';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-handler.use(requireUser).put(updateCategory).delete(deleteCategory);
+handler
+  .use(requireUser)
+  .use(
+    providePermissionClients({
+      key: 'id',
+      resourceIdType: 'space',
+      location: 'query'
+    })
+  )
+  .put(updateCategory)
+  .delete(deleteCategory);
 
 async function updateCategory(req: NextApiRequest, res: NextApiResponse<ProposalCategoryWithPermissions>) {
   const spaceId = req.query.id as string;
   const categoryId = req.query.categoryId as string;
   const categoryData = req.body as Partial<ProposalCategory>;
 
-  const permissions = await computeProposalCategoryPermissions({
+  const permissions = await req.basePermissionsClient.proposals.computeProposalCategoryPermissions({
     resourceId: categoryId,
     userId: req.session.user?.id
   });
@@ -33,7 +43,7 @@ async function updateCategory(req: NextApiRequest, res: NextApiResponse<Proposal
 }
 
 async function deleteCategory(req: NextApiRequest, res: NextApiResponse) {
-  const permissions = await computeProposalCategoryPermissions({
+  const permissions = await req.basePermissionsClient.proposals.computeProposalCategoryPermissions({
     resourceId: req.query.categoryId as string,
     userId: req.session.user?.id
   });


### PR DESCRIPTION

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed5920f</samp>

This pull request adds the feature of creating proposals with multiple authors, and refactors some of the existing code to use core errors and utilities. It modifies the `createProposal` function and the `ProposalPage` component to accept and store the authors field, and adds a new `validateProposalAuthorsAndReviewers` function to check the validity of the authors and reviewers. It also updates the test files and the API handlers to use the core package and the `providePermissionClients` middleware.

### WHY
Fix the creation of proposals with the author by passing this state through the app.

Harden logic to ensure we cannot inject external users to a proposal

Also added missing test coverage and included permissions logic for proposal creation endpoints
