### PR TITLE
immutable query public page and space data

### DIFF
--- a/hooks/useSharedPage.ts
+++ b/hooks/useSharedPage.ts
@@ -54,7 +54,8 @@ export const useSharedPage = () => {
     }
 
     return !loadedSpace;
-  }, [spacesLoaded, isPublicPath, spaces, spaceDomain]);
+  }, [spacesLoaded, isPublicPath, loadedSpace]);
+
   const {
     data: publicPage,
     isLoading: isPublicPageLoading,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9a0042</samp>

Improve `useSharedPage` hook by removing unnecessary dependencies. This avoids potential re-rendering or stale values when using the hook to access the `loadedSpace` value.

### WHY
Currently we refresh everything each time you click back to a tab on a public page. I tried to investiage why the 'public page' SWR hook keeps refreshing - maybe because it gets an error in response? But immutable fixes it completely. There's no need to keep updating the data for public users
