### PR TITLE
dont reset page props when permissions are updated

### DIFF
--- a/components/[pageId]/EditorPage/EditorPage.tsx
+++ b/components/[pageId]/EditorPage/EditorPage.tsx
@@ -45,6 +45,7 @@ export function EditorPage({ pageId: pageIdOrPath }: { pageId: string }) {
   useEffect(() => {
     return () => {
       setCurrentPageId('');
+      resetPageProps();
     };
   }, []);
 
@@ -64,10 +65,7 @@ export function EditorPage({ pageId: pageIdOrPath }: { pageId: string }) {
       // pass editMode thru to fix hot-reloading which resets the prop
       setPageProps({ permissions: page.permissionFlags, editMode });
     }
-    return () => {
-      resetPageProps();
-    };
-  }, [page?.permissionFlags]);
+  }, [page?.permissionFlags, setPageProps]);
 
   const savePage = useCallback(
     debouncePromise(async (updates: Partial<Page>) => {

--- a/components/[pageId]/EditorPage/EditorPage.tsx
+++ b/components/[pageId]/EditorPage/EditorPage.tsx
@@ -65,7 +65,7 @@ export function EditorPage({ pageId: pageIdOrPath }: { pageId: string }) {
       // pass editMode thru to fix hot-reloading which resets the prop
       setPageProps({ permissions: page.permissionFlags, editMode });
     }
-  }, [page?.permissionFlags, setPageProps]);
+  }, [page?.permissionFlags.edit_content]);
 
   const savePage = useCallback(
     debouncePromise(async (updates: Partial<Page>) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f3eb64</samp>

This pull request improves the state management of the `EditorPage` component. It prevents unwanted side effects when switching between pages and ensures the props are always in sync with the current page.

### WHY
Every time the page refreshes, it resets the page props. We should only reset page props when the editor dismounts
