### PR TITLE
Deploy APM to web sockets

### DIFF
--- a/.ebstalk.apps.env/websocket.env
+++ b/.ebstalk.apps.env/websocket.env
@@ -5,5 +5,6 @@ AUTH_SECRET="{{pull:secretsmanager:/io.cv.app/prd/auth_secret:SecretString:auth_
 DATABASE_URL="{{pull:secretsmanager:/io.cv.app/prd/db:SecretString:database_url}}"
 PERMISSIONS_API_URL="{{pull:secretsmanager:/io.cv.app/prd/permissions:SecretString:permissions_api_url}}"
 DD_API_KEY="{{pull:secretsmanager:/io.cv.app/shared/datadog:SecretString:dd_api_key}}"
+DD_AGENT_HOST="datadog-agent"
 REDIS_URI="{{pull:secretsmanager:/io.cv.app/prd/redis:SecretString:redis_uri}}"
 MIXPANEL_API_KEY="{{pull:secretsmanager:/io.cv.app/prd/mixpanel:SecretString:mixpanel_api_key}}"

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           NEXT_PUBLIC_APP_ENV: 'staging'
           NEXT_PUBLIC_DD_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_DD_CLIENT_TOKEN }}
-          #  - disabled so that each instance uses its own socket router by default
-          NEXT_PUBLIC_WEBSOCKETS_HOST: 'https://sockets.charmverse.co'
+          # disabled so that each instance uses its own socket router by default
+          # NEXT_PUBLIC_WEBSOCKETS_HOST: 'https://sockets.charmverse.co'
           NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_CLIENT_ID_STG }}
           NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_REDIRECT_URI: ${{ secrets.NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_REDIRECT_URI }}
           NEXT_PUBLIC_GOOGLE_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_API_KEY_STG }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -26,7 +26,8 @@ jobs:
         with:
           NEXT_PUBLIC_APP_ENV: 'staging'
           NEXT_PUBLIC_DD_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_DD_CLIENT_TOKEN }}
-          # NEXT_PUBLIC_WEBSOCKETS_HOST: 'https://sockets.charmverse.co' - disabled so that each instance uses its own socket router by default
+          #  - disabled so that each instance uses its own socket router by default
+          NEXT_PUBLIC_WEBSOCKETS_HOST: 'https://sockets.charmverse.co'
           NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_CLIENT_ID_STG }}
           NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_REDIRECT_URI: ${{ secrets.NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_REDIRECT_URI }}
           NEXT_PUBLIC_GOOGLE_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_API_KEY_STG }}

--- a/background/server/datadog.ts
+++ b/background/server/datadog.ts
@@ -3,7 +3,8 @@ import tracer from 'dd-trace';
 if (process.env.NODE_ENV === 'production') {
   tracer.init({
     logInjection: true,
-    runtimeMetrics: true
+    runtimeMetrics: true,
+    service: process.env.SERVICE_NAME
   });
   tracer.use('koa', {
     blocklist: ['/api/health_check']

--- a/background/server/datadog.ts
+++ b/background/server/datadog.ts
@@ -1,0 +1,11 @@
+import tracer from 'dd-trace';
+
+if (process.env.NODE_ENV === 'production') {
+  tracer.init({
+    logInjection: true,
+    runtimeMetrics: true
+  });
+  tracer.use('koa', {
+    blocklist: ['/api/health_check']
+  });
+}

--- a/background/websockets.ts
+++ b/background/websockets.ts
@@ -1,3 +1,6 @@
+// init app instrumentation
+import './server/datadog';
+
 import { createServer } from 'http';
 
 import { log } from '@charmverse/core/log';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,4 +133,5 @@ services:
       - prd-cron
       - prd-webapp
       - prd-sockets
+      - stg-sockets
       - ddtst

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,14 +60,14 @@ services:
   prd-sockets:
     extends:
       service: defaults
-    command: ['sh', '-c', 'node ./.next/server/websockets.js']
+    command: ['sh', '-c', 'node --require dd-trace/init ./.next/server/websockets.js']
     profiles:
       - prd-sockets
 
   stg-sockets:
     extends:
       service: defaults
-    command: ['sh', '-c', 'node ./.next/server/websockets.js']
+    command: ['sh', '-c', 'node --require dd-trace/init ./.next/server/websockets.js']
     environment:
       - NEXT_PUBLIC_APP_ENV=staging
     profiles:
@@ -90,12 +90,7 @@ services:
 
   permissions-api:
     image: '310849459438.dkr.ecr.us-east-1.amazonaws.com/charmverse-permissions-api:${PERMISSION_IMGTAG:-latest}'
-    command:
-      [
-        'sh',
-        '-c',
-        'node --max-old-space-size=750 --experimental-specifier-resolution=node  ./dist/main.js',
-      ]
+    command: ['sh', '-c', 'node --max-old-space-size=750 --experimental-specifier-resolution=node  ./dist/main.js']
     env_file:
       - '.env'
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,14 +60,14 @@ services:
   prd-sockets:
     extends:
       service: defaults
-    command: ['sh', '-c', 'node --require dd-trace/init ./.next/server/websockets.js']
+    command: ['sh', '-c', 'node ./.next/server/websockets.js']
     profiles:
       - prd-sockets
 
   stg-sockets:
     extends:
       service: defaults
-    command: ['sh', '-c', 'node --require dd-trace/init ./.next/server/websockets.js']
+    command: ['sh', '-c', 'node ./.next/server/websockets.js']
     environment:
       - NEXT_PUBLIC_APP_ENV=staging
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,5 +133,4 @@ services:
       - prd-cron
       - prd-webapp
       - prd-sockets
-      - stg-sockets
       - ddtst

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "concurrently": "^7.1.0",
         "cookies": "^0.8.0",
         "cryptr": "^6.1.0",
-        "dd-trace": "^3.3.1",
+        "dd-trace": "^4.2.0",
         "diff": "^5.1.0",
         "dotenv": "^16.0.0",
         "dotenv-cli": "^5.1.0",
@@ -6548,9 +6548,9 @@
       }
     },
     "node_modules/@datadog/native-appsec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-2.0.0.tgz",
-      "integrity": "sha512-XHARZ6MVgbnfOUO6/F3ZoZ7poXHJCNYFlgcyS2Xetuk9ITA5bfcooX2B2F7tReVB+RLJ+j8bsm0t55SyF04KDw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-3.2.0.tgz",
+      "integrity": "sha512-biAa7EFfuavjSWgSQaCit9CqGzr6Af5nhzfNNGJ38Y/Y387hDvLivAR374kK1z6XoxGZEOa+XPbVogmV/2Bcjw==",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
@@ -6560,9 +6560,9 @@
       }
     },
     "node_modules/@datadog/native-iast-rewriter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-1.1.2.tgz",
-      "integrity": "sha512-pigRfRtAjZjMjqIXyXb98S4aDnuHz/EmqpoxAajFZsNjBLM87YonwSY5zoBdCsOyA46ddKOJRoCQd5ZalpOFMQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.0.1.tgz",
+      "integrity": "sha512-Mm+FG3XxEbPrAfJQPOMHts7iZZXRvg9gnGeeFRGkyirmRcQcOpZO4wFe/8K61DUVa5pXpgAJQ2ZkBGYF1O9STg==",
       "dependencies": {
         "node-gyp-build": "^4.5.0"
       },
@@ -6581,37 +6581,42 @@
       }
     },
     "node_modules/@datadog/native-iast-taint-tracking": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.1.0.tgz",
-      "integrity": "sha512-TOrngpt6Qh52zWFOz1CkFXw0g43rnuUziFBtIMUsOLGzSHr9wdnTnE6HAyuvKy3f3ecAoZESlMfilGRKP93hXQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.5.0.tgz",
+      "integrity": "sha512-SOWIk1M6PZH0osNB191Voz2rKBPoF5hISWVSK9GiJPrD40+xjib1Z/bFDV7EkDn3kjOyordSBdNPG5zOqZJdyg==",
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       }
     },
     "node_modules/@datadog/native-metrics": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-1.5.0.tgz",
-      "integrity": "sha512-K63XMDx74RLhOpM8I9GGZR9ft0CNNB/RkjYPLHcVGvVnBR47zmWE2KFa7Yrtzjbk73+88PXI4nzqLyR3PJsaIQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+      "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
       "hasInstallScript": true,
       "dependencies": {
+        "node-addon-api": "^6.1.0",
         "node-gyp-build": "^3.9.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
+    "node_modules/@datadog/native-metrics/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+    },
     "node_modules/@datadog/pprof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-1.1.1.tgz",
-      "integrity": "sha512-5lYXUpikQhrJwzODtJ7aFM0oKmPccISnTCecuWhjxIj4/7UJv0DamkLak634bgEW+kiChgkKFDapHSesuXRDXQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-2.2.2.tgz",
+      "integrity": "sha512-6FVmgQoYvHVnpnAzfTHRIONJQprEJ6PdrfA3Kn4dfVEXZMH42PBRLSNWe4qoi5AKmr4SoIc6Ay7VAlHb/cDNjA==",
       "hasInstallScript": true,
       "dependencies": {
         "delay": "^5.0.0",
-        "findit2": "^2.2.3",
         "node-gyp-build": "^3.9.0",
         "p-limit": "^3.1.0",
         "pify": "^5.0.0",
-        "protobufjs": "^7.0.0",
+        "pprof-format": "^2.0.7",
         "source-map": "^0.7.3",
         "split": "^1.0.1"
       },
@@ -11273,6 +11278,24 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
+      "engines": {
+        "node": ">=8.12.0"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
@@ -18314,9 +18337,9 @@
       }
     },
     "node_modules/acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -21023,8 +21046,7 @@
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
-      "dev": true
+      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
     "node_modules/classnames": {
       "version": "2.3.2",
@@ -22722,21 +22744,23 @@
       "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "node_modules/dd-trace": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-3.12.1.tgz",
-      "integrity": "sha512-N72W5LxbGlslRDZ1gipq6uJNqdq+VvPVfOK9jgNw9/YML8YLrhf8vhJqO0CukrB9tQRAq0MRlBHZUFA5kRbJXw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.2.0.tgz",
+      "integrity": "sha512-YDR31HLjd4reAoFcOFnTQFEVKO/GtugsotDOoDVeuUtPs2Z9Awcy10m3/bEl91ipUt2x72jedchEUBNcAbRVFw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@datadog/native-appsec": "2.0.0",
-        "@datadog/native-iast-rewriter": "1.1.2",
-        "@datadog/native-iast-taint-tracking": "1.1.0",
-        "@datadog/native-metrics": "^1.5.0",
-        "@datadog/pprof": "^1.1.1",
+        "@datadog/native-appsec": "^3.2.0",
+        "@datadog/native-iast-rewriter": "2.0.1",
+        "@datadog/native-iast-taint-tracking": "^1.4.1",
+        "@datadog/native-metrics": "^2.0.0",
+        "@datadog/pprof": "^2.2.1",
         "@datadog/sketches-js": "^2.1.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/core": "<1.4.0",
         "crypto-randomuuid": "^1.0.0",
         "diagnostics_channel": "^1.1.0",
         "ignore": "^5.2.0",
-        "import-in-the-middle": "^1.3.4",
+        "import-in-the-middle": "^1.3.5",
         "ipaddr.js": "^2.0.1",
         "istanbul-lib-coverage": "3.2.0",
         "koalas": "^1.0.2",
@@ -22753,10 +22777,32 @@
         "path-to-regexp": "^0.1.2",
         "protobufjs": "^7.1.2",
         "retry": "^0.10.1",
-        "semver": "^5.5.0"
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
+      }
+    },
+    "node_modules/dd-trace/node_modules/@opentelemetry/api": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/dd-trace/node_modules/@opentelemetry/core": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/dd-trace/node_modules/lru-cache": {
@@ -22773,12 +22819,34 @@
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "node_modules/dd-trace/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
+    },
+    "node_modules/dd-trace/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dd-trace/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -27231,14 +27299,6 @@
         "micromatch": "^4.0.2"
       }
     },
-    "node_modules/findit2": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
-      "integrity": "sha512-lg/Moejf4qXovVutL0Lz4IsaPoNYMuxt4PA0nGqFxnJ1CTTGGlEO2wKgoDpwknhvZ8k4Q2F+eesgkLbG2Mxfog==",
-      "engines": {
-        "node": ">=0.8.22"
-      }
-    },
     "node_modules/firebase": {
       "version": "9.16.0",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.16.0.tgz",
@@ -29146,10 +29206,13 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.4.tgz",
-      "integrity": "sha512-TUXqqEFacJ2DWAeYOhHwGZTMJtFxFVw0C1pYA+AXmuWXZGnBqUhHdtVrSkSbW5D7k2yriBG45j23iH9TRtI+bQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.1.tgz",
+      "integrity": "sha512-hGG0PcCsykVo8MBVH8l0uEWLWW6DXMgJA9jvC0yps6M3uIJ8L/tagTCbyF8Ud5TtqJ8/jmZL1YkyySyeVkVQrA==",
       "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
     },
@@ -37678,6 +37741,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/pprof-format": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.0.7.tgz",
+      "integrity": "sha512-1qWaGAzwMpaXJP9opRa23nPnt2Egi7RMNoNBptEE/XwHbcn4fC2b/4U4bKc5arkGkIh2ZabpF2bEb+c5GNHEKA=="
     },
     "node_modules/preact": {
       "version": "10.11.3",
@@ -51103,17 +51171,17 @@
       }
     },
     "@datadog/native-appsec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-2.0.0.tgz",
-      "integrity": "sha512-XHARZ6MVgbnfOUO6/F3ZoZ7poXHJCNYFlgcyS2Xetuk9ITA5bfcooX2B2F7tReVB+RLJ+j8bsm0t55SyF04KDw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-3.2.0.tgz",
+      "integrity": "sha512-biAa7EFfuavjSWgSQaCit9CqGzr6Af5nhzfNNGJ38Y/Y387hDvLivAR374kK1z6XoxGZEOa+XPbVogmV/2Bcjw==",
       "requires": {
         "node-gyp-build": "^3.9.0"
       }
     },
     "@datadog/native-iast-rewriter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-1.1.2.tgz",
-      "integrity": "sha512-pigRfRtAjZjMjqIXyXb98S4aDnuHz/EmqpoxAajFZsNjBLM87YonwSY5zoBdCsOyA46ddKOJRoCQd5ZalpOFMQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.0.1.tgz",
+      "integrity": "sha512-Mm+FG3XxEbPrAfJQPOMHts7iZZXRvg9gnGeeFRGkyirmRcQcOpZO4wFe/8K61DUVa5pXpgAJQ2ZkBGYF1O9STg==",
       "requires": {
         "node-gyp-build": "^4.5.0"
       },
@@ -51126,32 +51194,39 @@
       }
     },
     "@datadog/native-iast-taint-tracking": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.1.0.tgz",
-      "integrity": "sha512-TOrngpt6Qh52zWFOz1CkFXw0g43rnuUziFBtIMUsOLGzSHr9wdnTnE6HAyuvKy3f3ecAoZESlMfilGRKP93hXQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.5.0.tgz",
+      "integrity": "sha512-SOWIk1M6PZH0osNB191Voz2rKBPoF5hISWVSK9GiJPrD40+xjib1Z/bFDV7EkDn3kjOyordSBdNPG5zOqZJdyg==",
       "requires": {
         "node-gyp-build": "^3.9.0"
       }
     },
     "@datadog/native-metrics": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-1.5.0.tgz",
-      "integrity": "sha512-K63XMDx74RLhOpM8I9GGZR9ft0CNNB/RkjYPLHcVGvVnBR47zmWE2KFa7Yrtzjbk73+88PXI4nzqLyR3PJsaIQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+      "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
       "requires": {
+        "node-addon-api": "^6.1.0",
         "node-gyp-build": "^3.9.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+          "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+        }
       }
     },
     "@datadog/pprof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-1.1.1.tgz",
-      "integrity": "sha512-5lYXUpikQhrJwzODtJ7aFM0oKmPccISnTCecuWhjxIj4/7UJv0DamkLak634bgEW+kiChgkKFDapHSesuXRDXQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-2.2.2.tgz",
+      "integrity": "sha512-6FVmgQoYvHVnpnAzfTHRIONJQprEJ6PdrfA3Kn4dfVEXZMH42PBRLSNWe4qoi5AKmr4SoIc6Ay7VAlHb/cDNjA==",
       "requires": {
         "delay": "^5.0.0",
-        "findit2": "^2.2.3",
         "node-gyp-build": "^3.9.0",
         "p-limit": "^3.1.0",
         "pify": "^5.0.0",
-        "protobufjs": "^7.0.0",
+        "pprof-format": "^2.0.7",
         "source-map": "^0.7.3",
         "split": "^1.0.1"
       },
@@ -54290,6 +54365,18 @@
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.1"
       }
+    },
+    "@opentelemetry/api": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+      "optional": true,
+      "peer": true
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
     },
     "@peculiar/asn1-schema": {
       "version": "2.3.3",
@@ -59856,9 +59943,9 @@
       }
     },
     "acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
       "requires": {}
     },
     "acorn-jsx": {
@@ -61958,8 +62045,7 @@
     "cjs-module-lexer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
-      "dev": true
+      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
     "classnames": {
       "version": "2.3.2",
@@ -63292,20 +63378,22 @@
       "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "dd-trace": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-3.12.1.tgz",
-      "integrity": "sha512-N72W5LxbGlslRDZ1gipq6uJNqdq+VvPVfOK9jgNw9/YML8YLrhf8vhJqO0CukrB9tQRAq0MRlBHZUFA5kRbJXw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.2.0.tgz",
+      "integrity": "sha512-YDR31HLjd4reAoFcOFnTQFEVKO/GtugsotDOoDVeuUtPs2Z9Awcy10m3/bEl91ipUt2x72jedchEUBNcAbRVFw==",
       "requires": {
-        "@datadog/native-appsec": "2.0.0",
-        "@datadog/native-iast-rewriter": "1.1.2",
-        "@datadog/native-iast-taint-tracking": "1.1.0",
-        "@datadog/native-metrics": "^1.5.0",
-        "@datadog/pprof": "^1.1.1",
+        "@datadog/native-appsec": "^3.2.0",
+        "@datadog/native-iast-rewriter": "2.0.1",
+        "@datadog/native-iast-taint-tracking": "^1.4.1",
+        "@datadog/native-metrics": "^2.0.0",
+        "@datadog/pprof": "^2.2.1",
         "@datadog/sketches-js": "^2.1.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/core": "<1.4.0",
         "crypto-randomuuid": "^1.0.0",
         "diagnostics_channel": "^1.1.0",
         "ignore": "^5.2.0",
-        "import-in-the-middle": "^1.3.4",
+        "import-in-the-middle": "^1.3.5",
         "ipaddr.js": "^2.0.1",
         "istanbul-lib-coverage": "3.2.0",
         "koalas": "^1.0.2",
@@ -63322,9 +63410,22 @@
         "path-to-regexp": "^0.1.2",
         "protobufjs": "^7.1.2",
         "retry": "^0.10.1",
-        "semver": "^5.5.0"
+        "semver": "^7.3.8"
       },
       "dependencies": {
+        "@opentelemetry/api": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+          "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
+        },
+        "@opentelemetry/core": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+          "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.3.1"
+          }
+        },
         "lru-cache": {
           "version": "7.14.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
@@ -63336,9 +63437,27 @@
           "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+          "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+              "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -66715,11 +66834,6 @@
         "micromatch": "^4.0.2"
       }
     },
-    "findit2": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
-      "integrity": "sha512-lg/Moejf4qXovVutL0Lz4IsaPoNYMuxt4PA0nGqFxnJ1CTTGGlEO2wKgoDpwknhvZ8k4Q2F+eesgkLbG2Mxfog=="
-    },
     "firebase": {
       "version": "9.16.0",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.16.0.tgz",
@@ -68184,10 +68298,13 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.4.tgz",
-      "integrity": "sha512-TUXqqEFacJ2DWAeYOhHwGZTMJtFxFVw0C1pYA+AXmuWXZGnBqUhHdtVrSkSbW5D7k2yriBG45j23iH9TRtI+bQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.1.tgz",
+      "integrity": "sha512-hGG0PcCsykVo8MBVH8l0uEWLWW6DXMgJA9jvC0yps6M3uIJ8L/tagTCbyF8Ud5TtqJ8/jmZL1YkyySyeVkVQrA==",
       "requires": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
     },
@@ -74712,6 +74829,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "pprof-format": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.0.7.tgz",
+      "integrity": "sha512-1qWaGAzwMpaXJP9opRa23nPnt2Egi7RMNoNBptEE/XwHbcn4fC2b/4U4bKc5arkGkIh2ZabpF2bEb+c5GNHEKA=="
     },
     "preact": {
       "version": "10.11.3",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "concurrently": "^7.1.0",
     "cookies": "^0.8.0",
     "cryptr": "^6.1.0",
-    "dd-trace": "^3.3.1",
+    "dd-trace": "^4.2.0",
     "diff": "^5.1.0",
     "dotenv": "^16.0.0",
     "dotenv-cli": "^5.1.0",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f245a0</samp>

This pull request enables Datadog tracing and monitoring for the websocket servers of the app. It adds the `dd-trace` library to the `docker-compose.yml` and `package.json` files, sets the `DD_AGENT_HOST` environment variable in the `websocket.env` file, and imports and configures the library in the `background/server/datadog.ts` and `background/websockets.ts` files.
