### PR TITLE
fixing action input wasn't properly set - also reverting to installing core from github directly

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -5,8 +5,9 @@ inputs:
     description: "Optional. Defaults to what's in package.json. Valid options are latest and custom version"
     required: false
   commit_core_pkg_upgrade:
-    required: false
     type: boolean
+    description: 'Define whether to commit the updated package.json back into repo'
+    required: false
     default: false
 
 runs:


### PR DESCRIPTION
…ackage install to main

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58a7348</samp>

Added a description for the `commit_core_pkg_upgrade` input in the `.github/actions/install/action.yml` file. This input helps users manage the core package dependencies of the app.

### WHY
<!-- author to complete -->
