### PR TITLE
adding more autoscale alb healthcheck configs

### DIFF
--- a/.ebextensions/04_autoscaling.config
+++ b/.ebextensions/04_autoscaling.config
@@ -1,0 +1,7 @@
+# this configures Beanstalk to restart the app if the app's health check fails
+Resources:
+  AWSEBAutoScalingGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      HealthCheckType: ELB
+      HealthCheckGracePeriod: 300

--- a/.ebextensions/05_alb_targetgrp.config
+++ b/.ebextensions/05_alb_targetgrp.config
@@ -1,0 +1,8 @@
+# tweaks the target group health check configurations
+Resources:
+  AWSEBV2LoadBalancerListener:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3

--- a/.ebextensions_websockets/05_alb_targetgrp.config
+++ b/.ebextensions_websockets/05_alb_targetgrp.config
@@ -1,0 +1,8 @@
+# tweaks the target group health check configurations
+Resources:
+  AWSEBV2LoadBalancerListener:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3


### PR DESCRIPTION
Tweaking the target group health checks which affects the beanstalk/autoscale healthcheck now that we switched to using ALB checks. 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 17a1d6f</samp>

This pull request updates the health check configurations for the app and websockets environments in Beanstalk. It uses the load balancer's health check to monitor and replace unhealthy instances, and adjusts the health check parameters to optimize the performance and availability of the app. It affects the files `.ebextensions/04_autoscaling.config`, `.ebextensions/05_alb_targetgrp.config`, and `.ebextensions_websockets/05_alb_targetgrp.config`.

### WHY
To better allow apps to detect whether the application needs to be restarted. 