### PR TITLE
Always allow Partner API keys through payment required check

### DIFF
--- a/lib/middleware/requireApiKey.ts
+++ b/lib/middleware/requireApiKey.ts
@@ -88,11 +88,18 @@ export async function getBotUser(spaceId: string): Promise<User> {
   return botUser;
 }
 
+type APIKeyType = 'space' | 'partner';
+
+type SpaceWithKey = {
+  space: Space;
+  apiKey: { type: APIKeyType; key: string };
+};
+
 /**
  * @returns Space linked to API key in the request
  * Throws if the API key or space do not exist
  */
-export async function setRequestSpaceFromApiKey(req: NextApiRequest): Promise<Space> {
+export async function setRequestSpaceFromApiKey(req: NextApiRequest): Promise<SpaceWithKey> {
   const apiKey = req.headers?.authorization?.split('Bearer').join('').trim() ?? (req.query.api_key as string);
 
   // Protect against api keys or nullish API Keys
@@ -111,7 +118,10 @@ export async function setRequestSpaceFromApiKey(req: NextApiRequest): Promise<Sp
     req.spaceIdRange = superApiKeyData.spaceIdRange;
     req.superApiToken = superApiKeyData.superApiKey;
 
-    return superApiKeyData.authorizedSpace;
+    return {
+      space: superApiKeyData.authorizedSpace,
+      apiKey: { key: superApiKeyData.superApiKey.token, type: 'partner' }
+    } as SpaceWithKey;
   }
 
   const spaceToken = await prisma.spaceApiToken.findFirst({
@@ -128,7 +138,7 @@ export async function setRequestSpaceFromApiKey(req: NextApiRequest): Promise<Sp
   }
 
   req.authorizedSpaceId = spaceToken.spaceId;
-  return spaceToken.space;
+  return { space: spaceToken.space, apiKey: { key: spaceToken.token, type: 'space' } } as SpaceWithKey;
 }
 
 /**
@@ -138,12 +148,14 @@ export async function setRequestSpaceFromApiKey(req: NextApiRequest): Promise<Sp
  */
 export async function requireApiKey(req: NextApiRequest, res: NextApiResponse, next: NextHandler) {
   try {
-    await setRequestSpaceFromApiKey(req);
+    const apiKeyCheck = await setRequestSpaceFromApiKey(req);
 
-    const client = await getPermissionsClient({ resourceId: req.authorizedSpaceId, resourceIdType: 'space' });
+    if (apiKeyCheck.apiKey.type === 'space') {
+      const client = await getPermissionsClient({ resourceId: req.authorizedSpaceId, resourceIdType: 'space' });
 
-    if (client.type === 'free') {
-      throw new SubscriptionRequiredError();
+      if (client.type === 'free') {
+        throw new SubscriptionRequiredError();
+      }
     }
 
     const querySpaceId = req.query?.spaceId;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5c2242</samp>

This pull request enhances the `requireApiKey` middleware to support partner API keys and free spaces. It also adds a test case to verify the new functionality. This is part of the feature to enable partner integrations with Charmverse.

### WHY
<!-- author to complete -->
