### PR TITLE
Updated max indentation level for list item

### DIFF
--- a/components/common/CharmEditor/components/listItem/commands.ts
+++ b/components/common/CharmEditor/components/listItem/commands.ts
@@ -39,7 +39,7 @@ import {
 import { isNodeTodo, removeTodoCheckedAttr, setTodoCheckedAttr } from './todo';
 import { liftFollowingList, liftSelectionList } from './transforms';
 
-const maxIndentation = 4;
+const maxIndentation = 15;
 
 // Returns the number of nested lists that are ancestors of the given selection
 const numberNestedLists = (resolvedPos: ResolvedPos, nodes: Schema['nodes']) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 178a446</samp>

Increased the maximum indentation level for lists in the `CharmEditor` component. This improves the user experience and functionality of the charm editor.

### WHY
<!-- author to complete -->
