### PR TITLE
Fixed member directory page showing 404 page

### DIFF
--- a/hooks/useCurrentSpace.ts
+++ b/hooks/useCurrentSpace.ts
@@ -11,8 +11,8 @@ import { useSpaces } from './useSpaces';
 export function useCurrentSpace(): { space?: Space; isLoading: boolean; refreshCurrentSpace: () => void } {
   const router = useRouter();
   const { spaces, isLoaded: isSpacesLoaded, setSpace } = useSpaces();
-  const { publicSpace, accessChecked } = useSharedPage();
-
+  const { publicSpace, accessChecked: publicAccessChecked, isPublicPath } = useSharedPage();
+  const isSharedPageLoaded = isPublicPath && publicAccessChecked;
   // Support for extracting domain from logged in view or shared bounties view
   // domain in query can be either space domain or custom domain
   const domainOrCustomDomain = router.query.domain;
@@ -25,10 +25,9 @@ export function useCurrentSpace(): { space?: Space; isLoading: boolean; refreshC
     }
   }, [space]);
 
-  if (!accessChecked || !isSpacesLoaded) {
-    return { isLoading: true, refreshCurrentSpace };
+  // if page is public and we are not loading space anymore OR if spaces are loaded
+  if (isSpacesLoaded || isSharedPageLoaded) {
+    return { space: space ?? (publicSpace || undefined), isLoading: false, refreshCurrentSpace };
   }
-
-  // We always want to return the space as priority since it's not just set by the URL
-  return { space: space ?? (publicSpace || undefined), isLoading: false, refreshCurrentSpace };
+  return { isLoading: true, refreshCurrentSpace };
 }

--- a/hooks/useCurrentSpace.ts
+++ b/hooks/useCurrentSpace.ts
@@ -25,7 +25,7 @@ export function useCurrentSpace(): { space?: Space; isLoading: boolean; refreshC
     }
   }, [space]);
 
-  if (!accessChecked && !isSpacesLoaded) {
+  if (!accessChecked || !isSpacesLoaded) {
     return { isLoading: true, refreshCurrentSpace };
   }
 

--- a/hooks/useSharedPage.ts
+++ b/hooks/useSharedPage.ts
@@ -87,6 +87,7 @@ export const useSharedPage = () => {
     hasError,
     hasSharedPageAccess,
     publicSpace: space,
+    isPublicPath,
     publicPage,
     publicPageType: (isBountiesPath
       ? 'bounties'


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b24ec2</samp>

Fix `useCurrentSpace` hook to return correct loading state and improve spaces loading and error handling.

### WHY
[Card](https://app.charmverse.io/charmverse/page-11477044710986362)
Even if the user, space was loaded and access was verified, the member directory page was showing the 404 error page. It's been fixed and I've checkout both proposals and bounties page for detecting any breaking changes.