### PR TITLE
remove emotion css style cache

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,3 @@
-import { CacheProvider } from '@emotion/react';
 import type { EmotionCache } from '@emotion/utils';
 import type { ExternalProvider, JsonRpcFetchFunc } from '@ethersproject/providers';
 import { Web3Provider } from '@ethersproject/providers';
@@ -44,7 +43,6 @@ import { useUserAcquisition } from 'hooks/useUserAcquisition';
 import { Web3AccountProvider } from 'hooks/useWeb3AuthSig';
 import { WebSocketClientProvider } from 'hooks/useWebSocketClient';
 import { AppThemeProvider } from 'theme/AppThemeProvider';
-import { createEmotionCache } from 'theme/createEmotionCache';
 import '@bangle.dev/tooltip/style.css';
 import '@skiff-org/prosemirror-tables/style/table-filters.css';
 import '@skiff-org/prosemirror-tables/style/table-headers.css';
@@ -102,9 +100,6 @@ import 'theme/lit-protocol/lit-protocol.scss';
 import 'theme/styles.scss';
 
 const getLibrary = (provider: ExternalProvider | JsonRpcFetchFunc) => new Web3Provider(provider);
-
-const clientSideEmotionCache = createEmotionCache();
-
 type NextPageWithLayout = NextPage & {
   getLayout: (page: ReactElement) => ReactElement;
 };
@@ -113,7 +108,7 @@ type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
   emotionCache?: EmotionCache;
 };
-export default function App({ Component, emotionCache = clientSideEmotionCache, pageProps }: AppPropsWithLayout) {
+export default function App({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout ?? ((page) => page);
   const router = useRouter();
 
@@ -145,52 +140,49 @@ export default function App({ Component, emotionCache = clientSideEmotionCache, 
     }
   }, [router.isReady]);
 
-  // DO NOT REMOVE CacheProvider - it protects MUI from Tailwind CSS in settings
   return (
-    <CacheProvider value={emotionCache}>
-      <AppThemeProvider>
-        <SnackbarProvider>
-          <ReactDndProvider>
-            <DataProviders>
-              <SettingsDialogProvider>
-                <NotificationsProvider>
-                  <LocalizationProvider>
-                    <FocalBoardProvider>
-                      <NotionProvider>
-                        <IntlProvider>
-                          <PageHead />
+    <AppThemeProvider>
+      <SnackbarProvider>
+        <ReactDndProvider>
+          <DataProviders>
+            <SettingsDialogProvider>
+              <NotificationsProvider>
+                <LocalizationProvider>
+                  <FocalBoardProvider>
+                    <NotionProvider>
+                      <IntlProvider>
+                        <PageHead />
 
-                          <RouteGuard>
-                            <ErrorBoundary>
-                              <Snackbar
-                                isOpen={isOldBuild}
-                                message='New CharmVerse platform update available. Please refresh.'
-                                actions={[
-                                  <IconButton key='reload' onClick={() => window.location.reload()} color='inherit'>
-                                    <RefreshIcon fontSize='small' />
-                                  </IconButton>
-                                ]}
-                                origin={{ vertical: 'top', horizontal: 'center' }}
-                                severity='warning'
-                                handleClose={() => setIsOldBuild(false)}
-                              />
+                        <RouteGuard>
+                          <ErrorBoundary>
+                            <Snackbar
+                              isOpen={isOldBuild}
+                              message='New CharmVerse platform update available. Please refresh.'
+                              actions={[
+                                <IconButton key='reload' onClick={() => window.location.reload()} color='inherit'>
+                                  <RefreshIcon fontSize='small' />
+                                </IconButton>
+                              ]}
+                              origin={{ vertical: 'top', horizontal: 'center' }}
+                              severity='warning'
+                              handleClose={() => setIsOldBuild(false)}
+                            />
 
-                              {getLayout(<Component {...pageProps} />)}
+                            {getLayout(<Component {...pageProps} />)}
 
-                              <GlobalComponents />
-                            </ErrorBoundary>
-                          </RouteGuard>
-                        </IntlProvider>
-                      </NotionProvider>
-                    </FocalBoardProvider>
-                  </LocalizationProvider>
-                </NotificationsProvider>
-              </SettingsDialogProvider>
-            </DataProviders>
-          </ReactDndProvider>
-        </SnackbarProvider>
-      </AppThemeProvider>
-    </CacheProvider>
+                            <GlobalComponents />
+                          </ErrorBoundary>
+                        </RouteGuard>
+                      </IntlProvider>
+                    </NotionProvider>
+                  </FocalBoardProvider>
+                </LocalizationProvider>
+              </NotificationsProvider>
+            </SettingsDialogProvider>
+          </DataProviders>
+        </ReactDndProvider>
+      </SnackbarProvider>
+    </AppThemeProvider>
   );
 }
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,13 +1,11 @@
-import createEmotionServer from '@emotion/server/create-instance';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 import React from 'react';
 
 import { blueColor } from 'theme/colors';
-import { createEmotionCache } from 'theme/createEmotionCache';
 
 // Source for Emotion SSR: https://github.com/mui/material-ui/tree/332081eb5e5e107d915e3c70f92e430dc364048f/examples/nextjs-with-typescript
 
-class MyDocument extends Document<{ emotionStyleTags: any }> {
+class MyDocument extends Document {
   render() {
     return (
       <Html lang='en'>
@@ -33,7 +31,6 @@ class MyDocument extends Document<{ emotionStyleTags: any }> {
             property='twitter:image'
             content='https://app.charmverse.io/images/logo_black_lightgrey_opengraph.png'
           />
-          {(this.props as any).emotionStyleTags}
         </Head>
         <body>
           <Main />
@@ -43,61 +40,4 @@ class MyDocument extends Document<{ emotionStyleTags: any }> {
     );
   }
 }
-
-// `getInitialProps` belongs to `_document` (instead of `_app`),
-// it's compatible with static-site generation (SSG).
-MyDocument.getInitialProps = async (ctx) => {
-  // Resolution order
-  //
-  // On the server:
-  // 1. app.getInitialProps
-  // 2. page.getInitialProps
-  // 3. document.getInitialProps
-  // 4. app.render
-  // 5. page.render
-  // 6. document.render
-  //
-  // On the server with error:
-  // 1. document.getInitialProps
-  // 2. app.render
-  // 3. page.render
-  // 4. document.render
-  //
-  // On the client
-  // 1. app.getInitialProps
-  // 2. page.getInitialProps
-  // 3. app.render
-  // 4. page.render
-
-  const originalRenderPage = ctx.renderPage;
-
-  // You can consider sharing the same Emotion cache between all the SSR requests to speed up performance.
-  // However, be aware that it can have global side effects.
-  const cache = createEmotionCache();
-  const { extractCriticalToChunks } = createEmotionServer(cache);
-
-  ctx.renderPage = () =>
-    originalRenderPage({
-      enhanceApp: (App: any) => (props) => <App emotionCache={cache} {...props} />
-    });
-
-  const initialProps = await Document.getInitialProps(ctx);
-  // This is important. It prevents Emotion to render invalid HTML.
-  // See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153
-  const emotionStyles = extractCriticalToChunks(initialProps.html);
-  const emotionStyleTags = emotionStyles.styles.map((style) => (
-    <style
-      data-emotion={`${style.key} ${style.ids.join(' ')}`}
-      key={style.key}
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: style.css }}
-    />
-  ));
-
-  return {
-    ...initialProps,
-    emotionStyleTags
-  };
-};
-
 export default MyDocument;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9421b7</samp>

This pull request simplifies the Emotion integration with Material UI and Next.js by removing unnecessary code from `./pages/_app.tsx` and `./pages/_document.tsx`. This makes the app faster and easier to maintain.

### WHY
Might be contributing to our memory issues. Also, I don't think this is necessary - for some reason it was helping to avoid an issue with Lit Protocol CSS but they no longer use tailwind. I checked our UI for gates and styles seem fine.

The one thing I checked is that the styles are being rendered still on the server-side, by doing 'view page source'

Related issue: https://github.com/mui/material-ui/issues/37468

Also emotion explicitly recommends using 'default' approach and not creating your own cache: https://emotion.sh/docs/ssr#default-approach
