### PR TITLE
Fixed proposal-source db being replicated in non-proposal source db

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSidebar.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSidebar.tsx
@@ -126,10 +126,10 @@ function ViewSidebar(props: Props) {
   }, [props.isOpen]);
 
   useEffect(() => {
-    if (props.pageId && props.view.fields.sourceType === 'proposals') {
+    if (props.pageId && props.view.fields.sourceType === 'proposals' && props.view.parentId === props.pageId) {
       updateProposalSource({ pageId: props.pageId });
     }
-  }, [props.pageId]);
+  }, [props.pageId, props.view.parentId, props.view.fields.sourceType]);
 
   return (
     <ClickAwayListener mouseEvent={props.isOpen ? 'onClick' : false} onClickAway={props.closeSidebar}>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28b037e</samp>

This pull request improves the type safety and error handling of the `updateCardsFromProposals` function and its related components. It also fixes a bug that caused unnecessary updates of the proposal source when switching views.

### WHY
[Conversation](https://discord.com/channels/894960387743698944/1118245084085878895)
