### PR TITLE
include Optimism chain for NFTs

### DIFF
--- a/lib/blockchain/getNFTs.ts
+++ b/lib/blockchain/getNFTs.ts
@@ -6,6 +6,9 @@ import { isTruthy } from 'lib/utilities/types';
 import type { SupportedChainId } from './provider/alchemy';
 import * as alchemyApi from './provider/alchemy';
 
+// eventually we will also include Mantle id
+export { supportedMainnets } from 'lib/blockchain/provider/alchemy';
+
 export type NFTData = {
   id: string;
   tokenId: string;

--- a/lib/blockchain/provider/alchemy.ts
+++ b/lib/blockchain/provider/alchemy.ts
@@ -4,6 +4,7 @@ import orderBy from 'lodash/orderBy';
 
 // https://docs.alchemy.com/docs/why-use-alchemy#-blockchains-supported
 export const supportedChainIds = [1, 5, 10, 137, 80001, 42161] as const;
+export const supportedMainnets = [1, 10, 137, 42161] as const;
 export type SupportedChainId = (typeof supportedChainIds)[number];
 
 interface NftMedia {

--- a/lib/profile/getUserNFTs.ts
+++ b/lib/profile/getUserNFTs.ts
@@ -1,8 +1,6 @@
 import { prisma } from '@charmverse/core/prisma-client';
 
-import { getNFTs } from 'lib/blockchain/getNFTs';
-
-export const supportedMainnets = [1, 137, 42161] as const;
+import { supportedMainnets, getNFTs } from 'lib/blockchain/getNFTs';
 
 export const getUserNFTs = async (userId: string) => {
   const profileItems = await prisma.profileItem.findMany({


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d77d055</samp>

This pull request refactors the code to use a single `supportedMainnets` constant for fetching NFTs from different blockchains using the Alchemy API. The constant is defined and exported in `lib/blockchain/provider/alchemy.ts` and imported in `lib/blockchain/getNFTs.ts` and `lib/profile/getUserNFTs.ts`.

### WHY
<!-- author to complete -->
