### PR TITLE
Clicking text field expand cell in database

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -329,7 +329,9 @@ function CenterPanel(props: Props) {
         showCard(card.id);
       }
 
-      e.stopPropagation();
+      if (activeView?.fields.viewType !== 'table') {
+        e.stopPropagation();
+      }
     },
     [activeView]
   );

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -176,6 +176,7 @@ function PropertyValueElement(props: Props) {
     value: value.toString(),
     autoExpand: true,
     onChange: setValue,
+    displayType,
     multiline: displayType === 'details' ? true : props.wrapColumn ?? false,
     onSave: () => {
       mutator.changePropertyValue(card, propertyTemplate.id, value);

--- a/components/common/BoardEditor/focalboard/src/widgets/TextInput.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/TextInput.tsx
@@ -54,6 +54,8 @@ function Editable({ multiline, displayType, ..._props }: TextInputProps, ref: Re
             className
           }}
           {...props}
+          inputRef={(input) => input && input.focus()}
+          onFocus={(e) => e.currentTarget.setSelectionRange(e.currentTarget.value.length, e.currentTarget.value.length)}
           multiline
         />
       }

--- a/components/common/BoardEditor/focalboard/src/widgets/TextInput.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/TextInput.tsx
@@ -2,12 +2,16 @@ import styled from '@emotion/styled';
 import { InputBase } from '@mui/material';
 import React, { forwardRef, useRef } from 'react';
 
+import type { PropertyValueDisplayType } from 'components/common/BoardEditor/interfaces';
+import PopperPopup from 'components/common/PopperPopup';
+
 import type { EditableProps, Focusable } from './editable';
 import { useEditable } from './editable';
 
 export type TextInputProps = EditableProps & {
   className?: string;
   multiline?: boolean;
+  displayType?: PropertyValueDisplayType;
 };
 
 const StyledInput = styled(InputBase)`
@@ -19,17 +23,50 @@ const StyledInput = styled(InputBase)`
   border: 0px;
 `;
 
-function Editable({ multiline, ..._props }: TextInputProps, ref: React.Ref<Focusable>): JSX.Element {
+function Editable({ multiline, displayType, ..._props }: TextInputProps, ref: React.Ref<Focusable>): JSX.Element {
   const elementRef = useRef<HTMLTextAreaElement>(null);
   const { className, ...props } = useEditable(_props, ref, elementRef);
+
+  // Keep it as before for card modal view
+  if (displayType === 'details') {
+    return (
+      <StyledInput
+        inputProps={{
+          className
+        }}
+        {...props}
+        fullWidth
+        multiline={multiline}
+      />
+    );
+  }
+
   return (
-    <StyledInput
-      inputProps={{
-        className
+    <PopperPopup
+      style={{ width: '100%' }}
+      paperSx={{
+        width: 350,
+        p: 2
       }}
-      {...props}
-      multiline={multiline}
-    />
+      popupContent={
+        <StyledInput
+          inputProps={{
+            className
+          }}
+          {...props}
+          multiline
+        />
+      }
+    >
+      <StyledInput
+        inputProps={{
+          className
+        }}
+        {...props}
+        fullWidth
+        multiline={multiline}
+      />
+    </PopperPopup>
   );
 }
 

--- a/components/common/CharmEditor/components/inlinePalette/editorItems/text.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/editorItems/text.tsx
@@ -20,6 +20,7 @@ import type { SpacePermissionFlags } from 'lib/permissions/spaces';
 
 import { insertNode, isAtBeginningOfLine } from '../../../utils';
 import * as bulletList from '../../bulletList';
+import { replaceToggleListCommand } from '../../listItem/commands';
 import { nestedPageSuggestMarkName } from '../../nestedPage/nestedPage.constants';
 import type { NestedPagePluginState } from '../../nestedPage/nestedPage.interfaces';
 import * as orderedList from '../../orderedList';
@@ -243,9 +244,9 @@ export function items(props: ItemsProps): PaletteItemTypeNoGroup[] {
       editorExecuteCommand: ({ palettePluginKey }) => {
         return (state, dispatch, view) => {
           rafCommandExec(view!, (_state, _dispatch, _view) => {
-            setBlockType(_state.schema.nodes.paragraph)(_state, _dispatch);
-            return toggleBulletList()(_view!.state, _view!.dispatch, _view);
+            return replaceToggleListCommand(state.schema.nodes.bulletList)(_state, _dispatch, _view);
           });
+
           return replaceSuggestionMarkWith(palettePluginKey, '')(state, dispatch, view);
         };
       }

--- a/components/common/CharmEditor/components/listItem/commands.ts
+++ b/components/common/CharmEditor/components/listItem/commands.ts
@@ -165,7 +165,7 @@ export function toggleList(listType: NodeType, itemType?: NodeType, todo?: boole
     const fromNode = selection.$from.node(selection.$from.depth - 2);
     const endNode = selection.$to.node(selection.$to.depth - 2);
     if (!fromNode || fromNode.type.name !== listType.name || !endNode || endNode.type.name !== listType.name) {
-      return toggleListCommand(listType, todo)(state, dispatch, view);
+      return toggleListCommand(listType)(state, dispatch, view);
     } else {
       // If current ListType is the same as `listType` in arg,
       // toggle the list to `p`.
@@ -191,6 +191,24 @@ export function toggleList(listType: NodeType, itemType?: NodeType, todo?: boole
       }
       return true;
     }
+  };
+}
+
+export function replaceToggleListCommand(listType: NodeType): Command {
+  return function (state, dispatch, view) {
+    if (dispatch) {
+      dispatch(state.tr.setSelection(adjustSelectionInList(state.doc, state.selection)));
+    }
+
+    if (!view) {
+      return false;
+    }
+
+    state = view.state;
+    liftListItems()(state, dispatch);
+    state = view.state;
+
+    return wrapInList(listType)(state, dispatch);
   };
 }
 

--- a/components/common/PopperPopup.tsx
+++ b/components/common/PopperPopup.tsx
@@ -14,10 +14,11 @@ interface PopperPopupProps {
   onOpen?: () => void;
   onClick?: () => void;
   paperSx?: SxProps<Theme>;
+  style?: React.CSSProperties;
 }
 
 export default function PopperPopup(props: PopperPopupProps) {
-  const { closeOnClick = false, popupContent, children, autoOpen = false, onClose, onOpen } = props;
+  const { style = {}, closeOnClick = false, popupContent, children, autoOpen = false, onClose, onOpen } = props;
 
   const popupState = usePopupState({ variant: 'popper', popupId: 'iframe-selector' });
   const toggleRef = useRef(null);
@@ -72,7 +73,7 @@ export default function PopperPopup(props: PopperPopupProps) {
   }, [toggleRef, autoOpen]);
 
   return (
-    <div ref={toggleRef}>
+    <div ref={toggleRef} style={style}>
       {children && (
         <div {...popoverToggleProps} onMouseDown={(e) => e.preventDefault()}>
           {children}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcf9442</samp>

This pull request enhances the `BoardEditor` component to support multiline text inputs in a table view. It adds a pop-up editor for editing long texts, customizes the popup toggle style, and adjusts the keyboard and value rendering logic for different view types. It modifies `TextInput.tsx`, `PopperPopup.tsx`, `centerPanel.tsx`, and `propertyValueElement.tsx`.

### WHY
[Card](https://app.charmverse.io/charmverse/page-49366552253645923?viewId=50d940bb-fdbd-40ba-9816-616d6138a663&cardId=6db9d7d9-c58d-4118-8fa3-d295383fe124)
