### PR TITLE
use correct board to retrieve list of view ids

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
@@ -110,7 +110,7 @@ function ViewHeader(props: Props) {
         disableUpdatingUrl={props.disableUpdatingUrl}
         maxTabsShown={maxTabsShown}
         openViewOptions={() => toggleViewOptions(true)}
-        viewIds={activeBoard?.fields.viewIds ?? []}
+        viewIds={viewsBoard?.fields.viewIds ?? []}
       />
 
       {/* add a view */}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6bd418d</samp>

Fixed view tabs not updating when switching boards in `BoardEditor`. Changed `viewIds` prop of `ViewHeader` component to use `viewsBoard` state variable.

### WHY
<!-- author to complete -->
