### PR TITLE
add spaceid to logs in web sockets

### DIFF
--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -40,6 +40,7 @@ type DocumentRoom = {
   participants: Map<string, DocumentEventHandler>;
   doc: {
     id: string;
+    spaceId: string;
     version: number;
     content: any;
     type: string;
@@ -82,6 +83,7 @@ export class DocumentEventHandler {
       socketId: this.id,
       userId: session.user?.id,
       pageId: session.documentId,
+      spaceId: docRoom?.doc.spaceId,
       pageVersion: docRoom?.doc.version,
       serverMessages: this.messages.server,
       clientMessages: this.messages.client
@@ -302,6 +304,7 @@ export class DocumentEventHandler {
         const room: DocumentRoom = {
           doc: {
             id: page.id,
+            spaceId: page.spaceId,
             content,
             type: page.type,
             galleryImage: page.galleryImage,
@@ -394,6 +397,7 @@ export class DocumentEventHandler {
       socketId: this.id,
       userId: this.getSession().user.id,
       pageId: room.doc.id,
+      spaceId: room.doc.spaceId,
       v: clientV,
       c: message.c,
       s: message.s,
@@ -460,7 +464,7 @@ export class DocumentEventHandler {
     const room = this.getDocumentRoomOrThrow();
     const clientV = message.v;
     const serverV = room?.doc.version;
-    const logData = { clientV, serverV, pageId: room?.doc.id, userId: session.user.id };
+    const logData = { clientV, serverV, pageId: room?.doc.id, spaceId: room?.doc.spaceId, userId: session.user.id };
     log.debug('Check version of document', logData);
     if (clientV === serverV) {
       this.sendMessage({ type: 'confirm_version', v: clientV });
@@ -623,7 +627,7 @@ export class DocumentEventHandler {
       return;
     }
 
-    log.debug('Saving document to db', { version: room.doc.version, pageId: room.doc.id });
+    log.debug('Saving document to db', { version: room.doc.version, pageId: room.doc.id, spaceId: room.doc.spaceId });
 
     const contentText = room.node.textContent;
     // check if content is empty only if it got changed


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d57fa4</samp>

This pull request adds the `spaceId` of the current space to the Datadog context and the websocket document events. This improves the logging and monitoring of the app's performance and activity across different spaces.

### WHY
Makes it easier to find all issues related to a particular space
