### PR TITLE
add alert to user when we receive duplicate messages

### DIFF
--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -158,7 +158,7 @@ export class DocumentEventHandler {
         ...logData,
         message
       });
-      // We dont know why this happens, but at least sometimes, the client never gets corrected and the user ends up losing all their data
+      // Dont know how it gets out of sync, but sometimes these are not in fact duplicate messages. And the user ends up losing all their changes as each new one is ignored.
       this.sendError('Your version of this document is out of sync with the server. Please refresh the page.');
       return;
     } else if (message.c > this.messages.client + 1) {

--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -158,6 +158,8 @@ export class DocumentEventHandler {
         ...logData,
         message
       });
+      // We dont know why this happens, but at least sometimes, the client never gets corrected and the user ends up losing all their data
+      this.sendError('Your version of this document is out of sync with the server. Please refresh the page.');
       return;
     } else if (message.c > this.messages.client + 1) {
       log.warn('Request resent of lost messages from client', {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ac2804</samp>

Added an error message to `DocumentEventHandler` to warn the user of potential sync issues. This is a temporary fix for a bug that causes the client to ignore some document events from the server.

### WHY
In this case, we have been seeing that the client messages are not in fact duplicate. I have not figured out how it gets out of sync yet.
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/eada879e-fa71-41be-a2be-8d51088440dc)
