### PR TITLE
only show 5 items in mentions dropdown by default

### DIFF
--- a/components/common/CharmEditor/components/mention/components/MentionSuggest.tsx
+++ b/components/common/CharmEditor/components/mention/components/MentionSuggest.tsx
@@ -28,7 +28,7 @@ export function MentionSuggest({ pluginKey }: { pluginKey: PluginKey<MentionPlug
   return null;
 }
 
-const DEFAULT_ITEM_LIMIT = 3;
+const DEFAULT_ITEM_LIMIT = 5;
 
 function MentionSuggestMenu({ pluginKey }: { pluginKey: PluginKey }) {
   const { members } = useMembers();

--- a/components/common/CharmEditor/components/mention/components/MentionSuggest.tsx
+++ b/components/common/CharmEditor/components/mention/components/MentionSuggest.tsx
@@ -1,8 +1,9 @@
 import { useEditorViewContext, usePluginState } from '@bangle.dev/react';
 import type { PageMeta } from '@charmverse/core/pages';
-import { Divider, MenuItem, Typography, Box } from '@mui/material';
+import { MoreHoriz } from '@mui/icons-material';
+import { Divider, ListItemIcon, MenuItem, Typography, Box } from '@mui/material';
 import type { PluginKey } from 'prosemirror-state';
-import { memo, useCallback, useEffect } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import UserDisplay from 'components/common/UserDisplay';
 import { useMembers } from 'hooks/useMembers';
@@ -27,6 +28,8 @@ export function MentionSuggest({ pluginKey }: { pluginKey: PluginKey<MentionPlug
   return null;
 }
 
+const DEFAULT_ITEM_LIMIT = 3;
+
 function MentionSuggestMenu({ pluginKey }: { pluginKey: PluginKey }) {
   const { members } = useMembers();
   const view = useEditorViewContext();
@@ -41,46 +44,48 @@ function MentionSuggestMenu({ pluginKey }: { pluginKey: PluginKey }) {
     [view, pluginKey]
   );
 
-  const triggerTextRegex = sanitizeForRegex(triggerText).toLowerCase();
-
-  const filterByUserCustomName = (member: Member) =>
-    member.properties
-      .find((prop) => prop.type === 'name')
-      ?.value?.toString()
-      .toLowerCase()
-      .match(triggerTextRegex);
-
-  const filterByDiscordName = (member: Member) =>
-    (member.profile?.social as Record<string, string>)?.discordUsername
-      ?.toString()
-      .toLowerCase()
-      .match(triggerTextRegex);
-
-  const filterByUsername = (member: Member) => member.username.toLowerCase().match(triggerTextRegex);
-
-  const filterByPath = (member: Member) => member.path?.toLowerCase().match(triggerTextRegex);
-
-  const filteredMembers =
-    triggerText.length !== 0
-      ? members.filter(
-          (member) =>
-            filterByUserCustomName(member) ||
-            filterByDiscordName(member) ||
-            filterByUsername(member) ||
-            filterByPath(member)
-        )
-      : members;
-
-  const filteredPages = Object.values(pages).filter(
-    (page) =>
-      page &&
-      !page?.deletedAt &&
-      (triggerText.length !== 0 ? (page.title || 'Untitled').toLowerCase().startsWith(triggerText.toLowerCase()) : true)
+  const [showAllMembers, setShowAllMembers] = useState(false);
+  const [showAllPages, setShowAllPages] = useState(false);
+  const searchText = sanitizeForRegex(triggerText).toLowerCase();
+  const filteredMembers = useMemo(
+    () =>
+      searchText.length !== 0
+        ? members.filter(
+            (member) =>
+              filterByUserCustomName(member, searchText) ||
+              filterByDiscordName(member, searchText) ||
+              filterByUsername(member, searchText) ||
+              filterByPath(member, searchText)
+          )
+        : members,
+    [members, searchText, searchText]
   );
+
+  const filteredPages = useMemo<PageMeta[]>(
+    () =>
+      Object.values(pages).filter(
+        (page) => page && !page.deletedAt && (!triggerText || page.title?.toLowerCase().startsWith(searchText))
+      ) as PageMeta[],
+    [pages, searchText]
+  );
+
+  const visibleFilteredMembers = showAllMembers ? filteredMembers : filteredMembers.slice(0, DEFAULT_ITEM_LIMIT);
+  const visibleFilteredPages = showAllPages ? filteredPages : filteredPages.slice(0, DEFAULT_ITEM_LIMIT);
   const totalItems = filteredMembers.length + filteredPages.length;
   const roundedCounter = (counter < 0 ? (counter % totalItems) + totalItems : counter) % totalItems;
   const selectedGroup = roundedCounter < filteredMembers.length ? 'members' : 'pages';
   const activeItemIndex = selectedGroup === 'members' ? roundedCounter : roundedCounter - filteredMembers.length;
+
+  function showAllMembersToggle() {
+    setShowAllMembers(true);
+  }
+
+  function showAllPagesToggle() {
+    setShowAllPages(true);
+  }
+
+  const hiddenPagesCount = filteredPages.length - DEFAULT_ITEM_LIMIT;
+  const hiddenMembersCount = filteredMembers.length - DEFAULT_ITEM_LIMIT;
 
   useEffect(() => {
     const activeDomElement = document.querySelector('.mention-selected') as HTMLDivElement;
@@ -88,6 +93,7 @@ function MentionSuggestMenu({ pluginKey }: { pluginKey: PluginKey }) {
       safeScrollIntoViewIfNeeded(activeDomElement, true);
     }
   }, [activeItemIndex]);
+
   return (
     <PopoverMenu
       container={tooltipContentDOM}
@@ -110,7 +116,7 @@ function MentionSuggestMenu({ pluginKey }: { pluginKey: PluginKey }) {
           </Typography>
         ) : (
           <div>
-            {filteredMembers.map((member, memberIndex) => {
+            {visibleFilteredMembers.map((member, memberIndex) => {
               const isSelected = selectedGroup === 'members' ? activeItemIndex === memberIndex : false;
               return (
                 <MenuItem
@@ -126,6 +132,9 @@ function MentionSuggestMenu({ pluginKey }: { pluginKey: PluginKey }) {
                 </MenuItem>
               );
             })}
+            {!showAllMembers && hiddenMembersCount > 0 && (
+              <ShowMoreMenuItem onClick={showAllMembersToggle}>{hiddenMembersCount} more results</ShowMoreMenuItem>
+            )}
           </div>
         )}
         <Divider
@@ -133,15 +142,53 @@ function MentionSuggestMenu({ pluginKey }: { pluginKey: PluginKey }) {
             my: 1
           }}
         />
-        <GroupLabel>Pages</GroupLabel>
+        <GroupLabel>Link to page</GroupLabel>
         <PagesList
           activeItemIndex={selectedGroup === 'pages' ? activeItemIndex : -1}
-          pages={filteredPages as PageMeta[]}
+          pages={visibleFilteredPages}
           onSelectPage={(pageId) => onSelectMention(pageId, 'page')}
         />
+
+        {!showAllPages && hiddenPagesCount > 0 && (
+          <ShowMoreMenuItem onClick={showAllPagesToggle}>{hiddenPagesCount} more results</ShowMoreMenuItem>
+        )}
       </Box>
     </PopoverMenu>
   );
+}
+
+function ShowMoreMenuItem({ onClick, children }: { onClick: VoidFunction; children: React.ReactNode }) {
+  return (
+    <MenuItem component='div' onClick={onClick}>
+      <ListItemIcon>
+        <MoreHoriz color='secondary' />
+      </ListItemIcon>
+      <Typography color='secondary'>{children}</Typography>
+    </MenuItem>
+  );
+}
+
+function filterByUserCustomName(member: Member, searchText: string) {
+  return member.properties
+    .find((prop) => prop.type === 'name')
+    ?.value?.toString()
+    .toLowerCase()
+    .match(searchText);
+}
+
+function filterByDiscordName(member: Member, searchText: string) {
+  return (member.profile?.social as Record<string, string>)?.discordUsername
+    ?.toString()
+    .toLowerCase()
+    .match(searchText);
+}
+
+function filterByUsername(member: Member, searchText: string) {
+  return member.username.toLowerCase().match(searchText);
+}
+
+function filterByPath(member: Member, searchText: string) {
+  return member.path?.toLowerCase().match(searchText);
 }
 
 export default memo(MentionSuggest);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5d452f5</samp>

This pull request enhances the mention suggest feature in the `CharmEditor` component. It allows users to see more relevant suggestions for members and pages when typing `@` in the editor. It also optimizes the filtering and rendering of the suggestions using hooks and functions. It modifies the file `MentionSuggest.tsx` to implement these changes.

### WHY
It takes like a full minute to display our mentions dropdown in CharmVerse. I believe that's because we are rendering all the pages at once. Notion limits it to 5 at first
<img width="366" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/eb60ebba-ff5b-4d57-b35f-0ec56f036dd2">

