### PR TITLE
Fix dialogs

### DIFF
--- a/components/settings/subscription/ConfirmFreeDowngradeModal.tsx
+++ b/components/settings/subscription/ConfirmFreeDowngradeModal.tsx
@@ -6,8 +6,7 @@ import Typography from '@mui/material/Typography';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 
 const subscriptionCancellationDetails = {
-  first:
-    'Cancelling CharmVerse Community Edition will revert this space to the Free Plan at the end of the current billing period. The following changes will be made: ',
+  first: 'If you use the Free Edition, the following changes will apply: ',
   list: [
     'All content will be public and shared on the web',
     'Custom roles will no longer apply',
@@ -27,11 +26,11 @@ type Props = {
 export function ConfirmFreeDowngradeModal({ isOpen, onClose, onConfirmDowngrade, disabled }: Props) {
   return (
     <ConfirmDeleteModal
-      title='Cancelling Community Edition'
+      title='Confirm Free Edition downgrade'
       size='large'
       open={isOpen}
-      buttonText='Yes'
-      secondaryButtonText='No'
+      buttonText='Downgrade to Free Edition'
+      secondaryButtonText='Keep current plan'
       question={
         <>
           <Typography>{subscriptionCancellationDetails.first}</Typography>
@@ -43,8 +42,6 @@ export function ConfirmFreeDowngradeModal({ isOpen, onClose, onConfirmDowngrade,
             ))}
           </List>
           <Typography>{subscriptionCancellationDetails.last}</Typography>
-          <br />
-          <Typography>Do you still want to Cancel?</Typography>
         </>
       }
       onConfirm={onConfirmDowngrade}

--- a/components/settings/subscription/ConfirmPlanCancellation.tsx
+++ b/components/settings/subscription/ConfirmPlanCancellation.tsx
@@ -1,0 +1,29 @@
+import Typography from '@mui/material/Typography';
+
+import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirmCancellation: () => void;
+  disabled: boolean;
+};
+export function ConfirmPlanCancellationModal({ isOpen, onClose, onConfirmCancellation, disabled }: Props) {
+  return (
+    <ConfirmDeleteModal
+      title='Confirm plan cancellation'
+      size='large'
+      open={isOpen}
+      buttonText='Cancel plan'
+      secondaryButtonText='Keep current plan'
+      question={
+        <Typography>
+          Your space will continue with the current plan until the end of the current billing period.
+        </Typography>
+      }
+      onConfirm={onConfirmCancellation}
+      onClose={onClose}
+      disabled={disabled}
+    />
+  );
+}

--- a/components/settings/subscription/SubscriptionActions.tsx
+++ b/components/settings/subscription/SubscriptionActions.tsx
@@ -7,6 +7,7 @@ import { useIsAdmin } from 'hooks/useIsAdmin';
 import type { SpaceSubscriptionWithStripeData } from 'lib/subscription/getActiveSpaceSubscription';
 
 import { ConfirmFreeDowngradeModal } from './ConfirmFreeDowngradeModal';
+import { ConfirmPlanCancellationModal } from './ConfirmPlanCancellation';
 
 export function SubscriptionActions({
   spaceSubscription,
@@ -35,6 +36,12 @@ export function SubscriptionActions({
     open: openConfirmFreeTierDowngradeDialog
   } = usePopupState({ variant: 'popover', popupId: 'susbcription-actions' });
 
+  const {
+    isOpen: isConfirmCancelPlanDialogOpen,
+    close: closeConfirmCancelPlanDialog,
+    open: openConfirmCancelPlanDialog
+  } = usePopupState({ variant: 'popover', popupId: 'susbcription-actions' });
+
   if (!isAdmin) {
     return null;
   }
@@ -51,9 +58,15 @@ export function SubscriptionActions({
           <Button disabled={loading} onClick={onUpgrade}>
             Update Plan
           </Button>
-          <Button disabled={loading} onClick={onCancelAtEnd} variant='text'>
+          <Button disabled={loading} onClick={openConfirmCancelPlanDialog} variant='text'>
             Cancel Plan
           </Button>
+          <ConfirmPlanCancellationModal
+            disabled={!isAdmin}
+            onConfirmCancellation={onCancelAtEnd}
+            onClose={closeConfirmCancelPlanDialog}
+            isOpen={isConfirmCancelPlanDialogOpen}
+          />
           {!isProdEnv && (
             <Button disabled={loading} onClick={onDelete} color='error' variant='outlined'>
               Delete Plan

--- a/hooks/useSettingsDialog.tsx
+++ b/hooks/useSettingsDialog.tsx
@@ -55,7 +55,7 @@ export function SettingsDialogProvider({ children }: { children: ReactNode }) {
 
     if (router.query.settingTab && SETTINGS_TABS.some((tab) => tab.path === router.query.settingTab)) {
       onClick(router.query.settingTab as string);
-      setUrlWithoutRerender(router.pathname, { settingTab: null });
+      router.push(router.asPath.split('?')[0]);
     }
     // If the user clicks a link inside the modal, close the modal only
     router.events.on('routeChangeStart', close);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8214e48</samp>

Fixed a bug in the settings dialog modal by using `router.push` instead of `setUrlWithoutRerender` to update the URL. This change affects the file `hooks/useSettingsDialog.tsx`.

### WHY
Dropping the parameter