### PR TITLE
Fix proposals disappearing on category creation

### DIFF
--- a/components/proposals/components/ProposalsViewOptions.tsx
+++ b/components/proposals/components/ProposalsViewOptions.tsx
@@ -88,7 +88,11 @@ export function ProposalsViewOptions({
               return <ProposalCategoryChip color={category.color} title={category.title} />;
             }
           }}
-          onChange={(e) => setCategoryIdFilter(e.target.value)}
+          onChange={(e) => {
+            if (e.target.value) {
+              setCategoryIdFilter(e.target.value);
+            }
+          }}
         >
           <MenuItem value='all'>All categories</MenuItem>
           {categories.map((category) => (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b41ea9</samp>

Fixed a bug in the category filter of the proposals view. The filter now only applies when a valid category is selected from the `ProposalsViewOptions` component.

### WHY
Proposals filter was set to empty state on new category creation. This is fixed
