### PR TITLE
fix wrapping of dialog title for users onboarding

### DIFF
--- a/components/common/UserProfile/UserProfileDialog.tsx
+++ b/components/common/UserProfile/UserProfileDialog.tsx
@@ -44,7 +44,7 @@ export function UserProfileDialog({
     <StyledDialog toolbar={<div />} fluidSize={fluidSize} onClose={onClickClose}>
       <ScrollableWindow>
         <Container fullWidth={fullWidth} top={20}>
-          {title && <Legend>{title}</Legend>}
+          {title && <Legend wrap>{title}</Legend>}
           {children}
         </Container>
       </ScrollableWindow>

--- a/components/common/UserProfile/components/CurrentUserProfile.tsx
+++ b/components/common/UserProfile/components/CurrentUserProfile.tsx
@@ -98,7 +98,8 @@ export function CurrentUserProfile({
     if (currentStep === 'email_step') {
       title = 'Welcome to CharmVerse';
     } else if (currentStep === 'profile_step') {
-      title = `Welcome to ${currentSpace.name}! Set up your profile`;
+      // wrap hyphens with word joiner so that it doesn't wrap: https://en.wikipedia.org/wiki/Word_joiner
+      title = `Welcome to ${currentSpace.name.replace(/-/g, '\ufeff-\ufeff')}! Set up your profile`;
     }
   }
 

--- a/components/settings/Legend.tsx
+++ b/components/settings/Legend.tsx
@@ -4,10 +4,19 @@ import type { TypographyProps } from '@mui/material/Typography';
 import Typography from '@mui/material/Typography';
 import type { ReactNode } from 'react';
 
+type LegendProps = TypographyProps & {
+  children: string | ReactNode;
+  helperText?: string | ReactNode;
+  noBorder?: boolean;
+  mb?: number;
+  pb?: number;
+  wrap?: boolean;
+};
+
 const StyledBox = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'noBorder'
-})<{ noBorder?: boolean }>`
-  white-space: nowrap;
+  shouldForwardProp: (prop) => prop !== 'noBorder' && prop !== 'wrap'
+})<{ noBorder?: boolean; wrap?: boolean }>`
+  white-space: ${({ wrap }) => (wrap ? 'normal' : 'nowrap')};
   border-bottom: ${({ noBorder, theme }) => (noBorder ? '0' : `1px solid ${theme.palette.divider}`)};
 `;
 
@@ -16,22 +25,14 @@ const StyledTypography = styled(Typography)`
   font-weight: bold;
 `;
 
-interface LegendProps extends TypographyProps {
-  children: string | ReactNode;
-  helperText?: string | ReactNode;
-  noBorder?: boolean;
-  mb?: number;
-  pb?: number;
-}
-
-function Legend({ children, helperText, noBorder, mb = 2, pb = 2, ...props }: LegendProps) {
+function Legend({ children, helperText, noBorder, mb = 2, pb = 2, wrap, ...props }: LegendProps) {
   return (
-    <StyledBox noBorder={noBorder} mb={mb} pb={pb}>
-      <StyledTypography noWrap {...props}>
+    <StyledBox noBorder={noBorder} mb={mb} pb={pb} wrap={wrap}>
+      <StyledTypography noWrap={!wrap} {...props}>
         {children}
       </StyledTypography>
       {helperText && (
-        <Typography color='secondary' mt={0.5} variant='caption' component='p'>
+        <Typography color='secondary' mt={0.5} variant='caption' component='p' sx={{ hyphens: 'auto' }}>
           {helperText}
         </Typography>
       )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe92f02</samp>

Improved the display of long space names in user profile dialogs. Used the `Legend` component with a `wrap` prop and word joiners to prevent unwanted line breaks and overflows. Modified `components/settings/Legend.tsx`, `components/common/UserProfile/components/CurrentUserProfile.tsx`, and `components/common/UserProfile/UserProfileDialog.tsx`.

### WHY
[<!-- author to complete -->](https://app.charmverse.io/charmverse/page-49366552253645923?viewId=50d940bb-fdbd-40ba-9816-616d6138a663&cardId=f250f68c-43ec-4cca-b06c-7df10c5211a5)

![image](https://github.com/charmverse/app.charmverse.io/assets/305398/bd76f3c1-833c-4e81-94b4-6b82149a014c)

