### PR TITLE
Tweak light mode orange

### DIFF
--- a/components/common/stories/Upgrade.stories.tsx
+++ b/components/common/stories/Upgrade.stories.tsx
@@ -1,0 +1,18 @@
+import { Box, Paper } from '@mui/material';
+
+import { UpgradeChip } from 'components/settings/subscription/UpgradeWrapper';
+
+export default {
+  title: 'common/Upgrade',
+  component: UpgradeChip
+};
+
+export function Upgrade() {
+  return (
+    <Paper sx={{ p: 4 }}>
+      <Box display='flex' width='100px' flexDirection='column' gap={4}>
+        <UpgradeChip forceDisplay />
+      </Box>
+    </Paper>
+  );
+}

--- a/components/settings/subscription/UpgradeWrapper.tsx
+++ b/components/settings/subscription/UpgradeWrapper.tsx
@@ -1,3 +1,5 @@
+import { useTheme } from '@emotion/react';
+import type { PaletteMode } from '@mui/material';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Tooltip from '@mui/material/Tooltip';
@@ -31,8 +33,10 @@ export function UpgradeWrapper({ children, upgradeContext, forceDisplay }: Props
     </Tooltip>
   );
 }
+
 export function UpgradeChip({ upgradeContext, forceDisplay }: Props) {
   const { isFreeSpace } = useIsFreeSpace();
+
   if (!isFreeSpace && !forceDisplay) {
     return null;
   }
@@ -40,7 +44,7 @@ export function UpgradeChip({ upgradeContext, forceDisplay }: Props) {
   return (
     <UpgradeWrapper upgradeContext={upgradeContext} forceDisplay>
       <Chip
-        color='orange'
+        color='warning'
         variant='outlined'
         label='UPGRADE'
         sx={{

--- a/components/settings/subscription/UpgradeWrapper.tsx
+++ b/components/settings/subscription/UpgradeWrapper.tsx
@@ -11,16 +11,16 @@ export const upgradeMessages = {
 };
 
 type Props = {
-  children: ReactNode;
   upgradeContext?: keyof typeof upgradeMessages;
+  forceDisplay?: boolean;
 };
 
-export function UpgradeWrapper({ children, upgradeContext }: Props) {
+export function UpgradeWrapper({ children, upgradeContext, forceDisplay }: Props & { children: ReactNode }) {
   const { openUpgradeSubscription } = useSettingsDialog();
 
   const { isFreeSpace } = useIsFreeSpace();
 
-  if (!isFreeSpace) {
+  if (!isFreeSpace && !forceDisplay) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;
   }
@@ -31,15 +31,14 @@ export function UpgradeWrapper({ children, upgradeContext }: Props) {
     </Tooltip>
   );
 }
-export function UpgradeChip({ upgradeContext }: Pick<Props, 'upgradeContext'>) {
+export function UpgradeChip({ upgradeContext, forceDisplay }: Props) {
   const { isFreeSpace } = useIsFreeSpace();
-
-  if (!isFreeSpace) {
+  if (!isFreeSpace && !forceDisplay) {
     return null;
   }
 
   return (
-    <UpgradeWrapper upgradeContext={upgradeContext}>
+    <UpgradeWrapper upgradeContext={upgradeContext} forceDisplay>
       <Chip
         color='orange'
         variant='outlined'
@@ -47,6 +46,7 @@ export function UpgradeChip({ upgradeContext }: Pick<Props, 'upgradeContext'>) {
         sx={{
           letterSpacing: '0.04em',
           fontSize: '9px',
+          width: 'fit-content',
           height: '16px',
           borderRadius: '3px',
           padding: '2px',

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -44,7 +44,7 @@ export const colors = {
   },
   orange: {
     dark: '#C44F1C',
-    light: '#F4D8D0'
+    light: '#FF7F00'
   },
   yellow: {
     dark: '#81730E',

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -44,7 +44,7 @@ export const colors = {
   },
   orange: {
     dark: '#C44F1C',
-    light: '#FF7F00'
+    light: '#F4D8D0'
   },
   yellow: {
     dark: '#81730E',


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4762645</samp>

This pull request enhances the UI and storybook of the `UpgradeChip` component, which encourages users to upgrade their subscription plan. It adds a `forceDisplay` prop to the component and its wrapper, changes the `orange` color in the theme, and creates a new storybook file for the component.

### WHY
Add upgrade to storybook, and fix the light mode color
