### PR TITLE
Show Billing in prod

### DIFF
--- a/components/settings/config.tsx
+++ b/components/settings/config.tsx
@@ -33,7 +33,7 @@ export const SETTINGS_TABS: SpaceSettingsTab[] = [
 
 export function getSettingsTabs({ isAdmin, space }: { space: Space; isAdmin: boolean }): SpaceSettingsTab[] {
   return SETTINGS_TABS.filter((tab) => {
-    return tab.path === 'subscription' ? !!isAdmin && space.domain.startsWith('cvt-') : true;
+    return tab.path === 'subscription' ? !!isAdmin : true;
   });
 }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9470d4c</samp>

Removed domain restriction for subscription tab in `config.tsx`. This allows all space admins to manage their billing settings with the new system.

### WHY
Show Billing tab in prod
