### PR TITLE
Fix: multiple tabs opening when a link is clicked

### DIFF
--- a/components/common/CharmEditor/components/inlineComment/inlineComment.plugins.tsx
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.plugins.tsx
@@ -65,15 +65,6 @@ export function plugin({ key }: { key: PluginKey }): RawPlugins {
             (event.target as HTMLElement).className +
             ((event.target as HTMLElement).parentNode as HTMLElement).className;
 
-          // Sometimes, inline comments are overlaid on links, which blocks proper behaviour. This allows links to open
-          const href = getLinkElement({
-            htmlElement: event.target as HTMLElement
-          })?.getAttribute('href');
-
-          if (href) {
-            window.open(href, '_blank');
-          }
-
           if (/charm-inline-comment/.test(className)) {
             return highlightMarkedElement({
               view,

--- a/components/common/CharmEditor/components/link/link.plugins.ts
+++ b/components/common/CharmEditor/components/link/link.plugins.ts
@@ -61,7 +61,7 @@ export function plugins({ key }: { key: PluginKey }) {
         }
       },
       props: {
-        handleClick: (view, _pos, event) => {
+        handleClickOn: (view, _pos, _node, _nodePos, event) => {
           const { schema } = view.state;
           const markType = schema.marks.link;
           let marks: Mark[] = [];
@@ -71,6 +71,8 @@ export function plugins({ key }: { key: PluginKey }) {
           const attrs = marks.find((markItem) => markItem.type.name === markType.name)?.attrs ?? {};
           if (attrs.href) {
             event.stopPropagation();
+            window.open(attrs.href, '_blank');
+            return true;
           }
           return false;
         },

--- a/components/common/CharmEditor/components/link/link.plugins.ts
+++ b/components/common/CharmEditor/components/link/link.plugins.ts
@@ -71,7 +71,6 @@ export function plugins({ key }: { key: PluginKey }) {
           const attrs = marks.find((markItem) => markItem.type.name === markType.name)?.attrs ?? {};
           if (attrs.href) {
             event.stopPropagation();
-            window.open(attrs.href, '_blank');
           }
           return false;
         },

--- a/components/common/CharmEditor/components/link/link.specs.ts
+++ b/components/common/CharmEditor/components/link/link.specs.ts
@@ -3,7 +3,7 @@ import type { BaseRawMarkSpec } from '@bangle.dev/core';
 
 export function spec() {
   const linkSpec = link.spec({
-    openOnClick: true
+    openOnClick: false
   }) as BaseRawMarkSpec;
 
   linkSpec.schema.toDOM = (node) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a60b815</samp>

Remove link opening behavior in charm editor. This allows users to edit links without leaving the editor or opening a new window.

### WHY

Source: https://discord.com/channels/894960387743698944/1116744433799536750/1116744433799536750

Two issues here:
1) the handleClickOn inside inline comment is always called even if there are not inline comments, so it would open a second tab
2) inside a bullet list, even after the first fix, we'd get 3 tabs open instead of 1 because handleClickOn() was being called three times (with the same inputs afaict). I fixed this by returning true.. but am curious if @Devorein has any idea around the source of this behavior? Seems like we might be doing something funky with lists.