### PR TITLE
remove archive in charm editor key

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -18,7 +18,6 @@ import type { FrontendParticipant } from 'components/common/CharmEditor/componen
 import { SnapshotVoteDetails } from 'components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails';
 import { VoteDetail } from 'components/common/CharmEditor/components/inlineVote/components/VoteDetail';
 import ScrollableWindow from 'components/common/PageLayout/components/ScrollableWindow';
-import { useProposalDetails } from 'components/proposals/hooks/useProposalDetails';
 import { useProposalPermissions } from 'components/proposals/hooks/useProposalPermissions';
 import { useBounties } from 'hooks/useBounties';
 import { useBountyPermissions } from 'hooks/useBountyPermissions';
@@ -99,7 +98,6 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
   const proposalId = page.proposalId;
 
   const { permissions: proposalPermissions } = useProposalPermissions({ proposalIdOrPath: proposalId as string });
-  const { proposal } = useProposalDetails(proposalId);
 
   // We can only edit the proposal from the top level
   const readonlyProposalProperties = !page.proposalId || readOnly;
@@ -169,7 +167,7 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
   }
 
   // create a key that updates when edit mode changes - default to 'editing' so we dont close sockets immediately
-  const editorKey = page.id + (editMode || 'editing') + pagePermissions.edit_content + String(proposal?.archived);
+  const editorKey = page.id + (editMode || 'editing') + pagePermissions.edit_content;
 
   function onConnectionError(error: Error) {
     setConnectionError(error);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2cec93</samp>

Refactored and cleaned up the `DocumentPage` component. Removed unnecessary code and simplified the `editorKey` logic.

### WHY
the value is 'undefined' and then true/false, which triggers a re-render of the whole editor. The proper fix is to set the editMode instead inside of EditorPage
