### PR TITLE
Checkout - Feedback changes + Accept coupon and promo codes

### DIFF
--- a/charmClient/apis/subscriptionApi.ts
+++ b/charmClient/apis/subscriptionApi.ts
@@ -43,7 +43,7 @@ export class SubscriptionApi {
   }
 
   validateDiscount(spaceId: string, payload: { coupon: string }) {
-    return http.POST<ValidatedCoupon>(`/api/spaces/${spaceId}/validate-discount`, payload);
+    return http.POST<void>(`/api/spaces/${spaceId}/validate-discount`, payload);
   }
 
   upgradeSpaceSubscription(spaceId: string, payload: UpgradeSubscriptionRequest) {

--- a/components/settings/subscription/CheckoutForm.tsx
+++ b/components/settings/subscription/CheckoutForm.tsx
@@ -251,24 +251,18 @@ export function CheckoutForm({
           <Divider sx={{ my: 2 }} />
           <Stack gap={0.5} my={2}>
             <Typography>Coupon code</Typography>
-            <Stack>
+            <Stack display='flex' flexDirection='row' gap={1}>
               <TextField
-                disabled={isProcessing || !!subscription.coupon}
+                disabled={isProcessing || !!subscription.coupon || validating}
                 {...registerCoupon}
                 error={!!errors.coupon}
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position='end'>
-                      <IconButton
-                        onClick={() => (subscription?.coupon ? handleCoupon(undefined) : handleCoupon(couponField))}
-                        disabled={(subscription?.coupon ? false : !couponField) || validating}
-                      >
-                        {subscription?.coupon ? <CloseIcon /> : <SendIcon />}
-                      </IconButton>
-                    </InputAdornment>
-                  )
-                }}
               />
+              <Button
+                onClick={() => (subscription?.coupon ? handleCoupon(undefined) : handleCoupon(couponField))}
+                disabled={isProcessing || validating || !couponField}
+              >
+                {subscription?.coupon ? 'Remove' : 'Apply'}
+              </Button>
             </Stack>
           </Stack>
           <Divider sx={{ my: 2 }} />
@@ -306,18 +300,21 @@ export function CheckoutForm({
               <Button
                 onClick={createSubscription}
                 loading={isProcessing}
-                disabled={emailError || !emailField || isProcessing || !stripe || !elements}
+                disabled={emailError || !emailField || isProcessing || !stripe || !elements || validating}
               >
                 {isProcessing ? 'Processing ... ' : 'Upgrade'}
               </Button>
-              <Button disabled={isProcessing} onClick={onCancel} color='secondary' variant='text'>
+              <Button disabled={isProcessing || validating} onClick={onCancel} color='secondary' variant='text'>
                 Cancel
               </Button>
             </Stack>
           </PaymentTabPanel>
           <PaymentTabPanel value={paymentType} index='crypto'>
             <Stack gap={1} display='flex' flexDirection='column'>
-              <Button onClick={() => startCryptoPayment()} disabled={emailError || !emailField || isProcessing}>
+              <Button
+                onClick={() => startCryptoPayment()}
+                disabled={emailError || !emailField || isProcessing || validating}
+              >
                 Upgrade
               </Button>
               <Button disabled={isProcessing} onClick={onCancel} color='secondary' variant='text'>

--- a/components/settings/subscription/CheckoutForm.tsx
+++ b/components/settings/subscription/CheckoutForm.tsx
@@ -32,7 +32,8 @@ export function CheckoutForm({
   blockQuota,
   subscription,
   emailField,
-  couponField
+  couponField,
+  validating
 }: {
   emailField: string;
   couponField: string;
@@ -44,26 +45,13 @@ export function CheckoutForm({
     email: string;
     coupon: string;
   }>;
+  validating: boolean;
   registerCoupon: UseFormRegisterReturn<'coupon'>;
   onCancel: VoidFunction;
   handleCoupon: (coupon: string | undefined) => Promise<void>;
 }) {
   const stripe = useStripe();
   const elements = useElements();
-
-  // const {
-  //   register,
-  //   getValues,
-  //   watch,
-  //   formState: { errors }
-  // } = useForm<{ email: string; coupon: string }>({
-  //   mode: 'onChange',
-  //   defaultValues: {
-  //     email: subscription.email || '',
-  //     coupon: subscription.coupon || ''
-  //   },
-  //   resolver: yupResolver(schema())
-  // });
 
   useEffect(() => {
     charmClient.track.trackAction('page_view', {
@@ -222,7 +210,6 @@ export function CheckoutForm({
         email: emailField
       }
     });
-    setPendingPayment(true);
   };
 
   const price = period === 'annual' ? communityProduct.pricing.annual / 12 : communityProduct.pricing.monthly;
@@ -273,10 +260,10 @@ export function CheckoutForm({
                   endAdornment: (
                     <InputAdornment position='end'>
                       <IconButton
-                        onClick={subscription?.coupon ? undefined : () => handleCoupon(couponField)}
-                        disabled={!!(subscription?.coupon || !couponField)}
+                        onClick={() => (subscription?.coupon ? handleCoupon(undefined) : handleCoupon(couponField))}
+                        disabled={(subscription?.coupon ? false : !couponField) || validating}
                       >
-                        <SendIcon />
+                        {subscription?.coupon ? <CloseIcon /> : <SendIcon />}
                       </IconButton>
                     </InputAdornment>
                   )

--- a/components/settings/subscription/CheckoutForm.tsx
+++ b/components/settings/subscription/CheckoutForm.tsx
@@ -13,6 +13,7 @@ import useSWRMutation from 'swr/mutation';
 import charmClient from 'charmClient';
 import Button from 'components/common/Button';
 import LoadingComponent from 'components/common/LoadingComponent';
+import { isProdEnv } from 'config/constants';
 import { useSnackbar } from 'hooks/useSnackbar';
 import type { SubscriptionPeriod } from 'lib/subscription/constants';
 import { communityProduct, loopCheckoutUrl } from 'lib/subscription/constants';
@@ -20,7 +21,7 @@ import type { CreateCryptoSubscriptionRequest, SubscriptionPaymentIntent } from 
 import type { UpdateSubscriptionRequest } from 'lib/subscription/updateProSubscription';
 
 import type { PaymentType } from './PaymentTabs';
-import { PaymentTabPanel } from './PaymentTabs';
+import PaymentTabs, { PaymentTabPanel } from './PaymentTabs';
 
 export function CheckoutForm({
   onCancel,
@@ -223,8 +224,7 @@ export function CheckoutForm({
       )}
       <Grid container gap={2} sx={{ flexWrap: { sm: 'nowrap' } }}>
         <Grid item xs={12} sm={8} onSubmit={createSubscription}>
-          {/* @TODO - Reactivate this once Loop works */}
-          {/* <PaymentTabs value={paymentType} onChange={changePaymentType} /> */}
+          {!isProdEnv && <PaymentTabs value={paymentType} onChange={changePaymentType} />}
           <PaymentTabPanel value={paymentType} index='card'>
             <PaymentElement options={{ paymentMethodOrder: ['card', 'us_bank_account'] }} />
           </PaymentTabPanel>

--- a/components/settings/subscription/CreateSubscriptionInformation.tsx
+++ b/components/settings/subscription/CreateSubscriptionInformation.tsx
@@ -105,7 +105,7 @@ export function CreateSubscriptionInformation({
           </List>
         </Grid>
       </Grid>
-      <Divider sx={{ mb: 1 }} />
+      <Divider sx={{ mb: 1, mt: 2 }} />
       <Grid container spacing={5} sx={{ wrap: { sm: 'nowrap' } }}>
         <Grid item xs={12} sm={4} display='flex' flexDirection='column' gap={1}>
           <Typography variant='h6' mb={1}>

--- a/components/settings/subscription/PaymentMethod.tsx
+++ b/components/settings/subscription/PaymentMethod.tsx
@@ -15,7 +15,7 @@ export function PaymentMethod({ paymentMethod }: { paymentMethod: PaymentMethodW
         <Typography>
           {paymentMethod.type === 'card' &&
             `${stringUtils.capitalize(paymentMethod?.brand || '')} **** ${paymentMethod.digits}`}
-          {paymentMethod.type === 'us_bank_account' && `${'ACH Debit'} **** ${paymentMethod.digits}`}
+          {paymentMethod.type === 'us_bank_account' && `ACH Debit **** ${paymentMethod.digits}`}
         </Typography>
         {paymentMethod.updateUrl && (
           <Link external href={paymentMethod.updateUrl}>

--- a/components/settings/subscription/PlanSelection.tsx
+++ b/components/settings/subscription/PlanSelection.tsx
@@ -56,7 +56,8 @@ export function PlanSelection({
             disabled={disabled}
             size='small'
             aria-label='Block quota slider'
-            valueLabelDisplay='off'
+            valueLabelDisplay='auto'
+            valueLabelFormat={(value) => `${value}K`}
             value={blockQuotaInThousands}
             step={10}
             min={10}

--- a/components/settings/subscription/SubscriptionInformation.tsx
+++ b/components/settings/subscription/SubscriptionInformation.tsx
@@ -222,7 +222,9 @@ export function SubscriptionInformation({
             open={isConfirmUpgradeDialogOpen}
             buttonText='Confirm'
             secondaryButtonText='Cancel'
-            question='You are about to change the subscription of your space. This will automatically charge your payment method.'
+            question={`You are about to change your plan. ${
+              spaceSubscription.blockQuota < blockQuota ? 'This will automatically charge your payment method.' : ''
+            }`}
             onConfirm={() => upgradeSpaceSubscription({ spaceId: space.id, payload: { period, blockQuota } })}
             onClose={closeConfirmUpgradeDialog}
             disabled={isLoadingUpgrade}

--- a/components/settings/subscription/SubscriptionSettings.tsx
+++ b/components/settings/subscription/SubscriptionSettings.tsx
@@ -48,7 +48,7 @@ export function SubscriptionSettings({ space }: { space: Space }) {
     isLoading: isLoadingSpaceSubscription,
     refetchSpaceSubscription
   } = useSpaceSubscription({
-    returnUrl: `${window?.location.origin}/${router.asPath}?settingTab=subscription`
+    returnUrl: `${window?.location.origin}${router.asPath}?settingTab=subscription`
   });
 
   const [showCheckoutForm, setShowCheckoutForm] = useState(false);

--- a/components/settings/subscription/SubscriptionSettings.tsx
+++ b/components/settings/subscription/SubscriptionSettings.tsx
@@ -16,7 +16,6 @@ import { useSnackbar } from 'hooks/useSnackbar';
 import type { SubscriptionPeriod } from 'lib/subscription/constants';
 import type { CreateProSubscriptionRequest } from 'lib/subscription/interfaces';
 
-import { SETTINGS_TABS } from '../config';
 import Legend from '../Legend';
 
 import { CheckoutForm } from './CheckoutForm';
@@ -32,8 +31,7 @@ const schema = () => {
   return yup
     .object({
       email: yup.string().email().required(),
-      coupon: yup.string().optional(),
-      validatedCouponId: yup.string().optional()
+      coupon: yup.string().optional()
     })
     .strict();
 };
@@ -50,9 +48,7 @@ export function SubscriptionSettings({ space }: { space: Space }) {
     isLoading: isLoadingSpaceSubscription,
     refetchSpaceSubscription
   } = useSpaceSubscription({
-    returnUrl: `${window?.location.origin}/${router.asPath}?settingTab=${
-      SETTINGS_TABS.find((tab) => tab.path === 'subscription')?.path
-    }`
+    returnUrl: `${window?.location.origin}/${router.asPath}?settingTab=subscription`
   });
 
   const [showCheckoutForm, setShowCheckoutForm] = useState(false);
@@ -65,8 +61,7 @@ export function SubscriptionSettings({ space }: { space: Space }) {
   } = useForm<FormValues>({
     defaultValues: {
       email: '',
-      coupon: '',
-      validatedCouponId: ''
+      coupon: ''
     },
     resolver: yupResolver(schema())
   });
@@ -85,7 +80,7 @@ export function SubscriptionSettings({ space }: { space: Space }) {
       },
       async onSuccess(data) {
         setShowCheckoutForm(true);
-        setValue('validatedCouponId', data.coupon || '');
+        setValue('coupon', data.coupon || '');
         setValue('email', data.email || '');
       }
     }
@@ -93,20 +88,15 @@ export function SubscriptionSettings({ space }: { space: Space }) {
 
   const emailField = watch('email');
   const couponField = watch('coupon');
-  const validatedCoupon = watch('validatedCouponId');
 
   const { trigger: validateCoupon, isMutating: isValidationLoading } = useSWRMutation(
     `/api/spaces/${space?.id}/subscription`,
     (_url, { arg }: Readonly<{ arg: { spaceId: string; payload: { coupon: string } } }>) =>
-      charmClient.subscription.validateDiscount(arg.spaceId, arg.payload).then((coupon) => {
-        setValue('validatedCouponId', coupon.couponId);
-        return coupon;
-      }),
+      charmClient.subscription.validateDiscount(arg.spaceId, arg.payload),
     {
       onError() {
         showMessage('Your coupon is not valid', 'error');
         setValue('coupon', '');
-        setValue('validatedCouponId', '');
       }
     }
   );
@@ -146,7 +136,7 @@ export function SubscriptionSettings({ space }: { space: Space }) {
         period,
         blockQuota: minimumBlockQuota > blockQuota ? minimumBlockQuota : blockQuota,
         billingEmail: emailField,
-        coupon: validatedCoupon
+        coupon: initialSubscriptionData?.coupon
       }
     });
   }
@@ -167,29 +157,28 @@ export function SubscriptionSettings({ space }: { space: Space }) {
           blockQuota: minimumBlockQuota > _blockQuota ? minimumBlockQuota : _blockQuota,
           period,
           billingEmail: emailField,
-          coupon: validatedCoupon
+          coupon: initialSubscriptionData?.coupon
         }
       });
     } else if (_period) {
       await createSubscription({
         spaceId: space.id,
-        payload: { blockQuota, period: _period, billingEmail: emailField, coupon: validatedCoupon }
+        payload: { blockQuota, period: _period, billingEmail: emailField, coupon: initialSubscriptionData?.coupon }
       });
     }
   };
 
   const handleCoupon = async (coupon: string | undefined) => {
-    let applicableCouponId: string | undefined;
     if (coupon) {
-      applicableCouponId = await validateCoupon({
+      await validateCoupon({
         spaceId: space.id,
         payload: { coupon }
-      }).then((validated) => validated?.couponId);
+      });
     }
 
     await createSubscription({
       spaceId: space.id,
-      payload: { blockQuota, period, coupon: applicableCouponId, billingEmail: emailField }
+      payload: { blockQuota, period, coupon, billingEmail: emailField }
     });
   };
 
@@ -219,7 +208,8 @@ export function SubscriptionSettings({ space }: { space: Space }) {
       </Stack>
     );
   }
-  const isLoading = isValidationLoading || isInitialSubscriptionLoading || isLoadingSpaceSubscription;
+
+  const isLoading = isInitialSubscriptionLoading || isLoadingSpaceSubscription;
 
   return (
     <Stack gap={1}>
@@ -272,6 +262,7 @@ export function SubscriptionSettings({ space }: { space: Space }) {
             onCancel={() => setShowCheckoutForm(false)}
             errors={errors}
             registerCoupon={{ ...register('coupon') }}
+            validating={isValidationLoading}
           />
         </Elements>
       )}

--- a/hooks/useSettingsDialog.tsx
+++ b/hooks/useSettingsDialog.tsx
@@ -55,7 +55,7 @@ export function SettingsDialogProvider({ children }: { children: ReactNode }) {
 
     if (router.query.settingTab && SETTINGS_TABS.some((tab) => tab.path === router.query.settingTab)) {
       onClick(router.query.settingTab as string);
-      router.push(router.asPath.split('?')[0]);
+      setUrlWithoutRerender(router.pathname, { settingTab: null });
     }
     // If the user clicks a link inside the modal, close the modal only
     router.events.on('routeChangeStart', close);

--- a/lib/subscription/__tests__/createProSubscription.spec.ts
+++ b/lib/subscription/__tests__/createProSubscription.spec.ts
@@ -119,7 +119,8 @@ describe('createProSubscription', () => {
     });
 
     expect(createSubscriptionsMockFn).toHaveBeenCalledWith({
-      coupon: '',
+      coupon: undefined,
+      promotion_code: undefined,
       metadata: {
         tier: 'pro',
         period: 'monthly',
@@ -136,6 +137,8 @@ describe('createProSubscription', () => {
       payment_settings: {
         save_default_payment_method: 'on_subscription'
       },
+      trial_period_days: undefined,
+      trial_settings: undefined,
       payment_behavior: 'default_incomplete',
       expand: ['latest_invoice.payment_intent']
     });

--- a/lib/subscription/createCryptoSubscription.ts
+++ b/lib/subscription/createCryptoSubscription.ts
@@ -9,6 +9,7 @@ export async function createCryptoSubscription({
   subscriptionId,
   email
 }: CreateCryptoSubscriptionRequest): Promise<CreateCryptoSubscriptionResponse> {
+  const encodedEmail = encodeURIComponent(email);
   const subscription = await stripeClient.subscriptions.retrieve(subscriptionId);
 
   const priceId = subscription.items.data[0].price.id;
@@ -25,6 +26,6 @@ export async function createCryptoSubscription({
   }
 
   return loopItem.url
-    ? `${loopItem.url}?embed=true&cartEnabled=false&email=${email}&sub=${subscriptionId}`
-    : `${loopCheckoutUrl}/${loopItem.entityId}/${loopItem.itemId}?embed=true&cartEnabled=false&email=${email}&sub=${subscriptionId}`;
+    ? `${loopItem.url}?embed=true&cartEnabled=false&email=${encodedEmail}&sub=${subscriptionId}`
+    : `${loopCheckoutUrl}/${loopItem.entityId}/${loopItem.itemId}?embed=true&cartEnabled=false&email=${encodedEmail}&sub=${subscriptionId}`;
 }

--- a/lib/subscription/createProSubscription.ts
+++ b/lib/subscription/createProSubscription.ts
@@ -5,6 +5,7 @@ import { InvalidStateError, NotFoundError } from 'lib/middleware';
 
 import { communityProduct } from './constants';
 import { getActiveSpaceSubscription } from './getActiveSpaceSubscription';
+import { getCouponId } from './getCouponId';
 import { getCommunityPrice } from './getProductPrice';
 import type { CreateProSubscriptionRequest, ProSubscriptionResponse, StripeMetadataKeys } from './interfaces';
 import { stripeClient } from './stripe';
@@ -98,6 +99,11 @@ export async function createProSubscription({
     await stripeClient.subscriptions.del(existingStripeSubscription.id);
   }
 
+  let promoCodeData;
+  if (coupon) {
+    promoCodeData = await getCouponId(coupon);
+  }
+
   const subscription = await stripeClient.subscriptions.create({
     metadata: {
       productId,
@@ -113,7 +119,14 @@ export async function createProSubscription({
         quantity: blockQuota
       }
     ],
-    coupon,
+    ...(promoCodeData
+      ? {
+          [promoCodeData.type]: promoCodeData.id
+        }
+      : {
+          coupon: undefined,
+          promotion_code: undefined
+        }),
     payment_settings: {
       save_default_payment_method: 'on_subscription'
     },
@@ -131,7 +144,6 @@ export async function createProSubscription({
 
   const invoice = subscription.latest_invoice as Stripe.Invoice;
   const paymentIntent = invoice.payment_intent as Stripe.PaymentIntent | null;
-  const discountCoupon = invoice.discount?.coupon?.id;
 
   return {
     subscriptionId: subscription.id,
@@ -149,7 +161,7 @@ export async function createProSubscription({
           clientSecret: paymentIntent.client_secret as string,
           subTotalPrice: ((subscription.latest_invoice as Stripe.Invoice).subtotal || 0) / 100,
           totalPrice: ((subscription.latest_invoice as Stripe.Invoice).total || 0) / 100,
-          coupon: discountCoupon
+          coupon
         }
       : undefined
   };

--- a/lib/subscription/createProSubscription.ts
+++ b/lib/subscription/createProSubscription.ts
@@ -5,7 +5,7 @@ import { InvalidStateError, NotFoundError } from 'lib/middleware';
 
 import { communityProduct } from './constants';
 import { getActiveSpaceSubscription } from './getActiveSpaceSubscription';
-import { getCouponId } from './getCouponId';
+import { getCouponDetails } from './getCouponDetails';
 import { getCommunityPrice } from './getProductPrice';
 import type { CreateProSubscriptionRequest, ProSubscriptionResponse, StripeMetadataKeys } from './interfaces';
 import { stripeClient } from './stripe';
@@ -101,7 +101,7 @@ export async function createProSubscription({
 
   let promoCodeData;
   if (coupon) {
-    promoCodeData = await getCouponId(coupon);
+    promoCodeData = await getCouponDetails(coupon);
   }
 
   const subscription = await stripeClient.subscriptions.create({

--- a/lib/subscription/getCouponDetails.ts
+++ b/lib/subscription/getCouponDetails.ts
@@ -2,7 +2,7 @@ import type Stripe from 'stripe';
 
 import { stripeClient } from './stripe';
 
-export async function getCouponId(
+export async function getCouponDetails(
   couponCode: string
 ): Promise<{ id: string; type: 'coupon' | 'promotion_code' } | undefined> {
   const listPromocode = await stripeClient.promotionCodes.list({ code: couponCode, active: true });

--- a/lib/subscription/getCouponId.ts
+++ b/lib/subscription/getCouponId.ts
@@ -1,0 +1,24 @@
+import type Stripe from 'stripe';
+
+import { stripeClient } from './stripe';
+
+export async function getCouponId(
+  couponCode: string
+): Promise<{ id: string; type: 'coupon' | 'promotion_code' } | undefined> {
+  const listPromocode = await stripeClient.promotionCodes.list({ code: couponCode, active: true });
+  const promocode: Stripe.PromotionCode | undefined = listPromocode.data[0];
+
+  if (!promocode) {
+    try {
+      const couponData = await stripeClient.coupons.retrieve(couponCode);
+      return { id: couponData.id, type: 'coupon' };
+    } catch (_) {
+      return undefined;
+    }
+  } else {
+    if (!promocode.coupon.valid) {
+      return undefined;
+    }
+    return { id: promocode.id, type: 'promotion_code' };
+  }
+}

--- a/pages/api/spaces/[id]/validate-discount.ts
+++ b/pages/api/spaces/[id]/validate-discount.ts
@@ -1,17 +1,10 @@
-import { DataNotFoundError, InvalidInputError } from '@charmverse/core/errors';
+import { InvalidInputError } from '@charmverse/core/errors';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
-import {
-  onError,
-  onNoMatch,
-  requireUser,
-  requireSpaceMembership,
-  requireKeys,
-  InvalidStateError
-} from 'lib/middleware';
+import { onError, onNoMatch, requireUser, requireSpaceMembership, requireKeys } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
-import { stripeClient } from 'lib/subscription/stripe';
+import { getCouponId } from 'lib/subscription/getCouponId';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
@@ -33,25 +26,15 @@ export type ValidatedCoupon = {
 
 async function validateDiscount(req: NextApiRequest, res: NextApiResponse<ValidatedCoupon>) {
   const couponCode = req.body.coupon;
+  const spaceId = req.query.id as string;
 
-  if (!couponCode) {
-    throw new InvalidInputError(`Please enter a coupon`);
+  const coupon = await getCouponId(couponCode);
+
+  if (!coupon) {
+    throw new InvalidInputError(`Invalid promotional code ${couponCode} for space ${spaceId}`);
   }
 
-  const matchedCoupon = await stripeClient.promotionCodes
-    .list()
-    .then((data) => data.data.find((coupon) => coupon.id === couponCode || coupon.code === couponCode));
-
-  if (!matchedCoupon) {
-    throw new DataNotFoundError(`Coupon not found ${matchedCoupon}`);
-  } else if (!matchedCoupon.coupon.valid) {
-    throw new InvalidStateError(`This coupon is not valid`);
-  }
-
-  res.status(200).send({
-    couponId: matchedCoupon.coupon.id,
-    valid: true
-  });
+  res.status(200).end();
 }
 
 export default withSessionRoute(handler);

--- a/pages/api/spaces/[id]/validate-discount.ts
+++ b/pages/api/spaces/[id]/validate-discount.ts
@@ -4,7 +4,7 @@ import nc from 'next-connect';
 
 import { onError, onNoMatch, requireUser, requireSpaceMembership, requireKeys } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
-import { getCouponId } from 'lib/subscription/getCouponId';
+import { getCouponDetails } from 'lib/subscription/getCouponDetails';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
@@ -28,7 +28,7 @@ async function validateDiscount(req: NextApiRequest, res: NextApiResponse<Valida
   const couponCode = req.body.coupon;
   const spaceId = req.query.id as string;
 
-  const coupon = await getCouponId(couponCode);
+  const coupon = await getCouponDetails(couponCode);
 
   if (!coupon) {
     throw new InvalidInputError(`Invalid promotional code ${couponCode} for space ${spaceId}`);

--- a/pages/api/v1/webhooks/stripe/index.ts
+++ b/pages/api/v1/webhooks/stripe/index.ts
@@ -326,6 +326,7 @@ export async function stripePayment(req: NextApiRequest, res: NextApiResponse): 
         const subscriptionData: Stripe.InvoiceLineItem | undefined = invoice.lines.data[0];
         const priceId = subscriptionData?.price?.id;
         const email = (stripeSubscription.customer as Stripe.Customer)?.email as string | undefined | null;
+        const encodedEmail = email ? `&email=${encodeURIComponent(email)}` : '';
 
         if (!stripeSubscription.metadata.loopCheckout && priceId) {
           const loopItems = await getLoopProducts();
@@ -340,8 +341,8 @@ export async function stripePayment(req: NextApiRequest, res: NextApiResponse): 
           }
 
           const loopUrl = loopItem.url
-            ? `${loopItem.url}?cartEnabled=false&email=${email}&sub=${subscriptionId}`
-            : `${loopCheckoutUrl}/${loopItem.entityId}/${loopItem.itemId}?&cartEnabled=false&email=${email}&sub=${subscriptionId}`;
+            ? `${loopItem.url}?cartEnabled=false${encodedEmail}&sub=${subscriptionId}`
+            : `${loopCheckoutUrl}/${loopItem.entityId}/${loopItem.itemId}?&cartEnabled=false${encodedEmail}&sub=${subscriptionId}`;
 
           await stripeClient.subscriptions.update(subscriptionId, {
             metadata: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfd8c23</samp>

Refactored the coupon validation and subscription creation logic to use Stripe's coupon id instead of coupon code and type. Simplified the `CheckoutForm` and `SubscriptionSettings` components to enable removing the coupon and show the validation status. Added a new `getCouponId` function to `lib/subscription/getCouponId.ts` to handle both coupon and promotion code types.

### WHY
Before we had only coupon codes.
After some changes, the coupon codes were not working anymore, only promo codes were working.

This PR introduces the flexibility for both to work or fail if none of the 2 are valid.
