### PR TITLE
save space id with page profiles in mixpanel

### DIFF
--- a/lib/metrics/mixpanel/updateTrackPageProfile.ts
+++ b/lib/metrics/mixpanel/updateTrackPageProfile.ts
@@ -27,6 +27,7 @@ export function getTrackPageProfile(page: PageWithPermissions) {
     Type: page.type,
     Deleted: !!page.deletedAt,
     Public: isPublic,
+    'Space Id': page.spaceId,
     'Is Database': ['board', 'inline_board', 'inline_linked_board', 'linked_board'].includes(page.type),
     'Page Created By': page.createdBy,
     'Page Updated At': page.updatedAt


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7e2a87</samp>

Add `Space Id` property to Mixpanel profile tracking. This enables measuring user activity and interest in different spaces on `app.charmverse.io`.

### WHY
Allows us to try building reports by space
