### PR TITLE
Use log.info when there is an error counting prosemirror blocks

### DIFF
--- a/lib/prosemirror/countBlocks.ts
+++ b/lib/prosemirror/countBlocks.ts
@@ -46,7 +46,7 @@ export function countBlocks(pageContent: any | null, spaceId?: string) {
         });
       }
     } catch (error) {
-      log.error('Error counting prosemirror blocks', { error, pageContent, spaceId });
+      log.info('Error counting prosemirror blocks', { error, pageContent, spaceId });
     }
   }
   return count;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04c94c2</samp>

Changed log level of `countBlocks` error from `error` to `info` in `lib/prosemirror/countBlocks.ts`. This reduces the noise in the error logs and improves the billing system.

### WHY
We are often having an error counting prosemirror blocks. This pollutes the datadog logs, and our current counts are within the correct magnitude.