### PR TITLE
Fix duplicate subs

### DIFF
--- a/lib/subscription/__tests__/createProSubscription.spec.ts
+++ b/lib/subscription/__tests__/createProSubscription.spec.ts
@@ -91,7 +91,7 @@ describe('createProSubscription', () => {
     (stripeClient.customers.update as jest.Mock<any, any>) = updateCustomersMockFn;
     (stripeClient.customers.search as jest.Mock<any, any>) = searchCustomersMockFn;
     (stripeClient.subscriptions.create as jest.Mock<any, any>) = createSubscriptionsMockFn;
-    (stripeClient.subscriptions.search as jest.Mock<any, any>) = searchSubscriptionsMockFn;
+    (stripeClient.subscriptions.list as jest.Mock<any, any>) = searchSubscriptionsMockFn;
     (stripeClient.customers.list as jest.Mock<any, any>) = listCustomersMockFn;
     (stripeClient.prices.list as jest.Mock<any, any>) = listPricesMockFn;
 

--- a/lib/subscription/createProSubscription.ts
+++ b/lib/subscription/createProSubscription.ts
@@ -53,12 +53,12 @@ export async function createProSubscription({
     query: `metadata['spaceId']:'${spaceId}'`
   });
 
-  const stripeSubscription = await stripeClient.subscriptions.list({
+  const stripeSubscriptions = await stripeClient.subscriptions.list({
     status: 'incomplete',
-    customer: existingCustomer.data?.[0]?.id
+    customer: existingCustomer.data?.[0]?.id || 'customer'
   });
 
-  const existingStripeSubscription: Stripe.Subscription | undefined = stripeSubscription.data?.find(
+  const existingStripeSubscription: Stripe.Subscription | undefined = stripeSubscriptions.data?.find(
     (sub) => sub.metadata.spaceId === spaceId
   );
 

--- a/lib/subscription/createProSubscription.ts
+++ b/lib/subscription/createProSubscription.ts
@@ -53,11 +53,14 @@ export async function createProSubscription({
     query: `metadata['spaceId']:'${spaceId}'`
   });
 
-  const stripeSubscription = await stripeClient.subscriptions.search({
-    query: `metadata["spaceId"]:"${spaceId}" AND status:"incomplete"`
+  const stripeSubscription = await stripeClient.subscriptions.list({
+    status: 'incomplete',
+    customer: existingCustomer.data?.[0]?.id
   });
 
-  const existingStripeSubscription: Stripe.Subscription | undefined = stripeSubscription.data?.[0];
+  const existingStripeSubscription: Stripe.Subscription | undefined = stripeSubscription.data?.find(
+    (sub) => sub.metadata.spaceId === spaceId
+  );
 
   const existingStripeCustomer = existingCustomer?.data.find((cus) => !cus.deleted);
 

--- a/lib/subscription/createProSubscription.ts
+++ b/lib/subscription/createProSubscription.ts
@@ -54,7 +54,7 @@ export async function createProSubscription({
   });
 
   const stripeSubscription = await stripeClient.subscriptions.search({
-    query: `metadata['spaceId']:'${spaceId}' AND status:'incomplete'`
+    query: `metadata["spaceId"]:"${spaceId}" AND status:"incomplete"`
   });
 
   const existingStripeSubscription: Stripe.Subscription | undefined = stripeSubscription.data?.[0];

--- a/lib/subscription/createProSubscription.ts
+++ b/lib/subscription/createProSubscription.ts
@@ -55,7 +55,7 @@ export async function createProSubscription({
 
   const stripeSubscriptions = await stripeClient.subscriptions.list({
     status: 'incomplete',
-    customer: existingCustomer.data?.[0]?.id || 'customer'
+    customer: existingCustomer.data?.[0]?.id || 'customer' // if we don't have a customer I added a dummy name so the array returned will be empty
   });
 
   const existingStripeSubscription: Stripe.Subscription | undefined = stripeSubscriptions.data?.find(


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e37f965</samp>

Fixed a bug that prevented some users from creating pro subscriptions with stripe. Changed the query string syntax in `lib/subscription/createProSubscription.ts` to use double quotes instead of single quotes.

### WHY
Fix for duplciating subscriptions
