### PR TITLE
add delay before closing room

### DIFF
--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -572,7 +572,12 @@ export class DocumentEventHandler {
     if (room) {
       room.participants.delete(this.id);
       if (room.participants.size === 0) {
-        docRooms.delete(room.doc.id);
+        // Cleanup: add a little delay in case some edits were sent at the same time the user disconnected
+        setTimeout(() => {
+          if (room.participants.size === 0) {
+            docRooms.delete(room.doc.id);
+          }
+        }, 100);
       } else {
         this.sendParticipantList();
       }


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
Not sure what the user was doing, and this is very rare, but I saw that an edit came in at the same millisecond as the disconnect event was triggered. The update gets ignored because the room doesn't exist:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/cd37b8a5-043c-4dfd-8628-13259c9050e2)


I think it is safe to add a bit of delay - but i make sure to check that the room is still empty before deleting it
