### PR TITLE
check for space id before requesting drafts

### DIFF
--- a/components/bounties/components/BountiesKanbanView.tsx
+++ b/components/bounties/components/BountiesKanbanView.tsx
@@ -54,14 +54,14 @@ export function BountiesKanbanView({ bounties, publicMode }: Props) {
   }
 
   useEffect(() => {
-    if (typeof router.query.bountyId === 'string') {
+    if (router.isReady && typeof router.query.bountyId === 'string') {
       showPage({
         bountyId: router.query.bountyId,
         readOnly: publicMode,
         onClose
       });
     }
-  }, [router.query.bountyId]);
+  }, [router.isReady, router.query.bountyId]);
 
   return (
     <div className='Kanban'>

--- a/components/forum/ForumFeedPage.tsx
+++ b/components/forum/ForumFeedPage.tsx
@@ -117,7 +117,7 @@ export function ForumPage() {
     }
   }
   useEffect(() => {
-    if (typeof router.query.postId === 'string') {
+    if (router.isReady && typeof router.query.postId === 'string') {
       showPost({
         postId: router.query.postId,
         onClose() {
@@ -125,7 +125,7 @@ export function ForumPage() {
         }
       });
     }
-  }, [router.query.postId]);
+  }, [router.isReady, router.query.postId]);
 
   useEffect(() => {
     if (currentSpace) {

--- a/components/forum/components/PostDialog/PostDialog.tsx
+++ b/components/forum/components/PostDialog/PostDialog.tsx
@@ -38,12 +38,11 @@ export function PostDialog({ post, isLoading, spaceId, onClose, newPostCategory 
   const [formInputs, setFormInputs] = useState<FormInputs>(post ?? { title: '', content: null, contentText: '' });
   const [contentUpdated, setContentUpdated] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
-  const { user } = useUser();
   const {
     data: draftedPosts = [],
     isLoading: isDraftsLoading,
     mutate: mutateDraftPosts
-  } = useSWR(user ? `/users/${user.id}/drafted-posts` : null, () => charmClient.forum.listDraftPosts({ spaceId }));
+  } = useSWR(spaceId ? `${spaceId}/drafted-posts` : null, () => charmClient.forum.listDraftPosts({ spaceId }));
 
   const { showPost, createPost } = usePostDialog();
   const isMobile = useSmallScreen();

--- a/components/forum/components/PostDialog/PostDialog.tsx
+++ b/components/forum/components/PostDialog/PostDialog.tsx
@@ -14,7 +14,6 @@ import { DialogTitle } from 'components/common/Modal';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import { FullPageActionsMenuButton } from 'components/common/PageActions/FullPageActionsMenuButton';
 import { useSmallScreen } from 'hooks/useMediaScreens';
-import { useUser } from 'hooks/useUser';
 import type { PostWithVotes } from 'lib/forums/posts/interfaces';
 import { setUrlWithoutRerender } from 'lib/utilities/browser';
 

--- a/components/forum/components/PostDialog/PostDialog.tsx
+++ b/components/forum/components/PostDialog/PostDialog.tsx
@@ -26,7 +26,7 @@ import { usePostDialog } from './hooks/usePostDialog';
 interface Props {
   post?: PostWithVotes | null;
   isLoading: boolean;
-  spaceId: string;
+  spaceId?: string;
   onClose: () => void;
   newPostCategory?: PostCategory | null;
 }
@@ -41,7 +41,9 @@ export function PostDialog({ post, isLoading, spaceId, onClose, newPostCategory 
     data: draftedPosts = [],
     isLoading: isDraftsLoading,
     mutate: mutateDraftPosts
-  } = useSWR(spaceId ? `${spaceId}/drafted-posts` : null, () => charmClient.forum.listDraftPosts({ spaceId }));
+  } = useSWR(spaceId ? `${spaceId}/drafted-posts` : null, () =>
+    charmClient.forum.listDraftPosts({ spaceId: spaceId! })
+  );
 
   const { showPost, createPost } = usePostDialog();
   const isMobile = useSmallScreen();
@@ -86,7 +88,7 @@ export function PostDialog({ post, isLoading, spaceId, onClose, newPostCategory 
         },
         { revalidate: false }
       );
-      if (post?.id === postId) {
+      if (spaceId && post?.id === postId) {
         createPost({ spaceId, category: newPostCategory || null });
       }
     });
@@ -140,7 +142,7 @@ export function PostDialog({ post, isLoading, spaceId, onClose, newPostCategory 
         }
       }}
     >
-      {!isLoading && (
+      {!isLoading && spaceId && (
         <PostPage
           formInputs={formInputs}
           setFormInputs={(_formInputs) => {

--- a/components/forum/components/PostDialog/PostDialog.tsx
+++ b/components/forum/components/PostDialog/PostDialog.tsx
@@ -14,6 +14,7 @@ import { DialogTitle } from 'components/common/Modal';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import { FullPageActionsMenuButton } from 'components/common/PageActions/FullPageActionsMenuButton';
 import { useSmallScreen } from 'hooks/useMediaScreens';
+import { useUser } from 'hooks/useUser';
 import type { PostWithVotes } from 'lib/forums/posts/interfaces';
 import { setUrlWithoutRerender } from 'lib/utilities/browser';
 
@@ -37,11 +38,13 @@ export function PostDialog({ post, isLoading, spaceId, onClose, newPostCategory 
   const [formInputs, setFormInputs] = useState<FormInputs>(post ?? { title: '', content: null, contentText: '' });
   const [contentUpdated, setContentUpdated] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const { user } = useUser();
+  // only load drafts if user is logged in
   const {
     data: draftedPosts = [],
     isLoading: isDraftsLoading,
     mutate: mutateDraftPosts
-  } = useSWR(spaceId ? `${spaceId}/drafted-posts` : null, () =>
+  } = useSWR(spaceId && user ? `${spaceId}/drafted-posts` : null, () =>
     charmClient.forum.listDraftPosts({ spaceId: spaceId! })
   );
 

--- a/components/forum/components/PostDialog/PostDialogGlobal.tsx
+++ b/components/forum/components/PostDialog/PostDialogGlobal.tsx
@@ -33,7 +33,7 @@ export default function PostDialogGlobal() {
   if (newPost || post || postId) {
     return (
       <PostDialog
-        key={post?.id}
+        key={postId}
         isLoading={!post && !newPost}
         post={post}
         newPostCategory={newPost?.category}

--- a/components/forum/components/PostDialog/PostDialogGlobal.tsx
+++ b/components/forum/components/PostDialog/PostDialogGlobal.tsx
@@ -33,7 +33,7 @@ export default function PostDialogGlobal() {
   if (newPost || post || postId) {
     return (
       <PostDialog
-        key={postId}
+        key={post?.id}
         isLoading={!post && !newPost}
         post={post}
         newPostCategory={newPost?.category}

--- a/components/forum/components/PostDialog/PostDialogGlobal.tsx
+++ b/components/forum/components/PostDialog/PostDialogGlobal.tsx
@@ -38,7 +38,7 @@ export default function PostDialogGlobal() {
         post={post}
         newPostCategory={newPost?.category}
         onClose={hidePost}
-        spaceId={post?.spaceId || (newPost?.spaceId as string)}
+        spaceId={post?.spaceId || newPost?.spaceId}
       />
     );
   }

--- a/components/proposals/components/ProposalsTable.tsx
+++ b/components/proposals/components/ProposalsTable.tsx
@@ -54,13 +54,13 @@ export function ProposalsTable({
   }
 
   useEffect(() => {
-    if (typeof router.query.id === 'string') {
+    if (router.isReady && typeof router.query.id === 'string') {
       showProposal({
         pageId: router.query.id,
         onClose
       });
     }
-  }, [router.query.id]);
+  }, [router.isReady, router.query.id]);
 
   return (
     <>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1de9265</samp>

Removed `user` and `useUser` from `PostDialog` component and used `spaceId` prop for fetching and creating posts. This improves performance and reduces complexity.

### WHY
<!-- author to complete -->
