### PR TITLE
enable runtime metrics in webapp

### DIFF
--- a/.ebstalk.apps.env/webapp.env
+++ b/.ebstalk.apps.env/webapp.env
@@ -8,6 +8,7 @@ DATABASE_URL="{{pull:secretsmanager:/io.cv.app/prd/db:SecretString:database_url}
 DAYLIGHT_API_KEY="{{pull:secretsmanager:/io.cv.app/prd/daylight:SecretString:api_key}}"
 DD_API_KEY="{{pull:secretsmanager:/io.cv.app/shared/datadog:SecretString:dd_api_key}}"
 DD_AGENT_HOST="datadog-agent"
+DD_RUNTIME_METRICS_ENABLED=true
 DEEPDAO_API_KEY="{{pull:secretsmanager:/io.cv.app/prd/deepdao:SecretString:deepdao_api_key}}"
 DISCORD_BOT_TOKEN="{{pull:secretsmanager:/io.cv.app/prd/discord:SecretString:discord_bot_token}}"
 DISCORD_EVENTS_WEBHOOK="{{pull:secretsmanager:/io.cv.app/prd/discord:SecretString:discord_events_webhook}}"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f45680c</samp>

Enable Datadog runtime metrics for webapp environment. This change helps monitor and optimize the app.charmverse.io webapp performance and resource usage by adding the `DD_RUNTIME_METRICS_ENABLED` variable to the `.ebstalk.apps.env/webapp.env` file.

### WHY
<!-- author to complete -->
https://docs.datadoghq.com/tracing/metrics/runtime_metrics/nodejs/?tab=environmentvariables