### PR TITLE
disable changing users edits to suggestions

### DIFF
--- a/components/common/CharmEditor/components/fiduswriter/collab/merge/index.ts
+++ b/components/common/CharmEditor/components/fiduswriter/collab/merge/index.ts
@@ -182,42 +182,45 @@ export class Merge {
       }
     });
 
-    let tracked;
-    let rebasedTrackedTr; // offline steps to be tracked
-    if (
-      // WRITE_ROLES.includes(this.mod.editor.docInfo.access_rights)
-      // &&
-      unconfirmedTr.steps.length > this.trackOfflineLimit ||
-      lostTr.steps.length > this.remoteTrackOfflineLimit
-    ) {
-      tracked = true;
-      // Either this user has made 50 changes since going offline,
-      // or the document has 20 changes to it. Therefore we add tracking
-      // to the changes of this user and ask user to clean up.
-      rebasedTrackedTr = trackedTransaction(
-        rebasedTr,
-        this.mod.editor.view.state,
-        this.mod.editor.user,
-        false,
-        new Date(Date.now() - this.mod.editor.clientTimeAdjustment)
-      );
-    } else {
-      tracked = false;
-      rebasedTrackedTr = rebasedTr;
-    }
+    // disable the following code which turns a users edits into suggestions.
+    // In testing, the user was not able to accept the suggesitons, and it might be better to just let them undo changes via history UI
+
+    // let tracked;
+    // let rebasedTrackedTr; // offline steps to be tracked
+    // if (
+    //   // WRITE_ROLES.includes(this.mod.editor.docInfo.access_rights)
+    //   // &&
+    //   unconfirmedTr.steps.length > this.trackOfflineLimit ||
+    //   lostTr.steps.length > this.remoteTrackOfflineLimit
+    // ) {
+    //   tracked = true;
+    //   // Either this user has made 50 changes since going offline,
+    //   // or the document has 20 changes to it. Therefore we add tracking
+    //   // to the changes of this user and ask user to clean up.
+    //   rebasedTrackedTr = trackedTransaction(
+    //     rebasedTr,
+    //     this.mod.editor.view.state,
+    //     this.mod.editor.user,
+    //     false,
+    //     new Date(Date.now() - this.mod.editor.clientTimeAdjustment)
+    //   );
+    // } else {
+    //   tracked = false;
+    //   rebasedTrackedTr = rebasedTr;
+    // }
 
     // this.mod.editor.docInfo.version = data.doc.v
-    rebasedTrackedTr.setMeta('remote', true);
-    this.mod.editor.view.dispatch(rebasedTrackedTr);
+    rebasedTr.setMeta('remote', true);
+    this.mod.editor.view.dispatch(rebasedTr);
 
-    if (tracked) {
-      log.warn(
-        'Showed alert to user after auto-merge: The document was modified substantially by other users while you were offline'
-      );
-      alert(
-        'The document was modified substantially by other users while you were offline. We have merged your changes in as tracked changes. You should verify that your edits still make sense.'
-      );
-    }
+    // if (tracked) {
+    //   log.warn(
+    //     'Showed alert to user after auto-merge: The document was modified substantially by other users while you were offline'
+    //   );
+    //   alert(
+    //     'The document was modified substantially by other users while you were offline. We have merged your changes in as tracked changes. You should verify that your edits still make sense.'
+    //   );
+    // }
   }
 
   getDocData(offlineDoc: Node) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dab3ed1</samp>

Disabled offline suggestions in `CharmEditor` to fix a bug. Users can now undo changes via the history UI.

### WHY
<!-- author to complete -->
