### PR TITLE
trim whitspace when entering inputs for token gate

### DIFF
--- a/lib/lit-protocol-modal/reusableComponents/litInput/LitInput.jsx
+++ b/lib/lit-protocol-modal/reusableComponents/litInput/LitInput.jsx
@@ -15,7 +15,7 @@ const LitInput = ({
              value={value}
              type={type}
              disabled={disabled}
-             onChange={(e) => setValue(e.target.value)}
+             onChange={(e) => setValue(e.target.value.trim())}
              className={'lsm-input'}/>
       {!loading ? (
         <p className={'lsm-input-error'}>


### PR DESCRIPTION
Noticed a user's gates were not working due to an extra empty space at the end of the contract. This change affects all inputs in the modal, and you can no longer type with a space since it gets trimmed immediately, but all the inputs seem to require space-less input anyway