### PR TITLE
update ethers to v6

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
@@ -1,5 +1,4 @@
 import type { UserGnosisSafe } from '@charmverse/core/prisma';
-import { BigNumber } from '@ethersproject/bignumber';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Divider, Menu, MenuItem } from '@mui/material';
 import type { AlertColor } from '@mui/material/Alert';
@@ -7,7 +6,7 @@ import Button from '@mui/material/Button';
 import ERC20ABI from 'abis/ERC20ABI.json';
 import { getChainById } from 'connectors';
 import type { Signer } from 'ethers';
-import { ethers } from 'ethers';
+import { parseEther, parseUnits, Contract } from 'ethers';
 import type { MouseEvent } from 'react';
 import { useState } from 'react';
 import useSWR from 'swr';
@@ -146,12 +145,12 @@ export function BountyPaymentButton({
       if (chainToUse.nativeCurrency.symbol === tokenSymbolOrAddress) {
         const tx = await web3signer.sendTransaction({
           to: receiver,
-          value: ethers.utils.parseEther(amount)
+          value: parseEther(amount)
         });
 
         onSuccess(tx.hash, chainToUse.chainId);
       } else if (isValidChainAddress(tokenSymbolOrAddress)) {
-        const tokenContract = new ethers.Contract(tokenSymbolOrAddress, ERC20ABI, web3signer);
+        const tokenContract = new Contract(tokenSymbolOrAddress, ERC20ABI, web3signer);
 
         const paymentMethod = paymentMethods.find(
           (method) => method.contractAddress === tokenSymbolOrAddress || method.id === tokenSymbolOrAddress
@@ -173,12 +172,12 @@ export function BountyPaymentButton({
           }
         }
 
-        const parsedTokenAmount = ethers.utils.parseUnits(amount, tokenDecimals);
+        const parsedTokenAmount = parseUnits(amount, tokenDecimals);
 
         // get allowance
         const allowance = await tokenContract.allowance(account, receiver);
 
-        if (BigNumber.from(allowance).lt(parsedTokenAmount)) {
+        if (BigInt(allowance) < parsedTokenAmount) {
           // approve if the allowance is small
           await tokenContract.approve(receiver, parsedTokenAmount);
         }

--- a/components/_app/Web3ConnectionManager/components/NetworkModal/utils/requestNetworkChange.ts
+++ b/components/_app/Web3ConnectionManager/components/NetworkModal/utils/requestNetworkChange.ts
@@ -1,5 +1,4 @@
 import { log } from '@charmverse/core/log';
-import { BigNumber } from '@ethersproject/bignumber';
 import type { ExternalProvider } from '@ethersproject/providers';
 import type { Blockchain } from 'connectors';
 import { RPC } from 'connectors';
@@ -8,7 +7,7 @@ type WindowType = Window & typeof globalThis & { ethereum: ExternalProvider };
 
 const requestNetworkChange = (targetNetwork: Blockchain, callback?: () => void) => async () => {
   // @ts-ignore Not using .toHexString(), because the method requires unpadded format: '0x1' for mainnet, not '0x01'
-  const chainId = `0x${(+BigNumber.from(RPC[targetNetwork].chainId)).toString(16)}`;
+  const chainId = `0x${(+BigInt.from(RPC[targetNetwork].chainId)).toString(16)}`;
 
   const { ethereum } = window as WindowType;
 

--- a/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
@@ -8,7 +8,7 @@ import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import { getChainById } from 'connectors';
-import { utils } from 'ethers';
+import { getAddress } from 'ethers';
 import { DateTime } from 'luxon';
 import { useEffect, useState } from 'react';
 
@@ -250,7 +250,7 @@ export function PublishingForm({ onSubmit, pageId }: Props) {
 
       const receipt: SnapshotReceipt = (await client.proposal(
         library,
-        utils.getAddress(account as string),
+        getAddress(account as string),
         proposalParams
       )) as SnapshotReceipt;
 

--- a/components/u/components/IdentityModal.tsx
+++ b/components/u/components/IdentityModal.tsx
@@ -3,7 +3,7 @@ import { Refresh as RefreshIcon } from '@mui/icons-material';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import { Box, Tooltip, Typography } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
-import { utils } from 'ethers';
+import { isAddress } from 'ethers';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
@@ -91,7 +91,7 @@ function IdentityModal(props: IdentityModalProps) {
                       <RefreshIcon fontSize='small' />
                     </IconButton>
                   </Tooltip>
-                ) : utils.isAddress(usernameToDisplay) ? (
+                ) : isAddress(usernameToDisplay) ? (
                   <Tooltip
                     //                    disableHoverListener
                     onMouseEnter={(e) => e.stopPropagation()}

--- a/hooks/useGnosisPayment.ts
+++ b/hooks/useGnosisPayment.ts
@@ -2,7 +2,7 @@ import type { MetaTransactionData } from '@safe-global/safe-core-sdk-types';
 import EthersAdapter from '@safe-global/safe-ethers-lib';
 import SafeServiceClient from '@safe-global/safe-service-client';
 import { getChainById } from 'connectors';
-import { ethers, utils } from 'ethers';
+import { ethers, getAddress } from 'ethers';
 import log from 'loglevel';
 
 import type { MultiPaymentResult } from 'components/bounties/components/MultiPaymentButton';
@@ -60,7 +60,7 @@ export function useGnosisPayment({ chainId, safeAddress, transactions, onSuccess
       safeAddress,
       safeTransactionData: safeTransaction.data,
       safeTxHash: txHash,
-      senderAddress: utils.getAddress(account),
+      senderAddress: getAddress(account),
       senderSignature: senderSignature.data,
       origin
     });

--- a/hooks/useWeb3AuthSig.tsx
+++ b/hooks/useWeb3AuthSig.tsx
@@ -3,7 +3,7 @@ import type { UserWallet } from '@charmverse/core/prisma';
 import { verifyMessage } from '@ethersproject/wallet';
 import { useWeb3React } from '@web3-react/core';
 import type { Signer } from 'ethers';
-import { getAddress, toUtf8Bytes } from 'ethers/lib/utils';
+import { getAddress, toUtf8Bytes } from 'ethers';
 import { SiweMessage } from 'lit-siwe';
 import type { ReactNode } from 'react';
 import { useCallback, createContext, useContext, useEffect, useMemo, useState } from 'react';

--- a/lib/blockchain/getENSName.ts
+++ b/lib/blockchain/getENSName.ts
@@ -1,11 +1,11 @@
 import { log } from '@charmverse/core/log';
-import { ethers } from 'ethers';
+import { isValidName, JsonRpcProvider } from 'ethers';
 
 import { isTestEnv } from 'config/constants';
 
 const providerKey = process.env.ALCHEMY_API_KEY;
 const providerUrl = `https://eth-mainnet.alchemyapi.io/v2/${providerKey}`;
-const provider = providerKey ? new ethers.providers.JsonRpcProvider(providerUrl) : null;
+const provider = providerKey ? new JsonRpcProvider(providerUrl) : null;
 
 export function getENSName(address: string) {
   if (!provider) {
@@ -32,7 +32,7 @@ export async function getENSDetails(ensName?: string | null) {
     return null;
   }
 
-  if (!ethers.utils.isValidName(ensName)) {
+  if (!isValidName(ensName)) {
     log.warn(`The ens name ${ensName} you provided is not valid`);
     return null;
   }

--- a/lib/blockchain/signAndVerify.ts
+++ b/lib/blockchain/signAndVerify.ts
@@ -1,4 +1,4 @@
-import { getAddress, verifyMessage } from 'ethers/lib/utils';
+import { getAddress, verifyMessage } from 'ethers';
 import { SiweMessage } from 'lit-siwe';
 
 import { InvalidInputError } from '../utilities/errors';

--- a/lib/blockchain/switchNetwork.ts
+++ b/lib/blockchain/switchNetwork.ts
@@ -1,5 +1,5 @@
 import { getChainById } from 'connectors';
-import { ethers } from 'ethers';
+import { toQuantity } from 'ethers';
 
 /**
  * See
@@ -11,7 +11,7 @@ export async function switchActiveNetwork(chainId: number) {
   try {
     await (window as any).ethereum.request({
       method: 'wallet_switchEthereumChain',
-      params: [{ chainId: ethers.utils.hexValue(chainId) }]
+      params: [{ chainId: toQuantity(chainId) }]
     });
   } catch (error: any) {
     if (error.code === 4902) {
@@ -26,7 +26,7 @@ export async function switchActiveNetwork(chainId: number) {
         params: [
           {
             ...chainInfo,
-            chainId: ethers.utils.hexValue(chainInfo?.chainId)
+            chainId: toQuantity(chainInfo?.chainId)
           }
         ]
       });

--- a/lib/blockchain/unstoppableDomains/verifyUnstoppableDomainsSignature.ts
+++ b/lib/blockchain/unstoppableDomains/verifyUnstoppableDomainsSignature.ts
@@ -1,4 +1,4 @@
-import { verifyMessage } from 'ethers/lib/utils';
+import { verifyMessage } from 'ethers';
 import { SiweMessage } from 'lit-siwe';
 
 import { lowerCaseEqual } from 'lib/utilities/strings';

--- a/lib/gitcoin/getProjectDetails.ts
+++ b/lib/gitcoin/getProjectDetails.ts
@@ -1,6 +1,4 @@
-import { log } from '@charmverse/core/log';
 import type { Provider } from '@ethersproject/providers';
-import type { BigNumber } from 'ethers';
 
 import { getProjectRegistryContract } from 'lib/gitcoin/getProjectRegistryContract';
 import { getSafeOwners } from 'lib/gnosis/safe/getSafeOwners';
@@ -8,11 +6,11 @@ import { fetchFileByHash, getIpfsFileUrl } from 'lib/ipfs/fetchFileByHash';
 
 type MetadataOnchainDetails = {
   pointer: string;
-  protocol: BigNumber;
+  protocol: bigint;
 };
 
 type ProjectOnchainDetails = {
-  id: BigNumber;
+  id: bigint;
   metadata: MetadataOnchainDetails;
 };
 

--- a/lib/gnosis/getSafeTxStatus.ts
+++ b/lib/gnosis/getSafeTxStatus.ts
@@ -2,7 +2,6 @@ import { log } from '@charmverse/core/log';
 import { ApplicationStatus } from '@charmverse/core/prisma';
 import { AlchemyProvider } from '@ethersproject/providers';
 import type { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types';
-import { BigNumber } from 'ethers';
 
 import { getGnosisService } from 'lib/gnosis/gnosis';
 
@@ -57,5 +56,5 @@ export async function getSafeTxStatus({
 }
 
 function hasValue(safeTx: SafeMultisigTransactionResponse): boolean {
-  return BigNumber.from(safeTx.value || '0').gt(0) || !!safeTx.data;
+  return BigInt(safeTx.value || '0') > 0 || !!safeTx.data;
 }

--- a/lib/gnosis/gnosis.ts
+++ b/lib/gnosis/gnosis.ts
@@ -4,9 +4,8 @@ import EthersAdapter from '@safe-global/safe-ethers-lib';
 import type { SafeInfoResponse, SafeMultisigTransactionListResponse } from '@safe-global/safe-service-client';
 import SafeServiceClient from '@safe-global/safe-service-client';
 import { getChainById, RPC } from 'connectors';
-import type { Signer } from 'ethers';
-import { ethers } from 'ethers';
-import { getAddress } from 'ethers/lib/utils';
+import type { Signer, Provider } from 'ethers';
+import { ethers, getAddress } from 'ethers';
 import uniqBy from 'lodash/uniqBy';
 
 export type GnosisTransaction = SafeMultisigTransactionListResponse['results'][number];
@@ -16,7 +15,7 @@ function getGnosisRPCUrl(chainId: number) {
 }
 
 interface GetGnosisServiceProps {
-  signer: ethers.Signer | ethers.providers.Provider;
+  signer: Signer | Provider;
   chainId?: number;
   serviceUrl?: string;
 }

--- a/lib/gnosis/utils.ts
+++ b/lib/gnosis/utils.ts
@@ -1,11 +1,11 @@
 import { getChainShortname } from 'connectors';
-import { ethers } from 'ethers';
+import { formatEther, parseEther } from 'ethers';
 
 export function getFriendlyEthValue(value: string) {
-  const valueBigNumber = ethers.BigNumber.from(value);
-  const ethersValue = ethers.utils.formatEther(valueBigNumber);
-  const upperBound = ethers.BigNumber.from(ethers.utils.parseEther('0.001'));
-  if (valueBigNumber.gt(0) && valueBigNumber.lt(upperBound)) {
+  const valueBigNumber = BigInt(value);
+  const ethersValue = formatEther(valueBigNumber);
+  const upperBound = BigInt(parseEther('0.001'));
+  if (valueBigNumber > 0 && valueBigNumber < upperBound) {
     return '< 0.0001';
   } else {
     return ethersValue;

--- a/lib/tokens/validation.ts
+++ b/lib/tokens/validation.ts
@@ -1,4 +1,4 @@
-import { utils } from 'ethers';
+import { getAddress } from 'ethers';
 
 /**
  * Checks if the format of a given Ethereum address is acceptable
@@ -9,7 +9,7 @@ export function isValidChainAddress(address?: string) {
     return false;
   }
   try {
-    utils.getAddress(address);
+    getAddress(address);
     return true;
   } catch (error) {
     return false;

--- a/lib/utilities/__tests__/strings.spec.ts
+++ b/lib/utilities/__tests__/strings.spec.ts
@@ -1,5 +1,5 @@
 import type { UserWallet } from '@charmverse/core/prisma';
-import { utils, Wallet } from 'ethers';
+import { getAddress, Wallet } from 'ethers';
 
 import { randomETHWalletAddress } from 'testing/generateStubs';
 
@@ -94,7 +94,7 @@ describe('matchShortAddress', () => {
   it('should return true if the first argument is a short, or full lower / mixed case version of the wallet address', () => {
     const address = randomETHWalletAddress();
 
-    const withMixedCase = utils.getAddress(address);
+    const withMixedCase = getAddress(address);
 
     const shortAddress = shortWalletAddress(address);
 

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -1,5 +1,5 @@
 import type { UserWallet } from '@charmverse/core/prisma';
-import { utils } from 'ethers';
+import { isAddress } from 'ethers';
 import { customAlphabet } from 'nanoid';
 import * as dictionaries from 'nanoid-dictionary';
 import { validate } from 'uuid';
@@ -192,7 +192,7 @@ export function shortWalletAddress(string?: string): string {
     return '';
   }
 
-  if (utils.isAddress(string)) {
+  if (isAddress(string)) {
     return shortenHex(string).toLowerCase();
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "dotenv-expand": "^8.0.3",
         "emoji-js": "^3.7.0",
         "emoji-mart": "^3.0.1",
-        "ethers": "^5.5.4",
+        "ethers": "^6.5.1",
         "fetch-retry": "^5.0.4",
         "firebase": "^9.14.0",
         "firebase-admin": "^11.5.0",
@@ -280,9 +280,9 @@
       "dev": true
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
-      "integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
+      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -6039,17 +6039,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@charmverse/core/node_modules/@noble/hashes": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
     "node_modules/@charmverse/core/node_modules/@types/luxon": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.0.tgz",
@@ -6059,11 +6048,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
-    },
-    "node_modules/@charmverse/core/node_modules/aes-js": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz",
-      "integrity": "sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA=="
     },
     "node_modules/@charmverse/core/node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -6142,32 +6126,6 @@
         "@esbuild/win32-arm64": "0.17.18",
         "@esbuild/win32-ia32": "0.17.18",
         "@esbuild/win32-x64": "0.17.18"
-      }
-    },
-    "node_modules/@charmverse/core/node_modules/ethers": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.3.0.tgz",
-      "integrity": "sha512-CKFYvTne1YT4S1glTiu7TgGsj0t6c6GAD7evrIk8zbeUb6nK8dcUPAiAWM8uDX/1NmRTvLM9+1Vnn49hwKtEzw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.9.0",
-        "@noble/hashes": "1.1.2",
-        "@noble/secp256k1": "1.7.1",
-        "aes-js": "4.0.0-beta.3",
-        "tslib": "2.4.0",
-        "ws": "8.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@charmverse/core/node_modules/foreground-child": {
@@ -6291,11 +6249,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@charmverse/core/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
     "node_modules/@charmverse/core/node_modules/uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -6316,26 +6269,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@charmverse/core/node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@coinbase/wallet-sdk": {
@@ -6738,6 +6671,54 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@depay/web3-mock/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -9235,6 +9216,53 @@
         "axios": "^0.26.1",
         "ethers": "^5.5.4",
         "fast-json-stable-stringify": "^2.1.0"
+      }
+    },
+    "node_modules/@guildxyz/sdk/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -11849,6 +11877,53 @@
         "@safe-global/safe-core-sdk-types": "^1.9.0",
         "@safe-global/safe-core-sdk-utils": "^1.7.1",
         "ethers": "5.7.2"
+      }
+    },
+    "node_modules/@safe-global/safe-ethers-lib/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "node_modules/@safe-global/safe-service-client": {
@@ -26099,13 +26174,13 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.5.1.tgz",
+      "integrity": "sha512-jDpCnUGcyn39hnRUEtrulDZOtJcIPEz4Whccl3N9qhwdLsn1ELuDM9TgGgGJq6ph0p8/Uri+Wezmo/r69E+xkA==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+          "url": "https://github.com/sponsors/ethers-io/"
         },
         {
           "type": "individual",
@@ -26113,36 +26188,62 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+    },
+    "node_modules/ethers/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/ethjs-unit": {
@@ -34094,6 +34195,53 @@
         "react-dom": "^18.1.0",
         "react-select": "^5.3.2",
         "react-windowed-select": "^5.0.0"
+      }
+    },
+    "node_modules/lit-share-modal-v3/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "node_modules/lit-siwe": {
@@ -46247,9 +46395,9 @@
       "dev": true
     },
     "@adraffy/ens-normalize": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
-      "integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
+      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
     },
     "@ampproject/remapping": {
       "version": "2.2.0",
@@ -50733,11 +50881,6 @@
           "integrity": "sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==",
           "optional": true
         },
-        "@noble/hashes": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-          "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
-        },
         "@types/luxon": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.0.tgz",
@@ -50747,11 +50890,6 @@
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
           "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
-        },
-        "aes-js": {
-          "version": "4.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz",
-          "integrity": "sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA=="
         },
         "brace-expansion": {
           "version": "2.0.1",
@@ -50814,19 +50952,6 @@
             "@esbuild/win32-arm64": "0.17.18",
             "@esbuild/win32-ia32": "0.17.18",
             "@esbuild/win32-x64": "0.17.18"
-          }
-        },
-        "ethers": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.3.0.tgz",
-          "integrity": "sha512-CKFYvTne1YT4S1glTiu7TgGsj0t6c6GAD7evrIk8zbeUb6nK8dcUPAiAWM8uDX/1NmRTvLM9+1Vnn49hwKtEzw==",
-          "requires": {
-            "@adraffy/ens-normalize": "1.9.0",
-            "@noble/hashes": "1.1.2",
-            "@noble/secp256k1": "1.7.1",
-            "aes-js": "4.0.0-beta.3",
-            "tslib": "2.4.0",
-            "ws": "8.5.0"
           }
         },
         "foreground-child": {
@@ -50899,11 +51024,6 @@
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.1.tgz",
           "integrity": "sha512-uUWsN4aOxJAS8KOuf3QMyFtgm1pkb6I+KRZbRF/ghdf5T7sM+B1lLLzPDxswUjkmHyxQAVzEgG35E3NzDM9GVw=="
         },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        },
         "uuid": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -50916,12 +51036,6 @@
           "requires": {
             "isexe": "^2.0.0"
           }
-        },
-        "ws": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "requires": {}
         }
       }
     },
@@ -51222,6 +51336,46 @@
         "@depay/web3-constants": "^6.3.2",
         "ethers": "^5.7.1",
         "xhr2": "^0.2.1"
+      },
+      "dependencies": {
+        "ethers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.1",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.2",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.1",
+            "@ethersproject/wordlists": "5.7.0"
+          }
+        }
       }
     },
     "@discoveryjs/json-ext": {
@@ -52943,6 +53097,45 @@
         "axios": "^0.26.1",
         "ethers": "^5.5.4",
         "fast-json-stable-stringify": "^2.1.0"
+      },
+      "dependencies": {
+        "ethers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.1",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.2",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.1",
+            "@ethersproject/wordlists": "5.7.0"
+          }
+        }
       }
     },
     "@hookform/resolvers": {
@@ -54719,6 +54912,45 @@
         "@safe-global/safe-core-sdk-types": "^1.9.0",
         "@safe-global/safe-core-sdk-utils": "^1.7.1",
         "ethers": "5.7.2"
+      },
+      "dependencies": {
+        "ethers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.1",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.2",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.1",
+            "@ethersproject/wordlists": "5.7.0"
+          }
+        }
       }
     },
     "@safe-global/safe-service-client": {
@@ -65829,40 +66061,45 @@
       }
     },
     "ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.5.1.tgz",
+      "integrity": "sha512-jDpCnUGcyn39hnRUEtrulDZOtJcIPEz4Whccl3N9qhwdLsn1ELuDM9TgGgGJq6ph0p8/Uri+Wezmo/r69E+xkA==",
       "requires": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+          "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+        },
+        "@types/node": {
+          "version": "18.15.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+          "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+        },
+        "aes-js": {
+          "version": "4.0.0-beta.5",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+          "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "requires": {}
+        }
       }
     },
     "ethjs-unit": {
@@ -71898,6 +72135,45 @@
         "react-dom": "^18.2.0",
         "react-select": "^5.3.2",
         "react-windowed-select": "^5.0.0"
+      },
+      "dependencies": {
+        "ethers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.1",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.2",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.1",
+            "@ethersproject/wordlists": "5.7.0"
+          }
+        }
       }
     },
     "lit-siwe": {

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "dotenv-expand": "^8.0.3",
     "emoji-js": "^3.7.0",
     "emoji-mart": "^3.0.1",
-    "ethers": "^5.5.4",
+    "ethers": "^6.5.1",
     "fetch-retry": "^5.0.4",
     "firebase": "^9.14.0",
     "firebase-admin": "^11.5.0",

--- a/testing/__tests__/generateStubs.spec.ts
+++ b/testing/__tests__/generateStubs.spec.ts
@@ -1,4 +1,4 @@
-import { utils } from 'ethers';
+import { isAddress } from 'ethers';
 
 import { randomETHWalletAddress } from 'testing/generateStubs';
 
@@ -9,6 +9,6 @@ describe('randomETHWalletAddress', () => {
     expect(address).toBe(address.toLowerCase());
 
     // Address validity check
-    expect(utils.isAddress(address)).toBe(true);
+    expect(isAddress(address)).toBe(true);
   });
 });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3937626</samp>

This pull request updates the codebase to use the latest version of `ethers` and simplifies the imports and usage of `ethers` functions and types throughout the files. It also replaces `BigNumber` with `bigint` for numeric types and fixes some minor issues with the network chain ID format and the signature verification methods.

### WHY
Enables tree-shaking, will reduce our builds a bunch...

Currently blocked by gnosis SDK:
https://github.com/safe-global/safe-core-sdk/pull/442
https://github.com/safe-global/safe-core-sdk/issues/401
