### PR TITLE
Rename proposal status discussion into feedback

### DIFF
--- a/components/proposals/components/ProposalCategoryInput.tsx
+++ b/components/proposals/components/ProposalCategoryInput.tsx
@@ -6,7 +6,6 @@ import { useEffect, useMemo, useState } from 'react';
 import type { NewProposalCategory, ProposalCategory } from 'lib/proposal/interface';
 import type { BrandColor } from 'theme/colors';
 import { brandColorNames } from 'theme/colors';
-import { getRandomThemeColor } from 'theme/utils/getRandomThemeColor';
 
 type TempOption = NewProposalCategory & {
   inputValue: string;

--- a/components/proposals/components/ProposalCategoryInput.tsx
+++ b/components/proposals/components/ProposalCategoryInput.tsx
@@ -89,7 +89,9 @@ export default function ProposalCategoryInput({ disabled, options, value, onChan
       options={options}
       autoHighlight
       clearIcon={null}
-      renderOption={(_props, category) => <ProposalCategoryOption category={category} props={_props} />}
+      renderOption={(_props, category) => (
+        <ProposalCategoryOption category={category} props={_props} key={category.title} />
+      )}
       ChipProps={{
         // Avoids a bug where an error is thrown if the color is unsupported
         color: brandColorNames.includes(colorToDisplay as BrandColor) ? (colorToDisplay as BrandColor) : undefined,

--- a/lib/proposal/getProposalTasks.ts
+++ b/lib/proposal/getProposalTasks.ts
@@ -1,6 +1,5 @@
-import type { ProposalCategoryWithPermissions } from '@charmverse/core/dist/cjs/permissions';
+import type { ProposalCategoryWithPermissions } from '@charmverse/core/permissions';
 import type { ProposalStatus, User, WorkspaceEvent } from '@charmverse/core/prisma';
-import type { ProposalCategoryOperation } from '@charmverse/core/prisma-client';
 import { prisma } from '@charmverse/core/prisma-client';
 import { RateLimit } from 'async-sema';
 

--- a/lib/proposal/proposalStatusTransition.ts
+++ b/lib/proposal/proposalStatusTransition.ts
@@ -13,7 +13,7 @@ export const PROPOSAL_STATUSES = Object.keys(proposalStatusTransitionRecord) as 
 
 export const PROPOSAL_STATUS_LABELS: Record<ProposalStatus, string> = {
   draft: 'Draft',
-  discussion: 'Discussion',
+  discussion: 'Feedback',
   review: 'In Review',
   reviewed: 'Reviewed',
   vote_active: 'Vote Active',


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2627d23</samp>

This pull request improves the UI and code quality of the proposal feature. It fixes a React warning by adding a `key` prop to `ProposalCategoryOption`, and it changes the proposal status label from "Discussion` to `Feedback` in `proposalStatusTransition.ts` and the UI.

### WHY
Changes:
Rename proposal status discussion into feedback
Fixed missing key in autocomplete option in proposal window
Fix bad import of disc/cjs/....
