### PR TITLE
Don't create cards from archived proposals

### DIFF
--- a/lib/pages/createCardsFromProposals.ts
+++ b/lib/pages/createCardsFromProposals.ts
@@ -24,6 +24,9 @@ export async function createCardsFromProposals({
       spaceId,
       type: 'proposal',
       proposal: {
+        archived: {
+          not: true
+        },
         status: {
           not: 'draft'
         }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b7c853</samp>

This pull request improves the `createCardsFromProposals` function and its test file. It adds a filter to exclude archived proposals from card creation, and it tests this behavior with a new test case.

### WHY
Dont create cards in boards from archived proposals
