### PR TITLE
Fix typeform support for select

### DIFF
--- a/__integration-tests__/server/pages/api/v1/webhooks/addToDatabase/[apiPageKey].spec.ts
+++ b/__integration-tests__/server/pages/api/v1/webhooks/addToDatabase/[apiPageKey].spec.ts
@@ -41,11 +41,53 @@ describe('POST /api/v1/webhooks/addToDatabase/{apiPageKey}', () => {
       }
     });
 
+    const textFieldId = uuid();
+    const selectId = uuid();
+
     const sampleInput: TypeformResponse = {
+      definition: {
+        fields: [
+          {
+            id: textFieldId,
+            ref: '01H531GWT0DN41H4C16PFP05NS',
+            type: 'short_text',
+            title: "Hello, what's your name?",
+            properties: {}
+          },
+          {
+            id: selectId,
+            ref: '01H531GWVKAT474T5MS32VKKS9',
+            type: 'multiple_choice',
+            title: 'Nice to meet you, {{field:01H531GWT0DN41H4C16PFP05NS}}, how is your day going?',
+            properties: {},
+            choices: [
+              {
+                id: 'hYorZ9YweWhP',
+                label: 'Terrific!'
+              },
+              {
+                id: 'rXSf6v3tVel8',
+                label: 'Not so well...'
+              }
+            ]
+          }
+        ]
+      },
       answers: [
         {
-          field: { id: uuid(), type: 'short_text', title: 'Example title' },
+          field: { id: textFieldId, type: 'short_text', title: 'Example title' },
           text: `Example text`
+        },
+        {
+          type: 'choice',
+          choice: {
+            label: 'Barcelona'
+          },
+          field: {
+            id: selectId,
+            type: 'multiple_choice',
+            ref: '01H531GWVKAT474T5MS32VKKS9'
+          }
         }
       ],
       submitted_at: new Date().toISOString()

--- a/components/common/BoardEditor/focalboard/src/constants.ts
+++ b/components/common/BoardEditor/focalboard/src/constants.ts
@@ -1,3 +1,5 @@
+import { randomIntFromInterval } from 'lib/utilities/random';
+
 class Constants {
   static readonly menuColors: { [key: string]: string } = {
     propColorDefault: 'Default',
@@ -114,4 +116,10 @@ class Constants {
   ];
 }
 
-export { Constants };
+function randomBoardColor() {
+  const boardColors = Object.keys(Constants.menuColors);
+  const randomIndex = randomIntFromInterval(0, boardColors.length - 1);
+  return boardColors[randomIndex];
+}
+
+export { Constants, randomBoardColor };

--- a/lib/typeform/transformWebhookBodyFormResponse.ts
+++ b/lib/typeform/transformWebhookBodyFormResponse.ts
@@ -1,5 +1,7 @@
 import uniqBy from 'lodash/uniqBy';
+import { v4 as uuid } from 'uuid';
 
+import { randomBoardColor } from 'components/common/BoardEditor/focalboard/src/constants';
 import type { PageProperty } from 'lib/public-api';
 import { isTruthy } from 'lib/utilities/types';
 
@@ -23,6 +25,9 @@ export function transformWebhookBodyFormResponse(data: BodyFormResponse, propert
       const optionId = b.question.options?.find((o) => o.value === b.answer)?.id;
       if (optionId) {
         b.answer = optionId;
+      } else {
+        const newOptionId = uuid();
+        b.question.options?.push({ id: newOptionId, value: b.answer, color: randomBoardColor() });
       }
     }
 
@@ -32,8 +37,11 @@ export function transformWebhookBodyFormResponse(data: BodyFormResponse, propert
           const optionId = b.question.options?.find((o) => o.value === a)?.id;
           if (optionId) {
             return optionId;
+          } else {
+            const newOptionId = uuid();
+            b.question.options.push({ id: newOptionId, value: a, color: randomBoardColor() });
+            return newOptionId;
           }
-          return null;
         })
         .filter(isTruthy);
       b.answer = transformedAnswer;
@@ -44,6 +52,7 @@ export function transformWebhookBodyFormResponse(data: BodyFormResponse, propert
   const otherCardProperties = properties.filter(
     (prop) => !updatedBody.find((q) => prop.description === q.question.description && prop.type === q.question.type)
   );
+
   const allProperties = [...updatedBody.map((b) => b.question), ...otherCardProperties];
 
   return { allProperties, updatedBody };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b481dee</samp>

Added support for dynamic options for select and multi-select properties in database boards. Updated the `transformWebhookBodyFormResponse` function, the `addToDatabase` webhook, and the `constants.ts` file to handle new options and update the database schema accordingly. Modified the integration test input to match the Typeform response format.

### WHY
Fix support for select fields from typeform