### PR TITLE
Do not set cross domain cookies

### DIFF
--- a/lib/session/getIronOptions.ts
+++ b/lib/session/getIronOptions.ts
@@ -1,24 +1,16 @@
-import type { IncomingMessage } from 'http';
-
 import type { IronSessionOptions } from 'iron-session';
 
 import { baseUrl, cookieName } from 'config/constants';
 import { authSecret } from 'lib/session/config';
-import { getAppApexDomain } from 'lib/utilities/domains/getAppApexDomain';
-import { getValidCustomDomain } from 'lib/utilities/domains/getValidCustomDomain';
-import { isLocalhostAlias } from 'lib/utilities/domains/isLocalhostAlias';
 
-export function getIronOptions(req?: IncomingMessage): IronSessionOptions {
-  const customDomain = getValidCustomDomain(req?.headers.host);
-
+export function getIronOptions(): IronSessionOptions {
   const ironOptions: IronSessionOptions = {
     cookieName,
     password: authSecret,
     cookieOptions: {
       sameSite: 'strict' as const,
       // secure: true should be used in production (HTTPS) but can't be used in development (HTTP)
-      secure: typeof baseUrl === 'string' && baseUrl.includes('https'),
-      domain: isLocalhostAlias(req?.headers.host) || customDomain ? undefined : getAppApexDomain()
+      secure: typeof baseUrl === 'string' && baseUrl.includes('https')
     }
   };
   return ironOptions;

--- a/lib/session/removeOldCookie.ts
+++ b/lib/session/removeOldCookie.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { cookieName } from 'config/constants';
+import { getAppApexDomain } from 'lib/utilities/domains/getAppApexDomain';
 import { isLocalhostAlias } from 'lib/utilities/domains/isLocalhostAlias';
 
 export async function removeOldCookieFromResponse(req: NextApiRequest, res: NextApiResponse, keepSession?: boolean) {
@@ -13,8 +14,8 @@ export async function removeOldCookieFromResponse(req: NextApiRequest, res: Next
 
   res.setHeader('Set-Cookie', [
     ...setCookiesArray,
-    // remove old non cross-domain cookie
-    `${cookieName}=; Max-Age=0; Path=/; HttpOnly;`
+    // remove old cross-domain cookie
+    `${cookieName}=; Domain=${getAppApexDomain()}; Max-Age=0; Path=/; HttpOnly;`
   ]);
 
   if (keepSession) {

--- a/lib/utilities/browser.ts
+++ b/lib/utilities/browser.ts
@@ -174,14 +174,10 @@ export function setCookie({
   expiresInDays: number;
 }) {
   const expires = new Date();
-  const domain = isLocalhostAlias() ? undefined : `Domain=${getAppApexDomain()};`;
   const secure = typeof baseUrl === 'string' && baseUrl.includes('https') ? 'secure;' : '';
 
   expires.setDate(expires.getDate() + expiresInDays);
-
-  document.cookie = `${name}=${encodeURIComponent(
-    value
-  )}; ${domain} expires=${expires.toUTCString()}; path=/; ${secure}}`;
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires.toUTCString()}; path=/; ${secure}}`;
 }
 
 export function deleteCookie(name: string) {

--- a/lib/websockets/authentication.ts
+++ b/lib/websockets/authentication.ts
@@ -58,5 +58,5 @@ function getSessionFromSocket(socket: Socket) {
   const req = new IncomingMessage();
   req.headers = socket.handshake.headers;
   const res = new ServerResponse(req);
-  return getIronSession(req, res, getIronOptions(req));
+  return getIronSession(req, res, getIronOptions());
 }

--- a/pages/api/profile/index.ts
+++ b/pages/api/profile/index.ts
@@ -86,6 +86,7 @@ async function getUser(req: NextApiRequest, res: NextApiResponse<LoggedInUser | 
   }
 
   res.setHeader('Cache-Control', 'no-store');
+  await removeOldCookieFromResponse(req, res, true);
 
   return res.status(200).json(profile);
 }

--- a/pages/api/profile/index.ts
+++ b/pages/api/profile/index.ts
@@ -86,7 +86,6 @@ async function getUser(req: NextApiRequest, res: NextApiResponse<LoggedInUser | 
   }
 
   res.setHeader('Cache-Control', 'no-store');
-  await removeOldCookieFromResponse(req, res, true);
 
   return res.status(200).json(profile);
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ad251c</samp>

Simplified and fixed the cookie domain logic for session management across different domains and subdomains. Removed unused code and imports related to the old cookie domain logic from various files. Updated the `getIronOptions` function and its calls to reflect the new logic.

### WHY
We decided to not move forward with cross-domain cookies
