### PR TITLE
add support in focalboard for green color

### DIFF
--- a/components/common/BoardEditor/focalboard/src/constants.ts
+++ b/components/common/BoardEditor/focalboard/src/constants.ts
@@ -2,6 +2,7 @@ class Constants {
   static readonly menuColors: { [key: string]: string } = {
     propColorDefault: 'Default',
     propColorGray: 'Gray',
+    propColorGreen: 'Green',
     propColorTurquoise: 'Turquoise',
     propColorOrange: 'Orange',
     propColorYellow: 'Yellow',

--- a/components/common/BoardEditor/focalboard/src/styles/labels.scss
+++ b/components/common/BoardEditor/focalboard/src/styles/labels.scss
@@ -12,6 +12,11 @@
   background-color: var(--bg-turquoise);
 }
 
+.propColorGreen,
+.propColorGreen:hover {
+  background-color: var(--bg-green);
+}
+
 .propColorOrange,
 .propColorOrange:hover {
   background-color: var(--bg-orange);

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -89,6 +89,7 @@ export const focalboardColorsMap: { [key: string]: SupportedColor } = {
   propColorDefault: 'default',
   propColorGray: 'gray',
   propColorTurquoise: 'turquoise',
+  propColorGreen: 'green',
   propColorOrange: 'orange',
   propColorYellow: 'yellow',
   propColorTeal: 'teal',


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5235a17</samp>

Added a new property color green for the board editor. This involved adding a new constant, style rule, and theme value for the green color in `constants.ts`, `labels.scss`, and `colors.ts` respectively.

### WHY
<!-- author to complete -->
