### PR TITLE
Test/page public toggle

### DIFF
--- a/components/common/PageLayout/components/Header/components/ShareButton/components/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/ShareToWeb.tsx
@@ -77,6 +77,8 @@ export default function ShareToWeb({ pageId, pagePermissions, refreshPermissions
 
   const shareAlertMessage = currentPage ? alerts[currentPage.type] : undefined;
 
+  console.log({ pages, currentPagePermissions });
+
   async function togglePublic() {
     if (publicPermission) {
       await charmClient.deletePermission({ permissionId: publicPermission.id });

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/ShareToWeb.tsx
@@ -60,6 +60,7 @@ const alerts: Partial<Record<PageType, string>> = {
 
 export default function ShareToWeb({ pageId, pagePermissions, refreshPermissions }: Props) {
   const router = useRouter();
+
   const { pages } = usePages();
   const [copied, setCopied] = useState<boolean>(false);
 

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/ShareToWeb.tsx
@@ -77,8 +77,6 @@ export default function ShareToWeb({ pageId, pagePermissions, refreshPermissions
 
   const shareAlertMessage = currentPage ? alerts[currentPage.type] : undefined;
 
-  console.log({ pages, currentPagePermissions });
-
   async function togglePublic() {
     if (publicPermission) {
       await charmClient.deletePermission({ permissionId: publicPermission.id });

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/__tests__/ShareToWeb.spec.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/__tests__/ShareToWeb.spec.tsx
@@ -47,7 +47,7 @@ describe('shareToWeb', () => {
   it('should render the toggle as checked if no public permission exists or as unchecked if a public permission exists', async () => {
     const pageId = uuid();
 
-    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValue({
+    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValueOnce({
       permissions: new AvailablePagePermissions().full
     });
 
@@ -61,6 +61,10 @@ describe('shareToWeb', () => {
     // Important part of the test
     expect(toggle).not.toBeChecked();
     expect(toggle).not.toBeDisabled();
+
+    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValueOnce({
+      permissions: new AvailablePagePermissions().full
+    });
 
     // Re-render this with a public permission
     resultWithPermissions.rerender(
@@ -89,7 +93,7 @@ describe('shareToWeb', () => {
   it('should render an enabled public toggle only if a user has permissions to toggle the public status of the page', async () => {
     const pageId = uuid();
 
-    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValue({
+    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValueOnce({
       permissions: new AvailablePagePermissions().full
     });
 
@@ -107,7 +111,7 @@ describe('shareToWeb', () => {
   it('should render a disabled public toggle if a user does not have permissions to toggle the public status of the page', async () => {
     const pageId = uuid();
 
-    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValue({
+    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValueOnce({
       permissions: new AvailablePagePermissions().empty
     });
 
@@ -125,16 +129,16 @@ describe('shareToWeb', () => {
   it('should render a disabled unchecked public toggle if the space has activated public proposals, the page is a proposal page and proposal status is draft', async () => {
     const pageId = uuid();
 
-    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValue({
+    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValueOnce({
       permissions: new AvailablePagePermissions().full
     });
-    (useProposal as jest.Mock<ReturnType<typeof useProposal>>).mockReturnValue({
+    (useProposal as jest.Mock<ReturnType<typeof useProposal>>).mockReturnValueOnce({
       proposal: {
         status: 'draft'
       } as any
     });
 
-    (usePages as jest.Mock).mockReturnValue({
+    (usePages as jest.Mock).mockReturnValueOnce({
       pages: {
         [pageId]: {
           type: 'proposal'
@@ -142,7 +146,7 @@ describe('shareToWeb', () => {
       }
     });
 
-    (useCurrentSpace as jest.Mock<Space>).mockReturnValue(
+    (useCurrentSpace as jest.Mock<Space>).mockReturnValueOnce(
       createMockSpace({
         publicProposals: true
       })
@@ -163,16 +167,16 @@ describe('shareToWeb', () => {
   it('should render a disabled checked public toggle if the space has activated public proposals, the page is a proposal page and proposal status is discussion or beyond', async () => {
     const pageId = uuid();
 
-    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValue({
+    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValueOnce({
       permissions: new AvailablePagePermissions().full
     });
-    (useProposal as jest.Mock<ReturnType<typeof useProposal>>).mockReturnValue({
+    (useProposal as jest.Mock<ReturnType<typeof useProposal>>).mockReturnValueOnce({
       proposal: {
         status: 'discussion'
       } as any
     });
 
-    (usePages as jest.Mock).mockReturnValue({
+    (usePages as jest.Mock).mockReturnValueOnce({
       pages: {
         [pageId]: {
           type: 'proposal'
@@ -180,7 +184,7 @@ describe('shareToWeb', () => {
       }
     });
 
-    (useCurrentSpace as jest.Mock<Space>).mockReturnValue(
+    (useCurrentSpace as jest.Mock<Space>).mockReturnValueOnce(
       createMockSpace({
         publicProposals: true
       })
@@ -201,11 +205,11 @@ describe('shareToWeb', () => {
   it('should render an enabled public toggle if the space has activated public proposals, user has permissions to toggle public status, and the page is not of type proposal', async () => {
     const pageId = uuid();
 
-    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValue({
+    (usePagePermissions as jest.Mock<ReturnType<typeof usePagePermissions>>).mockReturnValueOnce({
       permissions: new AvailablePagePermissions().full
     });
 
-    (usePages as jest.Mock).mockReturnValue({
+    (usePages as jest.Mock).mockReturnValueOnce({
       pages: {
         [pageId]: {
           type: 'page'
@@ -213,7 +217,7 @@ describe('shareToWeb', () => {
       }
     });
 
-    (useCurrentSpace as jest.Mock<Space>).mockReturnValue(
+    (useCurrentSpace as jest.Mock<Space>).mockReturnValueOnce(
       createMockSpace({
         publicProposals: true
       })

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/__tests__/ShareToWeb.spec.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/__tests__/ShareToWeb.spec.tsx
@@ -1,0 +1,139 @@
+import { AvailablePagePermissions } from '@charmverse/core/permissions/flags';
+import type { Space } from '@charmverse/core/prisma';
+import { render } from '@testing-library/react';
+import { v4 as uuid } from 'uuid';
+
+import { createMockSpace } from 'testing/mocks/space';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(() => ({
+    query: {},
+    route: '/',
+    pathname: '',
+    path: '',
+    asPath: ''
+  }))
+}));
+
+jest.mock('hooks/useProposal', () => ({
+  useProposal: jest.fn(() => ({}))
+}));
+
+jest.mock('charmClient');
+
+jest.mock('hooks/useCurrentSpace');
+jest.mock('hooks/usePagePermissions');
+// beforeEach(() => {
+//   jest.resetModules();
+// });
+
+afterEach(() => {});
+
+afterAll(() => {
+  jest.resetModules();
+});
+
+describe('shareToWeb', () => {
+  it('should render an enabled public toggle only if a user has permissions to toggle the public status of the page', async () => {
+    jest.doMock('hooks/useCurrentSpace', () => ({
+      useCurrentSpace: jest.fn(createMockSpace)
+    }));
+
+    const pageId = uuid();
+
+    jest.doMock('hooks/usePages', () => ({
+      usePages: jest.fn(() => ({
+        pages: {
+          [pageId]: {
+            type: 'page',
+            path: `path-${uuid()}`
+          }
+        }
+      }))
+    }));
+
+    // Test user without permissions
+    const usePagePermissions = await import('hooks/usePagePermissions');
+    // eslint-disable-next-line no-unused-expressions
+    usePagePermissions.usePagePermissions = jest.fn(() => ({ permissions: new AvailablePagePermissions().full }));
+    //  jest.doMock('hooks/usePagePermissions', () => ({
+    //   usePagePermissions: jest.fn(() => ({ permissions: new AvailablePagePermissions().full }))
+    // }));
+
+    const ShareToWeb = (await import('../ShareToWeb')).default;
+
+    const resultWithPermissions = render(
+      <ShareToWeb pageId={pageId} pagePermissions={[]} refreshPermissions={jest.fn()} />
+    );
+
+    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {}).children.item(0);
+    expect(toggle?.getAttribute('type')).toBe('checkbox');
+
+    // Important part of the test
+    expect(toggle).not.toBeDisabled();
+  });
+
+  it('should render a disabled public toggle if a user does not have permissions to toggle the public status of the page', async () => {
+    jest.doMock('hooks/useCurrentSpace', () => ({
+      useCurrentSpace: jest.fn(createMockSpace)
+    }));
+
+    const pageId = uuid();
+
+    jest.doMock('hooks/usePages', () => ({
+      usePages: jest.fn(() => ({
+        pages: {
+          [pageId]: {
+            type: 'page',
+            path: `path-${uuid()}`
+          }
+        }
+      }))
+    }));
+
+    // Test user without permissions
+    const usePagePermissions = await import('hooks/usePagePermissions');
+    // eslint-disable-next-line no-unused-expressions
+    usePagePermissions.usePagePermissions = jest.fn(() => ({ permissions: new AvailablePagePermissions().empty }));
+
+    const ShareToWeb = (await import('../ShareToWeb')).default;
+
+    const resultWithPermissions = render(
+      <ShareToWeb pageId={pageId} pagePermissions={[]} refreshPermissions={jest.fn()} />
+    );
+
+    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {}).children.item(0);
+    expect(toggle?.getAttribute('type')).toBe('checkbox');
+
+    // Important part of the test
+    expect(toggle).toBeDisabled();
+  });
+
+  // it('should render a disabled public toggle if the space has activated public proposals and the page is a proposal page', async () => {
+  //   jest.mock('hooks/useCurrentSpace', () => ({
+  //     useCurrentSpace: jest.fn(createMockSpace)
+  //   }));
+
+  //   jest.mock('hooks/usePagePermissions', () => ({
+  //     usePagePermissions: jest.fn(() => ({ permissions: new AvailablePagePermissions().full }))
+  //   }));
+
+  //   const pageId = uuid();
+
+  //   jest.mock('hooks/usePages', () => ({
+  //     usePages: jest.fn(() => ({
+  //       [pageId]: {
+  //         type: 'page'
+  //       }
+  //     }))
+  //   }));
+
+  //   const result = render(<ShareToWeb pageId={pageId} pagePermissions={[]} refreshPermissions={jest.fn()} />);
+
+  //   const toggle = result.getByTestId('toggle-public-page', {}).children.item(0);
+  //   expect(toggle?.getAttribute('disabled')).toBe('');
+  //   expect(toggle?.getAttribute('type')).toBe('checkbox');
+  // });
+
+  it('should render an enabled public toggle if the space has activated public proposals, user has permissions to toggle public status, and the page is not of type proposal', async () => {});
+});

--- a/jest.setup.browser.ts
+++ b/jest.setup.browser.ts
@@ -4,6 +4,12 @@
 // Used for __tests__/testing-library.js
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+import { configure } from '@testing-library/react';
+
+configure({
+  // Align data-test attribute with Playwright
+  testIdAttribute: 'data-test'
+});
 
 // fix dynamic imports in next.js 13: https://github.com/vercel/next.js/issues/41725
 jest.mock('next/dynamic', () => ({

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "db-tool:test": "dotenv -e .env.test.local -- npx prisma studio",
     "typecheck": "node_modules/typescript/bin/tsc --project tsconfig.json --noEmit",
     "test:setup-db": "./scripts/configure-db.sh",
-    "test:browser": "TZ=UTC jest --config='./jest.config.browser.ts'",
+    "test:browser": "TZ=UTC jest components/common/PageLayout/components/Header/components/ShareButton/components/__tests__/ShareToWeb.spec.ts --config='./jest.config.browser.ts'",
     "e2e:compile": "npx tsx esbuild.e2e.ts",
     "test:e2e": "dotenv -e .env.test.local -- npx playwright test --timeout=0",
     "test": "npm run test:ci -- --verbose --watch",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "db-tool:test": "dotenv -e .env.test.local -- npx prisma studio",
     "typecheck": "node_modules/typescript/bin/tsc --project tsconfig.json --noEmit",
     "test:setup-db": "./scripts/configure-db.sh",
-    "test:browser": "TZ=UTC jest components/common/PageLayout/components/Header/components/ShareButton/components/__tests__/ShareToWeb.spec.ts --config='./jest.config.browser.ts'",
+    "test:browser": "TZ=UTC jest --config='./jest.config.browser.ts'",
     "e2e:compile": "npx tsx esbuild.e2e.ts",
     "test:e2e": "dotenv -e .env.test.local -- npx playwright test --timeout=0",
     "test": "npm run test:ci -- --verbose --watch",

--- a/testing/customRender.tsx
+++ b/testing/customRender.tsx
@@ -10,7 +10,8 @@ import type { IContext } from 'hooks/useUser';
 import { UserContext } from 'hooks/useUser';
 import { createThemeLightSensitive } from 'theme';
 
-import { createMockSpace, createMockUser } from './mocks/user';
+import { createMockSpace } from './mocks/space';
+import { createMockUser } from './mocks/user';
 
 export const customRenderWithContext = (ui: ReactNode, { value, ...renderOptions }: { value?: Partial<IContext> }) => {
   const theme = createThemeLightSensitive('light');

--- a/testing/mocks/space.ts
+++ b/testing/mocks/space.ts
@@ -1,0 +1,37 @@
+import type { Space } from '@charmverse/core/prisma-client';
+import { v4 as uuid } from 'uuid';
+
+export const createMockSpace = (space?: Partial<Space>): Space => {
+  const newUserId = uuid();
+  return {
+    id: uuid(),
+    deletedAt: null,
+    createdAt: new Date(),
+    createdBy: newUserId,
+    updatedAt: new Date(),
+    updatedBy: newUserId,
+    name: 'Test Space',
+    domain: 'test-space',
+    customDomain: null,
+    discordServerId: null,
+    defaultVotingDuration: null,
+    origin: null,
+    paidTier: 'free',
+    snapshotDomain: null,
+    spaceImage: null,
+    defaultPostCategoryId: null,
+    notifyNewProposals: null,
+    requireProposalTemplate: null,
+    defaultPagePermissionGroup: null,
+    defaultPublicPages: null,
+    permissionConfigurationMode: null,
+    publicBountyBoard: null,
+    xpsEngineId: null,
+    superApiTokenId: null,
+    webhookSubscriptionUrl: null,
+    webhookSigningSecret: null,
+    publicProposals: null,
+    hiddenFeatures: [],
+    ...space
+  };
+};

--- a/testing/mocks/user.ts
+++ b/testing/mocks/user.ts
@@ -37,38 +37,3 @@ export function createMockUser(user?: Partial<LoggedInUser>): LoggedInUser {
     ...user
   };
 }
-
-export const createMockSpace = (space?: Partial<Space>): Space => {
-  const newUserId = uuid();
-  return {
-    id: uuid(),
-    deletedAt: null,
-    createdAt: new Date(),
-    createdBy: newUserId,
-    updatedAt: new Date(),
-    updatedBy: newUserId,
-    name: 'Test Space',
-    domain: 'test-space',
-    customDomain: null,
-    discordServerId: null,
-    defaultVotingDuration: null,
-    origin: null,
-    paidTier: 'free',
-    snapshotDomain: null,
-    spaceImage: null,
-    defaultPostCategoryId: null,
-    notifyNewProposals: null,
-    requireProposalTemplate: null,
-    defaultPagePermissionGroup: null,
-    defaultPublicPages: null,
-    permissionConfigurationMode: null,
-    publicBountyBoard: null,
-    xpsEngineId: null,
-    superApiTokenId: null,
-    webhookSubscriptionUrl: null,
-    webhookSigningSecret: null,
-    publicProposals: null,
-    hiddenFeatures: [],
-    ...space
-  };
-};


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 070e167</samp>

This pull request adds unit tests for the `ShareToWeb` component that allows users to share a page to the web. It also updates some testing configurations and refactors some testing utilities to improve the code quality and consistency.

### WHY
Regression test for public page toggle that ensures we can use when necessary, and also account for public proposals