### PR TITLE
Fix update proposalsSource

### DIFF
--- a/lib/pages/updateCardsFromProposals.ts
+++ b/lib/pages/updateCardsFromProposals.ts
@@ -51,6 +51,9 @@ export async function updateCardsFromProposals({
       spaceId,
       type: 'proposal',
       proposal: {
+        archived: {
+          not: true
+        },
         status: {
           not: 'draft'
         }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca86e2a</samp>

This pull request improves the tests and the logic for the `updateCardsFromProposals` function, which syncs the cards on the app with the proposals from the core. It uses a common test utility module, fixes some bugs, and excludes archived proposals from the sync process.

### WHY
Ignore archived proposals in updateCards
