### PR TITLE
Remove number from google form response page title

### DIFF
--- a/lib/google/forms/getCardsAndPages.ts
+++ b/lib/google/forms/getCardsAndPages.ts
@@ -34,8 +34,6 @@ type CharmVerseModelOutput = {
 // map Google data model to CharmVerse models
 export function getCardsAndPages(data: GoogleFormInput): CharmVerseModelOutput {
   const { cardParentId, rootId, createdBy, form, responses, permissions, spaceId } = data;
-  let nextIndex = data.nextIndex;
-
   const cardProperties = getCardProperties(form);
 
   const cardBlocks: PrismaBlockSortOf[] = [];
@@ -99,7 +97,7 @@ export function getCardsAndPages(data: GoogleFormInput): CharmVerseModelOutput {
       },
       createdAt: prismaBlock.createdAt,
       hasContent: true,
-      title: `Response ${nextIndex}`,
+      title: `Response`,
       type: 'card_synced',
       contentText: '',
       parentId: rootId, // important to inherit permissions
@@ -110,7 +108,6 @@ export function getCardsAndPages(data: GoogleFormInput): CharmVerseModelOutput {
       }
     };
     cardPages.push(cardPage);
-    nextIndex += 1;
   }
 
   return { cardProperties, cards: cardBlocks, pages: cardPages };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35106d8</samp>

Simplify the `getCardsAndPages` function in `lib/google/forms/getCardsAndPages.ts` by removing an unnecessary variable. This improves the clarity and accuracy of the response card titles.

### WHY
<!-- author to complete -->
