### PR TITLE
Fixed summon logo for role rows

### DIFF
--- a/components/settings/roles/components/RoleRow.tsx
+++ b/components/settings/roles/components/RoleRow.tsx
@@ -46,7 +46,7 @@ export function RoleRow({ readOnly, role, assignRoles, deleteRole, refreshRoles 
   } else if (role.source === 'guild_xyz') {
     descriptionIcon = <GuildXYZIcon />;
     description = <>This role is managed by Guild XYZ. Visit https://guild.xyz/ to modify this role</>;
-  } else if (role.source !== 'summon') {
+  } else if (role.source === 'summon') {
     descriptionIcon = theme.palette.mode === 'dark' ? <SummonLightIcon /> : <SummonDarkIcon />;
     description = <>This role is managed by Summon</>;
   }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5d4087</samp>

Fix Summon icon and description logic for role rows. This change corrects a UI bug in the `components/settings/roles/components/RoleRow.tsx` file that displayed the wrong icon and text for roles that were not created by the Summon feature.

### WHY
Remove summon logo for custom roles (the condition was inverted to see how it would look like for summon imported roles, but forgot to revert it before merging to prod)
