### PR TITLE
show some of the sidebar while rest is loading on page load

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
@@ -62,7 +62,7 @@ export default function BountyProperties(props: {
   const [currentBounty, setCurrentBounty] = useState<(BountyCreationData & BountyWithDetails) | null>();
   const [isAmountInputEmpty, setIsAmountInputEmpty] = useState<boolean>(false);
   const [capSubmissions, setCapSubmissions] = useState(false);
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const { isPublicSpace } = useIsPublicSpace();
 

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountySignupButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountySignupButton.tsx
@@ -22,7 +22,7 @@ interface Props {
 export function BountySignupButton({ pagePath }: Props) {
   const { account, walletAuthSignature, loginFromWeb3Account } = useWeb3AuthSig();
   const { user, setUser, isLoaded: isUserLoaded } = useUser();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { data: spaceWithGates } = useSWR(space ? `spaceByDomain/${space.domain}` : null, () =>
     charmClient.spaces.searchByDomain(space!.domain)
   );

--- a/components/[pageId]/DocumentPage/components/PageDeleteBanner.tsx
+++ b/components/[pageId]/DocumentPage/components/PageDeleteBanner.tsx
@@ -10,7 +10,7 @@ import { usePages } from 'hooks/usePages';
 
 export default function PageDeleteBanner({ pageId }: { pageId: string }) {
   const [isMutating, setIsMutating] = useState(false);
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const router = useRouter();
   const { pages } = usePages();
 

--- a/components/[pageId]/DocumentPage/components/PageTemplateBanner.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTemplateBanner.tsx
@@ -27,7 +27,7 @@ type Props = {
 };
 
 export function PageTemplateBanner({ pageType, parentId }: Props) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const theme = useTheme();
   const { pages } = usePages();
   const parentPage = parentId ? pages[parentId] : undefined;

--- a/components/[pageId]/EditorPage/EditorPage.tsx
+++ b/components/[pageId]/EditorPage/EditorPage.tsx
@@ -18,7 +18,7 @@ export function EditorPage({ pageId: pageIdOrPath }: { pageId: string }) {
   const { setCurrentPageId } = useCurrentPage();
   const { editMode, resetPageProps, setPageProps } = useCharmEditor();
   const [, setTitleState] = usePageTitle();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
 
   const {
     error: pageWithContentError,

--- a/components/_app/hooks/useSpaceGatesReevaluate.ts
+++ b/components/_app/hooks/useSpaceGatesReevaluate.ts
@@ -7,7 +7,7 @@ import { useWeb3AuthSig } from 'hooks/useWeb3AuthSig';
 
 export function useSpaceGatesReevaluate() {
   const { user, refreshUser } = useUser();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { getStoredSignature, account } = useWeb3AuthSig();
 
   useEffect(() => {

--- a/components/bounties/BountiesPage.tsx
+++ b/components/bounties/BountiesPage.tsx
@@ -45,7 +45,7 @@ const views: { label: string; view: 'gallery' | 'board' }[] = [
 ];
 
 export default function BountiesPage({ publicMode = false, bounties }: Props) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const router = useRouter();
 
   const currentView = views.find((view) => view.view === router.query.view) ?? views[0];

--- a/components/bounties/components/BountyStatusBadge.tsx
+++ b/components/bounties/components/BountyStatusBadge.tsx
@@ -152,7 +152,7 @@ export function BountyStatusNexusChip({
 }
 
 export function BountyStatusBadge({ truncate = false, hideStatus, bounty, layout = 'row' }: IBountyBadgeProps) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const bountyLink = `/${space?.domain}/bounties/${bounty.id}`;
 

--- a/components/bounties/components/NewBountyButton.tsx
+++ b/components/bounties/components/NewBountyButton.tsx
@@ -13,7 +13,7 @@ import type { BountyWithDetails } from 'lib/bounties';
 export function NewBountyButton() {
   const { user } = useUser();
   const router = useRouter();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const [currentUserPermissions] = useCurrentSpacePermissions();
   const suggestBounties = currentUserPermissions?.createBounty === false;
   const { setBounties } = useBounties();

--- a/components/common/BoardEditor/FocalBoardProvider.tsx
+++ b/components/common/BoardEditor/FocalBoardProvider.tsx
@@ -14,7 +14,7 @@ import { initialLoad } from './focalboard/src/store/initialLoad';
 // load focalboard data when a workspace is selected
 function FocalBoardWatcher({ children }: { children: JSX.Element }) {
   const dispatch = useAppDispatch();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const { subscribe } = useWebSocketClient();
 

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/AddBountyButton/AddBountyAction.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/AddBountyButton/AddBountyAction.tsx
@@ -25,7 +25,7 @@ export default function AddBountyAction({ readOnly, cardId }: Props) {
     return !!bounties.find((bounty) => bounty.page?.id === cardId) ?? null;
   }, [cardId, bounties]);
   const { user } = useUser();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { createDraftBounty } = useBounties();
 
   // clear draft bounty on close, just in case

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -107,7 +107,7 @@ function CenterPanel(props: Props) {
   const [loadingFormResponses, setLoadingFormResponses] = useState(false);
 
   const router = useRouter();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { pages, refreshPage, updatePage } = usePages();
   const { members } = useMembers();
   const { showMessage } = useSnackbar();

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.tsx
@@ -57,7 +57,7 @@ const KanbanCard = React.memo((props: Props) => {
   if (props.isManualSort && isOver) {
     className += ' dragover';
   }
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const { bounties } = useBounties();
   const linkedBounty = bounties.find((bounty) => bounty.page?.id === card.id);

--- a/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
@@ -71,7 +71,7 @@ function TableRow(props: Props) {
     pageUpdatedBy,
     saveTitle
   } = props;
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const titleRef = useRef<{ focus(selectAll?: boolean): void }>(null);
   const [title, setTitle] = useState('');
   const isManualSort = activeView.fields.sortOptions.length === 0;

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -50,7 +50,7 @@ export const PimpedButton = forwardRef<HTMLButtonElement, InputProps<ElementType
 
 // make sure teh id prop is on the same element as onClick
 const PimpedButtonWithNextLink = forwardRef<HTMLButtonElement, InputProps<ElementType>>((_props, ref) => {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
 
   const { href, external, children, id, onClick, target, 'data-test': dataTest, ...props } = _props;
   if (href && !_props.disabled) {

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -426,7 +426,7 @@ function CharmEditor({
   const router = useRouter();
   const { showMessage } = useSnackbar();
   const { mutate } = useSWRConfig();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { setCurrentPageActionDisplay } = usePageActionDisplay();
   const { user } = useUser();
   const isTemplate = pageType ? pageType.includes('template') : false;

--- a/components/common/CharmEditor/InlineCharmEditor.tsx
+++ b/components/common/CharmEditor/InlineCharmEditor.tsx
@@ -165,7 +165,7 @@ export default function CharmEditor({
   placeholderText,
   readOnly = false
 }: InlineCharmEditorProps) {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { user } = useUser();
 
   const onContentChangeDebounced = onContentChange

--- a/components/common/CharmEditor/components/inlinePalette/useEditorItems.ts
+++ b/components/common/CharmEditor/components/inlinePalette/useEditorItems.ts
@@ -30,7 +30,7 @@ export function useEditorItems({
   pageId?: string;
 }) {
   const { addNestedPage } = useNestedPage(pageId);
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { user } = useUser();
   const { pages } = usePages();
   const [userSpacePermissions] = useCurrentSpacePermissions();

--- a/components/common/CharmEditor/components/mention/components/Mention.tsx
+++ b/components/common/CharmEditor/components/mention/components/Mention.tsx
@@ -36,7 +36,7 @@ export default function Mention({ node }: NodeViewProps) {
   const { getMemberById } = useMembers();
   const { pages } = usePages();
   const member = getMemberById(attrs.value);
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   let value: ReactNode = null;
   if (attrs.type === 'page') {
     const page = pages[attrs.value];

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -41,7 +41,7 @@ const StyledTypography = styled(Typography)`
 `;
 
 export default function NestedPage({ node, currentPageId }: NodeViewProps & { currentPageId?: string }) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { pages } = usePages();
   const { categories } = useForumCategories();
   const documentPage = pages[node.attrs.id];

--- a/components/common/CharmEditor/components/nestedPage/hooks/useNestedPage.ts
+++ b/components/common/CharmEditor/components/nestedPage/hooks/useNestedPage.ts
@@ -9,7 +9,7 @@ import { useUser } from 'hooks/useUser';
 import { addPage } from 'lib/pages';
 
 export default function useNestedPage(currentPageId?: string) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { user } = useUser();
   const view = useEditorViewContext();
   const router = useRouter();

--- a/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
+++ b/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
@@ -31,7 +31,7 @@ function Component({ menuState }: { menuState: PluginState }) {
   const popupState = usePopupState({ variant: 'popover', popupId: 'user-role' });
   const view = useEditorViewContext();
   const { deletePage, pages } = usePages();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const boards = useAppSelector(getSortedBoards);
 
   function _getNode() {

--- a/components/common/CharmEditor/components/video/VideoNodeView.tsx
+++ b/components/common/CharmEditor/components/video/VideoNodeView.tsx
@@ -35,7 +35,7 @@ export function VideoNodeView({
   isPost = false
 }: CharmNodeViewProps & { isPost?: boolean }) {
   const attrs = node.attrs as VideoNodeAttrs;
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const [playbackIdWithToken, setPlaybackIdWithToken] = useState('');
 
   // poll endpoint until video is ready

--- a/components/common/CharmEditor/components/video/VideoUploadForm.tsx
+++ b/components/common/CharmEditor/components/video/VideoUploadForm.tsx
@@ -21,7 +21,7 @@ export function VideoUploadForm(props: Props) {
   const [uploadId, setUploadId] = useState<string | null>(null);
   const [progress, setProgress] = useState<number | null>(null);
   const [errorMessage, setErrorMessage] = useState('');
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   // poll endpoint until video is ready
   const { data: upload, error } = useSwr(

--- a/components/common/ImportZippedMarkdown.tsx
+++ b/components/common/ImportZippedMarkdown.tsx
@@ -17,7 +17,7 @@ type Props = InputProps & {
 };
 
 export function ImportZippedMarkdown({ onFile, ...props }: Props) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { mutatePagesList } = usePages();
   const [uploading, setIsUploading] = useState(false);
   const { showMessage } = useSnackbar();

--- a/components/common/Link.tsx
+++ b/components/common/Link.tsx
@@ -41,7 +41,7 @@ interface Props extends Omit<LinkProps, 'href'> {
 }
 
 export default function Link({ external, href, onClick, children, color = 'primary', ...restProps }: Props) {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
 
   if (!href) {
     return (

--- a/components/common/PageActions/components/DatabasePageActionList.tsx
+++ b/components/common/PageActions/components/DatabasePageActionList.tsx
@@ -60,7 +60,7 @@ export function DatabasePageActionList({ pagePermissions, onComplete, page }: Pr
   const { showMessage } = useSnackbar();
   const { members } = useMembers();
   const { user } = useUser();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { formatDateTime, formatDate } = useDateFormatter();
   const importConfirmationPopup = usePopupState({ variant: 'popover', popupId: 'import-confirmation-popup' });
   const { keys } = useApiPageKeys(pageId);

--- a/components/common/PageActions/components/DuplicatePageAction.tsx
+++ b/components/common/PageActions/components/DuplicatePageAction.tsx
@@ -24,7 +24,7 @@ export function DuplicatePageAction({
   onComplete?: VoidFunction;
   pagePermissions: PagePermissionFlags | undefined;
 }) {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const [userSpacePermissions] = useCurrentSpacePermissions();
   const router = useRouter();
   const { refreshBounty } = useBounties();

--- a/components/common/PageActions/components/SnapshotAction/ConnectSnapshot.tsx
+++ b/components/common/PageActions/components/SnapshotAction/ConnectSnapshot.tsx
@@ -39,7 +39,7 @@ export type FormValues = yup.InferType<typeof schema>;
 const DEFAULT_VOTING_DURATION = 7;
 
 export default function ConnectSnapshot() {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { setSpace } = useSpaces();
   const [formError, setFormError] = useState<SystemError | null>(null);
   const [touched, setTouched] = useState<boolean>(false);

--- a/components/common/PageActions/components/SnapshotAction/PublishToSnapshot.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishToSnapshot.tsx
@@ -24,7 +24,7 @@ interface Props {
 export function PublishToSnapshot({ pageId, snapshotProposalId, renderContent, onPublish = () => null }: Props) {
   const [checkingProposal, setCheckingProposal] = useState(!!snapshotProposalId);
   const [proposal, setProposal] = useState<SnapshotProposal | null>(null);
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
 
   const { isOpen, open, close } = usePopupState({ variant: 'popover', popupId: 'publish-proposal' });
 

--- a/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
@@ -51,7 +51,7 @@ const MIN_VOTING_OPTIONS = 2;
 export function PublishingForm({ onSubmit, pageId }: Props) {
   const { account, library } = useWeb3AuthSig();
 
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { members } = useMembers();
 
   const [snapshotSpace, setSnapshotSpace] = useState<SnapshotSpace | null>(null);

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -151,7 +151,7 @@ function PageLayout({ children }: PageLayoutProps) {
     onResize: setSidebarStorageWidth
   });
   const { user } = useUser();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const showSpaceMemberView = !!space && !!user && !!user?.spaceRoles.some((sr) => sr.spaceId === space.id);
 

--- a/components/common/PageLayout/components/AddNewCard.tsx
+++ b/components/common/PageLayout/components/AddNewCard.tsx
@@ -12,7 +12,7 @@ import { StyledIconButton } from './NewPageMenu';
 
 function AddNewCard({ pageId }: { pageId: string }) {
   const router = useRouter();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { pages } = usePages();
 
   return (

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -40,7 +40,7 @@ function HeaderComponent({ open, openSidebar }: HeaderProps) {
   const router = useRouter();
   const { user } = useUser();
   const basePageId = usePageIdFromPath();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { page: basePage } = usePage({
     pageIdOrPath: currentSpace ? basePageId : undefined,
     spaceId: currentSpace?.id

--- a/components/common/PageLayout/components/Header/components/BountyShareButton/ShareBountyBoard.tsx
+++ b/components/common/PageLayout/components/Header/components/BountyShareButton/ShareBountyBoard.tsx
@@ -49,7 +49,7 @@ interface Props {
 export default function ShareBountyBoard({ padding = 1 }: Props) {
   const [copied, setCopied] = useState<boolean>(false);
   const { setSpace } = useSpaces();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const isAdmin = useIsAdmin();
 
   // Current values of the public permission

--- a/components/common/PageLayout/components/Header/components/PageTitleWithBreadcrumbs.tsx
+++ b/components/common/PageLayout/components/Header/components/PageTitleWithBreadcrumbs.tsx
@@ -157,7 +157,7 @@ function BountyPageTitle({ basePath }: { basePath: string }) {
 }
 
 function PublicBountyPageTitle() {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   return (
     <PageTitle>
       {space && (

--- a/components/common/PageLayout/components/Header/components/ProposalsShareButton/ShareProposals.tsx
+++ b/components/common/PageLayout/components/Header/components/ProposalsShareButton/ShareProposals.tsx
@@ -50,7 +50,7 @@ interface Props {
 export default function ShareProposals({ padding = 1 }: Props) {
   const [copied, setCopied] = useState<boolean>(false);
   const { setSpace } = useSpaces();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const isAdmin = useIsAdmin();
   const { isPublicSpace } = useIsPublicSpace();
 

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PagePermissions/PagePermissions.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PagePermissions/PagePermissions.tsx
@@ -114,7 +114,7 @@ interface Props {
 
 export default function PagePermissions({ pageId, pagePermissions, refreshPermissions, pageType }: Props) {
   const { pages } = usePages();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { members, mutateMembers } = useMembers();
   const { roles } = useRoles();
   const popupState = usePopupState({ variant: 'popover', popupId: 'add-a-permission' });

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/ShareToWeb.tsx
@@ -64,7 +64,7 @@ export default function ShareToWeb({ pageId, pagePermissions, refreshPermissions
   const { pages } = usePages();
   const [copied, setCopied] = useState<boolean>(false);
 
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const publicPermission = pagePermissions.find((publicPerm) => publicPerm.assignee.group === 'public') ?? null;
 
   const { permissions: currentPagePermissions } = usePagePermissions({ pageIdOrPath: pageId });

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/__tests__/ShareToWeb.spec.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/__tests__/ShareToWeb.spec.tsx
@@ -1,5 +1,4 @@
 import { AvailablePagePermissions } from '@charmverse/core/permissions/flags';
-import type { Space } from '@charmverse/core/prisma-client';
 import { render } from '@testing-library/react';
 import { v4 as uuid, v4 } from 'uuid';
 
@@ -9,7 +8,7 @@ import { usePagePermissions } from 'hooks/usePagePermissions';
 import { usePages } from 'hooks/usePages';
 // import { usePages } from 'hooks/usePages';
 import { useProposal } from 'hooks/useProposal';
-import { createMockSpace } from 'testing/mocks/space';
+import { mockCurrentSpaceContext } from 'testing/mocks/useCurrentSpace';
 
 import ShareToWeb from '../ShareToWeb';
 
@@ -36,7 +35,7 @@ jest.mock('hooks/usePages', () => ({
   }))
 }));
 jest.mock('hooks/useCurrentSpace', () => ({
-  useCurrentSpace: jest.fn(() => createMockSpace())
+  useCurrentSpace: jest.fn(() => mockCurrentSpaceContext())
 }));
 
 afterAll(() => {
@@ -146,8 +145,8 @@ describe('shareToWeb', () => {
       }
     });
 
-    (useCurrentSpace as jest.Mock<Space>).mockReturnValueOnce(
-      createMockSpace({
+    (useCurrentSpace as jest.Mock<ReturnType<typeof useCurrentSpace>>).mockReturnValueOnce(
+      mockCurrentSpaceContext({
         publicProposals: true
       })
     );
@@ -184,8 +183,8 @@ describe('shareToWeb', () => {
       }
     });
 
-    (useCurrentSpace as jest.Mock<Space>).mockReturnValueOnce(
-      createMockSpace({
+    (useCurrentSpace as jest.Mock<ReturnType<typeof useCurrentSpace>>).mockReturnValueOnce(
+      mockCurrentSpaceContext({
         publicProposals: true
       })
     );
@@ -217,8 +216,8 @@ describe('shareToWeb', () => {
       }
     });
 
-    (useCurrentSpace as jest.Mock<Space>).mockReturnValueOnce(
-      createMockSpace({
+    (useCurrentSpace as jest.Mock<ReturnType<typeof useCurrentSpace>>).mockReturnValueOnce(
+      mockCurrentSpaceContext({
         publicProposals: true
       })
     );

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -72,7 +72,7 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
   const { pages, setPages, mutatePage } = usePages();
 
   const currentPage = usePageFromPath();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { user } = useUser();
   const [expanded, setExpanded] = useLocalStorage<string[]>(`${space?.id}.expanded-pages`, []);
   const { showMessage } = useSnackbar();

--- a/components/common/PageLayout/components/SearchInWorkspaceModal.tsx
+++ b/components/common/PageLayout/components/SearchInWorkspaceModal.tsx
@@ -106,7 +106,7 @@ export function SearchInWorkspaceModal(props: SearchInWorkspaceModalProps) {
   const { close, isOpen } = props;
   const router = useRouter();
   const { pages } = usePages();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const [expandPageList, setExpandPageList] = useState(false);
   const [options, setOptions] = useState<SearchResultItem[]>([]);
 

--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -132,7 +132,7 @@ interface SidebarProps {
 export default function Sidebar({ closeSidebar, navAction }: SidebarProps) {
   const router = useRouter();
   const { user, logoutUser } = useUser();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { categories } = useForumCategories();
   const [userSpacePermissions] = useCurrentSpacePermissions();
   const [isScrolled, setIsScrolled] = useState(false);

--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -222,11 +222,7 @@ export default function Sidebar({ closeSidebar, navAction }: SidebarProps) {
         </Box>
       </>
     );
-  }, [favoritePageIds, userSpacePermissions, navAction, addPage, isLoadingAccess]);
-
-  if (isLoadingAccess) {
-    return null;
-  }
+  }, [favoritePageIds, userSpacePermissions, navAction, addPage, showMemberFeatures]);
 
   return (
     <SidebarContainer>
@@ -263,36 +259,41 @@ export default function Sidebar({ closeSidebar, navAction }: SidebarProps) {
                 isOpen={searchInWorkspaceModalState.isOpen}
                 close={searchInWorkspaceModalState.close}
               />
-              {showMemberFeatures && (
-                <SidebarBox
-                  onClick={() => handleModalClick('invites')}
-                  icon={<GroupAddOutlinedIcon color='secondary' fontSize='small' />}
-                  label='Invites'
-                />
-              )}
-              <Divider sx={{ mx: 2, my: 1 }} />
-              {STATIC_PAGES.map((page) => {
-                if (
-                  !space.hiddenFeatures.includes(page.feature) &&
-                  (showMemberFeatures ||
-                    // Always show forum to space members. Show it to guests if they have access to at least 1 category
-                    (page.path === 'forum' && categories.length > 0))
-                ) {
-                  return (
-                    <SidebarLink
-                      key={page.path}
-                      href={`/${space.domain}/${page.path}`}
-                      active={router.pathname.startsWith(`/[domain]/${page.path}`)}
-                      icon={<PageIcon icon={null} pageType={page.path} />}
-                      label={page.title}
-                      onClick={navAction}
-                      data-test={`sidebar-link-${page.path}`}
-                    />
-                  );
-                }
 
-                return null;
-              })}
+              {!isLoadingAccess && (
+                <>
+                  {showMemberFeatures && (
+                    <SidebarBox
+                      onClick={() => handleModalClick('invites')}
+                      icon={<GroupAddOutlinedIcon color='secondary' fontSize='small' />}
+                      label='Invites'
+                    />
+                  )}
+                  <Divider sx={{ mx: 2, my: 1 }} />
+                  {STATIC_PAGES.map((page) => {
+                    if (
+                      !space.hiddenFeatures.includes(page.feature) &&
+                      (showMemberFeatures ||
+                        // Always show forum to space members. Show it to guests if they have access to at least 1 category
+                        (page.path === 'forum' && categories.length > 0))
+                    ) {
+                      return (
+                        <SidebarLink
+                          key={page.path}
+                          href={`/${space.domain}/${page.path}`}
+                          active={router.pathname.startsWith(`/[domain]/${page.path}`)}
+                          icon={<PageIcon icon={null} pageType={page.path} />}
+                          label={page.title}
+                          onClick={navAction}
+                          data-test={`sidebar-link-${page.path}`}
+                        />
+                      );
+                    }
+
+                    return null;
+                  })}
+                </>
+              )}
             </Box>
             {isMobile ? (
               <div>{pagesNavigation}</div>

--- a/components/common/PageLayout/components/Sidebar/SidebarSubmenu.tsx
+++ b/components/common/PageLayout/components/Sidebar/SidebarSubmenu.tsx
@@ -86,7 +86,7 @@ export default function SidebarSubmenu({
   const theme = useTheme();
   const showMobileFullWidthModal = !useMediaQuery(theme.breakpoints.down('sm'));
 
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { spaces, isCreatingSpace, setSpaces, isLoaded } = useSpaces();
   const [spaceFormOpen, setSpaceFormOpen] = useState(false);
   const { user } = useUser();

--- a/components/common/PageLayout/components/TrashModal.tsx
+++ b/components/common/PageLayout/components/TrashModal.tsx
@@ -46,7 +46,7 @@ const ArchivedPageItem = memo<{
   onRestore: (e: MouseEvent<HTMLButtonElement, MouseEvent>, pageId: string) => void;
   onDelete: (e: MouseEvent<HTMLButtonElement, MouseEvent>, pageId: string) => void;
 }>(({ onRestore, onDelete, disabled, archivedPage }) => {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   return (
     <MenuItem
@@ -81,7 +81,7 @@ const ArchivedPageItem = memo<{
 export default function TrashModal({ onClose, isOpen }: { onClose: () => void; isOpen: boolean }) {
   const [isMutating, setIsMutating] = useState(false);
   const [searchText, setSearchText] = useState('');
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const currentPagePath = usePageIdFromPath();
   const { mutatePagesRemove, pages, getPageByPath } = usePages();
   const dispatch = useAppDispatch();

--- a/components/common/UserProfile/UserProfileDialogGlobal.tsx
+++ b/components/common/UserProfile/UserProfileDialogGlobal.tsx
@@ -9,7 +9,7 @@ import { useUserProfile } from './hooks/useUserProfile';
 
 export function UserProfileDialogGlobal() {
   const { hideUserProfile, memberId } = useUserProfile();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { getMemberById } = useMembers();
   const member = memberId ? getMemberById(memberId) : null;
   const { user } = useUser();

--- a/components/common/UserProfile/components/CurrentUserProfile.tsx
+++ b/components/common/UserProfile/components/CurrentUserProfile.tsx
@@ -32,7 +32,7 @@ export function CurrentUserProfile({
   isOnboarding?: boolean;
 }) {
   const { showMessage } = useSnackbar();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { memberPropertyValues, updateSpaceValues, refreshPropertyValues } = useMemberPropertyValues(currentUser.id);
 
   const [userDetails, setUserDetails] = useState<EditableFields>({});

--- a/components/common/form/CustomERCTokenForm.tsx
+++ b/components/common/form/CustomERCTokenForm.tsx
@@ -63,7 +63,7 @@ export default function PaymentForm({ onSubmit, defaultChainId = 1 }: Props) {
   });
 
   const [, , refreshPaymentMethods] = usePaymentMethods();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const [allowManualInput, setAllowManualInput] = useState(false);
   const [formError, setFormError] = useState<ISystemError | null>(null);

--- a/components/forum/ForumFeedPage.tsx
+++ b/components/forum/ForumFeedPage.tsx
@@ -30,7 +30,7 @@ import { usePostCategoryPermissions } from './hooks/usePostCategoryPermissions';
 export function ForumPage() {
   const [search, setSearch] = useState('');
   const router = useRouter();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const sort = router.query.sort as PostSortOption | undefined;
   const { createPost, showPost } = usePostDialog();
   const { categories, isCategoriesLoaded, getPostableCategories } = useForumCategories();

--- a/components/forum/components/CategoryContextMenu.tsx
+++ b/components/forum/components/CategoryContextMenu.tsx
@@ -31,7 +31,7 @@ type Props = {
 
 export function CategoryContextMenu({ category, onChange, onDelete, onSetNewDefaultCategory, permissions }: Props) {
   const [tempName, setTempName] = useState(category.name || '');
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const isAdmin = useIsAdmin();
 
   const { isPublicSpace } = useIsPublicSpace();

--- a/components/forum/components/PostList/PostList.tsx
+++ b/components/forum/components/PostList/PostList.tsx
@@ -35,7 +35,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
 
 export function ForumPostList({ search, categoryId, sort }: ForumPostsProps) {
   const ref = useRef();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const bottomPostReached = useOnScreen(ref);
   const [morePostsAvailable, setMorePostsAvailable] = useState(false);
   const { members } = useMembers();

--- a/components/forum/components/PostList/components/PostCard.tsx
+++ b/components/forum/components/PostList/components/PostCard.tsx
@@ -40,7 +40,7 @@ export function PostCard({ post, user, category }: ForumPostProps) {
   const { id: postId } = pagePost;
   const router = useRouter();
   const { showPost } = usePostDialog();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
 
   const permissions = usePostPermissions({ postIdOrPath: post.id });
 

--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -66,7 +66,7 @@ export function PostPage({
   showOtherCategoryPosts,
   newPostCategory
 }: Props) {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { user } = useUser();
   const { categories, getForumCategoryById } = useForumCategories();
   const { showMessage } = useSnackbar();

--- a/components/forum/components/PostPage/components/CategoryPosts.tsx
+++ b/components/forum/components/PostPage/components/CategoryPosts.tsx
@@ -14,7 +14,7 @@ import { setUrlWithoutRerender } from 'lib/utilities/browser';
 import { usePostDialog } from '../../PostDialog/hooks/usePostDialog';
 
 export function CategoryPosts({ categoryId, postId }: { postId: string; categoryId: string }) {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { categories } = useForumCategories();
   const category = categories.find((_category) => _category.id === categoryId);
   const [sort, setSort] = useState<ListForumPostsRequest['sort']>('new');

--- a/components/forum/components/PostPage/components/PostCategoryInput.tsx
+++ b/components/forum/components/PostPage/components/PostCategoryInput.tsx
@@ -31,7 +31,7 @@ export function PostCategoryInput({
 }) {
   const { categories, getPostableCategories } = useForumCategories();
 
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const postCategory = categories?.find((category) => {
     if (!categoryId && space?.defaultPostCategoryId && category.id === space.defaultPostCategoryId) {

--- a/components/forum/components/permissions/PostCategoryPermissionRow.tsx
+++ b/components/forum/components/permissions/PostCategoryPermissionRow.tsx
@@ -40,7 +40,7 @@ export function PostCategoryRolePermissionRow({
   deletePermission
 }: Props) {
   const roles = useRoles();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const defaultExists = !!defaultPermissionLevel;
   const usingDefault = defaultExists && !existingPermissionId;

--- a/components/forum/components/permissions/PostCategoryPermissions.tsx
+++ b/components/forum/components/permissions/PostCategoryPermissions.tsx
@@ -42,7 +42,7 @@ function PostCategoryPermissions({ postCategory, permissions }: Props) {
   const { roles } = useRoles();
   const addRolesDialog = usePopupState({ variant: 'popover', popupId: 'add-roles-dialog' });
 
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   async function deletePermission(id: string) {
     await charmClient.permissions.forum.deletePostCategoryPermission(id);
     mutatePermissions((list) => list?.filter((p) => p.id !== id));

--- a/components/forum/components/permissions/PostCategoryPermissionsPublic.tsx
+++ b/components/forum/components/permissions/PostCategoryPermissionsPublic.tsx
@@ -20,7 +20,7 @@ type Props = {
   postCategory: PostCategory;
 };
 function PostCategoryPermissions({ postCategory }: Props) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   if (!space) {
     return (

--- a/components/members/components/MemberDirectoryGalleryView.tsx
+++ b/components/members/components/MemberDirectoryGalleryView.tsx
@@ -39,7 +39,7 @@ function MemberDirectoryGalleryCard({ member }: { member: Member }) {
     return record;
   }, {} as any);
 
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { user } = useUser();
 
   const isNameHidden = !propertiesRecord.name?.enabledViews.includes('gallery');

--- a/components/members/components/MemberDirectoryTableView.tsx
+++ b/components/members/components/MemberDirectoryTableView.tsx
@@ -42,7 +42,7 @@ function MemberDirectoryTableRow({ member }: { member: Member }) {
   const twitterUrl = (member.profile?.social as Social)?.twitterURL ?? '';
   const twitterHandle = twitterUrl.split('/').at(-1);
   const discordUsername = (member.profile?.social as Social)?.discordUsername;
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { user } = useUser();
   const { properties = [] } = useMemberProperties();
   const visibleProperties = properties.filter((property) => property.enabledViews.includes('table'));

--- a/components/proposals/ProposalsPage.tsx
+++ b/components/proposals/ProposalsPage.tsx
@@ -23,7 +23,7 @@ import { useProposals } from './hooks/useProposals';
 export function ProposalsPage() {
   const { categories = [] } = useProposalCategories();
   const { pages } = usePages();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { isPublicSpace } = useIsPublicSpace();
   const {
     data,

--- a/components/proposals/components/ProposalCategoryContextMenu.tsx
+++ b/components/proposals/components/ProposalCategoryContextMenu.tsx
@@ -22,7 +22,7 @@ type Props = {
 
 export function ProposalCategoryContextMenu({ category }: Props) {
   const [tempName, setTempName] = useState(category.title || '');
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { mutateCategory, deleteCategory } = useProposalCategories();
   const { showMessage } = useSnackbar();
 

--- a/components/proposals/components/ProposalDialog/ProposalDialogProperties.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalDialogProperties.tsx
@@ -44,7 +44,7 @@ export function ProposalDialogProperties({
   const { categories } = useProposalCategories();
 
   const { pages } = usePages();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const [detailsExpanded, setDetailsExpanded] = useState(true);
   const [selectedProposalTemplateId, setSelectedProposalTemplateId] = useState<null | string>(null);
   const { members } = useMembers();

--- a/components/proposals/components/ProposalDialog/ProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalPage.tsx
@@ -34,7 +34,7 @@ type Props = {
 };
 
 export function ProposalPage({ setFormInputs, formInputs, contentUpdated, setContentUpdated }: Props) {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { showMessage } = useSnackbar();
   const { showProposal } = useProposalDialog();
   const [_, { width: containerWidth }] = useElementSize();

--- a/components/proposals/components/permissions/ProposalCategoryPermissionRow.tsx
+++ b/components/proposals/components/permissions/ProposalCategoryPermissionRow.tsx
@@ -37,7 +37,7 @@ export function ProposalCategoryRolePermissionRow({
   deletePermission
 }: Props) {
   const roles = useRoles();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const defaultExists = !!defaultPermissionLevel;
   const usingDefault = defaultExists && !existingPermissionId;

--- a/components/proposals/components/permissions/ProposalCategoryPermissions.tsx
+++ b/components/proposals/components/permissions/ProposalCategoryPermissions.tsx
@@ -38,7 +38,7 @@ function ProposalCategoryPermissions({ proposalCategory, permissions }: Props) {
   const { roles } = useRoles();
   const addRolesDialog = usePopupState({ variant: 'popover', popupId: 'add-roles-dialog' });
 
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   async function deletePermission(id: string) {
     await charmClient.permissions.proposals.deleteProposalCategoryPermission(id);
     mutatePermissions((list) => list?.filter((p) => p.id !== id));

--- a/components/proposals/hooks/useProposalCategories.ts
+++ b/components/proposals/hooks/useProposalCategories.ts
@@ -6,7 +6,7 @@ import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import type { NewProposalCategory } from 'lib/proposal/interface';
 
 export function useProposalCategories() {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   // Might need better ACL in the future
   const { data: categories, mutate } = useSWR(
     () => (currentSpace ? `proposals/${currentSpace.id}/categories` : null),

--- a/components/settings/SettingsDialog.tsx
+++ b/components/settings/SettingsDialog.tsx
@@ -95,7 +95,7 @@ function TabPanel(props: TabPanelProps) {
 }
 
 export function SpaceSettingsDialog() {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const isMobile = useSmallScreen();
   const { activePath, onClose, onClick, open } = useSettingsDialog();
   const { memberSpaces } = useSpaces();

--- a/components/settings/invites/components/InviteLinks/components/InviteLinksTable.tsx
+++ b/components/settings/invites/components/InviteLinks/components/InviteLinksTable.tsx
@@ -28,7 +28,7 @@ interface Props {
 
 export default function InvitesTable(props: Props) {
   const { isAdmin, invites, onDelete, refetchInvites } = props;
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const [copied, setCopied] = useState<{ [id: string]: boolean }>({});
 

--- a/components/settings/invites/components/TokenGates/components/TokenGatesTable.tsx
+++ b/components/settings/invites/components/TokenGates/components/TokenGatesTable.tsx
@@ -67,7 +67,7 @@ export default function TokenGatesTable({ isAdmin, onDelete, tokenGates }: Props
   const [testResult, setTestResult] = useState<TestResult>({});
   const litClient = useLitProtocol();
   const [descriptions, setDescriptions] = useState<(string | null)[]>([]);
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { showMessage } = useSnackbar();
   const shareLink = `${window.location.origin}/join?domain=${space?.domain}`;
   const { openWalletSelectorModal } = useContext(Web3Connection);

--- a/components/settings/roles/components/ImportDiscordRolesMenuItem.tsx
+++ b/components/settings/roles/components/ImportDiscordRolesMenuItem.tsx
@@ -7,7 +7,7 @@ import DiscordIcon from 'public/images/discord_logo.svg';
 
 export default function ImportDiscordRolesMenuItem() {
   const router = useRouter();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const isAdmin = useIsAdmin();
 

--- a/components/settings/roles/components/ImportGuildRolesMenuItem.tsx
+++ b/components/settings/roles/components/ImportGuildRolesMenuItem.tsx
@@ -21,7 +21,7 @@ export default function ImportGuildRolesMenuItem({ onClose }: { onClose: () => v
   const [fetchingGuilds, setFetchingGuilds] = useState(false);
   const [importingRoles, setImportingRoles] = useState(false);
   const [selectedGuildIds, setSelectedGuildIds] = useState<number[]>([]);
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { user: currentUser } = useUser();
   const addresses = currentUser?.wallets.map((w) => w.address) ?? [];
   const { showMessage } = useSnackbar();

--- a/components/settings/roles/components/MemberRow.tsx
+++ b/components/settings/roles/components/MemberRow.tsx
@@ -68,7 +68,7 @@ function MemberActions({
   memberRoleId?: string;
   readOnly: boolean;
 }) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { showMessage } = useSnackbar();
   const { unassignRole } = useRoles();
   const { makeAdmin, makeGuest, makeMember, members, removeFromSpace, getMemberById } = useMembers();

--- a/components/settings/roles/components/RolePermissions/RolePermissions.tsx
+++ b/components/settings/roles/components/RolePermissions/RolePermissions.tsx
@@ -138,7 +138,7 @@ function reducerWithContext({ id }: { id: string }) {
 }
 
 export function RolePermissions({ targetGroup, id, callback = () => null }: Props) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { categories: proposalCategories = [] } = useProposalCategories();
   const { categories: forumCategories = [] } = useForumCategories();
   const isAdmin = useIsAdmin();

--- a/components/settings/roles/components/RolePermissions/components/DefaultPagePermissions.tsx
+++ b/components/settings/roles/components/RolePermissions/components/DefaultPagePermissions.tsx
@@ -22,7 +22,7 @@ const pagePermissionDescriptions: Record<PagePermissionLevelWithoutCustomAndProp
   view: 'Space members can only view pages.'
 };
 export function DefaultPagePermissions() {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { setSpace } = useSpaces();
 
   const [isUpdatingPagePermission, setIsUpdatingPagePermission] = useState(false);

--- a/components/settings/roles/hooks/useImportDiscordRoles.ts
+++ b/components/settings/roles/hooks/useImportDiscordRoles.ts
@@ -15,7 +15,7 @@ export function useImportDiscordRoles() {
   const { showMessage } = useSnackbar();
   const isAdmin = useIsAdmin();
   const router = useRouter();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { refreshRoles } = useRoles();
   const { onClick } = useSettingsDialog();
 

--- a/components/settings/subscription/CheckoutForm.tsx
+++ b/components/settings/subscription/CheckoutForm.tsx
@@ -83,7 +83,7 @@ export function CheckoutForm({
 
   const billingEmail = watch('billingEmail');
 
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const [isProcessing, setIsProcessing] = useState(false);
   const { showMessage } = useSnackbar();
   const [period, setPeriod] = useState<SubscriptionPeriod>('monthly');

--- a/components/votes/components/NewProposalButton.tsx
+++ b/components/votes/components/NewProposalButton.tsx
@@ -20,7 +20,7 @@ import { setUrlWithoutRerender } from 'lib/utilities/browser';
 
 export function NewProposalButton({ mutateProposals }: { mutateProposals: KeyedMutator<ProposalWithUsers[]> }) {
   const router = useRouter();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { showProposal } = useProposalDialog();
   const { getCategoriesWithCreatePermission, getDefaultCreateCategory } = useProposalCategories();
   const isAdmin = useIsAdmin();

--- a/hooks/useBounties.tsx
+++ b/hooks/useBounties.tsx
@@ -40,7 +40,7 @@ export const BountiesContext = createContext<Readonly<IContext>>({
 });
 
 export function BountiesProvider({ children }: { children: ReactNode }) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const { user } = useUser();
   const [bounties, bountiesRef, setBounties] = useRefState<BountyWithDetails[]>([]);

--- a/hooks/useCurrentSpace.ts
+++ b/hooks/useCurrentSpace.ts
@@ -1,3 +1,4 @@
+import type { Space } from '@charmverse/core/prisma';
 import { useRouter } from 'next/router';
 
 import { useSharedPage } from 'hooks/useSharedPage';
@@ -5,9 +6,9 @@ import { filterSpaceByDomain } from 'lib/spaces/filterSpaceByDomain';
 
 import { useSpaces } from './useSpaces';
 
-export function useCurrentSpace() {
+export function useCurrentSpace(): { space?: Space; isLoading: boolean } {
   const router = useRouter();
-  const { spaces } = useSpaces();
+  const { spaces, isLoaded: isSpacesLoaded } = useSpaces();
   const { publicSpace, accessChecked } = useSharedPage();
 
   // Support for extracting domain from logged in view or shared bounties view
@@ -16,8 +17,10 @@ export function useCurrentSpace() {
 
   const space = filterSpaceByDomain(spaces, domainOrCustomDomain as string);
 
-  if (accessChecked) {
-    // We always want to return the space as priority since it's not just set by the URL
-    return space ?? publicSpace;
+  if (!accessChecked && !isSpacesLoaded) {
+    return { isLoading: true };
   }
+
+  // We always want to return the space as priority since it's not just set by the URL
+  return { space: space ?? (publicSpace || undefined), isLoading: false };
 }

--- a/hooks/useCurrentSpacePermissions.ts
+++ b/hooks/useCurrentSpacePermissions.ts
@@ -6,7 +6,7 @@ import { useCurrentSpace } from './useCurrentSpace';
 import { useUser } from './useUser';
 
 export function useCurrentSpacePermissions() {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   // We want dependency on user so we refetch permissions on space or user change
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { user } = useUser();

--- a/hooks/useForumCategories.tsx
+++ b/hooks/useForumCategories.tsx
@@ -37,7 +37,7 @@ export const PostCategoriesContext = createContext<Readonly<IContext>>({
 });
 
 export function PostCategoriesProvider({ children }: { children: ReactNode }) {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { setSpace } = useSpaces();
 
   const { user } = useUser();

--- a/hooks/useHasMemberLevel.tsx
+++ b/hooks/useHasMemberLevel.tsx
@@ -11,12 +11,10 @@ type MemberLevelOutput = {
 
 export function useHasMemberLevel(level: MemberLevel): MemberLevelOutput {
   const space = useCurrentSpace();
-  const { isLoaded: isSpacesLoaded, spaces } = useSpaces();
+  const { spaces } = useSpaces();
   const { user, isLoaded: isUserLoaded } = useUser();
-
   if (
     !isUserLoaded ||
-    !isSpacesLoaded ||
     // This condition is required for the interim state where the user has the spaces loaded, but the space has not yet been set
     // We assert a condition of having at least one space in the array to avoid impacting users without a space
     (spaces.length > 0 && !space)

--- a/hooks/useHasMemberLevel.tsx
+++ b/hooks/useHasMemberLevel.tsx
@@ -1,25 +1,18 @@
 import { useCurrentSpace } from './useCurrentSpace';
-import { useSpaces } from './useSpaces';
 import { useUser } from './useUser';
 
 type MemberLevel = 'admin' | 'member' | 'guest';
 
 type MemberLevelOutput = {
-  hasAccess: boolean | null;
+  hasAccess?: boolean;
   isLoadingAccess: boolean;
 };
 
 export function useHasMemberLevel(level: MemberLevel): MemberLevelOutput {
-  const space = useCurrentSpace();
-  const { spaces } = useSpaces();
+  const { space, isLoading: isSpaceLoading } = useCurrentSpace();
   const { user, isLoaded: isUserLoaded } = useUser();
-  if (
-    !isUserLoaded ||
-    // This condition is required for the interim state where the user has the spaces loaded, but the space has not yet been set
-    // We assert a condition of having at least one space in the array to avoid impacting users without a space
-    (spaces.length > 0 && !space)
-  ) {
-    return { hasAccess: null, isLoadingAccess: true };
+  if (!isUserLoaded || isSpaceLoading) {
+    return { isLoadingAccess: true };
   }
 
   if (!space || !user) {

--- a/hooks/useIsAdmin.ts
+++ b/hooks/useIsAdmin.ts
@@ -3,7 +3,7 @@ import { useUser } from 'hooks/useUser';
 import isSpaceAdmin from 'lib/users/isSpaceAdmin';
 
 export function useIsAdmin() {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { user } = useUser();
 
   return isSpaceAdmin(user, space?.id);

--- a/hooks/useIsCharmverseSpace.tsx
+++ b/hooks/useIsCharmverseSpace.tsx
@@ -10,7 +10,7 @@ const defaultDomains = ['charmverse'];
  * Use this hook for reserving some features in prod for charmverse users only
  */
 export function useIsCharmverseSpace(allowedDomains = defaultDomains) {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
 
   return !isProdEnv || allowedDomains.includes(currentSpace?.domain ?? '') || currentSpace?.domain.startsWith('cvt-');
 }

--- a/hooks/useIsPublicSpace.tsx
+++ b/hooks/useIsPublicSpace.tsx
@@ -5,7 +5,7 @@ type SpaceSubscriptionMeta = {
 };
 
 export function useIsPublicSpace(): SpaceSubscriptionMeta {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   return { isPublicSpace: space?.paidTier === 'free' };
 }

--- a/hooks/useIsSpaceMember.tsx
+++ b/hooks/useIsSpaceMember.tsx
@@ -15,7 +15,7 @@ const IsSpaceMemberContext = createContext<Readonly<Context>>({
 });
 
 export function IsSpaceMemberProvider({ children }: { children: ReactNode }) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { user } = useUser();
   const value = useMemo(() => {
     if (!user || !space) {

--- a/hooks/useMemberProperties.tsx
+++ b/hooks/useMemberProperties.tsx
@@ -40,7 +40,7 @@ const MemberPropertiesContext = createContext<Readonly<Context>>({
 });
 
 export function MemberPropertiesProvider({ children }: { children: ReactNode }) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const { data: properties, mutate: mutateProperties } = useSWR(
     () => (space ? `members/properties/${space?.id}` : null),

--- a/hooks/useMembers.tsx
+++ b/hooks/useMembers.tsx
@@ -39,7 +39,7 @@ const MembersContext = createContext<Readonly<Context>>({
 });
 
 export function MembersProvider({ children }: { children: ReactNode }) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const {
     data: members,

--- a/hooks/useNotionImport.tsx
+++ b/hooks/useNotionImport.tsx
@@ -44,7 +44,7 @@ export function NotionProvider({ children }: Props) {
   const { showMessage } = useSnackbar();
   const [modalOpen, setModalOpen] = useState(false);
   const { mutate } = useSWRConfig();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const dispatch = useAppDispatch();
   const notionCode = getCookie(AUTH_CODE_COOKIE);
   const notionError = getCookie(AUTH_ERROR_COOKIE);

--- a/hooks/usePages.tsx
+++ b/hooks/usePages.tsx
@@ -47,7 +47,7 @@ export const PagesContext = createContext<Readonly<PagesContext>>({
 });
 
 export function PagesProvider({ children }: { children: ReactNode }) {
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const currentSpaceId = useRef<undefined | string>();
   const router = useRouter();
   const { user } = useUser();

--- a/hooks/usePaymentMethods.tsx
+++ b/hooks/usePaymentMethods.tsx
@@ -16,7 +16,7 @@ export const PaymentMethodsContext = createContext<Readonly<IContext>>([[], () =
 
 export function PaymentMethodsProvider({ children }: { children: ReactNode }) {
   const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([]);
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   useEffect(() => {
     refreshPaymentMethods();

--- a/hooks/useRoles.ts
+++ b/hooks/useRoles.ts
@@ -7,7 +7,7 @@ import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useMembers } from 'hooks/useMembers';
 
 export function useRoles() {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { mutateMembers } = useMembers();
 
   const { data: roles } = useSWR(

--- a/hooks/useSpaceWebhook.ts
+++ b/hooks/useSpaceWebhook.ts
@@ -28,7 +28,7 @@ const convertToEventMap = (webhook: SetSpaceWebhookResponse | null | undefined) 
 };
 
 export default function useWebhookSubscription(spaceId: string) {
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const { data: spaceWebhook, isLoading } = useSWR(
     () => (space ? `webhook/${space.id}` : null),

--- a/hooks/useUserSpaceNotifications.ts
+++ b/hooks/useUserSpaceNotifications.ts
@@ -8,7 +8,7 @@ import { useUser } from 'hooks/useUser';
 
 function useSpaceNotificationsData() {
   const { user } = useUser();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const { data, error, isLoading, mutate } = useSWRImmutable(
     user && currentSpace ? `/api/profile/space-notifications/${user.id}/${currentSpace.id}` : null,
     () => {

--- a/hooks/useVotes.tsx
+++ b/hooks/useVotes.tsx
@@ -53,7 +53,7 @@ export function VotesProvider({ children }: { children: ReactNode }) {
   const [parent, setParent] = useState<{ pageId?: string; postId?: string } | null>(null);
   const [votes, setVotes] = useState<IContext['votes']>({});
   const { user } = useUser();
-  const currentSpace = useCurrentSpace();
+  const { space: currentSpace } = useCurrentSpace();
   const [isLoading, setIsLoading] = useState(true);
   const { mutate: mutateTasks, tasks: userTasks } = useTasks();
 

--- a/hooks/useWebSocketClient.tsx
+++ b/hooks/useWebSocketClient.tsx
@@ -46,7 +46,7 @@ let socket: SocketConnection;
 export function WebSocketClientProvider({ children }: { children: ReactNode }) {
   const [messageLog, setMessageLog] = useState<LoggedMessage[]>([]);
 
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
 
   const { current: eventFeed } = useRef(new PubSub<ServerMessage['type'], ServerMessage['payload']>());
 

--- a/pages/[domain]/index.tsx
+++ b/pages/[domain]/index.tsx
@@ -15,7 +15,7 @@ import { getSubdomainPath } from 'lib/utilities/browser';
 export default function RedirectToMainPage() {
   const router = useRouter();
   const { user, isLoaded } = useUser();
-  const space = useCurrentSpace();
+  const { space } = useCurrentSpace();
   const { pages, loadingPages } = usePages();
   const defaultPageKey: string = space?.domain ? getKey(`last-page-${space.domain}`) : '';
   const defaultPage = defaultPageKey ? typeof window !== 'undefined' && localStorage.getItem(defaultPageKey) : null;

--- a/testing/mocks/useCurrentSpace.ts
+++ b/testing/mocks/useCurrentSpace.ts
@@ -1,0 +1,12 @@
+import type { Space } from '@charmverse/core/prisma-client';
+
+import type { useCurrentSpace } from 'hooks/useCurrentSpace';
+
+import { createMockSpace } from './space';
+
+export const mockCurrentSpaceContext = (space?: Partial<Space>): ReturnType<typeof useCurrentSpace> => {
+  return {
+    space: createMockSpace(space),
+    isLoading: false
+  };
+};


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b513e09</samp>

This pull request enhances the sidebar component of the app by refactoring the code and optimizing the rendering. It also moves the `useHasMemberLevel` hook to the `Sidebar.tsx` file, where it is exclusively used, and removes unnecessary variables and imports.

### WHY
We can start rendering the sidebar, its background and top links while we're waiting to load the setting for member features.

The more we can render before stuff loads, the more we can render on server-side as well.

Currently, the sidebar is a white space at first:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/315591ac-c887-42e1-b0c0-b3a1d7ecc5dd)
