### PR TITLE
move banner components into their respective locations

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -8,7 +8,7 @@ import { memo, useEffect, useRef } from 'react';
 import { useElementSize } from 'usehooks-ts';
 
 import { PageComments } from 'components/[pageId]/Comments/PageComments';
-import { ProposalBanner } from 'components/common/Banners/ProposalBanner';
+import { ProposalBanner } from 'components/[pageId]/DocumentPage/components/ProposalBanner';
 import AddBountyButton from 'components/common/BoardEditor/focalboard/src/components/cardDetail/AddBountyButton';
 import CardDetailProperties from 'components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties';
 import CommentsList from 'components/common/BoardEditor/focalboard/src/components/cardDetail/commentsList';

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -8,7 +8,6 @@ import { memo, useEffect, useRef } from 'react';
 import { useElementSize } from 'usehooks-ts';
 
 import { PageComments } from 'components/[pageId]/Comments/PageComments';
-import { ProposalBanner } from 'components/[pageId]/DocumentPage/components/ProposalBanner';
 import AddBountyButton from 'components/common/BoardEditor/focalboard/src/components/cardDetail/AddBountyButton';
 import CardDetailProperties from 'components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties';
 import CommentsList from 'components/common/BoardEditor/focalboard/src/components/cardDetail/commentsList';
@@ -34,6 +33,7 @@ import PageBanner from './components/PageBanner';
 import PageDeleteBanner from './components/PageDeleteBanner';
 import PageHeader from './components/PageHeader';
 import { PageTemplateBanner } from './components/PageTemplateBanner';
+import { ProposalBanner } from './components/ProposalBanner';
 import { ProposalProperties } from './components/ProposalProperties';
 
 export const Container = styled(({ fullWidth, top, ...props }: any) => <Box {...props} top={top || 0} />)<{

--- a/components/[pageId]/DocumentPage/components/ProposalBanner.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalBanner.tsx
@@ -2,9 +2,8 @@ import EastIcon from '@mui/icons-material/East';
 import { Typography, Stack } from '@mui/material';
 import { useRouter } from 'next/router';
 
+import { StyledBanner } from 'components/common/Banners/Banner';
 import Link from 'components/common/Link';
-
-import { StyledBanner } from './Banner';
 
 export function ProposalBanner({ type, proposalId }: { type: 'page' | 'post'; proposalId: string }) {
   const router = useRouter();

--- a/components/_app/GlobalComponents.tsx
+++ b/components/_app/GlobalComponents.tsx
@@ -1,4 +1,3 @@
-import { PaidAnnouncementBanner } from 'components/common/Banners/PaidAnnouncementBanner';
 import HexagonalAvatarMask from 'components/common/HexagonalAvatarMask';
 import Snackbar from 'components/common/Snackbar';
 import { UserProfileDialogGlobal } from 'components/common/UserProfile/UserProfileDialogGlobal';

--- a/components/common/BoardEditor/components/PageWebhookBanner.tsx
+++ b/components/common/BoardEditor/components/PageWebhookBanner.tsx
@@ -2,7 +2,7 @@ import type { BoxProps } from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
-import { StyledBanner } from './Banner';
+import { StyledBanner } from '../../Banners/Banner';
 
 export function PageWebhookBanner({ type, url, ...restProps }: BoxProps & { type: string; url: string }) {
   return (

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -23,7 +23,7 @@ import { v4 as uuid } from 'uuid';
 import charmClient from 'charmClient';
 import PageBanner, { randomBannerImage } from 'components/[pageId]/DocumentPage/components/PageBanner';
 import PageDeleteBanner from 'components/[pageId]/DocumentPage/components/PageDeleteBanner';
-import { PageWebhookBanner } from 'components/common/Banners/PageWebhookBanner';
+import { PageWebhookBanner } from 'components/common/BoardEditor/components/PageWebhookBanner';
 import { createTableView } from 'components/common/BoardEditor/focalboard/src/components/addViewMenu';
 import { getBoard } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import {

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -20,11 +20,10 @@ import { useSharedPage } from 'hooks/useSharedPage';
 import { useUser } from 'hooks/useUser';
 import { useWindowSize } from 'hooks/useWindowSize';
 
-import { PaidAnnouncementBanner } from '../Banners/PaidAnnouncementBanner';
-
 import CurrentPageFavicon from './components/CurrentPageFavicon';
 import { Header, headerHeight } from './components/Header/Header';
 import PageContainer from './components/PageContainer';
+import { PaidAnnouncementBanner } from './components/PaidAnnouncementBanner';
 import Sidebar from './components/Sidebar';
 
 const MAX_SIDEBAR_WIDTH = 500;

--- a/components/common/PageLayout/components/PaidAnnouncementBanner.tsx
+++ b/components/common/PageLayout/components/PaidAnnouncementBanner.tsx
@@ -2,10 +2,9 @@ import CloseIcon from '@mui/icons-material/Close';
 import EastIcon from '@mui/icons-material/East';
 import { Box, IconButton, Stack, Typography } from '@mui/material';
 
+import { StyledBanner } from 'components/common/Banners/Banner';
 import Link from 'components/common/Link';
 import { useLocalStorage } from 'hooks/useLocalStorage';
-
-import { StyledBanner } from './Banner';
 
 export function PaidAnnouncementBanner() {
   const [showPaidAnnouncementBar, setShowPaidAnnouncementBar] = useLocalStorage('show-paid-banner', true);

--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -7,8 +7,8 @@ import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import { PageTitleInput } from 'components/[pageId]/DocumentPage/components/PageTitleInput';
+import { ProposalBanner } from 'components/[pageId]/DocumentPage/components/ProposalBanner';
 import { Container } from 'components/[pageId]/DocumentPage/DocumentPage';
-import { ProposalBanner } from 'components/common/Banners/ProposalBanner';
 import Button from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19fd04b</samp>

Refactored banner components to improve code organization and reusability. Moved `PaidAnnouncementBanner` and `ProposalBanner` components to their respective page-level folders and extracted `StyledBanner` as a common base component under `components/common/Banners/Banner.tsx`. Updated import paths accordingly.

### WHY
We don't group components by type, but rather hierarchy in the app when possible.
