### PR TITLE
Feat/udomain oauth v2

### DIFF
--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -21,8 +21,7 @@ import type { AnyIdLogin } from 'components/login/LoginButton';
 import { useCustomDomain } from 'hooks/useCustomDomain';
 import type { UnstoppableDomainsAuthSig } from 'lib/blockchain/unstoppableDomains';
 import { extractDomainFromProof } from 'lib/blockchain/unstoppableDomains/client';
-import { getAppUrl } from 'lib/utilities/browser';
-import { isLocalhostAlias } from 'lib/utilities/domains/isLocalhostAlias';
+import { getCallbackDomain } from 'lib/oauth/getCallbackDomain';
 import type { DisabledAccountError } from 'lib/utilities/errors';
 import { BrowserPopupError } from 'lib/utilities/errors';
 
@@ -50,7 +49,6 @@ export function WalletSelector({ loginSuccess, onError = () => null }: Props) {
   } = useContext(Web3Connection);
   const { error } = useWeb3React();
   const { active, activate, connector, setError } = useWeb3React();
-  const { isOnCustomDomain } = useCustomDomain();
 
   const [uAuthPopupError, setUAuthPopupError] = useState<BrowserPopupError | null>(null);
   const handleConnect = (_connector: AbstractConnector) => {
@@ -92,7 +90,7 @@ export function WalletSelector({ loginSuccess, onError = () => null }: Props) {
   }, [error, openNetworkModal, closeWalletSelectorModal]);
 
   const clientID = process.env.NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_CLIENT_ID as string;
-  const redirectUri = typeof window === 'undefined' ? '' : window.location.origin;
+  const redirectUri = getCallbackDomain(typeof window === 'undefined' ? '' : window.location.hostname).toString();
   log.info('Connect redirectUri', redirectUri);
 
   async function handleUnstoppableDomainsLogin() {
@@ -160,24 +158,24 @@ export function WalletSelector({ loginSuccess, onError = () => null }: Props) {
             isLoading={activatingConnector === walletLink}
           />
         </Grid>
-        {!isOnCustomDomain && (
-          <Grid item xs={12}>
-            <ConnectorButton
-              name='Unstoppable Domains'
-              onClick={handleUnstoppableDomainsLogin}
-              iconUrl='unstoppable-domains.png'
-              disabled={false}
-              isActive={false}
-              isLoading={isConnectingIdentity}
-            />
-            {uAuthPopupError && (
-              <Alert severity='warning'>
-                Could not open Unstoppable Domains. Please ensure popups are enabled for the CharmVerse site in your
-                browser.
-              </Alert>
-            )}
-          </Grid>
-        )}
+
+        <Grid item xs={12}>
+          <ConnectorButton
+            name='Unstoppable Domains'
+            onClick={handleUnstoppableDomainsLogin}
+            iconUrl='unstoppable-domains.png'
+            disabled={false}
+            isActive={false}
+            isLoading={isConnectingIdentity}
+          />
+          {uAuthPopupError && (
+            <Alert severity='warning'>
+              Could not open Unstoppable Domains. Please ensure popups are enabled for the CharmVerse site in your
+              browser.
+            </Alert>
+          )}
+        </Grid>
+
         <Grid item>
           <Typography variant='caption' align='center'>
             New to Ethereum wallets?{' '}

--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -3,29 +3,24 @@ import type { IdentityType } from '@charmverse/core/prisma';
 import ArrowSquareOut from '@mui/icons-material/Launch';
 import { Grid, IconButton, Typography } from '@mui/material';
 import Alert from '@mui/material/Alert';
-import Tooltip from '@mui/material/Tooltip';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { AbstractConnector } from '@web3-react/abstract-connector';
 import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
 import { injected, walletConnect, walletLink } from 'connectors';
 import { WalletConnectV2Connector } from 'connectors/walletConnectV2Connector';
-import { useContext, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
-import charmClient from 'charmClient';
 import { useMetamaskConnect } from 'components/_app/Web3ConnectionManager/hooks/useMetamaskConnect';
 import ErrorComponent from 'components/common/errors/WalletError';
 import Link from 'components/common/Link';
 import { Modal } from 'components/common/Modal';
 import type { AnyIdLogin } from 'components/login/LoginButton';
-import { useCustomDomain } from 'hooks/useCustomDomain';
-import type { UnstoppableDomainsAuthSig } from 'lib/blockchain/unstoppableDomains';
-import { extractDomainFromProof } from 'lib/blockchain/unstoppableDomains/client';
+import { useUnstoppableDomains } from 'hooks/useUnstoppableDomains';
 import { getCallbackDomain } from 'lib/oauth/getCallbackDomain';
 import type { DisabledAccountError } from 'lib/utilities/errors';
-import { BrowserPopupError } from 'lib/utilities/errors';
 
-import { Web3Connection } from '../../Web3ConnectionManager';
+import { useWeb3ConnectionManager } from '../../Web3ConnectionManager';
 
 import { ConnectorButton } from './components/ConnectorButton';
 import processConnectionError from './utils/processConnectionError';
@@ -40,17 +35,15 @@ type Props = {
 export function WalletSelector({ loginSuccess, onError = () => null }: Props) {
   const {
     setActivatingConnector,
-    isWalletSelectorModalOpen,
     closeWalletSelectorModal,
     openNetworkModal,
-    setIsConnectingIdentity,
     isConnectingIdentity,
     activatingConnector
-  } = useContext(Web3Connection);
+  } = useWeb3ConnectionManager();
   const { error } = useWeb3React();
   const { active, activate, connector, setError } = useWeb3React();
+  const { uAuthPopupError, unstoppableDomainsLogin } = useUnstoppableDomains();
 
-  const [uAuthPopupError, setUAuthPopupError] = useState<BrowserPopupError | null>(null);
   const handleConnect = (_connector: AbstractConnector) => {
     setActivatingConnector(_connector);
     activate(_connector, undefined, true).catch((err) => {
@@ -77,47 +70,17 @@ export function WalletSelector({ loginSuccess, onError = () => null }: Props) {
   }, [active]);
 
   useEffect(() => {
-    if (!isWalletSelectorModalOpen) {
-      setUAuthPopupError(null);
-    }
-  }, [isWalletSelectorModalOpen]);
-
-  useEffect(() => {
     if (error instanceof UnsupportedChainIdError) {
       closeWalletSelectorModal();
       openNetworkModal();
     }
   }, [error, openNetworkModal, closeWalletSelectorModal]);
 
-  const clientID = process.env.NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_CLIENT_ID as string;
   const redirectUri = getCallbackDomain(typeof window === 'undefined' ? '' : window.location.hostname).toString();
   log.info('Connect redirectUri', redirectUri);
 
   async function handleUnstoppableDomainsLogin() {
-    const UAuth = (await import('@uauth/js')).default;
-    const uauth = new UAuth({
-      clientID,
-      redirectUri,
-      scope: 'openid wallet'
-    });
-
-    setIsConnectingIdentity(true);
-    try {
-      const authSig = (await uauth.loginWithPopup()) as any as UnstoppableDomainsAuthSig;
-      const user = await charmClient.unstoppableDomains.login({ authSig });
-
-      const domain = extractDomainFromProof(authSig);
-
-      loginSuccess({ displayName: domain, identityType: 'UnstoppableDomain', user });
-    } catch (err) {
-      if ((err as DisabledAccountError)?.errorType === 'Disabled account') {
-        onError(err as DisabledAccountError);
-      } else if ((err as Error).message.match('failed to be constructed')) {
-        setUAuthPopupError(new BrowserPopupError());
-      }
-      setIsConnectingIdentity(false);
-      log.error(err);
-    }
+    unstoppableDomainsLogin({ loginSuccess, onError });
   }
 
   return (
@@ -198,7 +161,7 @@ function resetWalletConnector(connector: AbstractConnector) {
   }
 }
 export function WalletSelectorModal({ loginSuccess, onError }: Props) {
-  const { isWalletSelectorModalOpen, closeWalletSelectorModal } = useContext(Web3Connection);
+  const { isWalletSelectorModalOpen, closeWalletSelectorModal } = useWeb3ConnectionManager();
   return (
     <Modal open={isWalletSelectorModalOpen} onClose={closeWalletSelectorModal}>
       <WalletSelector loginSuccess={loginSuccess} onError={onError} />

--- a/hooks/useUnstoppableDomains.ts
+++ b/hooks/useUnstoppableDomains.ts
@@ -1,0 +1,103 @@
+import { log } from '@charmverse/core/log';
+import { useState, useEffect } from 'react';
+
+import charmClient from 'charmClient';
+import { useWeb3ConnectionManager } from 'components/_app/Web3ConnectionManager/Web3ConnectionManager';
+import type { AnyIdLogin } from 'components/login/LoginButton';
+import { useCustomDomain } from 'hooks/useCustomDomain';
+import { usePopupLogin } from 'hooks/usePopupLogin';
+import { extractDomainFromProof, type UnstoppableDomainsAuthSig } from 'lib/blockchain/unstoppableDomains';
+import { getCallbackDomain } from 'lib/oauth/getCallbackDomain';
+import type { UdomainsPopupLoginState } from 'lib/oauth/interfaces';
+import { getAppUrl } from 'lib/utilities/browser';
+import { DisabledAccountError, BrowserPopupError } from 'lib/utilities/errors';
+
+const clientID = process.env.NEXT_PUBLIC_UNSTOPPABLE_DOMAINS_CLIENT_ID as string;
+
+const UDOMAINS_AUTH_URL = '/authenticate/udomains';
+
+export function useUnstoppableDomains() {
+  const [uAuthPopupError, setUAuthPopupError] = useState<BrowserPopupError | null>(null);
+  const { isWalletSelectorModalOpen, setIsConnectingIdentity } = useWeb3ConnectionManager();
+  const { isOnCustomDomain } = useCustomDomain();
+  const { openPopupLogin } = usePopupLogin<UdomainsPopupLoginState>();
+
+  useEffect(() => {
+    if (!isWalletSelectorModalOpen) {
+      setUAuthPopupError(null);
+    }
+  }, [isWalletSelectorModalOpen]);
+
+  const getUauthClient = async (callbackPath = '') => {
+    const redirectUri = getCallbackDomain(typeof window === 'undefined' ? '' : window.location.hostname).toString();
+    log.info('Connect unstoppable domains redirectUri', redirectUri);
+
+    const UAuth = (await import('@uauth/js')).default;
+    const uauth = new UAuth({
+      clientID,
+      redirectUri: `${redirectUri}${callbackPath}`,
+      scope: 'openid wallet'
+    });
+
+    return uauth;
+  };
+
+  async function loginWithAuthSig(authSig: UnstoppableDomainsAuthSig) {
+    const user = await charmClient.unstoppableDomains.login({ authSig });
+    const domain = extractDomainFromProof(authSig);
+
+    return { user, domain };
+  }
+
+  async function unstoppableDomainsLogin({
+    loginSuccess,
+    onError
+  }: {
+    loginSuccess: (loginInfo: AnyIdLogin<'UnstoppableDomain'>) => any;
+    onError?: (err: DisabledAccountError) => void;
+  }) {
+    if (isOnCustomDomain) {
+      const popupLoginCallback = async (data: UdomainsPopupLoginState) => {
+        if ('authSig' in data) {
+          const { user, domain } = await loginWithAuthSig(data.authSig);
+          loginSuccess({ displayName: domain, identityType: 'UnstoppableDomain', user });
+        } else if ('error' in data) {
+          onError?.(new DisabledAccountError(data.error));
+        }
+      };
+
+      return openPopupLogin(`${getAppUrl().toString()}${UDOMAINS_AUTH_URL}?action=login`, popupLoginCallback);
+    }
+
+    const uauth = await getUauthClient();
+
+    try {
+      const authSig = (await uauth.loginWithPopup()) as any as UnstoppableDomainsAuthSig;
+      const { user, domain } = await loginWithAuthSig(authSig);
+
+      loginSuccess({ displayName: domain, identityType: 'UnstoppableDomain', user });
+    } catch (err) {
+      if ((err as DisabledAccountError)?.errorType === 'Disabled account') {
+        onError?.(err as DisabledAccountError);
+      } else if ((err as Error).message.match('failed to be constructed')) {
+        setUAuthPopupError(new BrowserPopupError());
+      }
+      setIsConnectingIdentity(false);
+      log.error(err);
+    }
+  }
+
+  async function unstoppableDomainsRedirectLogin() {
+    const uauth = await getUauthClient(UDOMAINS_AUTH_URL);
+    uauth.login();
+  }
+
+  async function loginCallback() {
+    const uauth = await getUauthClient(UDOMAINS_AUTH_URL);
+    const res = await uauth.loginCallback();
+
+    return res.authorization as unknown as UnstoppableDomainsAuthSig;
+  }
+
+  return { uAuthPopupError, unstoppableDomainsLogin, unstoppableDomainsRedirectLogin, loginCallback };
+}

--- a/lib/oauth/getCallbackDomain.ts
+++ b/lib/oauth/getCallbackDomain.ts
@@ -7,11 +7,11 @@ import { getValidSubdomain } from 'lib/utilities/getValidSubdomain';
 export function getCallbackDomain(host: string | undefined) {
   const protocol = isProdEnv || isStagingEnv ? `https://` : `http://`;
 
-  if (!host) {
-    if (isDevEnv) {
-      return `http://localhost:3000/`;
-    }
+  if (isDevEnv) {
+    return `http://localhost:3000`;
+  }
 
+  if (!host) {
     return `${protocol}//${appSubdomain}.${getAppApexDomain()}`;
   }
 

--- a/lib/oauth/interfaces.ts
+++ b/lib/oauth/interfaces.ts
@@ -1,3 +1,4 @@
+import type { UnstoppableDomainsAuthSig } from 'lib/blockchain/unstoppableDomains';
 import type { LoginWithGoogleRequest } from 'lib/google/loginWithGoogle';
 
 export type OauthFlowType = 'page' | 'popup';
@@ -9,3 +10,5 @@ export type OauthLoginState<T = undefined> = {
 } & T;
 
 export type GooglePopupLoginState = OauthLoginState<{ googleToken: LoginWithGoogleRequest } | { error: string }>;
+
+export type UdomainsPopupLoginState = OauthLoginState<{ authSig: UnstoppableDomainsAuthSig } | { error: string }>;

--- a/pages/authenticate/udomains.tsx
+++ b/pages/authenticate/udomains.tsx
@@ -1,0 +1,54 @@
+import Box from '@mui/material/Box';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+import LoadingComponent from 'components/common/LoadingComponent';
+import { useUnstoppableDomains } from 'hooks/useUnstoppableDomains';
+import type { UdomainsPopupLoginState } from 'lib/oauth/interfaces';
+
+export default function Oauth() {
+  const { unstoppableDomainsRedirectLogin, loginCallback } = useUnstoppableDomains();
+  const router = useRouter();
+  const action: string | null = (router.query.action as string) || (router.asPath.includes('code') ? 'callback' : null);
+  const [loginState, setLoginState] = useState<UdomainsPopupLoginState | null>(null);
+
+  async function getCredentials() {
+    try {
+      const authSig = await loginCallback();
+      setLoginState({ status: 'success', authSig });
+    } catch (e: any) {
+      setLoginState({ status: 'error', error: e.message || 'Failed to login with unstoppable domains' });
+    }
+  }
+
+  useEffect(() => {
+    if (!action) return;
+
+    if (action === 'login') {
+      unstoppableDomainsRedirectLogin();
+    } else if (action === 'callback') {
+      getCredentials();
+    }
+  }, [router.query.action]);
+
+  useEffect(() => {
+    if (!loginState) return;
+
+    const listener = (event: MessageEvent<any>) => {
+      if (event.source && event.origin) {
+        const message: UdomainsPopupLoginState = loginState;
+        event.source.postMessage(message, { targetOrigin: event.origin });
+      }
+    };
+
+    window.addEventListener('message', listener);
+
+    return () => window.removeEventListener('message', listener);
+  }, [loginState]);
+
+  return (
+    <Box height='100vh' width='100vw' display='flex' alignItems='center' justifyContent='center'>
+      <LoadingComponent isLoading />
+    </Box>
+  );
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f83c48c</samp>

Added support for Unstoppable Domains login using OAuth and UAuth. Refactored the Unstoppable Domains login logic in `WalletSelectorModal.tsx` using a custom hook `useUnstoppableDomains.ts`. Added a new page `authenticate/udomains.tsx` to handle the OAuth flow. Fixed the callback domain issue in development mode in `getCallbackDomain.ts`. Added new types for Unstoppable Domains login state in `interfaces.ts`.

### WHY
<!-- author to complete -->
