### PR TITLE
Re-enable mathematical calculations on tables

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/calculations/calculation.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/calculations/calculation.tsx
@@ -38,6 +38,7 @@ function Calculation(props: Props): JSX.Element {
       onClose={props.onMenuClose}
       onChange={props.onChange}
       anchorEl={props.anchorEl}
+      property={props.property}
     />
   );
 

--- a/components/common/BoardEditor/focalboard/src/components/calculations/options.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/calculations/options.tsx
@@ -169,6 +169,8 @@ type CommonCalculationOptionProps = {
   anchorEl: HTMLElement | null;
   menuOpen: boolean;
   menuItemComponent?: (props: { data: any; onClick: (e: MouseEvent) => void }) => JSX.Element;
+  // eslint-disable-next-line react/no-unused-prop-types
+  property?: { type: string };
 };
 
 // Props used by the base calculation option component


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
It was removed when I linted/fixed focalboard code! THere's an error on the interface because the 'property' prop is not used immediately. So I probably removed that, and then removed the property in the component in a later step

https://github.com/charmverse/app.charmverse.io/pull/1037/files#diff-97af1d06fcedb8222510a9f3140bd2946d32fdb958575f6030d4a37d01035857