### PR TITLE
Fixes to Proposals as a source

### DIFF
--- a/lib/pages/__tests__/updateCardsFromProposals.spec.ts
+++ b/lib/pages/__tests__/updateCardsFromProposals.spec.ts
@@ -82,7 +82,7 @@ describe('updateCardsFromProposals()', () => {
   it('should create cards from proposals if there are new proposals added', async () => {
     await generateProposal({
       authors: [user.id],
-      proposalStatus: 'draft',
+      proposalStatus: 'discussion',
       reviewers: [
         {
           group: 'user',
@@ -97,7 +97,7 @@ describe('updateCardsFromProposals()', () => {
 
     const pageProposal2 = await generateProposal({
       authors: [user.id],
-      proposalStatus: 'draft',
+      proposalStatus: 'discussion',
       reviewers: [
         {
           group: 'user',
@@ -155,7 +155,7 @@ describe('updateCardsFromProposals()', () => {
   it('should delete cards from proposals', async () => {
     const pageProposal = await generateProposal({
       authors: [user.id],
-      proposalStatus: 'draft',
+      proposalStatus: 'discussion',
       reviewers: [
         {
           group: 'user',
@@ -197,7 +197,7 @@ describe('updateCardsFromProposals()', () => {
   it('should permanently delete cards from proposals', async () => {
     const pageProposal = await generateProposal({
       authors: [user.id],
-      proposalStatus: 'draft',
+      proposalStatus: 'discussion',
       reviewers: [
         {
           group: 'user',

--- a/lib/pages/__tests__/updateCardsFromProposals.spec.ts
+++ b/lib/pages/__tests__/updateCardsFromProposals.spec.ts
@@ -1,9 +1,8 @@
 import { DataNotFoundError } from '@charmverse/core/errors';
 import { prisma } from '@charmverse/core/prisma-client';
-import type { Block, Page, Space, User } from '@charmverse/core/prisma-client';
+import type { Page, Space, User } from '@charmverse/core/prisma-client';
 import { v4 } from 'uuid';
 
-import { prismaToBlock } from 'lib/focalboard/block';
 import type { BoardView } from 'lib/focalboard/boardView';
 import { InvalidStateError } from 'lib/middleware';
 import { generateUserAndSpaceWithApiToken, generateBoard, generateProposal } from 'testing/setupDatabase';
@@ -11,7 +10,7 @@ import { generateUserAndSpaceWithApiToken, generateBoard, generateProposal } fro
 import { createCardsFromProposals } from '../createCardsFromProposals';
 import { updateCardsFromProposals } from '../updateCardsFromProposals';
 
-describe('updateCardsFromProposals', () => {
+describe('updateCardsFromProposals()', () => {
   let user: User;
   let space: Space;
   let board: Page;
@@ -20,36 +19,20 @@ describe('updateCardsFromProposals', () => {
     const generated = await generateUserAndSpaceWithApiToken();
     user = generated.user;
     space = generated.space;
-    const generatedBoard = await generateBoard({
+    board = await generateBoard({
       createdBy: user.id,
       spaceId: space.id
     });
-    board = generatedBoard;
   });
 
   beforeEach(async () => {
-    await prisma.$transaction([
-      prisma.page.deleteMany({
-        where: {
-          id: {
-            not: undefined
-          }
-        }
-      }),
-      prisma.proposal.deleteMany({
-        where: {
-          id: {
-            not: undefined
-          }
-        }
-      })
-    ]);
+    await prisma.$transaction([prisma.page.deleteMany(), prisma.proposal.deleteMany()]);
   });
 
   it('should update cards from proposals', async () => {
     const pageProposal = await generateProposal({
       authors: [user.id],
-      proposalStatus: 'draft',
+      proposalStatus: 'discussion',
       reviewers: [
         {
           group: 'user',
@@ -139,6 +122,34 @@ describe('updateCardsFromProposals', () => {
     });
 
     expect(newCreatedCard?.syncWithPageId).toBe(pageProposal2.id);
+  });
+
+  it('should not create cards from draft proposals', async () => {
+    // populate board view
+    await createCardsFromProposals({ boardId: board.id, spaceId: space.id, userId: user.id });
+
+    const pageProposal2 = await generateProposal({
+      authors: [],
+      proposalStatus: 'draft',
+      reviewers: [],
+      spaceId: space.id,
+      userId: user.id
+    });
+
+    await updateCardsFromProposals({
+      boardId: board.id,
+      spaceId: space.id,
+      userId: user.id
+    });
+
+    const newCreatedCard = await prisma.page.findFirst({
+      where: {
+        type: 'card',
+        syncWithPageId: pageProposal2.id
+      }
+    });
+
+    expect(newCreatedCard).toBeNull();
   });
 
   it('should delete cards from proposals', async () => {

--- a/lib/pages/createCardPage.ts
+++ b/lib/pages/createCardPage.ts
@@ -9,7 +9,7 @@ import { getPagePath } from 'lib/pages/utils';
 export async function createCardPage(
   pageInfo: Record<keyof Pick<Page, 'title' | 'boardId' | 'createdBy' | 'spaceId'>, string> & {
     properties: Record<string, string | string[]>;
-  } & Partial<Pick<Page, 'content' | 'hasContent' | 'contentText' | 'syncWithPageId'>>
+  } & Partial<Pick<Page, 'content' | 'hasContent' | 'contentText' | 'syncWithPageId' | 'createdAt'>>
 ): Promise<{ page: Page; block: Block }> {
   const board = await prisma.block.findFirst({
     where: {
@@ -31,6 +31,7 @@ export async function createCardPage(
           id: pageInfo.createdBy
         }
       },
+      createdAt: pageInfo.createdAt,
       updatedBy: pageInfo.createdBy,
       type: 'card',
       rootId: pageInfo.boardId,

--- a/lib/pages/createCardsFromProposals.ts
+++ b/lib/pages/createCardsFromProposals.ts
@@ -100,10 +100,14 @@ export async function createCardsFromProposals({
 
   const cards: { page: Page; block: Block }[] = [];
   for (const pageProposal of pageProposals) {
+    const createdAt = pageProposal.workspaceEvents.find(
+      (event) => event.type === 'proposal_status_change' && (event.meta as any).newStatus === 'discussion'
+    )?.createdAt;
     const _card = await createCardPage({
       title: pageProposal.title,
       boardId,
       spaceId: pageProposal.spaceId,
+      createdAt,
       createdBy: userId,
       properties: { [newBoardField.id]: `${pageProposal.path}` },
       hasContent: pageProposal.hasContent,

--- a/lib/pages/createCardsFromProposals.ts
+++ b/lib/pages/createCardsFromProposals.ts
@@ -23,7 +23,15 @@ export async function createCardsFromProposals({
     where: {
       spaceId,
       type: 'proposal',
+      proposal: {
+        status: {
+          not: 'draft'
+        }
+      },
       deletedAt: null
+    },
+    include: {
+      workspaceEvents: true
     }
   });
   const board = (await prisma.block.findUnique({

--- a/lib/pages/updateCardsFromProposals.ts
+++ b/lib/pages/updateCardsFromProposals.ts
@@ -49,7 +49,15 @@ export async function updateCardsFromProposals({
   const pageProposals = await prisma.page.findMany({
     where: {
       spaceId,
-      type: 'proposal'
+      type: 'proposal',
+      proposal: {
+        status: {
+          not: 'draft'
+        }
+      }
+    },
+    include: {
+      workspaceEvents: true
     }
   });
 

--- a/lib/pages/updateCardsFromProposals.ts
+++ b/lib/pages/updateCardsFromProposals.ts
@@ -147,10 +147,14 @@ export async function updateCardsFromProposals({
    */
   const newCards: { page: Page; block: Block }[] = [];
   for (const pageProposal of newPageProposals) {
+    const createdAt = pageProposal.workspaceEvents.find(
+      (event) => event.type === 'proposal_status_change' && (event.meta as any).newStatus === 'discussion'
+    )?.createdAt;
     const _card = await createCardPage({
       title: pageProposal.title,
       boardId,
       spaceId: pageProposal.spaceId,
+      createdAt,
       createdBy: userId,
       properties: { [boardCardProp?.id || '']: `${pageProposal.path}` },
       hasContent: pageProposal.hasContent,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 041a36a</samp>

The pull request improves the functionality and testing of the `createCardsFromProposals` and `updateCardsFromProposals` functions, which convert proposals to Trello cards and card pages. It fixes bugs related to draft proposals and card page creation dates, and adds an option to specify the creation date of a card page. It also refactors and enhances the test files for these functions.

### WHY
1. dont import draft proposals
2. use the date a proposal was 'created' (ie set to discussion) as created date