### PR TITLE
fix copying summaries in charm editor

### DIFF
--- a/components/common/CharmEditor/components/disclosure/disclosure.ts
+++ b/components/common/CharmEditor/components/disclosure/disclosure.ts
@@ -16,13 +16,17 @@ function summarySpec(): RawSpecs {
     schema: {
       content: '(paragraph | heading)',
       group: 'block',
-      parseDOM: [{ tag: 'summary' }],
+      parseDOM: [{ tag: 'div.summary' }],
       toDOM: (): DOMOutputSpec => {
-        return ['summary'];
+        return ['div.summary', 0];
       }
     },
     markdown: {
-      toMarkdown: () => null
+      toMarkdown: (state, node) => {
+        state.text(node.textContent, false);
+        state.ensureNewLine();
+        state.closeBlock(node);
+      }
     }
   };
 }
@@ -35,13 +39,17 @@ function detailsSpec(): RawSpecs {
       content: 'disclosureSummary block+',
       defining: true,
       group: 'block',
-      parseDOM: [{ tag: 'details' }],
+      parseDOM: [{ tag: 'div.summary-details' }],
       toDOM: (): DOMOutputSpec => {
-        return ['details', 0];
+        return ['div.summary-details', 0];
       }
     },
     markdown: {
-      toMarkdown: () => null
+      toMarkdown: (state, node) => {
+        state.text(node.textContent, false);
+        state.ensureNewLine();
+        state.closeBlock(node);
+      }
     }
   };
 }

--- a/components/common/CharmEditor/components/disclosure/disclosure.ts
+++ b/components/common/CharmEditor/components/disclosure/disclosure.ts
@@ -16,9 +16,9 @@ function summarySpec(): RawSpecs {
     schema: {
       content: '(paragraph | heading)',
       group: 'block',
-      parseDOM: [{ tag: 'div.summary' }],
+      parseDOM: [{ tag: 'summary' }],
       toDOM: (): DOMOutputSpec => {
-        return ['div.summary', 0];
+        return ['summary', 0];
       }
     },
     markdown: {
@@ -39,9 +39,9 @@ function detailsSpec(): RawSpecs {
       content: 'disclosureSummary block+',
       defining: true,
       group: 'block',
-      parseDOM: [{ tag: 'div.summary-details' }],
+      parseDOM: [{ tag: 'details' }],
       toDOM: (): DOMOutputSpec => {
-        return ['div.summary-details', 0];
+        return ['details', 0];
       }
     },
     markdown: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77b05bb</samp>

Changed the disclosure element in the `CharmEditor` to use custom `div` tags instead of native `summary` and `details` tags. This improved the styling, behavior, and markdown serialization of the disclosure element.

### WHY
For some reason, using 'summary' the inner text content gets lost. The toDOM and parseDOM is overriden by the Node view, so we can use whatever HTML we want, and the only downside I can think of is that it won't carry the collapsible function when copying to other HTML editors.