### PR TITLE
add script to generate orphan pages with no links

### DIFF
--- a/scripts/getOrphanPages.ts
+++ b/scripts/getOrphanPages.ts
@@ -1,0 +1,97 @@
+import { prisma } from '@charmverse/core/prisma-client';
+import { Page } from '@charmverse/core/prisma';
+import { Node } from 'prosemirror-model';
+import { getNodeFromJson } from 'lib/prosemirror/getNodeFromJson';
+import type { PageContent } from 'lib/prosemirror/interfaces';
+import { findChildren } from '@bangle.dev/utils';
+import { writeFileSync } from 'fs';
+const hostName = 'https://app.charmverse.io';
+//const hostName = 'http://localhost:3000';
+const filename = 'unlinked-pages.csv';
+
+async function getOrphans(domain: string) {
+  const { pages } = await prisma.space.findFirstOrThrow({
+    where: { domain },
+    include: {
+      pages: {
+        select: {
+          id: true,
+          path: true,
+          title: true,
+          content: true,
+          createdAt: true,
+          createdBy: true,
+          parentId: true,
+          deletedAt: true,
+          type: true
+        }
+      }
+    }
+  });
+
+  const orphans = new Map<string, (typeof pages)[number]>();
+  pages.forEach((page) => {
+    if (page.type !== 'board' && page.type !== 'page') {
+      return;
+    }
+    const reference = pages.find(({ content, id, deletedAt, type }) => {
+      if (deletedAt || !content) {
+        return;
+      }
+      try {
+        const doc = getNodeFromJson(content);
+        const linksToPage = findChildren(doc, (node) => {
+          if (node.type.name === 'page') {
+            if (node.attrs.id === page.id) {
+              return true;
+            }
+          }
+          const linkMark = node.marks.some((mark) => {
+            return mark.type.name === 'link' && mark.attrs.href?.includes(page.path);
+          });
+          if (linkMark) {
+            return true;
+          }
+          return false;
+        });
+        return linksToPage.length > 0;
+      } catch (error) {
+        console.error('could not read page', id, error);
+        return false;
+      }
+    });
+
+    if (!reference) {
+      orphans.set(page.id, page);
+    }
+  });
+
+  const results = [...orphans].map(([id, orphan]) => ({
+    id,
+    createdAt: orphan.createdAt,
+    createdBy: orphan.createdBy,
+    parentId: orphan.parentId,
+    url: `${hostName}/${domain}/${orphan.path}`,
+    title: orphan.title
+  }));
+  console.log('orphans', results);
+  console.log('Orphan count:', results.length, 'of', pages.length, 'pages');
+
+  let csv = 'Page Title, Page URL, Parent Page Title, Author, Created Date\n';
+
+  const users = new Map<string, { username: string }>();
+
+  for (let page of results) {
+    const parent = page.parentId ? await prisma.page.findUnique({ where: { id: page.parentId } }) : null;
+    const author =
+      users.get(page.createdBy) ||
+      (await prisma.user.findUniqueOrThrow({ where: { id: page.createdBy }, select: { username: true } }));
+    users.set(page.createdBy, author);
+    // write to CSV file
+    const columns = [page.title, page.url, parent?.title || '', author.username, page.createdAt.toDateString()];
+    csv += columns.join(',') + '\n';
+  }
+  writeFileSync(`${process.cwd()}/${filename}`, csv);
+}
+
+getOrphans('brilliant-orange-tarantula');


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f621765</samp>

Added a script `getOrphanPages.ts` to find and export orphan pages in a space. Orphan pages are pages that are not linked from any other page in the space. The script takes a domain argument and outputs a CSV file with the page URLs and authors.

### WHY
<!-- author to complete -->
