### PR TITLE
check if emoji is null when parsing icons

### DIFF
--- a/components/common/Emoji.tsx
+++ b/components/common/Emoji.tsx
@@ -1,3 +1,4 @@
+import { log } from '@charmverse/core/log';
 import styled from '@emotion/styled';
 import type { ComponentProps, ReactNode } from 'react';
 import { memo } from 'react';
@@ -54,17 +55,19 @@ export const Emoji = styled.div<{ size?: ImgSize }>`
 
 // Use system font for Mac OS, but Twitter emojis for everyone else
 export function getTwitterEmoji(emoji: string): string | null {
-  if (isMac()) return null;
-
-  // @ts-ignore - library type is incorrect
-  const html = twemoji.parse(emoji, {
-    // the original maxCDN went down Jan 11, 2023
-    base: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/',
-    folder: 'svg',
-    ext: '.svg'
-  }) as string;
-  const match = /<img.*?src="(.*?)"/.exec(html);
-  return match ? match[1] : null;
+  if (isMac() || !emoji) return null;
+  try {
+    const html = twemoji.parse(emoji, {
+      // the original maxCDN went down Jan 11, 2023
+      base: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/',
+      folder: 'svg',
+      ext: '.svg'
+    }) as string;
+    const match = /<img.*?src="(.*?)"/.exec(html);
+    return match ? match[1] : null;
+  } catch (error) {
+    log.error('Could not parse emoji', { emoji, error });
+  }
 }
 
 function EmojiIcon({


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5375286</samp>

Enhanced `getTwitterEmoji` function in `Emoji.tsx` component to handle errors and log them using `log` module.

### WHY
I figured this one out by looking at the minified stack trace. Error was `childNodes of null`, and it turns out there's a callout on the page where the emoji is somehow null.