### PR TITLE
Add logs when deleting comments

### DIFF
--- a/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
@@ -80,7 +80,6 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
   const renderRef = useRef<HTMLDivElement>(null);
   const { user } = useUser();
   const enableFidusEditor = Boolean(user && pageId && trackChanges && !isContentControlled);
-  const [isLoading, setIsLoading] = useState(enableFidusEditor);
   const isLoadingRef = useRef(enableFidusEditor);
   const useSockets = user && pageId && trackChanges && (!readOnly || enableComments) && !isContentControlled;
 
@@ -124,9 +123,10 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
       // for now, just use a standard error message to be over-cautious
       showMessage(error.message, 'warning');
     }
-    log.error('[ws/ceditor]: Error message displayed to user', { error });
-    if (isLoading) {
-      setIsLoading(false);
+    log.error('[ws/ceditor]: Error message displayed to user', {
+      error
+    });
+    if (isLoadingRef.current) {
       isLoadingRef.current = false;
       setEditorContent(_editor, initialContent);
     }
@@ -173,7 +173,7 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
     const _editor = new CoreBangleEditor(renderRef.current!, editorViewPayloadRef.current);
 
     if (isContentControlled) {
-      setIsLoading(false);
+      isLoadingRef.current = false;
     } else if (useSockets) {
       if (authResponse) {
         log.info('Init FidusEditor');
@@ -182,7 +182,6 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
           docId: pageId,
           enableSuggestionMode: enableSuggestions,
           onDocLoaded: () => {
-            setIsLoading(false);
             isLoadingRef.current = false;
           },
           onParticipantUpdate
@@ -190,12 +189,10 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
         fEditor.init(_editor.view, authResponse.authToken, (error) => _onError(_editor, error));
       } else if (authError) {
         log.warn('Loading readonly mode of editor due to web socket failure', { error: authError });
-        setIsLoading(false);
         isLoadingRef.current = false;
         setEditorContent(_editor, initialContent);
       }
     } else if (pageId && readOnly) {
-      setIsLoading(false);
       isLoadingRef.current = false;
       setEditorContent(_editor, initialContent);
     }
@@ -222,10 +219,13 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
         ref={editorRef}
         className='bangle-editor-core'
         data-page-id={pageId}
-        style={{ minHeight: showLoader && isLoading ? '200px' : undefined, cursor: readOnly ? 'default' : 'text' }}
+        style={{
+          minHeight: showLoader && isLoadingRef.current ? '200px' : undefined,
+          cursor: readOnly ? 'default' : 'text'
+        }}
         onClick={() => !readOnly && editor?.view.focus()}
       >
-        <StyledLoadingComponent isLoading={showLoader && isLoading} />
+        <StyledLoadingComponent isLoading={showLoader && isLoadingRef.current} />
         <div ref={renderRef} id={pageId} className={className} style={style} />
       </div>
       {nodeViews.map((nodeView) => {

--- a/components/common/CharmEditor/components/fiduswriter/collab/merge/index.ts
+++ b/components/common/CharmEditor/components/fiduswriter/collab/merge/index.ts
@@ -149,6 +149,7 @@ export class Merge {
     } else {
       // The server seems to have lost some data. We reset.
       this.mod.doc.loadDocument(data);
+      log.error('Server has lost data, reset the document');
     }
   }
 

--- a/pages/api/pages/[id]/comments/[commentId]/index.ts
+++ b/pages/api/pages/[id]/comments/[commentId]/index.ts
@@ -1,3 +1,4 @@
+import { log } from '@charmverse/core/log';
 import type { PageComment } from '@charmverse/core/prisma';
 import { prisma } from '@charmverse/core/prisma-client';
 import type { NextApiRequest, NextApiResponse } from 'next';
@@ -75,6 +76,7 @@ async function deletePageCommentHandler(req: NextApiRequest, res: NextApiRespons
 
   if (pageComment.createdBy === userId || isAdmin) {
     await deletePageComment({ commentId, userId });
+    log.info('User deleted a page comment', { commentId, pageId, userId });
   } else {
     throw new ActionNotPermittedError('You do not have permission to delete this comment.');
   }

--- a/pages/api/threads/[id]/index.ts
+++ b/pages/api/threads/[id]/index.ts
@@ -44,7 +44,7 @@ async function deleteThreadController(req: NextApiRequest, res: NextApiResponse)
   }
 
   await deleteThread(threadId);
-  log.info(`Deleted page comment`, { userId, pageId: thread.pageId, threadId });
+  log.info(`Deleted page inline comment thread`, { userId, pageId: thread.pageId, threadId });
 
   return res.status(200).json({ ok: true });
 }

--- a/pages/api/threads/[id]/index.ts
+++ b/pages/api/threads/[id]/index.ts
@@ -1,3 +1,4 @@
+import { log } from '@charmverse/core/log';
 import { prisma } from '@charmverse/core/prisma-client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
@@ -43,6 +44,7 @@ async function deleteThreadController(req: NextApiRequest, res: NextApiResponse)
   }
 
   await deleteThread(threadId);
+  log.info(`Deleted page comment`, { userId, pageId: thread.pageId, threadId });
 
   return res.status(200).json({ ok: true });
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0555a4f</samp>

Added logging to the APIs for deleting page comments and threads. Used the `log` module to record the user and comment details in `pages/api/pages/[id]/comments/[commentId]/index.ts` and `pages/api/threads/[id]/index.ts`.

### WHY
<!-- author to complete -->
