### PR TITLE
fix nft links for optimism

### DIFF
--- a/components/common/CharmEditor/components/nft/NFTNodeView.tsx
+++ b/components/common/CharmEditor/components/nft/NFTNodeView.tsx
@@ -166,9 +166,11 @@ function NFTView({ nft }: { nft: { image: string; title: string; link: string } 
             >
               {nft.title}
             </Typography>
-            <Button href={nft.link} target='_blank' size='small' color='secondary' variant='outlined'>
-              View
-            </Button>
+            {nft.link && (
+              <Button href={nft.link} target='_blank' size='small' color='secondary' variant='outlined'>
+                View
+              </Button>
+            )}
           </Box>
         </CardContent>
       </CardActionArea>

--- a/components/common/CharmEditor/components/nft/__tests__/utils.spec.ts
+++ b/components/common/CharmEditor/components/nft/__tests__/utils.spec.ts
@@ -62,17 +62,8 @@ describe('NFT Utils', () => {
 
   const toURLCases = [
     {
-      // basic example
+      // ethereum
       url: 'https://opensea.io/assets/ethereum/0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21/1273',
-      nft: {
-        chain: 1,
-        contract: '0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21',
-        token: '1273'
-      }
-    },
-    {
-      // supports foreign language urls
-      url: 'https://opensea.io/fr/assets/ethereum/0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21/1273',
       nft: {
         chain: 1,
         contract: '0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21',

--- a/components/common/CharmEditor/components/nft/__tests__/utils.spec.ts
+++ b/components/common/CharmEditor/components/nft/__tests__/utils.spec.ts
@@ -1,62 +1,123 @@
-import { extractAttrsFromUrl } from '../utils';
-
-const extractionCases = [
-  {
-    // basic example
-    url: 'https://opensea.io/assets/ethereum/0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21/1273',
-    result: {
-      chain: 1,
-      contract: '0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21',
-      token: '1273'
-    }
-  },
-  {
-    // supports foreign language urls
-    url: 'https://opensea.io/fr/assets/ethereum/0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21/1273',
-    result: {
-      chain: 1,
-      contract: '0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21',
-      token: '1273'
-    }
-  },
-  {
-    // polygon
-    url: 'https://opensea.io/assets/matic/0x78f887a92602bb58cc7a8bba3fb83a11393568fc/67875155203898376266226417105519496041030022655099455128664563017684613070889',
-    result: {
-      chain: 137,
-      contract: '0x78f887a92602bb58cc7a8bba3fb83a11393568fc',
-      token: '67875155203898376266226417105519496041030022655099455128664563017684613070889'
-    }
-  },
-  {
-    // arbitrum
-    url: 'https://opensea.io/assets/arbitrum/0xebba467ecb6b21239178033189ceae27ca12eadf/77',
-    result: {
-      chain: 42161,
-      contract: '0xebba467ecb6b21239178033189ceae27ca12eadf',
-      token: '77'
-    }
-  },
-  {
-    // optimism
-    url: 'https://opensea.io/assets/optimism/0x0d42d13e3e2f97b1589525cd2f288caac79593ae/0',
-    result: {
-      chain: 10,
-      contract: '0x0d42d13e3e2f97b1589525cd2f288caac79593ae',
-      token: '0'
-    }
-  },
-  {
-    // ignores an unrecognized network (ex: avalanche)
-    url: 'https://opensea.io/assets/avalanche/0xe35587bd1985c98173ce7b6ab6fc0f9ae3a53e79/3816',
-    result: null
-  }
-];
+import { getNFTUrl, extractAttrsFromUrl } from '../utils';
 
 describe('NFT Utils', () => {
+  const extractionCases = [
+    {
+      // basic example
+      url: 'https://opensea.io/assets/ethereum/0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21/1273',
+      result: {
+        chain: 1,
+        contract: '0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21',
+        token: '1273'
+      }
+    },
+    {
+      // supports foreign language urls
+      url: 'https://opensea.io/fr/assets/ethereum/0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21/1273',
+      result: {
+        chain: 1,
+        contract: '0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21',
+        token: '1273'
+      }
+    },
+    {
+      // polygon
+      url: 'https://opensea.io/assets/matic/0x78f887a92602bb58cc7a8bba3fb83a11393568fc/67875155203898376266226417105519496041030022655099455128664563017684613070889',
+      result: {
+        chain: 137,
+        contract: '0x78f887a92602bb58cc7a8bba3fb83a11393568fc',
+        token: '67875155203898376266226417105519496041030022655099455128664563017684613070889'
+      }
+    },
+    {
+      // arbitrum
+      url: 'https://opensea.io/assets/arbitrum/0xebba467ecb6b21239178033189ceae27ca12eadf/77',
+      result: {
+        chain: 42161,
+        contract: '0xebba467ecb6b21239178033189ceae27ca12eadf',
+        token: '77'
+      }
+    },
+    {
+      // optimism
+      url: 'https://opensea.io/assets/optimism/0x0d42d13e3e2f97b1589525cd2f288caac79593ae/0',
+      result: {
+        chain: 10,
+        contract: '0x0d42d13e3e2f97b1589525cd2f288caac79593ae',
+        token: '0'
+      }
+    },
+    {
+      // ignores an unrecognized network (ex: avalanche)
+      url: 'https://opensea.io/assets/avalanche/0xe35587bd1985c98173ce7b6ab6fc0f9ae3a53e79/3816',
+      result: null
+    }
+  ];
+
   extractionCases.forEach((testCase) => {
     test(`extractAttrsFromUrl() should match OpenSea URL: ${testCase.url}`, () => {
       expect(extractAttrsFromUrl(testCase.url)).toEqual(testCase.result);
+    });
+  });
+
+  const toURLCases = [
+    {
+      // basic example
+      url: 'https://opensea.io/assets/ethereum/0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21/1273',
+      nft: {
+        chain: 1,
+        contract: '0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21',
+        token: '1273'
+      }
+    },
+    {
+      // supports foreign language urls
+      url: 'https://opensea.io/fr/assets/ethereum/0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21/1273',
+      nft: {
+        chain: 1,
+        contract: '0x1185e1eef5d34fdac843bb6b15fd9ac588a3ab21',
+        token: '1273'
+      }
+    },
+    {
+      // polygon
+      url: 'https://opensea.io/assets/matic/0x78f887a92602bb58cc7a8bba3fb83a11393568fc/67875155203898376266226417105519496041030022655099455128664563017684613070889',
+      nft: {
+        chain: 137,
+        contract: '0x78f887a92602bb58cc7a8bba3fb83a11393568fc',
+        token: '67875155203898376266226417105519496041030022655099455128664563017684613070889'
+      }
+    },
+    {
+      // arbitrum
+      url: 'https://stratosnft.io/assets/0xebba467ecb6b21239178033189ceae27ca12eadf/77',
+      nft: {
+        chain: 42161,
+        contract: '0xebba467ecb6b21239178033189ceae27ca12eadf',
+        token: '77'
+      }
+    },
+    {
+      // optimism
+      url: 'https://opensea.io/assets/optimism/0x0d42d13e3e2f97b1589525cd2f288caac79593ae/0',
+      nft: {
+        chain: 10,
+        contract: '0x0d42d13e3e2f97b1589525cd2f288caac79593ae',
+        token: '0'
+      }
+    }
+  ];
+
+  toURLCases.forEach((testCase) => {
+    test(`getNFTUrl() should generate a URL for test case`, () => {
+      if (testCase.result) {
+        const url = getNFTUrl({
+          chain: testCase.result.chain,
+          token: testCase.result.token,
+          contract: testCase.result.contract
+        });
+        expect(url).toEqual(testCase.url);
+      }
     });
   });
 });

--- a/components/common/CharmEditor/components/nft/__tests__/utils.spec.ts
+++ b/components/common/CharmEditor/components/nft/__tests__/utils.spec.ts
@@ -110,14 +110,12 @@ describe('NFT Utils', () => {
 
   toURLCases.forEach((testCase) => {
     test(`getNFTUrl() should generate a URL for test case`, () => {
-      if (testCase.result) {
-        const url = getNFTUrl({
-          chain: testCase.result.chain,
-          token: testCase.result.token,
-          contract: testCase.result.contract
-        });
-        expect(url).toEqual(testCase.url);
-      }
+      const url = getNFTUrl({
+        chain: testCase.nft.chain,
+        token: testCase.nft.token,
+        contract: testCase.nft.contract
+      });
+      expect(url).toEqual(testCase.url);
     });
   });
 });

--- a/components/common/CharmEditor/components/nft/utils.ts
+++ b/components/common/CharmEditor/components/nft/utils.ts
@@ -1,3 +1,5 @@
+import { log } from '@charmverse/core/log';
+
 import type { SupportedChainId } from 'lib/blockchain/provider/alchemy';
 
 import type { NodeAttrs } from './nft.specs';
@@ -8,6 +10,13 @@ const openseaChainsByPath: Record<string, SupportedChainId | undefined> = {
   matic: 137,
   optimism: 10
 };
+
+const openseaPathsByChain = Object.entries(openseaChainsByPath).reduce<Record<string, string>>((acc, [path, chain]) => {
+  if (chain) {
+    acc[chain.toString()] = path;
+  }
+  return acc;
+}, {});
 
 // a function to extract user screen name and tweet id from a tweet url
 export function extractAttrsFromUrl(url: string): NodeAttrs | null {
@@ -28,4 +37,30 @@ export function extractAttrsFromUrl(url: string): NodeAttrs | null {
     contract: match[3],
     token: match[4]
   };
+}
+
+export function getNFTUrl({
+  chain,
+  contract,
+  token
+}: {
+  chain: number;
+  contract: string;
+  token: string;
+}): string | null {
+  let link: null | string = null;
+  switch (chain) {
+    case 42161:
+      link = `https://stratosnft.io/assets/${contract}/${token}`;
+      break;
+    case 1:
+    case 10:
+    case 137:
+      link = `https://opensea.io/assets/${openseaPathsByChain[chain]}/${contract}/${token}`;
+      break;
+    default:
+      log.warn('Chain not configured for NFT URL', { chain });
+      break;
+  }
+  return link;
 }

--- a/lib/blockchain/getNFTs.ts
+++ b/lib/blockchain/getNFTs.ts
@@ -1,5 +1,6 @@
 import type { UserWallet } from '@charmverse/core/prisma';
 
+import { getNFTUrl } from 'components/common/CharmEditor/components/nft/utils';
 import { isTruthy } from 'lib/utilities/types';
 
 import type { SupportedChainId } from './provider/alchemy';
@@ -59,15 +60,7 @@ function mapNftFromAlchemy(
     // errors include "Contract does not have any code"
     return null;
   }
-  let link = '';
-  const tokenId = nft.id.tokenId.startsWith('0x') ? parseInt(nft.id.tokenId, 16) : nft.id.tokenId;
-  if (chainId === 42161) {
-    link = `https://stratosnft.io/assets/${nft.contract.address}/${tokenId}`;
-  } else if (chainId === 1) {
-    link = `https://opensea.io/assets/ethereum/${nft.contract.address}/${tokenId}`;
-  } else if (chainId === 137) {
-    link = `https://opensea.io/assets/matic/${nft.contract.address}/${tokenId}`;
-  }
+  const link = getNFTUrl({ chain: chainId, contract: nft.contract.address, token: nft.id.tokenId }) ?? '';
   // not sure if 'raw' or 'gateway' is best, but for this NFT, the 'raw' url no longer exists: https://opensea.io/assets/ethereum/0x1821d56d2f3bc5a5aba6420676a4bbcbccb2f7fd/3382
   const image = nft.media[0].gateway?.startsWith('https://') ? nft.media[0].gateway : nft.media[0].raw;
   return {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0725d9</samp>

Added a new utility function `getNFTUrl` to generate platform-specific URLs for NFTs based on their chain ID, contract address, and token ID. Refactored existing code in `lib/blockchain/getNFTs.ts` and `components/common/CharmEditor/components/nft/__tests__/utils.spec.ts` to use this function and improve readability and testability.

### WHY
<!-- author to complete -->
