### PR TITLE
better redirects after deleting a space

### DIFF
--- a/__e2e__/po/settings/spaceProfileSettings.po.ts
+++ b/__e2e__/po/settings/spaceProfileSettings.po.ts
@@ -11,6 +11,10 @@ export class SpaceProfileSettings extends SettingsModal {
 
   readonly submitSpaceUpdateButton: Locator;
 
+  readonly deleteSpaceButton: Locator;
+
+  readonly confirmDeleteSpaceButton: Locator;
+
   readonly bountyVisibilityToggle: Locator;
 
   readonly forumVisibilityToggle: Locator;
@@ -24,6 +28,8 @@ export class SpaceProfileSettings extends SettingsModal {
     this.spaceNameInput = page.locator('data-test=space-name-input >> input');
     this.spaceDomainInput = page.locator('data-test=space-domain-input >> input');
     this.submitSpaceUpdateButton = page.locator('data-test=submit-space-update');
+    this.deleteSpaceButton = page.locator('data-test=submit-space-delete');
+    this.confirmDeleteSpaceButton = page.locator('data-test=confirm-delete-button');
 
     // Space feature visibility toggles
     this.bountyVisibilityToggle = page.locator(`data-test=space-feature-toggle-bounties`);

--- a/__e2e__/settings/deleteSpace.spec.ts
+++ b/__e2e__/settings/deleteSpace.spec.ts
@@ -1,0 +1,35 @@
+import { test as base } from '@playwright/test';
+import { v4 } from 'uuid';
+
+import { generateSpaceForUser } from 'testing/utils/spaces';
+
+import { SpaceProfileSettings } from '../po/settings/spaceProfileSettings.po';
+import { generateUserAndSpace } from '../utils/mocks';
+import { login } from '../utils/session';
+
+type Fixtures = {
+  spaceSettings: SpaceProfileSettings;
+};
+
+const test = base.extend<Fixtures>({
+  spaceSettings: ({ page }, use) => use(new SpaceProfileSettings(page))
+});
+
+test('Space settings - delete space', async ({ page, spaceSettings }) => {
+  const { space, user } = await generateUserAndSpace({ spaceName: v4(), isAdmin: true, onboarded: true });
+  const spaceToDelete = await generateSpaceForUser({ user });
+  // go to a page to which we don't have access
+
+  await login({ page, userId: user.id });
+
+  await spaceSettings.goTo(spaceToDelete.domain);
+
+  await spaceSettings.waitForSpaceSettingsURL();
+
+  await spaceSettings.openSettingsModal();
+
+  await spaceSettings.deleteSpaceButton.click();
+  await spaceSettings.confirmDeleteSpaceButton.click();
+
+  await spaceSettings.waitForSpaceSettingsURL(space.domain);
+});

--- a/__e2e__/settings/deleteSpace.spec.ts
+++ b/__e2e__/settings/deleteSpace.spec.ts
@@ -15,21 +15,39 @@ const test = base.extend<Fixtures>({
   spaceSettings: ({ page }, use) => use(new SpaceProfileSettings(page))
 });
 
-test('Space settings - delete space', async ({ page, spaceSettings }) => {
-  const { space, user } = await generateUserAndSpace({ spaceName: v4(), isAdmin: true, onboarded: true });
-  const spaceToDelete = await generateSpaceForUser({ user });
-  // go to a page to which we don't have access
+test.describe('Space settings - delete space', () => {
+  // test('When user has another space, redirect to next space', async ({ page, spaceSettings }) => {
+  //   const { space, user } = await generateUserAndSpace({ spaceName: v4(), isAdmin: true, onboarded: true });
+  //   const spaceToDelete = await generateSpaceForUser({ user });
 
-  await login({ page, userId: user.id });
+  //   await login({ page, userId: user.id });
 
-  await spaceSettings.goTo(spaceToDelete.domain);
+  //   await spaceSettings.goTo(spaceToDelete.domain);
 
-  await spaceSettings.waitForSpaceSettingsURL();
+  //   await spaceSettings.waitForSpaceSettingsURL();
 
-  await spaceSettings.openSettingsModal();
+  //   await spaceSettings.openSettingsModal();
 
-  await spaceSettings.deleteSpaceButton.click();
-  await spaceSettings.confirmDeleteSpaceButton.click();
+  //   await spaceSettings.deleteSpaceButton.click();
+  //   await spaceSettings.confirmDeleteSpaceButton.click();
 
-  await spaceSettings.waitForSpaceSettingsURL(space.domain);
+  //   await spaceSettings.waitForSpaceSettingsURL(space.domain);
+  // });
+
+  test('When user has no more spaces, redirect to /createSpace', async ({ page, spaceSettings }) => {
+    const { space, user } = await generateUserAndSpace({ spaceName: v4(), isAdmin: true, onboarded: true });
+
+    await login({ page, userId: user.id });
+
+    await spaceSettings.goTo(space.domain);
+
+    await spaceSettings.waitForSpaceSettingsURL();
+
+    await spaceSettings.openSettingsModal();
+
+    await spaceSettings.deleteSpaceButton.click();
+    await spaceSettings.confirmDeleteSpaceButton.click();
+
+    await spaceSettings.page.waitForURL('**/createSpace');
+  });
 });

--- a/__e2e__/utils/mocks.ts
+++ b/__e2e__/utils/mocks.ts
@@ -35,7 +35,7 @@ export async function logoutBrowserUser({ browserPage }: { browserPage: BrowserP
   await browserPage.request.post(`${baseUrl}/api/session/logout`);
 }
 
-// Note: the endpoint creates a user when wallet address is provided
+// DEPRECATED - mock data should be generated directly, not using webapp features
 export async function createUser({
   browserPage,
   address
@@ -52,6 +52,7 @@ export async function createUser({
     .then((res) => res.json());
 }
 
+// DEPRECATED - mock data should be generated directly, not using webapp features
 export async function createSpace({
   browserPage,
   permissionConfigurationMode,
@@ -84,6 +85,7 @@ export async function createSpace({
   }
 }
 
+// DEPRECATED - mock data should be generated directly, not using webapp features
 export async function getPages({
   browserPage,
   spaceId
@@ -95,6 +97,9 @@ export async function getPages({
 }
 
 /**
+ *
+ * DEPRECATED - Use generateUserAndSpace instead. Mock data should be generated directly, not using webapp features
+ *
  * @browserPage - the page object for the browser context that will execute the requests
  *
  * @isOnboarded Default to true so all user / space pairs start as onboarded, and the tester can focus on the happy path they are targeting

--- a/components/common/Modal/ConfirmDeleteModal.tsx
+++ b/components/common/Modal/ConfirmDeleteModal.tsx
@@ -46,6 +46,7 @@ export default function ConfirmDeleteModal({
             overflow: 'hidden',
             textOverflow: 'ellipsis'
           }}
+          data-test='confirm-delete-button'
           onClick={_onConfirm}
           disabled={disabled}
         >

--- a/components/common/RouteGuard.tsx
+++ b/components/common/RouteGuard.tsx
@@ -27,7 +27,6 @@ export default function RouteGuard({ children }: { children: ReactNode }) {
   const isLoading = !isLoaded || !isSpacesLoaded || !accessChecked;
   const authorizedSpaceDomainRef = useRef('');
   const spaceDomain = (router.query.domain as string) || '';
-  const hasSpaceDomain = !!spaceDomain;
 
   useEffect(() => {
     const defaultPageKey: string = spaceDomain ? getKey(`last-page-${spaceDomain}`) : '';
@@ -118,7 +117,7 @@ export default function RouteGuard({ children }: { children: ReactNode }) {
       }
     }
     // condition: trying to access a space without access
-    else if (!isAvailableToLoggedInUsers && hasSpaceDomain && !filterSpaceByDomain(spaces, _spaceDomain)) {
+    else if (!isAvailableToLoggedInUsers && !!_spaceDomain && !filterSpaceByDomain(spaces, _spaceDomain)) {
       log.info('[RouteGuard]: send to join space page');
       if (authorizedSpaceDomainRef.current === _spaceDomain) {
         authorizedSpaceDomainRef.current = '';

--- a/components/settings/space/SpaceSettings.tsx
+++ b/components/settings/space/SpaceSettings.tsx
@@ -13,6 +13,7 @@ import Button from 'components/common/Button';
 import FieldLabel from 'components/common/form/FieldLabel';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import ConnectSnapshot from 'components/common/PageActions/components/SnapshotAction/ConnectSnapshot';
+import { getDefaultWorkspaceUrl } from 'components/login/LoginPage';
 import Legend from 'components/settings/Legend';
 import { SetupCustomDomain } from 'components/settings/space/components/SetupCustomDomain';
 import { useIsAdmin } from 'hooks/useIsAdmin';
@@ -296,7 +297,15 @@ export function SpaceSettings({ space }: { space: Space }) {
             if (isAdmin) {
               await charmClient.spaces.deleteSpace(space.id);
               const filteredSpaces = spaces.filter((s) => s.id !== space.id);
-              setSpaces(filteredSpaces);
+              // redirect user to the next space if they have one
+              if (filteredSpaces.length > 0) {
+                router.push(getDefaultWorkspaceUrl(filteredSpaces));
+              } else {
+                router.push('/createSpace');
+              }
+              setTimeout(() => {
+                setSpaces(filteredSpaces);
+              });
             }
           }}
         />

--- a/components/settings/space/SpaceSettings.tsx
+++ b/components/settings/space/SpaceSettings.tsx
@@ -260,7 +260,7 @@ export function SpaceSettings({ space }: { space: Space }) {
               <Button disableElevation size='large' data-test='submit-space-update' disabled={!isDirty} type='submit'>
                 Save
               </Button>
-              <Button variant='outlined' color='error' onClick={deleteWorkspace}>
+              <Button variant='outlined' color='error' onClick={deleteWorkspace} data-test='submit-space-delete'>
                 Delete Space
               </Button>
             </Grid>

--- a/components/settings/space/SpaceSettings.tsx
+++ b/components/settings/space/SpaceSettings.tsx
@@ -299,13 +299,11 @@ export function SpaceSettings({ space }: { space: Space }) {
               const filteredSpaces = spaces.filter((s) => s.id !== space.id);
               // redirect user to the next space if they have one
               if (filteredSpaces.length > 0) {
-                router.push(getDefaultWorkspaceUrl(filteredSpaces));
+                await router.push(getDefaultWorkspaceUrl(filteredSpaces));
               } else {
-                router.push('/createSpace');
+                await router.push('/createSpace');
               }
-              setTimeout(() => {
-                setSpaces(filteredSpaces);
-              });
+              setSpaces(filteredSpaces);
             }
           }}
         />

--- a/lib/members/__tests__/getSpaceMemberRoles.spec.ts
+++ b/lib/members/__tests__/getSpaceMemberRoles.spec.ts
@@ -17,12 +17,12 @@ beforeAll(async () => {
   const { user: u1, space } = await generateUserAndSpaceWithApiToken(undefined, true);
   user1 = u1;
   u1Space1 = space;
-  u1Space2 = await generateSpaceForUser(user1);
+  u1Space2 = await generateSpaceForUser({ user: user1 });
 
   // User with 2 spaces, 1 common with user 1
   const { user: u2 } = await generateUserAndSpaceWithApiToken(undefined, true);
   user2 = await addUserToSpace({ spaceId: u1Space1.id, userId: u2.id, isAdmin: false });
-  await generateSpaceForUser(user2);
+  await generateSpaceForUser({ user: user2 });
 
   const role1 = await generateRole({ spaceId: u1Space1.id, roleName: 'test role 1', createdBy: u1.id });
   const role2 = await generateRole({ spaceId: u1Space1.id, roleName: 'test role 2', createdBy: u1.id });

--- a/lib/members/__tests__/getSpaceMembers.spec.ts
+++ b/lib/members/__tests__/getSpaceMembers.spec.ts
@@ -11,7 +11,7 @@ describe('getSpaceMembers', () => {
   it(`Should get space members based on custom member property value`, async () => {
     const user1 = await createUserFromWallet();
     const user2 = await createUserFromWallet();
-    const space = await generateSpaceForUser(user1);
+    const space = await generateSpaceForUser({ user: user1 });
     await addUserToSpace({ spaceId: space.id, userId: user2.id, isAdmin: false });
 
     const textMemberProperty = await createMemberProperty({

--- a/lib/members/__tests__/getSpacesPropertyValues.spec.ts
+++ b/lib/members/__tests__/getSpacesPropertyValues.spec.ts
@@ -24,12 +24,12 @@ beforeAll(async () => {
   const { user: u1, space } = await generateUserAndSpaceWithApiToken(undefined, true);
   user1 = u1;
   u1Space1 = space;
-  u1Space2 = await generateSpaceForUser(user1);
+  u1Space2 = await generateSpaceForUser({ user: user1 });
 
   // User with 2 spaces, 1 common with user 1
   const { user: u2 } = await generateUserAndSpaceWithApiToken(undefined, true);
   user2 = await addUserToSpace({ spaceId: u1Space1.id, userId: u2.id, isAdmin: false });
-  await generateSpaceForUser(user2);
+  await generateSpaceForUser({ user: user2 });
 
   // User with no common spaces
   const { user: u3 } = await generateUserAndSpaceWithApiToken(undefined, true);

--- a/lib/members/__tests__/updateMemberPropertyVisibility.spec.ts
+++ b/lib/members/__tests__/updateMemberPropertyVisibility.spec.ts
@@ -25,7 +25,7 @@ beforeAll(async () => {
   // User with 2 spaces, 1 common with user 1
   const { user: u2 } = await generateUserAndSpaceWithApiToken(undefined, true);
   user2 = await addUserToSpace({ spaceId: u1Space1.id, userId: u2.id, isAdmin: false });
-  await generateSpaceForUser(user2);
+  await generateSpaceForUser({ user: user2 });
 
   // Create name property manually as generateMemberProperty don't allow creating default properties
   property1 = await prisma.memberProperty.create({

--- a/pages/createSpace.tsx
+++ b/pages/createSpace.tsx
@@ -1,25 +1,15 @@
 import { Box, Card, Grid, Typography } from '@mui/material';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 
 import getBaseLayout from 'components/common/BaseLayout/BaseLayout';
 import { CreateSpaceForm } from 'components/common/CreateSpaceForm/CreateSpaceForm';
 import Image from 'components/common/Image';
 import { Container } from 'components/login/components/LoginLayout';
 import Footer from 'components/login/Footer';
-import { getDefaultWorkspaceUrl } from 'components/login/LoginPage';
 import { useSpaces } from 'hooks/useSpaces';
 import splashImage from 'public/images/artwork/world.png';
 
 export default function CreateSpace() {
   const { spaces, isLoaded } = useSpaces();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (spaces.length > 0) {
-      router.push(getDefaultWorkspaceUrl(spaces));
-    }
-  }, [spaces]);
 
   if (!spaces || !isLoaded) {
     return null;

--- a/pages/join.tsx
+++ b/pages/join.tsx
@@ -72,7 +72,7 @@ export default function JoinWorkspace() {
         {domain && spaceFromPath && <SpaceAccessGate space={spaceFromPath} />}
         {isRouterReady && (spaceFromPathNotFound || !domain) && <SpaceAccessGateWithSearch defaultValue={domain} />}
       </Card>
-      <AlternateRouteButton href={`${getAppUrl()}/createSpace`}>Create a space</AlternateRouteButton>
+      <AlternateRouteButton href={`${getAppUrl()}createSpace`}>Create a space</AlternateRouteButton>
     </Box>
   );
 }

--- a/testing/utils/spaces.ts
+++ b/testing/utils/spaces.ts
@@ -39,7 +39,17 @@ export async function addUserToSpace({
 /**
  * Utility to create a space by existing user
  */
-export async function generateSpaceForUser(user: LoggedInUser, isAdmin = true, spaceName = 'Example space') {
+export async function generateSpaceForUser({
+  user,
+  isAdmin = true,
+  spaceName = 'Example space',
+  skipOnboarding = true
+}: {
+  user: LoggedInUser;
+  isAdmin?: boolean;
+  spaceName?: string;
+  skipOnboarding?: boolean;
+}) {
   const existingSpaceId = user.spaceRoles?.[0]?.spaceId;
 
   let space = null;
@@ -67,7 +77,9 @@ export async function generateSpaceForUser(user: LoggedInUser, isAdmin = true, s
         spaceRoles: {
           create: {
             userId: user.id,
-            isAdmin
+            isAdmin,
+            // skip onboarding for normal test users
+            onboarded: skipOnboarding
           }
         }
       },


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 210680a</samp>

This pull request enhances the space creation and deletion features by refactoring the redirection logic and fixing a rendering issue. It affects the `SpaceSettings` and `createSpace` components.

### WHY
Currently, when you delete a space we jsut send you to the token gate trying to join that space... i think we lost a redirect at some point.
Also, allow someone to go to createSpace and not be redirected to someplace else
