### PR TITLE
updating to opt for the cheaper t3a.small instance over t3.small

### DIFF
--- a/.cdk/staging-stack.ts
+++ b/.cdk/staging-stack.ts
@@ -86,12 +86,12 @@ export class CdkDeployStack extends Stack {
       {
         namespace: 'aws:autoscaling:asg',
         optionName: 'Custom Availability Zones',
-        value: 'us-east-1a,us-east-1b,us-east-1c'
+        value: 'us-east-1a,us-east-1d,us-east-1c,us-east-1f'
       },
       {
         namespace: 'aws:ec2:instances',
         optionName: 'InstanceTypes',
-        value: 't3.small'
+        value: 't3a.small,t3.small'
       },
       {
         // ALB health check


### PR DESCRIPTION
and updating the availability zones to include 1f,1d and remove 1b

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c04130</samp>

Updated the Elastic Beanstalk configuration in `.cdk/staging-stack.ts` to use more availability zones and instance types in us-east-1. This aims to improve the app.charmverse.io website's availability and performance.

### WHY
<!-- author to complete -->
