### PR TITLE
Configure Beanstalk to restart websockets on crash

### DIFF
--- a/.ebextensions_websockets/04_autoscaling.config
+++ b/.ebextensions_websockets/04_autoscaling.config
@@ -1,0 +1,7 @@
+# this configures Beanstalk to restart the app if the app's health check fails
+Resources:
+  AWSEBAutoScalingGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      HealthCheckType: ELB
+      HealthCheckGracePeriod: 10

--- a/background/server/app.ts
+++ b/background/server/app.ts
@@ -9,6 +9,14 @@ const router = new Router();
 router.get('/', routes.healthCheck);
 router.get('/health_check', routes.healthCheck);
 
+// TODO: Remove this route before merging to master
+router.get('/kill-me', (ctx) => {
+  setTimeout(() => {
+    throw new Error('Killed by /kill-me');
+  }, 1000);
+  ctx.body = 'I shot the sheriff, but I did not shoot the deputy.';
+});
+
 app.use(routes.errorHandler).use(router.routes()).use(router.allowedMethods());
 
 export default app;


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
<!-- author to complete -->
