### PR TITLE
fix Brave browser sockets connection

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -164,6 +164,9 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
     setPageProps({ participants });
   }
 
+  // create a key that updates when edit mode changes - default to 'editing' so we dont close sockets immediately
+  const editorKey = page.id + (editMode || 'editing') + pagePermissions.edit_content;
+
   return (
     <>
       {!!page?.deletedAt && (
@@ -203,7 +206,7 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
                       ? `Describe the bounty. Type '/' to see the list of available commands`
                       : undefined
                   }
-                  key={page.id + editMode + String(pagePermissions?.edit_content)}
+                  key={editorKey}
                   content={page.content as PageContent}
                   readOnly={readOnly}
                   autoFocus={false}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4902b3b</samp>

This pull request improves the performance and reliability of the `Editor` component on document pages by using a new `editorKey` variable. The `editorKey` is based on the `pageId`, the `editMode`, and the `pagePermissions` props of the `DocumentPage` component.

### WHY
My hypothesis is that Brave browser has an issue when you open/close a connection very quickly, based on this issue: https://github.com/brave/brave-browser/issues/27419. I noticed this is happening for us because `editMode` is always null at first, so we re-render CharmEditor very quickly, closing the first socket connection and opening a second one almost immediately.