### PR TITLE
only enable subdomain redirects for production

### DIFF
--- a/.ebstalk.apps.env/webapp.env
+++ b/.ebstalk.apps.env/webapp.env
@@ -41,4 +41,3 @@ STRIPE_WEBHOOK_SECRET="{{pull:secretsmanager:/io.cv.app/prd/stripe:SecretString:
 LOOP_API_KEY="{{pull:secretsmanager:/io.cv.app/prd/loop:SecretString:loop_api_key}}"
 LOOP_API_ID="{{pull:secretsmanager:/io.cv.app/prd/loop:SecretString:loop_api_id}}"
 SUDO_API_KEY="{{pull:secretsmanager:/io.cv.app/prd/sudoapi:SecretString:sudo_api_key}}"
-FORCE_SUBDOMAINS="{{pull:secretsmanager:/io.cv.app/prd/subdomains:SecretString:force_subdomains}}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
         '-c',
         'npm run prisma:deploy && node --require dd-trace/init node_modules/.bin/next start --keepAliveTimeout 70000'
       ]
+    environment:
+      - FORCE_SUBDOMAINS=true
     profiles:
       - prd-webapp
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46416b9</samp>

This pull request removes the `FORCE_SUBDOMAINS` feature from the web app and enables it for the `nginx` service. This simplifies the domain management and avoids subdomain conflicts.

### WHY
<!-- author to complete -->
