### PR TITLE
Fix duplicating a bounty with two roles

### DIFF
--- a/lib/pages/__tests__/duplicatePage.spec.ts
+++ b/lib/pages/__tests__/duplicatePage.spec.ts
@@ -2,7 +2,7 @@ import type { Prisma } from '@charmverse/core/prisma';
 import { prisma } from '@charmverse/core/prisma-client';
 import { v4 as uid } from 'uuid';
 
-import { createPage, generateUserAndSpace } from 'testing/setupDatabase';
+import { createPage, generateRole, generateBounty, generateUserAndSpace } from 'testing/setupDatabase';
 
 import { duplicatePage } from '../duplicatePage';
 
@@ -180,5 +180,46 @@ describe('duplicatePage', () => {
         ).toBe(true);
       }
     });
+  });
+
+  it('should duplicate a bounty with permissions', async () => {
+    const { space: _space, user: _user } = await generateUserAndSpace();
+
+    const role = await generateRole({
+      spaceId: _space.id,
+      createdBy: _user.id
+    });
+    // include a 2nd role to test that the permissions are duplicated correctly
+    const role2 = await generateRole({
+      spaceId: _space.id,
+      createdBy: _user.id
+    });
+
+    const bounty = await generateBounty({
+      createdBy: _user.id,
+      spaceId: _space.id,
+      bountyPermissions: {
+        reviewer: [
+          {
+            group: 'role',
+            id: role.id
+          },
+          {
+            group: 'role',
+            id: role2.id
+          }
+        ]
+      }
+    });
+
+    const { pages } = await duplicatePage({ pageId: bounty.id, parentId: null, spaceId: _space.id });
+    const bountyPage = pages[0];
+    expect(bountyPage).toBeTruthy();
+    const permissions = await prisma.bountyPermission.findMany({
+      where: {
+        bountyId: bountyPage.id
+      }
+    });
+    expect(permissions.length).toBe(3); // 1 is added by default for some reason
   });
 });

--- a/lib/templates/__tests__/exportWorkspacePages.spec.ts
+++ b/lib/templates/__tests__/exportWorkspacePages.spec.ts
@@ -5,8 +5,13 @@ import fs from 'node:fs/promises';
 import type { PageWithPermissions } from '@charmverse/core/pages';
 import type { Page, Space, User } from '@charmverse/core/prisma';
 
-import { createBounty } from 'lib/bounties';
-import { createPage, generateBoard, generateProposal, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+import {
+  createPage,
+  generateBounty,
+  generateBoard,
+  generateProposal,
+  generateUserAndSpace
+} from 'testing/setupDatabase';
 
 import { exportWorkspacePages, exportWorkspacePagesToDisk } from '../exportWorkspacePages';
 
@@ -20,7 +25,7 @@ let page_1_1_1: PageWithPermissions;
 let boardPage: Page;
 
 beforeAll(async () => {
-  const generated = await generateUserAndSpaceWithApiToken();
+  const generated = await generateUserAndSpace();
   space = generated.space;
   user = generated.user;
 
@@ -120,7 +125,7 @@ describe('exportWorkspacePages', () => {
   });
 
   it('should ignore deleted pages', async () => {
-    const { space: spaceWithDeletedPage, user: _user } = await generateUserAndSpaceWithApiToken();
+    const { space: spaceWithDeletedPage, user: _user } = await generateUserAndSpace();
 
     await createPage({
       parentId: null,
@@ -148,34 +153,29 @@ describe('exportWorkspacePages', () => {
   });
 
   it('should not ignore bounties', async () => {
-    const { space: spaceWithDeletedPage, user: _user } = await generateUserAndSpaceWithApiToken();
+    const { space: _space, user: _user } = await generateUserAndSpace();
 
-    const bounty = await createBounty({
+    const bounty = await generateBounty({
       createdBy: _user.id,
-      spaceId: spaceWithDeletedPage.id
-    });
-
-    const returnedPage = await createPage({
-      parentId: null,
-      title: 'Root 1',
-      index: 1,
-      createdBy: _user.id,
-      spaceId: spaceWithDeletedPage.id
+      spaceId: _space.id
     });
 
     const data = await exportWorkspacePages({
-      sourceSpaceIdOrDomain: spaceWithDeletedPage.id
+      sourceSpaceIdOrDomain: _space.id
     });
 
-    const pageIds = [bounty.id, returnedPage.id];
+    expect(data.pages.length).toBe(1);
+    const page = data.pages[0];
 
-    expect(data.pages.length).toBe(2);
-    expect(pageIds.includes(data.pages[0].id)).toBeTruthy();
-    expect(pageIds.includes(data.pages[1].id)).toBeTruthy();
+    expect(page).toMatchObject(
+      expect.objectContaining({
+        id: bounty.id
+      })
+    );
   });
 
   it('should not ignore proposals', async () => {
-    const { space: spaceWithDeletedPage, user: _user } = await generateUserAndSpaceWithApiToken();
+    const { space: spaceWithDeletedPage, user: _user } = await generateUserAndSpace();
 
     const generatedProposal = await generateProposal({
       authors: [_user.id],

--- a/lib/templates/__tests__/importWorkspacePages.spec.ts
+++ b/lib/templates/__tests__/importWorkspacePages.spec.ts
@@ -7,7 +7,7 @@ import type { Page, Space, User } from '@charmverse/core/prisma';
 import { prisma } from '@charmverse/core/prisma-client';
 import { v4 } from 'uuid';
 
-import { createPage, generateBoard, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+import { createPage, generateBoard, generateUserAndSpace } from 'testing/setupDatabase';
 
 import { exportWorkspacePages, exportWorkspacePagesToDisk } from '../exportWorkspacePages';
 import { importWorkspacePages } from '../importWorkspacePages';
@@ -24,7 +24,7 @@ let totalSourcePages = 0;
 let totalSourceBlocks = 0;
 
 beforeAll(async () => {
-  const generated = await generateUserAndSpaceWithApiToken();
+  const generated = await generateUserAndSpace();
   space = generated.space;
   user = generated.user;
 
@@ -73,7 +73,7 @@ beforeAll(async () => {
 
 describe('importWorkspacePages', () => {
   it('should import data from the export function into the target workspace', async () => {
-    const { space: targetSpace } = await generateUserAndSpaceWithApiToken();
+    const { space: targetSpace } = await generateUserAndSpace();
 
     const data = await exportWorkspacePages({
       sourceSpaceIdOrDomain: space.domain
@@ -101,7 +101,7 @@ describe('importWorkspacePages', () => {
   });
 
   it('should accept a filename as the source data input', async () => {
-    const { space: targetSpace } = await generateUserAndSpaceWithApiToken();
+    const { space: targetSpace } = await generateUserAndSpace();
 
     const exportName = `test-${v4()}`;
 

--- a/lib/templates/importWorkspacePages.ts
+++ b/lib/templates/importWorkspacePages.ts
@@ -358,7 +358,7 @@ export async function generateImportWorkspacePages({
       permissions.forEach(({ id, ...bountyPermission }) => {
         bountyPermissionArgs.push({
           ...bountyPermission,
-          spaceId: space.id,
+          spaceId: bountyPermission.spaceId ? space.id : null,
           bountyId: oldNewPageIdHashMap[node.id]
         });
       });

--- a/testing/setupDatabase.ts
+++ b/testing/setupDatabase.ts
@@ -231,9 +231,9 @@ export async function generateBounty({
   contentText = '',
   spaceId,
   createdBy,
-  status,
+  status = 'open',
   maxSubmissions,
-  approveSubmitters,
+  approveSubmitters = false,
   title = 'Example',
   rewardToken = 'ETH',
   rewardAmount = 1,
@@ -243,8 +243,10 @@ export async function generateBounty({
   page = {},
   type = 'bounty',
   id
-}: Pick<Bounty, 'createdBy' | 'spaceId' | 'status' | 'approveSubmitters'> &
-  Partial<Pick<Bounty, 'id' | 'maxSubmissions' | 'chainId' | 'rewardAmount' | 'rewardToken'>> &
+}: Pick<Bounty, 'createdBy' | 'spaceId'> &
+  Partial<
+    Pick<Bounty, 'id' | 'maxSubmissions' | 'chainId' | 'rewardAmount' | 'rewardToken' | 'status' | 'approveSubmitters'>
+  > &
   Partial<Pick<Page, 'title' | 'content' | 'contentText' | 'type'>> & {
     bountyPermissions?: Partial<BountyPermissions>;
     pagePermissions?: Omit<Prisma.PagePermissionCreateManyInput, 'pageId'>[];


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 33e4058</samp>

This pull request improves the test code and the functionality for duplicating and importing bounty pages across workspaces. It refactors some test cases to use more efficient and readable helper functions, simplifies the `generateBounty` function in `testing/setupDatabase.ts`, and updates the `recursivePagePrep` function in `lib/templates/importWorkspacePages.ts` to handle null spaceIds for imported permissions.

### WHY
<!-- author to complete -->
