### PR TITLE
Compute proposal permissions for vote

### DIFF
--- a/pages/api/votes/[id]/index.ts
+++ b/pages/api/votes/[id]/index.ts
@@ -51,7 +51,11 @@ async function updateVote(req: NextApiRequest, res: NextApiResponse<Vote | { err
       createdBy: true,
       pageId: true,
       postId: true,
-      page: true
+      page: {
+        select: {
+          proposalId: true
+        }
+      }
     }
   });
 

--- a/pages/api/votes/[id]/index.ts
+++ b/pages/api/votes/[id]/index.ts
@@ -65,12 +65,12 @@ async function updateVote(req: NextApiRequest, res: NextApiResponse<Vote | { err
 
   if (vote.pageId && vote.page) {
     if (vote.page.proposalId) {
-      const proposalPermissiong = await req.basePermissionsClient.proposals.computeProposalPermissions({
+      const proposalPermissions = await req.basePermissionsClient.proposals.computeProposalPermissions({
         userId,
         resourceId: vote.pageId
       });
 
-      if (!proposalPermissiong.create_vote) {
+      if (!proposalPermissions.create_vote) {
         throw new UnauthorisedActionError('You do not have permissions to update the vote.');
       }
     } else {

--- a/pages/api/votes/[id]/index.ts
+++ b/pages/api/votes/[id]/index.ts
@@ -63,8 +63,8 @@ async function updateVote(req: NextApiRequest, res: NextApiResponse<Vote | { err
     throw new DataNotFoundError(`Cannot update vote as vote with id ${voteId} was not found.`);
   }
 
-  if (vote.pageId && vote.page) {
-    if (vote.page.proposalId) {
+  if (vote.pageId) {
+    if (vote.page?.proposalId) {
       const proposalPermissions = await req.basePermissionsClient.proposals.computeProposalPermissions({
         userId,
         resourceId: vote.pageId


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe6e1b0</samp>

Modified `updateVote` function to support proposal pages. Added `page` field to query and checked proposal permissions.

### WHY
This fixes both paid and free plan permissions
