### PR TITLE
allow users to insert new rows from action menu

### DIFF
--- a/components/common/CharmEditor/components/inlinePalette/inlinePalette.ts
+++ b/components/common/CharmEditor/components/inlinePalette/inlinePalette.ts
@@ -107,7 +107,6 @@ function pluginsFactory({ key }: { key: PluginKey }) {
           }
           const marks = selection.$from.marks();
           const mark = _schema.mark(paletteMarkName, { trigger: _trigger });
-
           const textBefore = selection.$from.nodeBefore?.text;
           // Insert a space so we follow the convention of <space> trigger
           if (textBefore && !textBefore.endsWith(' ')) {

--- a/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
+++ b/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
@@ -12,6 +12,7 @@ import type { MenuProps } from '@mui/material';
 import { ListItemIcon, ListItemText, Menu, ListItemButton, Tooltip, Typography } from '@mui/material';
 import { bindMenu, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
 import { NodeSelection } from 'prosemirror-state';
+import type { MouseEvent } from 'react';
 import reactDOM from 'react-dom';
 
 import charmClient from 'charmClient';
@@ -64,7 +65,7 @@ function Component({ menuState }: { menuState: PluginState }) {
 
     const nodeStart = topPos.pos;
     const nodeSize = pmNode && pmNode.type.name !== 'doc' ? pmNode.nodeSize : 0;
-    let nodeEnd = nodeStart + nodeSize; // nodeSize includes the start and end tokens, so we need to subtract 1
+    let nodeEnd = nodeStart + (nodeSize - 1); // nodeSize includes the start and end tokens, so we need to subtract 1
 
     // dont delete past end of document - according to PM guide, use content.size not nodeSize for the doc
     if (nodeEnd > view.state.doc.content.size) {
@@ -149,7 +150,7 @@ function Component({ menuState }: { menuState: PluginState }) {
     }
     const insertPos = e.altKey
       ? // insert before
-        node.nodeStart
+        node.nodeStart - 1
       : // insert after
       node.node.type.name === 'columnLayout'
       ? node.nodeEnd - 1

--- a/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
+++ b/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
@@ -11,7 +11,8 @@ import {
 import type { MenuProps } from '@mui/material';
 import { ListItemIcon, ListItemText, Menu, ListItemButton, Tooltip, Typography } from '@mui/material';
 import { bindMenu, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
-import { NodeSelection } from 'prosemirror-state';
+import { Fragment } from 'prosemirror-model';
+import { TextSelection } from 'prosemirror-state';
 import type { MouseEvent } from 'react';
 import reactDOM from 'react-dom';
 
@@ -156,15 +157,21 @@ function Component({ menuState }: { menuState: PluginState }) {
       ? node.nodeEnd - 1
       : node.nodeEnd;
     const tr = view.state.tr;
-
+    // TODO: Trigger component select menu
+    // const emptyLine = view.state.schema.nodes.paragraph.create(
+    //   null,
+    //   Fragment.fromArray([
+    //     view.state.schema.text('', [view.state.schema.mark('inline-command-palette-paletteMark', { trigger: '/' })])
+    //   ])
+    // );
     const emptyLine = view.state.schema.nodes.paragraph.create();
-    const newTr = safeInsert(emptyLine, insertPos)(tr);
+    // const newTr = safeInsert(emptyLine, insertPos)(tr);
 
-    // if (node.nodeEnd) {
-    //   const resolvedPos = tr.doc.resolve(node.nodeEnd);
-    //   tr.setSelection(new NodeSelection(resolvedPos));
-    // }
-    view.dispatch(newTr.scrollIntoView());
+    tr.setSelection(TextSelection.create(tr.doc, insertPos));
+    tr.replaceSelectionWith(emptyLine, false);
+    tr.setSelection(TextSelection.create(tr.doc, insertPos + 1));
+    view.dispatch(tr.scrollIntoView());
+    view.focus();
   }
 
   const optionKey = isMac() ? 'Option' : 'Alt';

--- a/components/common/CharmEditor/components/rowActions/rowActions.ts
+++ b/components/common/CharmEditor/components/rowActions/rowActions.ts
@@ -1,7 +1,6 @@
 import { createElement } from '@bangle.dev/core';
 import type { EditorView, PluginKey } from '@bangle.dev/pm';
 import { Plugin } from '@bangle.dev/pm';
-import { isMarkActiveInSelection } from '@bangle.dev/utils';
 import throttle from 'lodash/throttle';
 import { NodeSelection } from 'prosemirror-state';
 // @ts-ignore
@@ -17,6 +16,8 @@ export interface PluginState {
   rowNodeOffset?: number;
 }
 
+const docLeftMargin = 50;
+
 export function plugins({ key }: { key: PluginKey }) {
   const tooltipDOM = createElement(['div', { class: 'row-handle' }]);
 
@@ -24,7 +25,7 @@ export function plugins({ key }: { key: PluginKey }) {
     // @ts-ignore
     const containerXOffset = e.target.getBoundingClientRect().left;
     const clientX = e.clientX!;
-    const left = clientX - containerXOffset < 50 ? clientX + 50 : clientX;
+    const left = clientX - containerXOffset < docLeftMargin ? clientX + docLeftMargin : clientX;
 
     const startPos = posAtCoords(view, { left, top: e.clientY! });
 

--- a/components/common/CharmEditor/components/rowActions/rowActions.ts
+++ b/components/common/CharmEditor/components/rowActions/rowActions.ts
@@ -25,6 +25,11 @@ export function plugins({ key }: { key: PluginKey }) {
     if (view.isDestroyed) {
       return;
     }
+    // mouse is hovering over the editor container (left side margin for example)
+    // @ts-ignore
+    if (e.target === view.dom) {
+      return;
+    }
     // @ts-ignore
     const startPos = view.posAtDOM(e.target, 0);
 
@@ -35,7 +40,7 @@ export function plugins({ key }: { key: PluginKey }) {
     // const left = clientX - containerXOffset < docLeftMargin ? clientX + docLeftMargin : clientX;
     // const startPos = posAtCoords(view, { left, top: e.clientY! });
 
-    if (startPos) {
+    if (startPos !== undefined) {
       // Step 1. grab the top-most ancestor of the related DOM element
       const dom = rowNodeAtPos(view, startPos);
       const rowNode = dom.rowNode;
@@ -145,6 +150,10 @@ export function posAtCoords(view: EditorView, coords: { left: number; top: numbe
 export function rowNodeAtPos(view: EditorView, startPos: number) {
   const dom = view.domAtPos(startPos);
   let rowNode = dom.node;
+  // if startPos = 0, domAtPos gives us the doc container
+  if (rowNode === view.dom) {
+    rowNode = view.dom.children[0] || view.dom;
+  }
   // Note: for leaf nodes, domAtPos() only returns the parent with an offset. text nodes have an offset but don't have childNodes
   // ref: https://github.com/atlassian/prosemirror-utils/issues/8
   if (dom.offset && dom.node.childNodes[dom.offset]) {

--- a/components/common/CharmEditor/components/rowActions/rowActions.ts
+++ b/components/common/CharmEditor/components/rowActions/rowActions.ts
@@ -7,6 +7,8 @@ import { NodeSelection } from 'prosemirror-state';
 import { __serializeForClipboard as serializeForClipboard } from 'prosemirror-view';
 
 // inspiration for this plugin: https://discuss.prosemirror.net/t/creating-a-wrapper-for-all-blocks/3310/9
+// helpful links:
+// Indexing in PM: https://prosemirror.net/docs/guide/#doc.indexing
 
 export interface PluginState {
   tooltipDOM: HTMLElement;
@@ -16,18 +18,22 @@ export interface PluginState {
   rowNodeOffset?: number;
 }
 
-const docLeftMargin = 50;
-
 export function plugins({ key }: { key: PluginKey }) {
   const tooltipDOM = createElement(['div', { class: 'row-handle' }]);
 
   function onMouseOver(view: EditorView, e: MouseEventInit) {
+    if (view.isDestroyed) {
+      return;
+    }
     // @ts-ignore
-    const containerXOffset = e.target.getBoundingClientRect().left;
-    const clientX = e.clientX!;
-    const left = clientX - containerXOffset < docLeftMargin ? clientX + docLeftMargin : clientX;
+    const startPos = view.posAtDOM(e.target, 0);
 
-    const startPos = posAtCoords(view, { left, top: e.clientY! });
+    // old way of determining pos using coords - maybe not needed?
+    // const docLeftMargin = 50;
+    // const containerXOffset = e.target.getBoundingClientRect().left;
+    // const clientX = e.clientX!;
+    // const left = clientX - containerXOffset < docLeftMargin ? clientX + docLeftMargin : clientX;
+    // const startPos = posAtCoords(view, { left, top: e.clientY! });
 
     if (startPos) {
       // Step 1. grab the top-most ancestor of the related DOM element

--- a/components/common/CharmEditor/utils.ts
+++ b/components/common/CharmEditor/utils.ts
@@ -2,7 +2,6 @@ import type { EditorView } from '@bangle.dev/pm';
 import { safeInsert } from '@bangle.dev/utils';
 import type { Node } from 'prosemirror-model';
 import type { EditorState, Transaction } from 'prosemirror-state';
-import { TextSelection } from 'prosemirror-state';
 
 export const undoEventName = 'editor-undo';
 

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -487,16 +487,17 @@ ol li {
 // handles on the side of each row
 .row-handle {
   display: initial;
-  left: 20px;
+  left: 0px;
   top: -1000px;
   position: absolute;
-  width: 30px;
+  width: 56px;
   height: 24px;
   margin-top: 5px;
-  opacity: 0;
+  // opacity: 0;
   transition: opacity 0.2s ease-in-out;
 
   .charm-drag-handle {
+    display: flex;
     cursor: grab;
     opacity: 0.5;
     transition: opacity 0.2s ease-in-out;


### PR DESCRIPTION
Feature: 
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/96932962-22a9-4d00-884b-a877ca1803cf)

Known issues:
when you hover over the row actions and move your cursor up/down, you might expect for the row actions to follow This currently is not possible due to how we get the current node position from prosemirror. But I'd like to see if there's a workaround in the future

Testing:
I changed the algo a bit on how we find the hovered positions. So I tested Duplicate and Delete as well, particularly when the component is on the first row on a document. 