### PR TITLE
Disable WalletConnect

### DIFF
--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -2,8 +2,9 @@ import { log } from '@charmverse/core/log';
 import type { IdentityType } from '@charmverse/core/prisma';
 import ArrowSquareOut from '@mui/icons-material/Launch';
 import { Grid, IconButton, Typography } from '@mui/material';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import Alert from '@mui/material/Alert';
+import Tooltip from '@mui/material/Tooltip';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import type { AbstractConnector } from '@web3-react/abstract-connector';
 import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
@@ -134,14 +135,19 @@ export function WalletSelector({ loginSuccess, onError = () => null }: Props) {
         </Grid>
 
         <Grid item xs={12}>
-          <ConnectorButton
-            name='WalletConnect'
-            onClick={() => handleConnect(walletConnect)}
-            iconUrl='walletconnect.svg'
-            disabled={connector === walletConnect || !!activatingConnector}
-            isActive={connector === walletConnect}
-            isLoading={activatingConnector === walletConnect}
-          />
+          <Tooltip title='This signin method is unavailable while we migrate WalletConnect to the new version'>
+            <div>
+              <ConnectorButton
+                name='WalletConnect'
+                onClick={() => handleConnect(walletConnect)}
+                iconUrl='walletconnect.svg'
+                // disabled={connector === walletConnect || !!activatingConnector}
+                disabled
+                isActive={connector === walletConnect}
+                isLoading={activatingConnector === walletConnect}
+              />
+            </div>
+          </Tooltip>
         </Grid>
         <Grid item xs={12}>
           <ConnectorButton


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fba3ff</samp>

Disabled WalletConnect option in `WalletSelectorModal` and added a tooltip to inform users of its upcoming replacement. Used `Tooltip` component from `@mui/material` for the message.

### WHY

WalletConnect v1 is now unavailable. This prevents using the login method while we migrate to v2

<img width="505" alt="Screenshot 2023-06-30 at 17 48 59" src="https://github.com/charmverse/app.charmverse.io/assets/18669748/f9a522e3-08a5-4395-9d46-c795663cf1d1">

