### PR TITLE
Resize text field popup size based on wrap status and cell dimensions

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -35,6 +35,7 @@ type Props = {
   displayType?: PropertyValueDisplayType;
   showTooltip?: boolean;
   wrapColumn?: boolean;
+  columnRef?: React.RefObject<HTMLDivElement>;
 };
 
 function PropertyValueElement(props: Props) {
@@ -184,7 +185,8 @@ function PropertyValueElement(props: Props) {
     onCancel: () => setValue(propertyValue || ''),
     validator: (newValue: string) => validateProp(propertyTemplate.type, newValue),
     spellCheck: propertyTemplate.type === 'text',
-    wrapColumn: props.wrapColumn ?? false
+    wrapColumn: props.wrapColumn ?? false,
+    columnRef: props.columnRef
   };
 
   if (editableFields.includes(propertyTemplate.type)) {

--- a/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
@@ -181,6 +181,9 @@ function TableRow(props: Props) {
             </Box>
           );
         }
+
+        const columnRef = columnRefs.get(template.id);
+
         return (
           <div
             className='octo-table-cell'
@@ -189,7 +192,7 @@ function TableRow(props: Props) {
               alignItems: 'flex-start',
               width: columnWidth(props.resizingColumn, props.activeView.fields.columnWidths, props.offset, template.id)
             }}
-            ref={columnRefs.get(template.id)}
+            ref={columnRef}
             onPaste={(e) => e.stopPropagation()}
           >
             {!props.readOnly && templateIndex === 0 && (
@@ -206,6 +209,7 @@ function TableRow(props: Props) {
               updatedAt={pageUpdatedAt}
               updatedBy={pageUpdatedBy}
               displayType='table'
+              columnRef={columnRef}
               wrapColumn={activeView.fields.columnWrappedIds?.includes(template.id)}
             />
           </div>

--- a/components/common/BoardEditor/focalboard/src/widgets/TextInput.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/TextInput.tsx
@@ -32,6 +32,13 @@ function Editable(
   const elementRef = useRef<HTMLTextAreaElement>(null);
   const { className, ...props } = useEditable(_props, ref, elementRef);
 
+  const memoizedHeight = React.useMemo(() => {
+    if (wrapColumn && columnRef?.current) {
+      return `${columnRef?.current?.clientHeight}px`;
+    }
+    return 'fit-content';
+  }, [wrapColumn, columnRef?.current]);
+
   // Keep it as before for card modal view
   if (displayType === 'details') {
     return (
@@ -52,7 +59,7 @@ function Editable(
       paperSx={{
         width: 350,
         p: 2,
-        height: wrapColumn && columnRef?.current ? `${columnRef?.current?.clientHeight}px` : 'fit-content'
+        height: memoizedHeight
       }}
       popoverProps={{
         anchorOrigin: {

--- a/components/common/BoardEditor/focalboard/src/widgets/TextInput.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/TextInput.tsx
@@ -13,6 +13,7 @@ export type TextInputProps = EditableProps & {
   multiline?: boolean;
   displayType?: PropertyValueDisplayType;
   wrapColumn?: boolean;
+  columnRef?: React.RefObject<HTMLDivElement>;
 };
 
 const StyledInput = styled(InputBase)`
@@ -25,7 +26,7 @@ const StyledInput = styled(InputBase)`
 `;
 
 function Editable(
-  { multiline, wrapColumn, displayType, ..._props }: TextInputProps,
+  { multiline, columnRef, wrapColumn, displayType, ..._props }: TextInputProps,
   ref: React.Ref<Focusable>
 ): JSX.Element {
   const elementRef = useRef<HTMLTextAreaElement>(null);
@@ -51,7 +52,7 @@ function Editable(
       paperSx={{
         width: 350,
         p: 2,
-        height: wrapColumn ? 'calc(100vh - 32px)' : 'fit-content'
+        height: wrapColumn && columnRef?.current ? `${columnRef?.current?.clientHeight}px` : 'fit-content'
       }}
       popoverProps={{
         anchorOrigin: {
@@ -59,7 +60,7 @@ function Editable(
           horizontal: 'left'
         },
         transformOrigin: {
-          vertical: 'center',
+          vertical: 'bottom',
           horizontal: 'left'
         }
       }}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a899c86</samp>

This pull request enhances the `BoardEditor` module by improving the popover positioning and appearance for editing property values in a table. It adds a new `columnRef` prop to the `PropertyValueElement` and `TextInput` components, and refactors the `TableRow` component to use a constant for the column reference map.

### WHY
For a small text-cell it opens the popup component as full-height (when wrapped column is toggled on)
