### PR TITLE
Fix getAccessibleProposals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5995,7 +5995,7 @@
     },
     "node_modules/@charmverse/core": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/charmverse/core.git#82284542389319409cab198caaab1ceae6ce3574",
+      "resolved": "git+ssh://git@github.com/charmverse/core.git#8bfd4b24fe4be9021000128919828ba90cdc670d",
       "hasInstallScript": true,
       "dependencies": {
         "@datadog/browser-logs": "^4.42.2",
@@ -50698,7 +50698,7 @@
       "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
     },
     "@charmverse/core": {
-      "version": "git+ssh://git@github.com/charmverse/core.git#82284542389319409cab198caaab1ceae6ce3574",
+      "version": "git+ssh://git@github.com/charmverse/core.git#8bfd4b24fe4be9021000128919828ba90cdc670d",
       "from": "@charmverse/core@github:charmverse/core#main",
       "requires": {
         "@datadog/browser-logs": "^4.42.2",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3225068</samp>

The pull request simplifies the logic and parameters of the `getAccessibleProposals` function, which determines which proposals a user can see and edit. It also updates the tests for this function to match the new behavior. The function now only shows proposals that are at discussion stage or beyond, and only to authors or reviewers depending on a flag. The changes affect the files `lib/permissions/proposals/getAccessibleProposals.ts` and `lib/permissions/proposals/__tests__/getAccessibleProposals.spec.ts`.

### WHY
Users cannot see draft proposals