### PR TITLE
allow user to connect using Mantle network

### DIFF
--- a/connectors/index.ts
+++ b/connectors/index.ts
@@ -267,21 +267,6 @@ const RPC = {
     iconUrl: '/images/cryptoLogos/zksync-era-logo.svg',
     shortName: 'zksync'
   },
-  MANTLE_TESTNET: {
-    chainId: 5001,
-    chainName: 'Mantle - Testnet',
-    nativeCurrency: {
-      name: 'Testnet Mantle',
-      symbol: 'MNT',
-      decimals: 18,
-      address: '0x0000000000000000000000000000000000000000',
-      logoURI: 'https://cryptototem.com/wp-content/uploads/2023/01/Mantle-logo.jpg'
-    },
-    rpcUrls: ['https://rpc.testnet.mantle.xyz'],
-    blockExplorerUrls: ['https://explorer.testnet.mantle.xyz'],
-    iconUrl: '/images/cryptoLogos/mantle-logo.svg',
-    shortName: 'mantle-testnet'
-  },
   MANTLE: {
     chainId: 5000,
     chainName: 'Mantle',
@@ -296,6 +281,21 @@ const RPC = {
     blockExplorerUrls: ['https://explorer.mantle.xyz'],
     iconUrl: '/images/cryptoLogos/mantle-logo.svg',
     shortName: 'mantle'
+  },
+  MANTLE_TESTNET: {
+    chainId: 5001,
+    chainName: 'Mantle - Testnet',
+    nativeCurrency: {
+      name: 'Testnet Mantle',
+      symbol: 'MNT',
+      decimals: 18,
+      address: '0x0000000000000000000000000000000000000000',
+      logoURI: 'https://cryptototem.com/wp-content/uploads/2023/01/Mantle-logo.jpg'
+    },
+    rpcUrls: ['https://rpc.testnet.mantle.xyz'],
+    blockExplorerUrls: ['https://explorer.testnet.mantle.xyz'],
+    iconUrl: '/images/cryptoLogos/mantle-logo.svg',
+    shortName: 'mantle-testnet'
   }
 } as const;
 
@@ -362,7 +362,8 @@ const supportedChains: Blockchain[] = [
   'SEPOLIA',
   'MUMBAI',
   'ZKSYNC',
-  'MANTLE_TESTNET'
+  'MANTLE_TESTNET',
+  'MANTLE'
 ];
 
 const supportedChainIds = supportedChains.map((_) => RPC[_].chainId);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d7e454</samp>

Add Mantle mainnet support and update network configuration in `connectors/index.ts`. This allows users to interact with the Mantle mainnet network and its contracts from the app.

### WHY
<!-- author to complete -->
