### PR TITLE
Fix UI freezes caused by checkboxes and some browser extensions

### DIFF
--- a/components/common/CharmEditor/components/listItem/listItem.nodeViewPlugin.ts
+++ b/components/common/CharmEditor/components/listItem/listItem.nodeViewPlugin.ts
@@ -93,6 +93,15 @@ export function listItemNodeViewPlugin(name: string, readOnly?: boolean) {
 
         // Connect the two contentDOM and containerDOM for pm to write to
         instance.containerDOM?.appendChild(instance.contentDOM!);
+
+        // Disable mutation observer for all attributes except checked
+        instance.ignoreMutation = (mutation) => {
+          if (mutation.type === 'attributes' && mutation.attributeName !== 'checked') {
+            return true;
+          }
+
+          return false;
+        };
       },
 
       // We need to achieve a two way binding of the todoChecked state.


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c274900</samp>

Improve CharmEditor performance by adding custom ignoreMutation function to `listItem` nodeView. This function prevents re-rendering of the nodeView when `listItem` attributes change, except for `checked`.

### WHY
Prevent checkboxes from infinite re-rendering
