### PR TITLE
only retrieve page shareable state once

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountySignupButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountySignupButton.tsx
@@ -2,7 +2,7 @@ import type { PageMeta } from '@charmverse/core/pages';
 import { Box } from '@mui/material';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useEffect, useState } from 'react';
-import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
 import Button from 'components/common/Button';
@@ -23,7 +23,7 @@ export function BountySignupButton({ pagePath }: Props) {
   const { account, walletAuthSignature, loginFromWeb3Account } = useWeb3AuthSig();
   const { user, setUser, isLoaded: isUserLoaded } = useUser();
   const { space } = useCurrentSpace();
-  const { data: spaceWithGates } = useSWR(space ? `spaceByDomain/${space.domain}` : null, () =>
+  const { data: spaceWithGates } = useSWRImmutable(space ? `spaceByDomain/${space.domain}` : null, () =>
     charmClient.spaces.searchByDomain(space!.domain)
   );
   const loginViaTokenGateModal = usePopupState({ variant: 'popover', popupId: 'login-via-token-gate' });

--- a/hooks/useSharedPage.ts
+++ b/hooks/useSharedPage.ts
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
-import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
 import { useSpaces } from 'hooks/useSpaces';
@@ -59,13 +59,17 @@ export const useSharedPage = () => {
     data: publicPage,
     isLoading: isPublicPageLoading,
     error: publicPageError
-  } = useSWR(shouldLoadPublicPage ? `public/${pageKey}` : null, () => charmClient.getPublicPage(pageKey || ''));
+  } = useSWRImmutable(shouldLoadPublicPage ? `public/${pageKey}` : null, () =>
+    charmClient.getPublicPage(pageKey || '')
+  );
 
   const {
     data: space,
     isLoading: isSpaceLoading,
     error: spaceError
-  } = useSWR(spaceDomain ? `space/${spaceDomain}` : null, () => charmClient.spaces.searchByDomain(spaceDomain || ''));
+  } = useSWRImmutable(spaceDomain ? `space/${spaceDomain}` : null, () =>
+    charmClient.spaces.searchByDomain(spaceDomain || '')
+  );
 
   const hasError = !!publicPageError || !!spaceError;
   const hasPublicBounties = space?.publicBountyBoard || space?.paidTier === 'free';

--- a/pages/join.tsx
+++ b/pages/join.tsx
@@ -3,7 +3,7 @@ import { Alert, Box, Card, Divider } from '@mui/material';
 import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
-import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
 import getBaseLayout from 'components/common/BaseLayout/BaseLayout';
@@ -42,7 +42,9 @@ export default function JoinWorkspace() {
     data: spaceFromPath,
     isLoading: isSpaceLoading,
     error: spaceError
-  } = useSWR(domain ? `space/${domain}` : null, () => charmClient.spaces.searchByDomain(stripUrlParts(domain || '')));
+  } = useSWRImmutable(domain ? `space/${domain}` : null, () =>
+    charmClient.spaces.searchByDomain(stripUrlParts(domain || ''))
+  );
 
   useEffect(() => {
     const connectedSpace = filterSpaceByDomain(spaces, domain);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 15213ec</samp>

Refactored some components and hooks to use `useSWRImmutable` for immutable data fetching. This improves the app's performance and consistency by avoiding unnecessary revalidation of data that does not change.

### WHY
Every time i go back to a tab we're making 7 API requests. This one doesn't seem to need to be refreshed, since it's used to just determine if a page is public or not.