### PR TITLE
allow deleting spaces with no subscription

### DIFF
--- a/__integration-tests__/server/pages/api/spaces/[id]/index.spec.ts
+++ b/__integration-tests__/server/pages/api/spaces/[id]/index.spec.ts
@@ -80,7 +80,7 @@ describe('DELETE /api/spaces - Delete space', () => {
     expect(dbSpace).toBeNull();
   });
 
-  it('Should fail if user is not a part of the space and respond with 401', async () => {
+  it('Should fail if user is not an admin and respond with 401', async () => {
     const data = await generateUserAndSpace();
     const sessionCookie = await loginUser(data.user.id);
     await request(baseUrl).put(`/api/spaces/${data.space.id}`).set('Cookie', sessionCookie).expect(401);

--- a/__integration-tests__/server/pages/api/spaces/[id]/index.spec.ts
+++ b/__integration-tests__/server/pages/api/spaces/[id]/index.spec.ts
@@ -9,15 +9,13 @@ import { baseUrl, loginUser } from 'testing/mockApiCall';
 import { generateSpaceUser, generateUserAndSpace } from 'testing/setupDatabase';
 
 let space: Space;
-let adminUser: LoggedInUser;
 let memberUser: LoggedInUser;
 
 let adminCookie: string;
 let memberCookie: string;
 
 beforeAll(async () => {
-  const { space: generatedSpace, user: generatedUser } = await generateUserAndSpace({ isAdmin: true });
-  adminUser = generatedUser;
+  const { space: generatedSpace, user: adminUser } = await generateUserAndSpace({ isAdmin: true });
   memberUser = await generateSpaceUser({ isAdmin: false, spaceId: generatedSpace.id });
   space = generatedSpace;
   adminCookie = await loginUser(adminUser.id);

--- a/__integration-tests__/server/pages/api/spaces/[id]/index.spec.ts
+++ b/__integration-tests__/server/pages/api/spaces/[id]/index.spec.ts
@@ -1,11 +1,12 @@
 import type { Space } from '@charmverse/core/prisma';
+import { prisma } from '@charmverse/core/prisma-client';
 import request from 'supertest';
 import { v4 } from 'uuid';
 
 import type { UpdateableSpaceFields } from 'lib/spaces/updateSpace';
 import type { LoggedInUser } from 'models';
 import { baseUrl, loginUser } from 'testing/mockApiCall';
-import { generateSpaceUser, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+import { generateSpaceUser, generateUserAndSpace } from 'testing/setupDatabase';
 
 let space: Space;
 let adminUser: LoggedInUser;
@@ -15,7 +16,7 @@ let adminCookie: string;
 let memberCookie: string;
 
 beforeAll(async () => {
-  const { space: generatedSpace, user: generatedUser } = await generateUserAndSpaceWithApiToken(undefined, true);
+  const { space: generatedSpace, user: generatedUser } = await generateUserAndSpace({ isAdmin: true });
   adminUser = generatedUser;
   memberUser = await generateSpaceUser({ isAdmin: false, spaceId: generatedSpace.id });
   space = generatedSpace;
@@ -67,5 +68,23 @@ describe('PUT /api/spaces - Update space profile', () => {
       spaceImage: `https://new-space-logo-${v4()}.png`
     };
     await request(baseUrl).put(`/api/spaces/${space.id}`).set('Cookie', memberCookie).send(update).expect(401);
+  });
+});
+
+describe('DELETE /api/spaces - Delete space', () => {
+  it('Should allow an admin to delete a space, responding 200', async () => {
+    const data = await generateUserAndSpace({ isAdmin: true });
+    const sessionCookie = await loginUser(data.user.id);
+    await request(baseUrl).delete(`/api/spaces/${data.space.id}`).set('Cookie', sessionCookie).expect(200);
+    const dbSpace = await prisma.space.findUnique({ where: { id: data.space.id } });
+    expect(dbSpace).toBeNull();
+  });
+
+  it('Should fail if user is not a part of the space and respond with 401', async () => {
+    const data = await generateUserAndSpace();
+    const sessionCookie = await loginUser(data.user.id);
+    await request(baseUrl).put(`/api/spaces/${data.space.id}`).set('Cookie', sessionCookie).expect(401);
+    const dbSpace = await prisma.space.findUnique({ where: { id: data.space.id } });
+    expect(dbSpace).not.toBeNull();
   });
 });

--- a/lib/subscription/deleteProSubscription.ts
+++ b/lib/subscription/deleteProSubscription.ts
@@ -1,8 +1,6 @@
 import { log } from '@charmverse/core/log';
 import { prisma } from '@charmverse/core/prisma-client';
 
-import { NotFoundError } from 'lib/middleware';
-
 import { stripeClient } from './stripe';
 
 export async function deleteProSubscription({ spaceId, userId }: { spaceId: string; userId: string }) {
@@ -23,7 +21,8 @@ export async function deleteProSubscription({ spaceId, userId }: { spaceId: stri
   });
 
   if (!spaceSubscription) {
-    throw new NotFoundError(`Subscription not found for space ${spaceId}`);
+    log.warn('No subscription to delete', { spaceId });
+    return;
   }
 
   await prisma.stripeSubscription.update({
@@ -58,5 +57,6 @@ export async function deleteProSubscription({ spaceId, userId }: { spaceId: stri
       subscriptionId: spaceSubscription.subscriptionId,
       customerId: spaceSubscription.customerId
     });
+    throw err;
   }
 }

--- a/pages/api/spaces/[id]/index.ts
+++ b/pages/api/spaces/[id]/index.ts
@@ -74,7 +74,7 @@ async function deleteSpace(req: NextApiRequest, res: NextApiResponse) {
   const spaceId = req.query.id as string;
   const userId = req.session.user.id;
 
-  await deleteProSubscription({ spaceId, userId }).catch();
+  await deleteProSubscription({ spaceId, userId });
 
   await prisma.space.delete({
     where: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 545a796</samp>

Improved error handling and logging for deleting pro subscriptions and spaces. Removed unnecessary `.catch()` method from `deleteProSubscription` function call in `pages/api/spaces/[id]/index.ts` to propagate errors to the API response.

### WHY
Not sure if simply calling catch() is enough to actually catch the error because i couldn't delete spaces in my dev env. And regardless it seems like a good idea to prevent someone from deleting their space if we are still going to charge them.