### PR TITLE
Dont show proposal notifications if no action exists

### DIFF
--- a/lib/proposal/__tests__/getProposalTasks.spec.ts
+++ b/lib/proposal/__tests__/getProposalTasks.spec.ts
@@ -359,4 +359,20 @@ describe('getProposalTasks', () => {
 
     expect(proposalTasks.unmarked).toEqual([]);
   });
+
+  it('Should not return notifications when there is no action', async () => {
+    const { user, space } = await generateUserAndSpace({});
+
+    await testUtilsProposals.generateProposal({
+      proposalStatus: 'reviewed',
+      spaceId: space.id,
+      authors: [],
+      reviewers: [],
+      userId: user.id
+    });
+
+    const proposalTasks = await getProposalTasks(user.id);
+
+    expect(proposalTasks.unmarked).toEqual([]);
+  });
 });

--- a/lib/proposal/getProposalTasks.ts
+++ b/lib/proposal/getProposalTasks.ts
@@ -222,16 +222,16 @@ export async function getProposalTasks(userId: string): Promise<{
         isAuthor,
         isReviewer
       });
+      if (!action) {
+        return;
+      }
+      // Check notifications are enabled for space-wide proposal notifications
+      const notifyNewEvents = page.space.notifyNewProposals && page.space.notifyNewProposals < workspaceEvent.createdAt;
+      if (!notifyNewEvents && (action === 'discuss' || action === 'vote')) {
+        return;
+      }
 
       if (workspaceEvent) {
-        // Check notifications are enabled for space-wide proposal notifications
-        const notifyNewEvents =
-          page.space.notifyNewProposals && page.space.notifyNewProposals < workspaceEvent.createdAt;
-
-        if (!notifyNewEvents && (action === 'discuss' || action === 'vote')) {
-          return;
-        }
-
         const proposalTask = {
           id: workspaceEvent.id,
           eventDate: workspaceEvent.createdAt,

--- a/lib/proposal/getProposalTasks.ts
+++ b/lib/proposal/getProposalTasks.ts
@@ -222,16 +222,18 @@ export async function getProposalTasks(userId: string): Promise<{
         isAuthor,
         isReviewer
       });
+
       if (!action) {
-        return;
-      }
-      // Check notifications are enabled for space-wide proposal notifications
-      const notifyNewEvents = page.space.notifyNewProposals && page.space.notifyNewProposals < workspaceEvent.createdAt;
-      if (!notifyNewEvents && (action === 'discuss' || action === 'vote')) {
         return;
       }
 
       if (workspaceEvent) {
+        // Check notifications are enabled for space-wide proposal notifications
+        const notifyNewEvents =
+          page.space.notifyNewProposals && page.space.notifyNewProposals < workspaceEvent.createdAt;
+        if (!notifyNewEvents && (action === 'discuss' || action === 'vote')) {
+          return;
+        }
         const proposalTask = {
           id: workspaceEvent.id,
           eventDate: workspaceEvent.createdAt,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at efe41c4</samp>

This pull request improves the `getProposalTasks` function and its test coverage. It adds a test case for proposals with no action required, and a condition to skip unnecessary checks for such proposals in the function.

### WHY
<!-- author to complete -->
