### PR TITLE
Make sure missing viewIds in boar will not crash the app

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/addViewMenu.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/addViewMenu.tsx
@@ -48,8 +48,8 @@ function AddViewMenu(props: AddViewProps) {
   const showView = props.showView;
 
   const views = props.views.filter((view) => !view.fields.inline);
-  const viewIds =
-    props.board.fields.viewIds.length === views.length ? props.board.fields.viewIds : views.map((view) => view.id);
+  const viewIdsFromFields = props.board.fields?.viewIds ?? [];
+  const viewIds = viewIdsFromFields.length === views.length ? viewIdsFromFields : views.map((view) => view.id);
 
   const popupState = usePopupState({ variant: 'popover', popupId: 'add-view-menu' });
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b09727</samp>

Fixed a bug in `AddViewMenu` component that could cause a crash when `props.board.fields` is undefined or null. Added a new variable `viewIdsFromFields` to safely get the `viewIds` array from `props.board.fields`.

### WHY
https://app.charmverse.io/charmverse/page-49366552253645923?viewId=50d940bb-fdbd-40ba-9816-616d6138a663&cardId=3bfdcc71-9b42-4b4c-a0c8-03176ff7c5e4
