### PR TITLE
updating base docker image to be the recommended version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Install dependencies only when needed
 
 # Use node-slim because node-alpine does not seem to supports the `sharp` npm library that gets built
-FROM node:18-slim AS BASE_APP
+FROM node:lts-slim AS BASE_APP
 
 # useful for node-alpine
 # RUN apk add --no-cache libc6-compat git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Install dependencies only when needed
 
 # Use node-slim because node-alpine does not seem to supports the `sharp` npm library that gets built
-FROM node:lts-slim AS BASE_APP
+FROM node:18.15.0-slim AS BASE_APP
 
 # useful for node-alpine
 # RUN apk add --no-cache libc6-compat git


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9902792</samp>

Updated the Dockerfile to use the latest LTS version of node for better stability and security. This is part of a pull request to improve the website performance and dependencies.

### WHY
need openssl this is the recommended version with built in openssl
