### PR TITLE
Custom image upload for page and board icon

### DIFF
--- a/components/[pageId]/DocumentPage/components/PageHeader.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeader.tsx
@@ -9,13 +9,13 @@ import { memo } from 'react';
 
 import { BlockIcons } from 'components/common/BoardEditor/focalboard/src/blockIcons';
 import { randomEmojiList } from 'components/common/BoardEditor/focalboard/src/emojiList';
-import EmojiPicker from 'components/common/BoardEditor/focalboard/src/widgets/emojiPicker';
 import Menu from 'components/common/BoardEditor/focalboard/src/widgets/menu';
 import MenuWrapper from 'components/common/BoardEditor/focalboard/src/widgets/menuWrapper';
 import EmojiIcon from 'components/common/Emoji';
 import { randomIntFromInterval } from 'lib/utilities/random';
 
 import { randomBannerImage } from './PageBanner';
+import { PageHeaderIcon } from './PageHeaderIcon';
 import { PageTitleInput } from './PageTitleInput';
 
 const PageControlItem = styled(ListItemButton)`
@@ -102,8 +102,8 @@ function PageHeader({ headerImage, icon, readOnly, setPage, title, updatedAt }: 
                     }}
                   />
                   <Menu.SubMenu id='pick' icon={<EmojiEmotionsOutlinedIcon />} name='Pick icon'>
-                    <EmojiPicker
-                      onSelect={(emoji) => {
+                    <PageHeaderIcon
+                      updatePageIcon={(emoji) => {
                         updatePageIcon(emoji);
                       }}
                     />

--- a/components/[pageId]/DocumentPage/components/PageHeaderIcon.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeaderIcon.tsx
@@ -47,6 +47,7 @@ export function PageHeaderIcon({ updatePageIcon }: { updatePageIcon: (icon: stri
               sx={{
                 width: '100%'
               }}
+              uploadDisclaimer='Recommended size is 280 × 280 pixels'
               isUploading={isUploading}
               setIsUploading={setIsUploading}
               setImage={updatePageIcon}

--- a/components/[pageId]/DocumentPage/components/PageHeaderIcon.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeaderIcon.tsx
@@ -1,0 +1,52 @@
+import { Stack, TextField } from '@mui/material';
+import { useState } from 'react';
+
+import EmojiPicker from 'components/common/BoardEditor/focalboard/src/widgets/emojiPicker';
+import Button from 'components/common/Button';
+import { ImageUploadButton } from 'components/common/ImageSelector/ImageUploadButton';
+import MultiTabs from 'components/common/MultiTabs';
+
+export function PageHeaderIcon({ updatePageIcon }: { updatePageIcon: (icon: string) => void }) {
+  const [isUploading, setIsUploading] = useState(false);
+  const [imageLink, setImageLink] = useState('');
+  return (
+    <MultiTabs
+      disabled={isUploading}
+      tabs={[
+        [
+          'Emojis',
+          <EmojiPicker
+            key='upload'
+            onSelect={(emoji) => {
+              updatePageIcon(emoji);
+            }}
+          />
+        ],
+        [
+          'Custom',
+          <Stack key='custom' spacing={1}>
+            <Stack flexDirection='row' gap={1}>
+              <TextField
+                value={imageLink}
+                onChange={(e) => {
+                  setImageLink(e.target.value);
+                }}
+                disabled={isUploading}
+                placeholder='Paste link to an image ...'
+              />
+              <Button
+                onClick={() => {
+                  updatePageIcon(imageLink);
+                }}
+                disabled={isUploading || imageLink.length === 0}
+              >
+                Submit
+              </Button>
+            </Stack>
+            <ImageUploadButton isUploading={isUploading} setIsUploading={setIsUploading} setImage={updatePageIcon} />
+          </Stack>
+        ]
+      ]}
+    />
+  );
+}

--- a/components/[pageId]/DocumentPage/components/PageHeaderIcon.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeaderIcon.tsx
@@ -7,11 +7,9 @@ import { ImageUploadButton } from 'components/common/ImageSelector/ImageUploadBu
 import MultiTabs from 'components/common/MultiTabs';
 
 export function PageHeaderIcon({ updatePageIcon }: { updatePageIcon: (icon: string) => void }) {
-  const [isUploading, setIsUploading] = useState(false);
   const [imageLink, setImageLink] = useState('');
   return (
     <MultiTabs
-      disabled={isUploading}
       tabs={[
         [
           'Emojis',
@@ -31,25 +29,23 @@ export function PageHeaderIcon({ updatePageIcon }: { updatePageIcon: (icon: stri
                 onChange={(e) => {
                   setImageLink(e.target.value);
                 }}
-                disabled={isUploading}
                 placeholder='Paste link to an image ...'
               />
               <Button
                 onClick={() => {
                   updatePageIcon(imageLink);
                 }}
-                disabled={isUploading || imageLink.length === 0}
+                disabled={imageLink.length === 0}
               >
                 Submit
               </Button>
             </Stack>
             <ImageUploadButton
+              variant='outlined'
               sx={{
                 width: '100%'
               }}
               uploadDisclaimer='Recommended size is 280 × 280 pixels'
-              isUploading={isUploading}
-              setIsUploading={setIsUploading}
               setImage={updatePageIcon}
             />
           </Stack>

--- a/components/[pageId]/DocumentPage/components/PageHeaderIcon.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeaderIcon.tsx
@@ -43,7 +43,14 @@ export function PageHeaderIcon({ updatePageIcon }: { updatePageIcon: (icon: stri
                 Submit
               </Button>
             </Stack>
-            <ImageUploadButton isUploading={isUploading} setIsUploading={setIsUploading} setImage={updatePageIcon} />
+            <ImageUploadButton
+              sx={{
+                width: '100%'
+              }}
+              isUploading={isUploading}
+              setIsUploading={setIsUploading}
+              setImage={updatePageIcon}
+            />
           </Stack>
         ]
       ]}

--- a/components/common/BoardEditor/focalboard/src/components/blockIconSelector.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/blockIconSelector.tsx
@@ -5,6 +5,7 @@ import EmojiEmotionsOutlinedIcon from '@mui/icons-material/EmojiEmotionsOutlined
 import React from 'react';
 import { useIntl } from 'react-intl';
 
+import { PageHeaderIcon } from 'components/[pageId]/DocumentPage/components/PageHeaderIcon';
 import PageIcon from 'components/common/Emoji';
 
 import { BlockIcons } from '../blockIcons';
@@ -48,10 +49,9 @@ const BlockIconSelector = React.memo((props: Props) => {
               icon={<EmojiEmotionsOutlinedIcon />}
               name={intl.formatMessage({ id: 'ViewTitle.pick-icon', defaultMessage: 'Pick icon' })}
             >
-              <EmojiPicker
-                onSelect={(emoji) => {
-                  // onSelectEmoji(emoji);
-                  setPage({ icon: emoji });
+              <PageHeaderIcon
+                updatePageIcon={(icon) => {
+                  setPage({ icon });
                 }}
               />
             </Menu.SubMenu>

--- a/components/common/BoardEditor/focalboard/src/widgets/emojiPicker.scss
+++ b/components/common/BoardEditor/focalboard/src/widgets/emojiPicker.scss
@@ -18,7 +18,21 @@
   }
 }
 
+div[role="tabpanel"] .EmojiPicker .emoji-mart {
+
+  .emoji-mart-category-label span {
+    background: var(--background-paper);
+  }
+
+  background: none;
+  border: none;
+}
+
 // Remove emoji mark footer with watermark
 .emoji-mart-scroll + .emoji-mart-bar {
   display: none;
+}
+
+.emoji-mart-bar {
+  border: none;
 }

--- a/components/common/BoardEditor/focalboard/src/widgets/emojiPicker.scss
+++ b/components/common/BoardEditor/focalboard/src/widgets/emojiPicker.scss
@@ -36,3 +36,16 @@ div[role="tabpanel"] .EmojiPicker .emoji-mart {
 .emoji-mart-bar {
   border: none;
 }
+
+.emoji-mart-anchor-icon {
+  cursor: pointer;
+}
+
+.emoji-mart-anchor-selected {
+  // This is an inline style so we need to use !important to override it
+  color: var(--primary-color) !important;
+
+  .emoji-mart-anchor-bar {
+    background: var(--primary-color) !important;
+  }
+}

--- a/components/common/BoardEditor/focalboard/src/widgets/emojiPicker.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/emojiPicker.tsx
@@ -1,7 +1,5 @@
 import type { BaseEmoji } from 'emoji-mart';
 import { Picker } from 'emoji-mart';
-import type { FC } from 'react';
-import React from 'react';
 
 import 'emoji-mart/css/emoji-mart.css';
 

--- a/components/common/Emoji.tsx
+++ b/components/common/Emoji.tsx
@@ -78,7 +78,15 @@ function EmojiIcon({
 }: ComponentProps<typeof Emoji> & { icon: string | ReactNode; size?: ImgSize }) {
   let iconContent: string | ReactNode = icon;
   if (typeof icon === 'string' && icon.startsWith('http')) {
-    iconContent = <img src={icon} />;
+    iconContent = (
+      <img
+        src={icon}
+        // Transferred from notion
+        style={{
+          objectFit: 'cover'
+        }}
+      />
+    );
   } else if (typeof icon === 'string') {
     const twemojiImage = getTwitterEmoji(icon);
     if (twemojiImage) {

--- a/components/common/ImageSelector/ImageSelector.tsx
+++ b/components/common/ImageSelector/ImageSelector.tsx
@@ -1,16 +1,14 @@
-import { log } from '@charmverse/core/log';
-import { Box, Button, TextField, Typography } from '@mui/material';
+import { Box, Button, TextField } from '@mui/material';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import MultiTabs from 'components/common/MultiTabs';
 import PopperPopup from 'components/common/PopperPopup';
-import { uploadToS3 } from 'lib/aws/uploadToS3Browser';
 
-import { PimpedButton } from '../Button';
 import { selectorPopupSizeConfig } from '../CharmEditor/components/common/selectorPopupSizeConfig';
 
 import ImageSelectorGallery from './ImageSelectorGallery';
+import { ImageUploadButton } from './ImageUploadButton';
 
 interface ImageSelectorProps {
   autoOpen?: boolean;
@@ -58,38 +56,13 @@ export default function ImageSelector({
                     width: '100%'
                   }}
                 >
-                  <PimpedButton
-                    loading={isUploading}
-                    loadingMessage='Uploading image'
-                    disabled={isUploading}
-                    component='label'
+                  <ImageUploadButton
+                    isUploading={isUploading}
+                    setIsUploading={setIsUploading}
+                    setImage={onImageSelect}
+                    uploadDisclaimer={uploadDisclaimer}
                     variant='contained'
-                  >
-                    Choose an image
-                    <input
-                      type='file'
-                      hidden
-                      accept='image/*'
-                      onChange={async (e) => {
-                        setIsUploading(true);
-                        const firstFile = e.target.files?.[0];
-                        if (firstFile) {
-                          try {
-                            const { url } = await uploadToS3(firstFile);
-                            onImageSelect(url);
-                          } catch (error) {
-                            log.error('Error uploading image to s3', { error });
-                          }
-                        }
-                        setIsUploading(false);
-                      }}
-                    />
-                  </PimpedButton>
-                  {uploadDisclaimer && (
-                    <Typography variant='caption' color='secondary'>
-                      {uploadDisclaimer}
-                    </Typography>
-                  )}
+                  />
                 </Box>
               ],
               [

--- a/components/common/ImageSelector/ImageSelector.tsx
+++ b/components/common/ImageSelector/ImageSelector.tsx
@@ -27,7 +27,6 @@ export default function ImageSelector({
 }: ImageSelectorProps) {
   const [embedLink, setEmbedLink] = useState('');
   const tabs: [string, ReactNode][] = [];
-  const [isUploading, setIsUploading] = useState(false);
 
   if (galleryImages) {
     tabs.push(['Gallery', <ImageSelectorGallery key='gallery' onImageClick={onImageSelect} items={galleryImages} />]);
@@ -40,7 +39,6 @@ export default function ImageSelector({
       popupContent={
         <Box>
           <MultiTabs
-            disabled={isUploading}
             tabs={[
               ...tabs,
               [
@@ -56,13 +54,7 @@ export default function ImageSelector({
                     width: '100%'
                   }}
                 >
-                  <ImageUploadButton
-                    isUploading={isUploading}
-                    setIsUploading={setIsUploading}
-                    setImage={onImageSelect}
-                    uploadDisclaimer={uploadDisclaimer}
-                    variant='contained'
-                  />
+                  <ImageUploadButton setImage={onImageSelect} uploadDisclaimer={uploadDisclaimer} />
                 </Box>
               ],
               [

--- a/components/common/ImageSelector/ImageUploadButton.tsx
+++ b/components/common/ImageSelector/ImageUploadButton.tsx
@@ -2,6 +2,7 @@ import { log } from '@charmverse/core/log';
 import type { ButtonProps } from '@mui/material';
 import { Stack, Typography } from '@mui/material';
 
+import { useSnackbar } from 'hooks/useSnackbar';
 import { uploadToS3 } from 'lib/aws/uploadToS3Browser';
 
 import { PimpedButton } from '../Button';
@@ -12,6 +13,7 @@ export function ImageUploadButton({
   setIsUploading,
   uploadDisclaimer,
   variant = 'outlined',
+  fileSizeLimit,
   ...props
 }: {
   isUploading: boolean;
@@ -19,7 +21,10 @@ export function ImageUploadButton({
   setImage: (image: string) => void;
   uploadDisclaimer?: string;
   variant?: ButtonProps['variant'];
+  // file size limit in megabytes
+  fileSizeLimit?: number;
 } & ButtonProps) {
+  const { showMessage } = useSnackbar();
   return (
     <Stack alignItems='center' gap={1}>
       <PimpedButton
@@ -51,6 +56,11 @@ export function ImageUploadButton({
             setIsUploading(true);
             const firstFile = e.target.files?.[0];
             if (firstFile) {
+              if (firstFile.size > (fileSizeLimit ?? 10) * 1024 * 1024) {
+                showMessage(`File size limit is ${fileSizeLimit ?? 10}MB`, 'error');
+                setIsUploading(false);
+                return;
+              }
               try {
                 const { url } = await uploadToS3(firstFile);
                 setImage(url);

--- a/components/common/ImageSelector/ImageUploadButton.tsx
+++ b/components/common/ImageSelector/ImageUploadButton.tsx
@@ -1,0 +1,70 @@
+import { log } from '@charmverse/core/log';
+import type { ButtonProps } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
+
+import { uploadToS3 } from 'lib/aws/uploadToS3Browser';
+
+import { PimpedButton } from '../Button';
+
+export function ImageUploadButton({
+  setImage,
+  isUploading,
+  setIsUploading,
+  uploadDisclaimer,
+  variant = 'outlined'
+}: {
+  isUploading: boolean;
+  setIsUploading: (isUploading: boolean) => void;
+  setImage: (image: string) => void;
+  uploadDisclaimer?: string;
+  variant?: ButtonProps['variant'];
+}) {
+  return (
+    <Stack alignItems='center' gap={1}>
+      <PimpedButton
+        loading={isUploading}
+        loadingMessage='Uploading image'
+        disabled={isUploading}
+        component='label'
+        variant={variant}
+        sx={{
+          width: 'fit-content'
+        }}
+      >
+        Choose an image
+        <input
+          disabled={isUploading}
+          type='file'
+          style={{
+            opacity: 0,
+            position: 'absolute',
+            top: 0,
+            left: 0
+          }}
+          accept='image/*'
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+          onChange={async (e) => {
+            setIsUploading(true);
+            const firstFile = e.target.files?.[0];
+            if (firstFile) {
+              try {
+                const { url } = await uploadToS3(firstFile);
+                setImage(url);
+              } catch (error) {
+                log.error('Error uploading image to s3', { error });
+              }
+            }
+            setIsUploading(false);
+          }}
+        />
+      </PimpedButton>
+      {uploadDisclaimer && (
+        <Typography variant='caption' color='secondary'>
+          {uploadDisclaimer}
+        </Typography>
+      )}
+    </Stack>
+  );
+}

--- a/components/common/ImageSelector/ImageUploadButton.tsx
+++ b/components/common/ImageSelector/ImageUploadButton.tsx
@@ -11,14 +11,15 @@ export function ImageUploadButton({
   isUploading,
   setIsUploading,
   uploadDisclaimer,
-  variant = 'outlined'
+  variant = 'outlined',
+  ...props
 }: {
   isUploading: boolean;
   setIsUploading: (isUploading: boolean) => void;
   setImage: (image: string) => void;
   uploadDisclaimer?: string;
   variant?: ButtonProps['variant'];
-}) {
+} & ButtonProps) {
   return (
     <Stack alignItems='center' gap={1}>
       <PimpedButton
@@ -27,9 +28,7 @@ export function ImageUploadButton({
         disabled={isUploading}
         component='label'
         variant={variant}
-        sx={{
-          width: 'fit-content'
-        }}
+        {...props}
       >
         Choose an image
         <input

--- a/components/common/ImageSelector/ImageUploadButton.tsx
+++ b/components/common/ImageSelector/ImageUploadButton.tsx
@@ -9,7 +9,7 @@ import { PimpedButton } from '../Button';
 export function ImageUploadButton({
   setImage,
   uploadDisclaimer,
-  variant = 'outlined',
+  variant = 'contained',
   fileSizeLimitMB,
   ...props
 }: {

--- a/components/common/ImageSelector/ImageUploadButton.tsx
+++ b/components/common/ImageSelector/ImageUploadButton.tsx
@@ -57,7 +57,7 @@ export function ImageUploadButton({
             const firstFile = e.target.files?.[0];
             if (firstFile) {
               if (firstFile.size > (fileSizeLimit ?? 10) * 1024 * 1024) {
-                showMessage(`File size limit is ${fileSizeLimit ?? 10}MB`, 'error');
+                showMessage(`File size limit is ${fileSizeLimit ?? 10}MB`, 'warning');
                 setIsUploading(false);
                 return;
               }

--- a/components/common/ImageSelector/ImageUploadButton.tsx
+++ b/components/common/ImageSelector/ImageUploadButton.tsx
@@ -38,7 +38,10 @@ export function ImageUploadButton({
             opacity: 0,
             position: 'absolute',
             top: 0,
-            left: 0
+            left: 0,
+            width: '100%',
+            height: '100%',
+            cursor: 'pointer'
           }}
           accept='image/*'
           onClick={(e) => {

--- a/components/common/ImageSelector/ImageUploadButton.tsx
+++ b/components/common/ImageSelector/ImageUploadButton.tsx
@@ -32,7 +32,11 @@ export function ImageUploadButton({
         disabled={isUploading}
         component='label'
         variant={variant}
-        onClick={openFilePicker}
+        onClick={(e: any) => {
+          // This is necessary to prevent the file picker to open multiple times (this happens in the sidebar)
+          e.preventDefault();
+          openFilePicker();
+        }}
         {...props}
       >
         Choose an image
@@ -43,6 +47,7 @@ export function ImageUploadButton({
           hidden
           accept='image/*'
           onClick={(e) => {
+            // Without this the file picker doesn't open
             e.stopPropagation();
           }}
           onChange={onFileChange}

--- a/components/common/MultiTabs.tsx
+++ b/components/common/MultiTabs.tsx
@@ -1,4 +1,4 @@
-import Box from '@mui/material/Box';
+import Box, { BoxProps } from '@mui/material/Box';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import Typography from '@mui/material/Typography';
@@ -22,7 +22,7 @@ function TabPanel(props: TabPanelProps) {
       {...other}
     >
       {value === index && (
-        <Box sx={{ p: 3 }}>
+        <Box sx={{ p: 1 }}>
           <Typography component='div'>{children}</Typography>
         </Box>
       )}

--- a/components/common/MultiTabs.tsx
+++ b/components/common/MultiTabs.tsx
@@ -1,4 +1,4 @@
-import Box, { BoxProps } from '@mui/material/Box';
+import Box from '@mui/material/Box';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import Typography from '@mui/material/Typography';
@@ -22,7 +22,7 @@ function TabPanel(props: TabPanelProps) {
       {...other}
     >
       {value === index && (
-        <Box sx={{ p: 1 }}>
+        <Box sx={{ p: 3 }}>
           <Typography component='div'>{children}</Typography>
         </Box>
       )}

--- a/components/common/MultiTabs.tsx
+++ b/components/common/MultiTabs.tsx
@@ -22,7 +22,7 @@ function TabPanel(props: TabPanelProps) {
       {...other}
     >
       {value === index && (
-        <Box sx={{ p: 3 }}>
+        <Box sx={{ p: 2 }}>
           <Typography component='div'>{children}</Typography>
         </Box>
       )}

--- a/components/common/PageLayout/components/PageIcon.tsx
+++ b/components/common/PageLayout/components/PageIcon.tsx
@@ -59,7 +59,7 @@ function LinkedIcon({ children }: { children: ReactNode }) {
 }
 
 type PageIconProps = Omit<ComponentProps<typeof StyledPageIcon>, 'icon'> & {
-  icon?: string | null;
+  icon?: ReactNode | null;
   pageType?: AllPagesProp['type'];
   isEditorEmpty?: boolean;
   isLinkedPage?: boolean;

--- a/components/common/PageLayout/components/PageIcon.tsx
+++ b/components/common/PageLayout/components/PageIcon.tsx
@@ -59,7 +59,7 @@ function LinkedIcon({ children }: { children: ReactNode }) {
 }
 
 type PageIconProps = Omit<ComponentProps<typeof StyledPageIcon>, 'icon'> & {
-  icon?: ReactNode;
+  icon?: string | null;
   pageType?: AllPagesProp['type'];
   isEditorEmpty?: boolean;
   isLinkedPage?: boolean;
@@ -78,6 +78,7 @@ export function NoAccessPageIcon() {
 }
 
 export function PageIcon({ icon, isEditorEmpty, isLinkedPage = false, pageType, ...props }: PageIconProps) {
+  let iconComponent: ReactNode = icon;
   if (!icon) {
     if (pageType === 'linked_board') {
       return (
@@ -91,25 +92,34 @@ export function PageIcon({ icon, isEditorEmpty, isLinkedPage = false, pageType, 
         />
       );
     } else if (pageType === 'board' || pageType === 'inline_board' || pageType === 'inline_linked_board') {
-      icon = <StyledDatabaseIcon />;
+      iconComponent = <StyledDatabaseIcon />;
     } else if (pageType === 'proposal' || pageType === 'proposals') {
-      icon = <ProposalIcon />;
+      iconComponent = <ProposalIcon />;
     } else if (pageType === 'bounty' || pageType === 'bounties') {
-      icon = <BountyIcon />;
+      iconComponent = <BountyIcon />;
     } else if (pageType === 'members') {
-      icon = <AccountCircleIcon />;
+      iconComponent = <AccountCircleIcon />;
     } else if (pageType === 'forum' || pageType === 'forum_category') {
-      icon = <MessageOutlinedIcon />;
+      iconComponent = <MessageOutlinedIcon />;
     } else if (isEditorEmpty) {
-      icon = <EmptyPageIcon />;
+      iconComponent = <EmptyPageIcon />;
     } else {
-      icon = <FilledPageIcon />;
+      iconComponent = <FilledPageIcon />;
     }
+  } else if (typeof icon === 'string' && icon.startsWith('http')) {
+    iconComponent = (
+      <img
+        src={icon}
+        style={{
+          objectFit: 'cover'
+        }}
+      />
+    );
   }
 
   return isLinkedPage ? (
-    <StyledPageIcon icon={<LinkedIcon>{icon}</LinkedIcon>} {...props} />
+    <StyledPageIcon icon={<LinkedIcon>{iconComponent}</LinkedIcon>} {...props} />
   ) : (
-    <StyledPageIcon icon={icon} {...props} />
+    <StyledPageIcon icon={iconComponent} {...props} />
   );
 }

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -198,7 +198,7 @@ interface PageLinkProps {
   children?: ReactNode;
   href: string;
   label?: string;
-  labelIcon?: React.ReactNode;
+  labelIcon?: string;
   isEmptyContent?: boolean;
   pageType: Page['type'];
   pageId?: string;

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -198,7 +198,7 @@ interface PageLinkProps {
   children?: ReactNode;
   href: string;
   label?: string;
-  labelIcon?: string;
+  labelIcon?: ReactNode;
   isEmptyContent?: boolean;
   pageType: Page['type'];
   pageId?: string;

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -17,6 +17,7 @@ import React, { forwardRef, memo, useCallback, useMemo, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
+import { PageHeaderIcon } from 'components/[pageId]/DocumentPage/components/PageHeaderIcon';
 import { getSortedBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import EmojiPicker from 'components/common/BoardEditor/focalboard/src/widgets/emojiPicker';
@@ -280,7 +281,7 @@ function EmojiMenu({ popupState, pageId }: { popupState: any; pageId: string }) 
         e.stopPropagation();
       }}
     >
-      <EmojiPicker onSelect={onSelectEmoji} />
+      <PageHeaderIcon updatePageIcon={onSelectEmoji} />
     </Menu>
   );
 }

--- a/hooks/useS3UploadInput.ts
+++ b/hooks/useS3UploadInput.ts
@@ -1,3 +1,4 @@
+import { log } from '@charmverse/core/log';
 import { useState } from 'react';
 
 import { useFilePicker } from 'hooks/useFilePicker';
@@ -9,15 +10,18 @@ export const DEFAULT_MAX_FILE_SIZE_MB = 20;
 export type UploadedFileInfo = { url: string; fileName: string; size?: number };
 export type UploadedFileCallback = (info: UploadedFileInfo) => void;
 
-export const useS3UploadInput = (onFileUpload: UploadedFileCallback) => {
+export const useS3UploadInput = (
+  onFileUpload: UploadedFileCallback,
+  fileSizeLimitMB: number = DEFAULT_MAX_FILE_SIZE_MB
+) => {
   const { showMessage } = useSnackbar();
   const [isUploading, setIsUploading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [fileName, setFileName] = useState('');
 
   async function uploadFile(file: File) {
-    if (file.size > DEFAULT_MAX_FILE_SIZE_MB * 1024 ** 2) {
-      showMessage(`File size must be less than ${DEFAULT_MAX_FILE_SIZE_MB}MB`, 'error');
+    if (file.size > fileSizeLimitMB * 1024 ** 2) {
+      showMessage(`File size must be less than ${fileSizeLimitMB}MB`, 'error');
       return;
     }
 
@@ -28,12 +32,13 @@ export const useS3UploadInput = (onFileUpload: UploadedFileCallback) => {
     try {
       const { url } = await uploadToS3(file, { onUploadPercentageProgress: setProgress });
       onFileUpload({ url, fileName: file.name || '', size: file.size });
-    } catch (e) {
+    } catch (error) {
+      log.error('Error uploading image to s3', { error });
       showMessage('Failed to upload file. Please try again.', 'error');
     } finally {
       setIsUploading(false);
     }
   }
 
-  return { ...useFilePicker(uploadFile), isUploading, progress, fileName, sizeLimit: DEFAULT_MAX_FILE_SIZE_MB };
+  return { ...useFilePicker(uploadFile), isUploading, progress, fileName, sizeLimit: fileSizeLimitMB };
 };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ce86bd</samp>

This pull request adds the feature of custom image icons for pages and boards, and refactors some components to support this feature. It introduces a new `PageHeaderIcon` component that allows the user to choose between an emoji or an image as the icon, and uses it in the `PageHeader` and `blockIconSelector` components. It also extracts the image upload logic to a separate `ImageUploadButton` component, and updates the `ImageSelector`, `PageIcon`, and `PageTreeItem` components to handle image urls as icons. It applies some custom styles to the `EmojiPicker` component and the `img` element inside the `EmojiIcon` component to improve the appearance of the icons.

### WHY
[Card](https://app.charmverse.io/charmverse/page-059699641486480326)
