### PR TITLE
cleanup spacing for paid banner

### DIFF
--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -13,6 +13,7 @@ import { PageDialogProvider } from 'components/common/PageDialog/hooks/usePageDi
 import { SharedPageLayout } from 'components/common/PageLayout/SharedPageLayout';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { FocalboardViewsProvider } from 'hooks/useFocalboardViews';
+import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useLocalStorage } from 'hooks/useLocalStorage';
 import { useSmallScreen } from 'hooks/useMediaScreens';
 import { useResize } from 'hooks/useResize';
@@ -139,6 +140,7 @@ function PageLayout({ children }: PageLayoutProps) {
   const [storageOpen, setStorageOpen] = useLocalStorage('leftSidebar', !isMobile);
   const [sidebarStorageWidth, setSidebarStorageWidth] = useLocalStorage('leftSidebarWidth', 300);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const isAdmin = useIsAdmin();
 
   const {
     width: resizableSidebarWidth,
@@ -218,7 +220,7 @@ function PageLayout({ children }: PageLayoutProps) {
                 <>
                   <AppBar open={open} sidebarWidth={displaySidebarWidth} position='fixed'>
                     <Header open={open} openSidebar={handleDrawerOpen} />
-                    {space?.paidTier === 'pro' && <PaidAnnouncementBanner spaceId={space.id} />}
+                    {isAdmin && space?.paidTier === 'pro' && <PaidAnnouncementBanner spaceId={space.id} />}
                   </AppBar>
                   {isMobile ? (
                     <MuiDrawer

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -218,7 +218,7 @@ function PageLayout({ children }: PageLayoutProps) {
                 <>
                   <AppBar open={open} sidebarWidth={displaySidebarWidth} position='fixed'>
                     <Header open={open} openSidebar={handleDrawerOpen} />
-                    <PaidAnnouncementBanner />
+                    {space?.paidTier === 'pro' && <PaidAnnouncementBanner spaceId={space.id} />}
                   </AppBar>
                   {isMobile ? (
                     <MuiDrawer

--- a/components/common/PageLayout/components/PaidAnnouncementBanner.tsx
+++ b/components/common/PageLayout/components/PaidAnnouncementBanner.tsx
@@ -14,8 +14,8 @@ const UpgradeButton = styled(Button)`
   padding-top: 0;
 `;
 
-export function PaidAnnouncementBanner() {
-  const [showPaidAnnouncementBar, setShowPaidAnnouncementBar] = useLocalStorage('show-paid-banner', true);
+export function PaidAnnouncementBanner({ spaceId }: { spaceId: string }) {
+  const [showPaidAnnouncementBar, setShowPaidAnnouncementBar] = useLocalStorage(`show-paid-banner/${spaceId}`, true);
   const { onClick } = useSettingsDialog();
 
   return showPaidAnnouncementBar ? (

--- a/components/common/PageLayout/components/PaidAnnouncementBanner.tsx
+++ b/components/common/PageLayout/components/PaidAnnouncementBanner.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import CloseIcon from '@mui/icons-material/Close';
 import EastIcon from '@mui/icons-material/East';
 import { Box, IconButton, Stack, Typography } from '@mui/material';
@@ -6,6 +7,12 @@ import { StyledBanner } from 'components/common/Banners/Banner';
 import Button from 'components/common/Button';
 import { useLocalStorage } from 'hooks/useLocalStorage';
 import { useSettingsDialog } from 'hooks/useSettingsDialog';
+
+const UpgradeButton = styled(Button)`
+  font-weight: 600;
+  padding-bottom: 0;
+  padding-top: 0;
+`;
 
 export function PaidAnnouncementBanner() {
   const [showPaidAnnouncementBar, setShowPaidAnnouncementBar] = useLocalStorage('show-paid-banner', true);
@@ -17,21 +24,15 @@ export function PaidAnnouncementBanner() {
         <Typography component='div'>
           Community Edition available. Upgrade NOW using code <b>"charmed"</b> for 40% off for the 1st year.{' '}
           <Stack gap={0.5} flexDirection='row' alignItems='center' display='inline-flex'>
-            <Button
-              color='inherit'
+            <UpgradeButton
+              endIcon={<EastIcon />}
+              sx={{ ml: 2 }}
+              color='primary'
               onClick={() => onClick('subscription')}
-              variant='text'
-              sx={{
-                fontSize: 15,
-                fontWeight: 600,
-                '&:hover': {
-                  backgroundColor: 'transparent'
-                }
-              }}
+              variant='outlined'
             >
               UPGRADE
-              <EastIcon sx={{ position: 'relative', top: 1.5, fontSize: 16, ml: 1 }} />
-            </Button>
+            </UpgradeButton>
           </Stack>
         </Typography>
       </Box>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f57a373</samp>

Created a custom `UpgradeButton` component for the upgrade prompt in the `PaidAnnouncementBanner` component. This component enhances the UI and UX of the banner by using a styled `Button` component with an icon and a different color scheme.

### WHY
Fixes the current banner has some odd vertical spacing due to padding on the 'upgrade' button, and the close button is no longer lined up:

![image](https://github.com/charmverse/app.charmverse.io/assets/305398/c6c6609d-d08f-4180-8038-4ac4c946074d)
