### PR TITLE
downgrade next.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,7 @@
         "nanoevents": "^6.0.2",
         "nanoid": "^3.3.6",
         "nanoid-dictionary": "^3.0.0",
-        "next": "13.2",
+        "next": "^13.2.2",
         "next-connect": "^0.13.0",
         "next-swagger-doc": "^0.3.6",
         "node-cron": "^3.0.0",
@@ -10995,9 +10995,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.4.tgz",
-      "integrity": "sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA=="
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.2.tgz",
+      "integrity": "sha512-sBcFEJS8j2cNQemYy07TKUd8lSWj3/mzFA4GCTr/4T4LfYiw5Ep+PZ06AuFdR3z+jIZt9YqaXwUYi1J4p4yABQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.3.4",
@@ -11009,9 +11009,9 @@
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
-      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.2.tgz",
+      "integrity": "sha512-JHTnsNTl9gDQkWqggJFj6rQHK2+9lIMGolOPihfZBQAE48amVsGkYyFHbiuWnhwnYX99fCFWomARDwOtLAhzdQ==",
       "cpu": [
         "arm"
       ],
@@ -11024,9 +11024,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
-      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.2.tgz",
+      "integrity": "sha512-j3zfjrojWuejU7bjucwBFviN9hQkQ1HqRVYMp8PDX82LXMc2pV4uZ3e9jQ8qk3OWsA1m+luaBK8o46NvS/Tetg==",
       "cpu": [
         "arm64"
       ],
@@ -11039,9 +11039,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
-      "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.2.tgz",
+      "integrity": "sha512-X66dKAq6IBmkirnsWyvncJ9i3kWkE2WrRbXGoFoEPNoyjgtV2qyLyk4ET9JIS0TJ2u01qODML6j4pKeqK8rNLA==",
       "cpu": [
         "arm64"
       ],
@@ -11054,9 +11054,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
-      "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.2.tgz",
+      "integrity": "sha512-jsJKzVLlCNrG/Ot9Owv8QWUymAyS+Hcf/KQsXOYtL6PgvGqBMJ931SdaBpLOuyRD+sozTIRiAPCDwVgF/62PBQ==",
       "cpu": [
         "x64"
       ],
@@ -11069,9 +11069,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
-      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.2.tgz",
+      "integrity": "sha512-oToMAjhdGWSgSOimKJ9GwPxOqoBIbbVUKoFGP5Imy5UGbbsnyV2jSLGhoi2/dH1Ko5X5d1R1la/X05xNB/p6ag==",
       "cpu": [
         "x64"
       ],
@@ -11084,9 +11084,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
-      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.2.tgz",
+      "integrity": "sha512-DSgXP2kkLt+oM3fRWaa2xPAUmtTnoa+GBfV5Czbgv4htY1BKClobp7Bj909TZUswvxXJtXiW8GrJp2To5lQfmw==",
       "cpu": [
         "arm"
       ],
@@ -11099,9 +11099,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
-      "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.2.tgz",
+      "integrity": "sha512-HR1Nf7kz5NmijCiArJTz4bjJlbWyPA3JQ3SbxnPXDMPUkECBG1p0z6y2N2+oqNouMyOriNR6TSEgh7F2tASdZg==",
       "cpu": [
         "arm64"
       ],
@@ -11114,9 +11114,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
-      "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.2.tgz",
+      "integrity": "sha512-hDf08/yPZisKQ19lMHkVuQUmipmSq9QPzFmNDcV7e4QazTbIRwCC8J605EHedg+RGHS78CUwVhGQoQ2mbQ5y3w==",
       "cpu": [
         "arm64"
       ],
@@ -11129,9 +11129,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
-      "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.2.tgz",
+      "integrity": "sha512-9QeTU1YVhQXoVUOBXErJoExZR3XTovplMCTwB+RAtHu3oUGGs4KQFY8MoFUOmMA7CAJnKS+h1MD1T9/HDpS9PQ==",
       "cpu": [
         "x64"
       ],
@@ -11144,9 +11144,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
-      "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.2.tgz",
+      "integrity": "sha512-SvyejahQLY79YJFXU27AcoDbmRqdK08t7HAf5LmocLdR5fxIneg7Oim/pwcuS/w8pYqDSAiCiMO0AAxSfO5jZQ==",
       "cpu": [
         "x64"
       ],
@@ -11159,9 +11159,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
-      "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.2.tgz",
+      "integrity": "sha512-Av46kUBp1qtJdk/HrIHZMIARE+jcMSJLHcrs/MkbHR1p4iEXf3JkZRrdQDUKZaz/VHDYc7Qw+vUv7zmgPZJbmw==",
       "cpu": [
         "arm64"
       ],
@@ -11174,9 +11174,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
-      "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.2.tgz",
+      "integrity": "sha512-6HvAJY7yYfU+Ast3GPM8O+BsLGAdhZV0qUwHerJo5+Yzzx0VXW+OZTJ9O6RU01HBiMiqdz7SF3Or4Vca6WZKkQ==",
       "cpu": [
         "ia32"
       ],
@@ -11189,9 +11189,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
-      "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.2.tgz",
+      "integrity": "sha512-7oNoiepUMf43+/4kUdpeGGkEBd3bOQwzo4O+bq/jslHb1IrQ7b8ZF1ODQyrDd661um6q5D+0sOtyRZJpo8e1jQ==",
       "cpu": [
         "x64"
       ],
@@ -35986,11 +35986,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.2.4.tgz",
-      "integrity": "sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.2.2.tgz",
+      "integrity": "sha512-dDKfGBqSxqmqx5WN9tDFg0uGUkD/LGUxR29tpe8AEmo2SwfbPWf04qyvDcKmpjt2fCzP4132BvFRZFlg+11kGw==",
       "dependencies": {
-        "@next/env": "13.2.4",
+        "@next/env": "13.2.2",
         "@swc/helpers": "0.4.14",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -36003,19 +36003,19 @@
         "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "13.2.4",
-        "@next/swc-android-arm64": "13.2.4",
-        "@next/swc-darwin-arm64": "13.2.4",
-        "@next/swc-darwin-x64": "13.2.4",
-        "@next/swc-freebsd-x64": "13.2.4",
-        "@next/swc-linux-arm-gnueabihf": "13.2.4",
-        "@next/swc-linux-arm64-gnu": "13.2.4",
-        "@next/swc-linux-arm64-musl": "13.2.4",
-        "@next/swc-linux-x64-gnu": "13.2.4",
-        "@next/swc-linux-x64-musl": "13.2.4",
-        "@next/swc-win32-arm64-msvc": "13.2.4",
-        "@next/swc-win32-ia32-msvc": "13.2.4",
-        "@next/swc-win32-x64-msvc": "13.2.4"
+        "@next/swc-android-arm-eabi": "13.2.2",
+        "@next/swc-android-arm64": "13.2.2",
+        "@next/swc-darwin-arm64": "13.2.2",
+        "@next/swc-darwin-x64": "13.2.2",
+        "@next/swc-freebsd-x64": "13.2.2",
+        "@next/swc-linux-arm-gnueabihf": "13.2.2",
+        "@next/swc-linux-arm64-gnu": "13.2.2",
+        "@next/swc-linux-arm64-musl": "13.2.2",
+        "@next/swc-linux-x64-gnu": "13.2.2",
+        "@next/swc-linux-x64-musl": "13.2.2",
+        "@next/swc-win32-arm64-msvc": "13.2.2",
+        "@next/swc-win32-ia32-msvc": "13.2.2",
+        "@next/swc-win32-x64-msvc": "13.2.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.4.0",
@@ -54331,9 +54331,9 @@
       }
     },
     "@next/env": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.4.tgz",
-      "integrity": "sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA=="
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.2.tgz",
+      "integrity": "sha512-sBcFEJS8j2cNQemYy07TKUd8lSWj3/mzFA4GCTr/4T4LfYiw5Ep+PZ06AuFdR3z+jIZt9YqaXwUYi1J4p4yABQ=="
     },
     "@next/eslint-plugin-next": {
       "version": "12.3.4",
@@ -54345,81 +54345,81 @@
       }
     },
     "@next/swc-android-arm-eabi": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
-      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.2.tgz",
+      "integrity": "sha512-JHTnsNTl9gDQkWqggJFj6rQHK2+9lIMGolOPihfZBQAE48amVsGkYyFHbiuWnhwnYX99fCFWomARDwOtLAhzdQ==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
-      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.2.tgz",
+      "integrity": "sha512-j3zfjrojWuejU7bjucwBFviN9hQkQ1HqRVYMp8PDX82LXMc2pV4uZ3e9jQ8qk3OWsA1m+luaBK8o46NvS/Tetg==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
-      "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.2.tgz",
+      "integrity": "sha512-X66dKAq6IBmkirnsWyvncJ9i3kWkE2WrRbXGoFoEPNoyjgtV2qyLyk4ET9JIS0TJ2u01qODML6j4pKeqK8rNLA==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
-      "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.2.tgz",
+      "integrity": "sha512-jsJKzVLlCNrG/Ot9Owv8QWUymAyS+Hcf/KQsXOYtL6PgvGqBMJ931SdaBpLOuyRD+sozTIRiAPCDwVgF/62PBQ==",
       "optional": true
     },
     "@next/swc-freebsd-x64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
-      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.2.tgz",
+      "integrity": "sha512-oToMAjhdGWSgSOimKJ9GwPxOqoBIbbVUKoFGP5Imy5UGbbsnyV2jSLGhoi2/dH1Ko5X5d1R1la/X05xNB/p6ag==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
-      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.2.tgz",
+      "integrity": "sha512-DSgXP2kkLt+oM3fRWaa2xPAUmtTnoa+GBfV5Czbgv4htY1BKClobp7Bj909TZUswvxXJtXiW8GrJp2To5lQfmw==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
-      "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.2.tgz",
+      "integrity": "sha512-HR1Nf7kz5NmijCiArJTz4bjJlbWyPA3JQ3SbxnPXDMPUkECBG1p0z6y2N2+oqNouMyOriNR6TSEgh7F2tASdZg==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
-      "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.2.tgz",
+      "integrity": "sha512-hDf08/yPZisKQ19lMHkVuQUmipmSq9QPzFmNDcV7e4QazTbIRwCC8J605EHedg+RGHS78CUwVhGQoQ2mbQ5y3w==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
-      "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.2.tgz",
+      "integrity": "sha512-9QeTU1YVhQXoVUOBXErJoExZR3XTovplMCTwB+RAtHu3oUGGs4KQFY8MoFUOmMA7CAJnKS+h1MD1T9/HDpS9PQ==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
-      "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.2.tgz",
+      "integrity": "sha512-SvyejahQLY79YJFXU27AcoDbmRqdK08t7HAf5LmocLdR5fxIneg7Oim/pwcuS/w8pYqDSAiCiMO0AAxSfO5jZQ==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
-      "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.2.tgz",
+      "integrity": "sha512-Av46kUBp1qtJdk/HrIHZMIARE+jcMSJLHcrs/MkbHR1p4iEXf3JkZRrdQDUKZaz/VHDYc7Qw+vUv7zmgPZJbmw==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
-      "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.2.tgz",
+      "integrity": "sha512-6HvAJY7yYfU+Ast3GPM8O+BsLGAdhZV0qUwHerJo5+Yzzx0VXW+OZTJ9O6RU01HBiMiqdz7SF3Or4Vca6WZKkQ==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
-      "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.2.tgz",
+      "integrity": "sha512-7oNoiepUMf43+/4kUdpeGGkEBd3bOQwzo4O+bq/jslHb1IrQ7b8ZF1ODQyrDd661um6q5D+0sOtyRZJpo8e1jQ==",
       "optional": true
     },
     "@noble/ed25519": {
@@ -73645,24 +73645,24 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "next": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.2.4.tgz",
-      "integrity": "sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.2.2.tgz",
+      "integrity": "sha512-dDKfGBqSxqmqx5WN9tDFg0uGUkD/LGUxR29tpe8AEmo2SwfbPWf04qyvDcKmpjt2fCzP4132BvFRZFlg+11kGw==",
       "requires": {
-        "@next/env": "13.2.4",
-        "@next/swc-android-arm-eabi": "13.2.4",
-        "@next/swc-android-arm64": "13.2.4",
-        "@next/swc-darwin-arm64": "13.2.4",
-        "@next/swc-darwin-x64": "13.2.4",
-        "@next/swc-freebsd-x64": "13.2.4",
-        "@next/swc-linux-arm-gnueabihf": "13.2.4",
-        "@next/swc-linux-arm64-gnu": "13.2.4",
-        "@next/swc-linux-arm64-musl": "13.2.4",
-        "@next/swc-linux-x64-gnu": "13.2.4",
-        "@next/swc-linux-x64-musl": "13.2.4",
-        "@next/swc-win32-arm64-msvc": "13.2.4",
-        "@next/swc-win32-ia32-msvc": "13.2.4",
-        "@next/swc-win32-x64-msvc": "13.2.4",
+        "@next/env": "13.2.2",
+        "@next/swc-android-arm-eabi": "13.2.2",
+        "@next/swc-android-arm64": "13.2.2",
+        "@next/swc-darwin-arm64": "13.2.2",
+        "@next/swc-darwin-x64": "13.2.2",
+        "@next/swc-freebsd-x64": "13.2.2",
+        "@next/swc-linux-arm-gnueabihf": "13.2.2",
+        "@next/swc-linux-arm64-gnu": "13.2.2",
+        "@next/swc-linux-arm64-musl": "13.2.2",
+        "@next/swc-linux-x64-gnu": "13.2.2",
+        "@next/swc-linux-x64-musl": "13.2.2",
+        "@next/swc-win32-arm64-msvc": "13.2.2",
+        "@next/swc-win32-ia32-msvc": "13.2.2",
+        "@next/swc-win32-x64-msvc": "13.2.2",
         "@swc/helpers": "0.4.14",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "nanoevents": "^6.0.2",
     "nanoid": "^3.3.6",
     "nanoid-dictionary": "^3.0.0",
-    "next": "13.2",
+    "next": "^13.2.2",
     "next-connect": "^0.13.0",
     "next-swagger-doc": "^0.3.6",
     "node-cron": "^3.0.0",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9e26f1</samp>

Updated `next` dependency to use caret range for better compatibility and security. This fixes a dependabot alert for `package.json`.

### WHY
Dev server restarting every 10 minutes is really painful. I have another PR to try upgrading next.js but they have broken integration with socket.io, so we have no way to upgrade until that is also fixed. In the meantime, I don't recall a need to be on 13.2.4, and some users in Next's issues said that 13.2.2 was the last 'good' version.
