### PR TITLE
add spacing for close button on paid banner

### DIFF
--- a/components/common/Banners/PaidAnnouncementBanner.tsx
+++ b/components/common/Banners/PaidAnnouncementBanner.tsx
@@ -1,6 +1,6 @@
 import CloseIcon from '@mui/icons-material/Close';
 import EastIcon from '@mui/icons-material/East';
-import { IconButton, Stack, Typography } from '@mui/material';
+import { Box, IconButton, Stack, Typography } from '@mui/material';
 
 import Link from 'components/common/Link';
 import { useLocalStorage } from 'hooks/useLocalStorage';
@@ -10,27 +10,30 @@ import { StyledBanner } from './Banner';
 export function PaidAnnouncementBanner() {
   const [showPaidAnnouncementBar, setShowPaidAnnouncementBar] = useLocalStorage('show-paid-banner', true);
   return showPaidAnnouncementBar ? (
-    <StyledBanner top={50} data-test='paid-announcement-banner'>
-      <Typography component='div'>
-        Community Edition coming on June 30th. Includes complex role-based access control, API, & custom domain.{' '}
-        <Stack gap={0.5} flexDirection='row' alignItems='center' display='inline-flex'>
-          <Link
-            color='inherit'
-            target='_blank'
-            href='https://app.charmverse.io/charmverse/page-5371612014886058'
-            sx={{ fontWeight: 600 }}
-          >
-            More Details
-          </Link>
-          <EastIcon sx={{ position: 'relative', top: 1.5, fontSize: 16 }} />
-        </Stack>
-      </Typography>
+    <StyledBanner top={20} data-test='paid-announcement-banner'>
+      <Box pr={3}>
+        <Typography component='div'>
+          Community Edition coming on June 30th. Includes complex role-based access control, API, & custom domain.{' '}
+          <Stack gap={0.5} flexDirection='row' alignItems='center' display='inline-flex'>
+            <Link
+              color='inherit'
+              target='_blank'
+              href='https://app.charmverse.io/charmverse/page-5371612014886058'
+              sx={{ fontWeight: 600 }}
+            >
+              More Details
+            </Link>
+            <EastIcon sx={{ position: 'relative', top: 1.5, fontSize: 16 }} />
+          </Stack>
+        </Typography>
+      </Box>
       <IconButton
         onClick={() => setShowPaidAnnouncementBar(false)}
         size='small'
         sx={{
           position: 'absolute',
-          right: 5
+          right: 5,
+          top: 8
         }}
       >
         <CloseIcon fontSize='small' />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b37a54</samp>

Improved the appearance and usability of the `PaidAnnouncementBanner` component. Adjusted the spacing, margin, and alignment of the banner elements with `Box` and `top` props.

### WHY
Before:
<img width="530" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/b67babb6-875d-4eec-ae1c-9b2be60dca59">


After:
<img width="545" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/6d465c8f-97ba-48eb-b594-7279c90eb6b7">
