### PR TITLE
Refactor button import / export / naming

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/BountyProperties.tsx
@@ -11,9 +11,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import useSWR from 'swr';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/BoardEditor/focalboard/src/widgets/buttons/button';
+import ButtonBoard from 'components/common/BoardEditor/focalboard/src/widgets/buttons/button';
 import Switch from 'components/common/BoardEditor/focalboard/src/widgets/switch';
-import CharmButton from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { InputSearchBlockchain } from 'components/common/form/InputSearchBlockchain';
 import { InputSearchCrypto } from 'components/common/form/InputSearchCrypto';
 import { InputSearchReviewers } from 'components/common/form/InputSearchReviewers';
@@ -251,7 +251,7 @@ export default function BountyProperties(props: {
             alignSelf: 'center'
           }}
         >
-          <Button>Reward</Button>
+          <ButtonBoard>Reward</ButtonBoard>
         </div>
         <Tabs
           indicatorColor={readOnly ? 'secondary' : 'primary'}
@@ -284,7 +284,7 @@ export default function BountyProperties(props: {
             }}
           >
             <div className='octo-propertyname octo-propertyname--readonly'>
-              <Button>Chain</Button>
+              <ButtonBoard>Chain</ButtonBoard>
             </div>
             <InputSearchBlockchain
               disabled={readOnly}
@@ -311,7 +311,7 @@ export default function BountyProperties(props: {
             }}
           >
             <div className='octo-propertyname octo-propertyname--readonly'>
-              <Button>Token</Button>
+              <ButtonBoard>Token</ButtonBoard>
             </div>
             <InputSearchCrypto
               disabled={readOnly || !isTruthy(currentBounty?.chainId)}
@@ -340,7 +340,7 @@ export default function BountyProperties(props: {
             }}
           >
             <div className='octo-propertyname octo-propertyname--readonly'>
-              <Button>Amount</Button>
+              <ButtonBoard>Amount</ButtonBoard>
             </div>
             <TextField
               data-test='bounty-property-amount'
@@ -402,7 +402,7 @@ export default function BountyProperties(props: {
         }}
       >
         <div className='octo-propertyname octo-propertyname--readonly'>
-          <Button>Advanced settings</Button>
+          <ButtonBoard>Advanced settings</ButtonBoard>
         </div>
         <Tooltip title={isShowingAdvancedSettings ? 'Hide advanced settings' : 'Expand advanced settings'}>
           <IconButton size='small'>
@@ -417,7 +417,7 @@ export default function BountyProperties(props: {
       <Collapse in={isShowingAdvancedSettings} timeout='auto' unmountOnExit>
         <div className='octo-propertyrow'>
           <div className='octo-propertyname octo-propertyname--readonly'>
-            <Button>Require applications</Button>
+            <ButtonBoard>Require applications</ButtonBoard>
           </div>
           <Switch
             isOn={Boolean(currentBounty?.approveSubmitters)}
@@ -441,7 +441,7 @@ export default function BountyProperties(props: {
               className='octo-propertyname octo-propertyname--readonly'
               style={{ alignSelf: 'baseline', paddingTop: 8 }}
             >
-              <Button>Applicant role(s)</Button>
+              <ButtonBoard>Applicant role(s)</ButtonBoard>
             </div>
             <div style={{ width: '100%' }}>
               <InputSearchRoleMultiple
@@ -487,7 +487,7 @@ export default function BountyProperties(props: {
           }}
         >
           <div className='octo-propertyname octo-propertyname--readonly'>
-            <Button>Submission limit</Button>
+            <ButtonBoard>Submission limit</ButtonBoard>
           </div>
           <Switch
             isOn={capSubmissions}
@@ -509,7 +509,7 @@ export default function BountyProperties(props: {
             }}
           >
             <div className='octo-propertyname octo-propertyname--readonly'>
-              <Button>Max submissions</Button>
+              <ButtonBoard>Max submissions</ButtonBoard>
             </div>
             <TextField
               required
@@ -563,7 +563,7 @@ export default function BountyProperties(props: {
             className='octo-propertyname octo-propertyname--readonly'
             style={{ alignSelf: 'baseline', paddingTop: 12 }}
           >
-            <Button>Reviewer</Button>
+            <ButtonBoard>Reviewer</ButtonBoard>
           </div>
           <div style={{ width: '100%' }}>
             <InputSearchReviewers
@@ -606,12 +606,12 @@ export default function BountyProperties(props: {
 
       {draftBounty && !bountyFromContext && (
         <Box display='flex' gap={2} my={2}>
-          <CharmButton color='primary' onClick={confirmNewBounty}>
+          <Button color='primary' onClick={confirmNewBounty}>
             Confirm new bounty
-          </CharmButton>
-          <CharmButton color='secondary' variant='outlined' onClick={cancelDraftBounty}>
+          </Button>
+          <Button color='secondary' variant='outlined' onClick={cancelDraftBounty}>
             Cancel
-          </CharmButton>
+          </Button>
         </Box>
       )}
 

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantActions.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantActions.tsx
@@ -1,7 +1,7 @@
 import { Box, Tooltip } from '@mui/material';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useBounties } from 'hooks/useBounties';
 import { useSnackbar } from 'hooks/useSnackbar';
 import type { ApplicationWithTransactions } from 'lib/applications/actions';

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantTableRow.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyApplicantTableRow.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import charmClient from 'charmClient';
 import { BountyApplicantStatus } from 'components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantStatus';
 import { useRefreshApplicationStatus } from 'components/bounties/hooks/useRefreshApplicationStatus';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import UserDisplay from 'components/common/UserDisplay';
 import { useBounties } from 'hooks/useBounties';

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyPropertiesHeader.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyPropertiesHeader.tsx
@@ -8,7 +8,7 @@ import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import { BountyStatusBadge } from 'components/bounties/components/BountyStatusBadge';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useIsFreeSpace } from 'hooks/useIsFreeSpace';
 import { useSnackbar } from 'hooks/useSnackbar';
 import type { BountyWithDetails } from 'lib/bounties';

--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountySignupButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountySignupButton.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import { SpaceAccessGate } from 'components/common/SpaceAccessGate/SpaceAccessGate';
 import { WalletSign } from 'components/login/WalletSign';

--- a/components/[pageId]/DocumentPage/components/PageHeaderIcon.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeaderIcon.tsx
@@ -2,7 +2,7 @@ import { Stack, TextField } from '@mui/material';
 import { useState } from 'react';
 
 import EmojiPicker from 'components/common/BoardEditor/focalboard/src/widgets/emojiPicker';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { ImageUploadButton } from 'components/common/ImageSelector/ImageUploadButton';
 import MultiTabs from 'components/common/MultiTabs';
 

--- a/components/[pageId]/DocumentPage/components/SuggestionsSidebar.tsx
+++ b/components/[pageId]/DocumentPage/components/SuggestionsSidebar.tsx
@@ -5,7 +5,7 @@ import { Box, Stack } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { activateTrack } from 'components/common/CharmEditor/components/fiduswriter/state_plugins/track/helpers';
 import { acceptAll } from 'components/common/CharmEditor/components/fiduswriter/track/acceptAll';
 import { rejectAll } from 'components/common/CharmEditor/components/fiduswriter/track/rejectAll';

--- a/components/_app/Web3ConnectionManager/components/NetworkModal/components/NetworkButton/NetworkButton.tsx
+++ b/components/_app/Web3ConnectionManager/components/NetworkModal/components/NetworkButton/NetworkButton.tsx
@@ -4,7 +4,7 @@ import Tooltip from '@mui/material/Tooltip';
 import type { Blockchain } from 'connectors';
 import { RPC } from 'connectors';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useWeb3AuthSig } from 'hooks/useWeb3AuthSig';
 import { greyColor2 } from 'theme/colors';
 

--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/ConnectorButton.tsx
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/ConnectorButton.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { greyColor2 } from 'theme/colors';
 
 const ImageIcon = styled.img`

--- a/components/bounties/BountiesPage.tsx
+++ b/components/bounties/BountiesPage.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo } from 'react';
 import { CSVLink } from 'react-csv';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { EmptyStateVideo } from 'components/common/EmptyStateVideo';
 import Link from 'components/common/Link';
 import { PageDialogProvider } from 'components/common/PageDialog/hooks/usePageDialog';

--- a/components/bounties/components/MultiPaymentModal.tsx
+++ b/components/bounties/components/MultiPaymentModal.tsx
@@ -17,7 +17,7 @@ import { getChainById } from 'connectors';
 import { bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
 import { useEffect, useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { DialogTitle, Modal } from 'components/common/Modal';
 import UserDisplay from 'components/common/UserDisplay';
 import useImportSafes from 'hooks/useImportSafes';

--- a/components/bounties/components/NewBountyButton.tsx
+++ b/components/bounties/components/NewBountyButton.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { usePageDialog } from 'components/common/PageDialog/hooks/usePageDialog';
 import { useBounties } from 'hooks/useBounties';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';

--- a/components/common/BoardEditor/focalboard/src/components/addViewMenu.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/addViewMenu.tsx
@@ -15,7 +15,7 @@ import { v4 as uuid } from 'uuid';
 
 import charmClient from 'charmClient';
 import { publishIncrementalUpdate } from 'components/common/BoardEditor/publisher';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import type { Block } from 'lib/focalboard/block';
 import type { Board, IPropertyTemplate } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/commentsList.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/commentsList.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Avatar from 'components/common/Avatar';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import InlineCharmEditor from 'components/common/CharmEditor/InlineCharmEditor';
 import { useMembers } from 'hooks/useMembers';
 import { useUser } from 'hooks/useUser';

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -31,7 +31,7 @@ import {
   sortCards
 } from 'components/common/BoardEditor/focalboard/src/store/cards';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { addNewCards, isValidCsvResult } from 'components/common/PageActions/utils/databasePageOptions';
 import { webhookEndpoint } from 'config/constants';

--- a/components/common/BoardEditor/focalboard/src/components/createLinkedView.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/createLinkedView.tsx
@@ -4,7 +4,7 @@ import { Box, Collapse, Stack, Typography } from '@mui/material';
 import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { MobileDialog } from 'components/common/MobileDialog/MobileDialog';
 import { useSmallScreen } from 'hooks/useMediaScreens';
 

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/newCardButton.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/newCardButton.tsx
@@ -4,7 +4,7 @@ import { ButtonGroup, Typography } from '@mui/material';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import React from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { TemplatesMenu } from 'components/common/TemplatesMenu';
 import { usePagePermissions } from 'hooks/usePagePermissions';
 import { usePages } from 'hooks/usePages';

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { mutate } from 'swr';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Link from 'components/common/Link';
 import { usePages } from 'hooks/usePages';
 import type { Board, IPropertyTemplate } from 'lib/focalboard/board';

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderDisplayByMenu.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderDisplayByMenu.tsx
@@ -2,7 +2,7 @@ import CheckOutlinedIcon from '@mui/icons-material/CheckOutlined';
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import type { IPropertyTemplate } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';
 

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
@@ -31,7 +31,7 @@ import { injectIntl } from 'react-intl';
 
 import charmClient from 'charmClient';
 import { publishIncrementalUpdate } from 'components/common/BoardEditor/publisher';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import type { Board } from 'lib/focalboard/board';

--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewPropertyOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewPropertyOptions.tsx
@@ -4,7 +4,7 @@ import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { IconButton, ListItemIcon, ListItemText, MenuItem, Typography, Stack } from '@mui/material';
 import { useMemo } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import type { IPropertyTemplate } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';
 

--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions/components/GoogleForms/GoogleConnectButton.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions/components/GoogleForms/GoogleConnectButton.tsx
@@ -2,7 +2,7 @@
 
 import Script from 'next/script';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 
 import { googleIdentityServiceScript, useGoogleAuth } from './hooks/useGoogleAuth';
 

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Tooltip } from '@mui/material';
-import Button from '@mui/material/Button';
+import MaterialButton from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import MuiLink from '@mui/material/Link';
 import NextLink from 'next/link';
@@ -10,7 +10,7 @@ import { forwardRef } from 'react';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { getSubdomainPath } from 'lib/utilities/browser';
 
-const StyledButton = styled(Button)`
+const StyledButton = styled(MaterialButton)`
   white-space: nowrap;
 `;
 
@@ -18,7 +18,7 @@ export const StyledSpinner = styled(CircularProgress)`
   margin-left: 5px;
 `;
 
-type ButtonProps = ComponentProps<typeof Button>;
+type ButtonProps = ComponentProps<typeof MaterialButton>;
 export type InputProps<C extends ElementType = ElementType> = ButtonProps &
   // Omit 'variant' because it gets overridden sometimes by component
   Omit<ComponentProps<C>, 'variant'> & {
@@ -28,7 +28,7 @@ export type InputProps<C extends ElementType = ElementType> = ButtonProps &
     loadingMessage?: string;
   };
 
-export const PimpedButton = forwardRef<HTMLButtonElement, InputProps<ElementType>>((_props, ref) => {
+export const CharmedButton = forwardRef<HTMLButtonElement, InputProps<ElementType>>((_props, ref) => {
   const { children, loading, loadingMessage, disabledTooltip, ...props } = _props;
 
   const buttonComponent = (
@@ -49,16 +49,16 @@ export const PimpedButton = forwardRef<HTMLButtonElement, InputProps<ElementType
 });
 
 // make sure teh id prop is on the same element as onClick
-const PimpedButtonWithNextLink = forwardRef<HTMLButtonElement, InputProps<ElementType>>((_props, ref) => {
+export const Button = forwardRef<HTMLButtonElement, InputProps<ElementType>>((_props, ref) => {
   const { space: currentSpace } = useCurrentSpace();
 
   const { href, external, children, id, onClick, target, 'data-test': dataTest, ...props } = _props;
   if (href && !_props.disabled) {
     if (external) {
       return (
-        <PimpedButton ref={ref} href={href} id={id} onClick={onClick} target={target} {...props}>
+        <CharmedButton ref={ref} href={href} id={id} onClick={onClick} target={target} {...props}>
           {children}
-        </PimpedButton>
+        </CharmedButton>
       );
     }
     // @ts-ignore
@@ -73,16 +73,14 @@ const PimpedButtonWithNextLink = forwardRef<HTMLButtonElement, InputProps<Elemen
         onClick={mouseOnClick}
         data-test={dataTest}
       >
-        <PimpedButton {...props}>{children}</PimpedButton>
+        <CharmedButton {...props}>{children}</CharmedButton>
       </MuiLink>
     );
   }
 
   return (
-    <PimpedButton ref={ref} id={id} onClick={onClick} data-test={dataTest} {...props}>
+    <CharmedButton ref={ref} id={id} onClick={onClick} data-test={dataTest} {...props}>
       {children}
-    </PimpedButton>
+    </CharmedButton>
   );
 });
-
-export default PimpedButtonWithNextLink;

--- a/components/common/CharmEditor/components/CryptoPrice.tsx
+++ b/components/common/CharmEditor/components/CryptoPrice.tsx
@@ -8,7 +8,7 @@ import { CryptoCurrencies, getChainById } from 'connectors';
 import { useEffect, useState } from 'react';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { CoinLogoAndTicker } from 'components/common/CoinLogoAndTicker';
 import { InputSearchCrypto } from 'components/common/form/InputSearchCrypto';
 import { InputSearchCurrency } from 'components/common/form/InputSearchCurrency';

--- a/components/common/CharmEditor/components/PageThread.tsx
+++ b/components/common/CharmEditor/components/PageThread.tsx
@@ -26,7 +26,7 @@ import { bindMenu, usePopupState } from 'material-ui-popup-state/hooks';
 import type { MouseEvent } from 'react';
 import { forwardRef, memo, useEffect, useRef, useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import UserDisplay from 'components/common/UserDisplay';
 import { useDateFormatter } from 'hooks/useDateFormatter';
 import { usePreventReload } from 'hooks/usePreventReload';

--- a/components/common/CharmEditor/components/file/FileUploadForm.tsx
+++ b/components/common/CharmEditor/components/file/FileUploadForm.tsx
@@ -1,6 +1,6 @@
 import { Typography, Box } from '@mui/material';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { CircularProgressWithLabel } from 'components/common/CircularProgressWithLabel/CircularProgressWithLabel';
 import type { UploadedFileCallback } from 'hooks/useS3UploadInput';
 import { useS3UploadInput } from 'hooks/useS3UploadInput';

--- a/components/common/CharmEditor/components/inlineDatabase/components/ViewSelection.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/ViewSelection.tsx
@@ -2,7 +2,7 @@ import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 import { Box, Card, Divider, MenuItem, Typography } from '@mui/material';
 import { upperFirst } from 'lodash';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import type { BoardView } from 'lib/focalboard/boardView';
 import { formatViewTitle } from 'lib/focalboard/boardView';
 

--- a/components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails.tsx
+++ b/components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails.tsx
@@ -3,7 +3,7 @@ import { Box, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/mater
 import Alert from '@mui/material/Alert';
 import useSWR from 'swr';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Loader from 'components/common/LoadingComponent';
 import VoteStatusChip from 'components/votes/components/VoteStatusChip';
 import { useDateFormatter } from 'hooks/useDateFormatter';

--- a/components/common/CharmEditor/components/nft/NFTNodeView.tsx
+++ b/components/common/CharmEditor/components/nft/NFTNodeView.tsx
@@ -16,7 +16,7 @@ import { RiNftLine } from 'react-icons/ri';
 import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { InputSearchBlockchain } from 'components/common/form/InputSearchBlockchain';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { MIN_IMAGE_WIDTH } from 'lib/prosemirror/plugins/image/constants';

--- a/components/common/CharmEditor/components/video/VideoUploadForm.tsx
+++ b/components/common/CharmEditor/components/video/VideoUploadForm.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import useSwr from 'swr';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 
 type Props = {

--- a/components/common/CopyableAddress.tsx
+++ b/components/common/CopyableAddress.tsx
@@ -3,9 +3,8 @@ import Tooltip from '@mui/material/Tooltip';
 import { useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
+import { Button } from 'components/common/Button';
 import { shortenHex } from 'lib/utilities/strings';
-
-import Button from './Button';
 
 const StyledButton = styled(Button)`
   color: inherit;

--- a/components/common/CreateSpaceForm/CreateSpaceForm.tsx
+++ b/components/common/CreateSpaceForm/CreateSpaceForm.tsx
@@ -16,7 +16,7 @@ import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import FieldLabel from 'components/common/form/FieldLabel';
 import { DialogTitle } from 'components/common/Modal';
 import PrimaryButton from 'components/common/PrimaryButton';

--- a/components/common/CreateSpaceForm/TemplateOption.tsx
+++ b/components/common/CreateSpaceForm/TemplateOption.tsx
@@ -3,7 +3,7 @@ import { KeyboardArrowRight } from '@mui/icons-material';
 import { Box, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 
 type TemplateOptionProps = {
   icon?: ReactNode;

--- a/components/common/Debug/WebSocketTester.tsx
+++ b/components/common/Debug/WebSocketTester.tsx
@@ -1,6 +1,6 @@
 import Grid from '@mui/material/Grid';
 
-import { PimpedButton as Button } from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useWebSocketClient } from 'hooks/useWebSocketClient';
 
 export function WebSocketTester() {

--- a/components/common/ImageSelector/ImageUploadButton.tsx
+++ b/components/common/ImageSelector/ImageUploadButton.tsx
@@ -4,7 +4,7 @@ import { Stack, Typography } from '@mui/material';
 import type { UploadedFileCallback } from 'hooks/useS3UploadInput';
 import { useS3UploadInput } from 'hooks/useS3UploadInput';
 
-import { PimpedButton } from '../Button';
+import { Button } from '../Button';
 
 export function ImageUploadButton({
   setImage,
@@ -26,7 +26,7 @@ export function ImageUploadButton({
 
   return (
     <Stack alignItems='center' gap={1}>
-      <PimpedButton
+      <Button
         loading={isUploading}
         loadingMessage='Uploading image'
         disabled={isUploading}
@@ -52,7 +52,7 @@ export function ImageUploadButton({
           }}
           onChange={onFileChange}
         />
-      </PimpedButton>
+      </Button>
       {uploadDisclaimer && (
         <Typography variant='caption' color='secondary'>
           {uploadDisclaimer}

--- a/components/common/ImportZippedMarkdown.tsx
+++ b/components/common/ImportZippedMarkdown.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import charmClient from 'charmClient';
 import type { InputProps } from 'components/common/Button';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useFilePicker } from 'hooks/useFilePicker';
 import { useIsAdmin } from 'hooks/useIsAdmin';

--- a/components/common/Menu.tsx
+++ b/components/common/Menu.tsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 import { usePopupState, bindMenu, bindTrigger } from 'material-ui-popup-state/hooks';
 import { v4 } from 'uuid';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { StyledListItemText } from 'components/common/StyledListItemText';
 
 export interface MenuOption<T = any> {

--- a/components/common/Modal/ConfirmApiPageKeyModal.tsx
+++ b/components/common/Modal/ConfirmApiPageKeyModal.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import type { ReactNode } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import type { ModalProps } from 'components/common/Modal';
 import { Modal } from 'components/common/Modal';
 

--- a/components/common/Modal/ConfirmDeleteModal.tsx
+++ b/components/common/Modal/ConfirmDeleteModal.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import type { ReactNode } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import type { ModalProps } from 'components/common/Modal';
 import { Modal } from 'components/common/Modal';
 

--- a/components/common/Modal/ConfirmImportModal.tsx
+++ b/components/common/Modal/ConfirmImportModal.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography';
 import type { ChangeEvent, ReactNode } from 'react';
 import { useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import type { ModalProps } from 'components/common/Modal';
 import { Modal } from 'components/common/Modal';
 

--- a/components/common/Modal/ModalWithButtons.tsx
+++ b/components/common/Modal/ModalWithButtons.tsx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import type { ReactNode } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import type { ModalProps } from 'components/common/Modal';
 import { Modal } from 'components/common/Modal';
 

--- a/components/common/PageActions/components/DocumentPageActionList.tsx
+++ b/components/common/PageActions/components/DocumentPageActionList.tsx
@@ -14,7 +14,7 @@ import Typography from '@mui/material/Typography';
 import { useRouter } from 'next/router';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { ArchiveProposalMenuItem } from 'components/proposals/ArchiveProposalMenuItem';
 import { useProposalCategories } from 'components/proposals/hooks/useProposalCategories';
 import { useBounties } from 'hooks/useBounties';

--- a/components/common/PageActions/components/SnapshotAction/ConnectSnapshot.tsx
+++ b/components/common/PageActions/components/SnapshotAction/ConnectSnapshot.tsx
@@ -8,7 +8,7 @@ import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import FieldLabel from 'components/common/form/FieldLabel';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useIsAdmin } from 'hooks/useIsAdmin';

--- a/components/common/PageDialog/PageDialog.tsx
+++ b/components/common/PageDialog/PageDialog.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import charmClient from 'charmClient';
 import DocumentPage from 'components/[pageId]/DocumentPage';
 import Dialog from 'components/common/BoardEditor/focalboard/src/components/dialog';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useCurrentPage } from 'hooks/useCurrentPage';
 import { usePage } from 'hooks/usePage';
 import { usePages } from 'hooks/usePages';

--- a/components/common/PageLayout/NexusLayout.tsx
+++ b/components/common/PageLayout/NexusLayout.tsx
@@ -4,7 +4,7 @@ import MuiAppBar from '@mui/material/AppBar';
 import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { PageDialogProvider } from 'components/common/PageDialog/hooks/usePageDialog';
 import { PageDialogGlobal } from 'components/common/PageDialog/PageDialogGlobal';
 import { SpaceSettingsDialog } from 'components/settings/SettingsDialog';

--- a/components/common/PageLayout/SharedPageLayout.tsx
+++ b/components/common/PageLayout/SharedPageLayout.tsx
@@ -8,7 +8,7 @@ import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import { DocumentPageProviders } from 'components/[pageId]/DocumentPage/DocumentPageProviders';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { PageDialogProvider } from 'components/common/PageDialog/hooks/usePageDialog';
 import { PageDialogGlobal } from 'components/common/PageDialog/PageDialogGlobal';
 import CurrentPageFavicon from 'components/common/PageLayout/components/CurrentPageFavicon';

--- a/components/common/PageLayout/components/AnnouncementBanner.tsx
+++ b/components/common/PageLayout/components/AnnouncementBanner.tsx
@@ -5,7 +5,7 @@ import { Box, IconButton, Stack } from '@mui/material';
 import type { ReactNode } from 'react';
 
 import { StyledBanner } from 'components/common/Banners/Banner';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useLocalStorage } from 'hooks/useLocalStorage';
 import { useSettingsDialog } from 'hooks/useSettingsDialog';
 

--- a/components/common/PageLayout/components/Header/components/BountyShareButton/BountyShareButton.tsx
+++ b/components/common/PageLayout/components/Header/components/BountyShareButton/BountyShareButton.tsx
@@ -1,7 +1,7 @@
 import Popover from '@mui/material/Popover';
 import { bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 
 import ShareBountyBoard from './ShareBountyBoard';
 

--- a/components/common/PageLayout/components/Header/components/EditingModeToggle.tsx
+++ b/components/common/PageLayout/components/Header/components/EditingModeToggle.tsx
@@ -4,7 +4,7 @@ import { IconButton, useMediaQuery, ListItemIcon, ListItemText, Menu, MenuItem, 
 import PopupState, { bindMenu, bindTrigger } from 'material-ui-popup-state';
 import { memo } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useCharmEditor, EDIT_MODE_CONFIG } from 'hooks/useCharmEditor';
 import type { EditMode } from 'hooks/useCharmEditor';
 

--- a/components/common/PageLayout/components/Header/components/ProposalsShareButton/ProposalsShareButton.tsx
+++ b/components/common/PageLayout/components/Header/components/ProposalsShareButton/ProposalsShareButton.tsx
@@ -1,7 +1,7 @@
 import Popover from '@mui/material/Popover';
 import { bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 
 import ShareProposals from './ShareProposals';
 

--- a/components/common/PageLayout/components/Header/components/ShareButton/ShareButton.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/ShareButton.tsx
@@ -4,7 +4,7 @@ import { IconButton, Popover, Tooltip, useMediaQuery } from '@mui/material';
 import { bindPopover, usePopupState } from 'material-ui-popup-state/hooks';
 import { memo } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 
 import { PagePermissionsContainer } from './components/PagePermissionsContainer';
 

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/AddPagePermissionsForm.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/AddPagePermissionsForm.tsx
@@ -11,7 +11,7 @@ import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import InputEnumToOptions from 'components/common/form/InputEnumToOptions';
 import { InputSearchMemberMultiple } from 'components/common/form/InputSearchMember';
 import { InputSearchRoleMultiple } from 'components/common/form/InputSearchRole';

--- a/components/common/PrimaryButton.tsx
+++ b/components/common/PrimaryButton.tsx
@@ -1,11 +1,13 @@
+/* deprecated  use import { Button } from 'components/common/Button'; */
+
 import styled from '@emotion/styled';
 import { darken } from '@mui/material/styles';
 import type { ElementType } from 'react';
 
+import { Button, StyledSpinner } from 'components/common/Button';
 import { blueColor } from 'theme/colors';
 
 import type { InputProps } from './Button';
-import Button, { StyledSpinner } from './Button';
 
 const StyledButton = styled(Button)`
   background: ${blueColor};
@@ -34,8 +36,9 @@ const StyledButton = styled(Button)`
   }
 `;
 
-function PimpedButton<C extends ElementType>(props: InputProps<C>) {
+function DeprecatedButton<C extends ElementType>(props: InputProps<C>) {
   const { children, loading, loadingMessage, ...rest } = props;
+
   return (
     <StyledButton disabled={loading} {...rest}>
       {loading && loadingMessage ? loadingMessage : children}
@@ -44,4 +47,5 @@ function PimpedButton<C extends ElementType>(props: InputProps<C>) {
   );
 }
 
-export default PimpedButton;
+/* deprecated  use import { Button } from 'components/common/Button'; */
+export default DeprecatedButton;

--- a/components/common/SpaceAccessGate/components/DiscordGate/DiscordGate.tsx
+++ b/components/common/SpaceAccessGate/components/DiscordGate/DiscordGate.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, Grid, Stack, Typography } from '@mui/material';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import PrimaryButton from 'components/common/PrimaryButton';
 import { getDiscordLoginPath } from 'lib/discord/getDiscordLoginPath';
 

--- a/components/common/UserProfile/components/CurrentUserProfile.tsx
+++ b/components/common/UserProfile/components/CurrentUserProfile.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react';
 import { mutate } from 'swr';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Legend from 'components/settings/Legend';
 import type { EditableFields } from 'components/u/components/UserDetails/UserDetailsForm';
 import { UserDetailsForm } from 'components/u/components/UserDetails/UserDetailsForm';

--- a/components/common/UserProfile/components/MemberProfile.tsx
+++ b/components/common/UserProfile/components/MemberProfile.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@mui/material/styles';
 
 import { Container } from 'components/[pageId]/DocumentPage/DocumentPage';
 import Dialog from 'components/common/BoardEditor/focalboard/src/components/dialog';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { PublicProfile } from 'components/u/PublicProfile';
 import type { Member } from 'lib/members/interfaces';
 

--- a/components/common/UserProfile/components/OnboardingEmailForm.tsx
+++ b/components/common/UserProfile/components/OnboardingEmailForm.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useUser } from 'hooks/useUser';
 
 export const schema = yup.object({

--- a/components/common/comments/Comment.tsx
+++ b/components/common/comments/Comment.tsx
@@ -7,7 +7,7 @@ import { Box, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Stack, Too
 import { bindMenu, usePopupState } from 'material-ui-popup-state/hooks';
 import { useMemo, useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import InlineCharmEditor from 'components/common/CharmEditor/InlineCharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/InlineCharmEditor';

--- a/components/common/comments/CommentForm.tsx
+++ b/components/common/comments/CommentForm.tsx
@@ -1,7 +1,7 @@
 import { Stack, Box } from '@mui/material';
 import { useMemo, useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/InlineCharmEditor';
 import InlineCharmEditor from 'components/common/CharmEditor/InlineCharmEditor';

--- a/components/common/comments/CommentReply.tsx
+++ b/components/common/comments/CommentReply.tsx
@@ -1,7 +1,7 @@
 import { Stack, Box } from '@mui/material';
 import { useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/InlineCharmEditor';
 import InlineCharmEditor from 'components/common/CharmEditor/InlineCharmEditor';
 import type { CreateCommentPayload } from 'components/common/comments/interfaces';

--- a/components/common/form/CustomERCTokenForm.tsx
+++ b/components/common/form/CustomERCTokenForm.tsx
@@ -10,7 +10,7 @@ import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { FormError } from 'components/common/form/FormError.class';
 import { InputSearchBlockchain } from 'components/common/form/InputSearchBlockchain';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';

--- a/components/common/stories/Button.stories.tsx
+++ b/components/common/stories/Button.stories.tsx
@@ -1,7 +1,7 @@
 import { Check } from '@mui/icons-material';
 import { Box, Paper } from '@mui/material';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 
 export default {
   title: 'common/Buttons',

--- a/components/common/stories/Form.stories.tsx
+++ b/components/common/stories/Form.stories.tsx
@@ -1,6 +1,7 @@
 import { Box, Grid, Paper } from '@mui/material';
 import { useState } from 'react';
 
+import { Button } from 'components/common/Button';
 import { NumberInputField } from 'components/common/form/fields/NumberInputField';
 import { SelectField } from 'components/common/form/fields/SelectField';
 import { TextInputField } from 'components/common/form/fields/TextInputField';
@@ -9,7 +10,6 @@ import { TimezoneAutocomplete } from 'components/u/components/TimezoneAutocomple
 import UserDescription from 'components/u/components/UserDescription';
 import type { Social } from 'components/u/interfaces';
 
-import Button from '../Button';
 import type { SelectOptionType } from '../form/fields/Select/interfaces';
 
 export default {

--- a/components/forum/components/CategoryMenu.tsx
+++ b/components/forum/components/CategoryMenu.tsx
@@ -9,7 +9,7 @@ import startCase from 'lodash/startCase';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import { useForumCategories } from 'hooks/useForumCategories';
 import { useIsAdmin } from 'hooks/useIsAdmin';

--- a/components/forum/components/CreateForumPost.tsx
+++ b/components/forum/components/CreateForumPost.tsx
@@ -5,7 +5,7 @@ import CardContent from '@mui/material/CardContent';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import UserDisplay from 'components/common/UserDisplay';
 import { useUser } from 'hooks/useUser';
 

--- a/components/forum/components/EditCategoryDialog.tsx
+++ b/components/forum/components/EditCategoryDialog.tsx
@@ -7,7 +7,7 @@ import TextField from '@mui/material/TextField';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import { useSnackbar } from 'hooks/useSnackbar';
 

--- a/components/forum/components/PostCategoryPermissions/PaidPostCategoryPermissions/PaidPostCategoryPermissions.tsx
+++ b/components/forum/components/PostCategoryPermissions/PaidPostCategoryPermissions/PaidPostCategoryPermissions.tsx
@@ -3,7 +3,7 @@ import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { usePostCategoryPermissions } from 'components/forum/hooks/usePostCategoryPermissions';
 import { usePostCategoryPermissionsList } from 'components/forum/hooks/usePostCategoryPermissionsList';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';

--- a/components/forum/components/PostCategoryPermissions/PaidPostCategoryPermissions/PostCategoryPermissionAddRolesDialog.tsx
+++ b/components/forum/components/PostCategoryPermissions/PaidPostCategoryPermissions/PostCategoryPermissionAddRolesDialog.tsx
@@ -2,7 +2,7 @@ import type { PostCategoryPermissionLevel } from '@charmverse/core/prisma';
 import Grid from '@mui/material/Grid';
 import { useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { SmallSelect } from 'components/common/form/InputEnumToOptions';
 import { InputSearchRoleMultiple } from 'components/common/form/InputSearchRole';
 import type { BulkRolePostCategoryPermissionUpsert } from 'components/forum/hooks/usePostCategoryPermissionsList';

--- a/components/forum/components/PostCategoryPermissions/components/AddRolesRow.tsx
+++ b/components/forum/components/PostCategoryPermissions/components/AddRolesRow.tsx
@@ -1,6 +1,6 @@
 import Tooltip from '@mui/material/Tooltip';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 
 type Props = {
   onClick?: () => void;

--- a/components/forum/components/PostDialog/PostDialog.tsx
+++ b/components/forum/components/PostDialog/PostDialog.tsx
@@ -9,7 +9,7 @@ import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import Dialog from 'components/common/BoardEditor/focalboard/src/components/dialog';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { DialogTitle } from 'components/common/Modal';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import { FullPageActionsMenuButton } from 'components/common/PageActions/FullPageActionsMenuButton';

--- a/components/forum/components/PostList/PostList.tsx
+++ b/components/forum/components/PostList/PostList.tsx
@@ -8,7 +8,7 @@ import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'r
 import useSWRInfinite from 'swr/infinite';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useForumCategories } from 'hooks/useForumCategories';
 import { useMembers } from 'hooks/useMembers';

--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -9,7 +9,7 @@ import charmClient from 'charmClient';
 import { PageTitleInput } from 'components/[pageId]/DocumentPage/components/PageTitleInput';
 import { ProposalBanner } from 'components/[pageId]/DocumentPage/components/ProposalBanner';
 import { Container } from 'components/[pageId]/DocumentPage/DocumentPage';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
 import type { CommentSortType } from 'components/common/comments/CommentSort';

--- a/components/login/CollectEmail.tsx
+++ b/components/login/CollectEmail.tsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { DialogTitle, Modal } from 'components/common/Modal';
 

--- a/components/login/LoginButton.tsx
+++ b/components/login/LoginButton.tsx
@@ -12,7 +12,7 @@ import { useRef, useState } from 'react';
 
 import { WalletSelector } from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal';
 import { ConnectorButton } from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/ConnectorButton';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { DiscordLoginHandler } from 'components/login/components/DiscordLoginHandler';
 import { useCustomDomain } from 'hooks/useCustomDomain';
 import { useFirebaseAuth } from 'hooks/useFirebaseAuth';

--- a/components/login/LoginErrorModal.tsx
+++ b/components/login/LoginErrorModal.tsx
@@ -1,7 +1,7 @@
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Link from 'components/common/Link';
 import { Modal } from 'components/common/Modal';
 import { charmverseDiscordInvite } from 'config/constants';

--- a/components/members/MemberDirectoryPage.tsx
+++ b/components/members/MemberDirectoryPage.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 
 import { iconForViewType } from 'components/common/BoardEditor/focalboard/src/components/viewMenu';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import ErrorPage from 'components/common/errors/ErrorPage';
 import { CenteredPageContent } from 'components/common/PageLayout/components/PageContent';
 import { useFilteredMembers } from 'components/members/hooks/useFilteredMembers';

--- a/components/members/components/MemberDirectoryProperties/MemberPropertiesSidebarItem.tsx
+++ b/components/members/components/MemberDirectoryProperties/MemberPropertiesSidebarItem.tsx
@@ -8,7 +8,7 @@ import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useEffect, useRef, useState } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import FieldLabel from 'components/common/form/FieldLabel';
 import type { SelectOptionType } from 'components/common/form/fields/Select/interfaces';
 import { SelectOptionsList } from 'components/common/form/fields/Select/SelectOptionsList';

--- a/components/members/components/MemberDirectoryProperties/MemberPropertySidebarDetails.tsx
+++ b/components/members/components/MemberDirectoryProperties/MemberPropertySidebarDetails.tsx
@@ -6,7 +6,7 @@ import { Box, Collapse, IconButton, InputLabel, MenuItem, Stack, Tooltip, Typogr
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useEffect, useMemo, useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { InputSearchRoleMultiple } from 'components/common/form/InputSearchRole';
 import Modal from 'components/common/Modal';
 import type { CreateMemberPropertyPermissionInput, MemberPropertyWithPermissions } from 'lib/members/interfaces';

--- a/components/nexus/components/NotifyMeButton.tsx
+++ b/components/nexus/components/NotifyMeButton.tsx
@@ -3,7 +3,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useUser } from 'hooks/useUser';
 
 import NotifyMeModal from './NotifyMeModal';

--- a/components/nexus/components/NotifyMeModal.tsx
+++ b/components/nexus/components/NotifyMeModal.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { Modal } from 'components/common/Modal';
 
 export const schema = yup.object({

--- a/components/nexus/components/SnoozeButton.tsx
+++ b/components/nexus/components/SnoozeButton.tsx
@@ -9,7 +9,7 @@ import { bindMenu, bindPopover, bindTrigger, usePopupState } from 'material-ui-p
 import { useEffect, useRef, useState } from 'react';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import { useDateFormatter } from 'hooks/useDateFormatter';
 import { useUser } from 'hooks/useUser';

--- a/components/proposals/components/ProposalDialog/ProposalDialog.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalDialog.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { EditorPage } from 'components/[pageId]/EditorPage/EditorPage';
 import Dialog from 'components/common/BoardEditor/focalboard/src/components/dialog';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import LoadingComponent from 'components/common/LoadingComponent';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import { FullPageActionsMenuButton } from 'components/common/PageActions/FullPageActionsMenuButton';

--- a/components/proposals/components/ProposalDialog/ProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalPage.tsx
@@ -8,7 +8,7 @@ import { useElementSize } from 'usehooks-ts';
 import charmClient from 'charmClient';
 import PageHeader from 'components/[pageId]/DocumentPage/components/PageHeader';
 import { Container } from 'components/[pageId]/DocumentPage/DocumentPage';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
 import { ScrollableWindow } from 'components/common/PageLayout';

--- a/components/proposals/components/ProposalsTable.tsx
+++ b/components/proposals/components/ProposalsTable.tsx
@@ -3,7 +3,7 @@ import { Box, Grid, Tooltip, Typography } from '@mui/material';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import GridContainer from 'components/common/Grid/GridContainer';
 import GridHeader from 'components/common/Grid/GridHeader';
 import LoadingComponent from 'components/common/LoadingComponent';

--- a/components/proposals/components/ProposalsViewOptions.tsx
+++ b/components/proposals/components/ProposalsViewOptions.tsx
@@ -6,7 +6,7 @@ import Divider from '@mui/material/Divider';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import { ViewOptions } from 'components/common/ViewOptions';
 import { useIsAdmin } from 'hooks/useIsAdmin';

--- a/components/proposals/components/permissions/PaidProposalCategoryPermissions/PaidProposalCategoryPermissions.tsx
+++ b/components/proposals/components/permissions/PaidProposalCategoryPermissions/PaidProposalCategoryPermissions.tsx
@@ -9,7 +9,7 @@ import { usePopupState } from 'material-ui-popup-state/hooks';
 import useSWR from 'swr';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Loader from 'components/common/LoadingComponent';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useRoles } from 'hooks/useRoles';

--- a/components/proposals/components/permissions/PaidProposalCategoryPermissions/ProposalCategoryPermissionAddRolesDialog.tsx
+++ b/components/proposals/components/permissions/PaidProposalCategoryPermissions/ProposalCategoryPermissionAddRolesDialog.tsx
@@ -2,7 +2,7 @@ import type { ProposalCategoryPermissionLevel } from '@charmverse/core/prisma';
 import Grid from '@mui/material/Grid';
 import { useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { SmallSelect } from 'components/common/form/InputEnumToOptions';
 import { InputSearchRoleMultiple } from 'components/common/form/InputSearchRole';
 

--- a/components/proposals/components/permissions/components/AddRolesButton.tsx
+++ b/components/proposals/components/permissions/components/AddRolesButton.tsx
@@ -1,4 +1,4 @@
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 
 type Props = {
   onClick?: () => void;

--- a/components/settings/SettingsDialog.tsx
+++ b/components/settings/SettingsDialog.tsx
@@ -8,7 +8,7 @@ import DialogContent from '@mui/material/DialogContent';
 import IconButton from '@mui/material/IconButton';
 import type { ReactNode } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { SectionName } from 'components/common/PageLayout/components/Sidebar/Sidebar';
 import { SidebarLink } from 'components/common/PageLayout/components/Sidebar/SidebarButton';
 import { SubscriptionSettings } from 'components/settings/subscription/SubscriptionSettings';

--- a/components/settings/import/ImportSettings.tsx
+++ b/components/settings/import/ImportSettings.tsx
@@ -7,7 +7,7 @@ import { useEffect } from 'react';
 import { SiDiscourse } from 'react-icons/si';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { ImportZippedMarkdown } from 'components/common/ImportZippedMarkdown';
 import Link from 'components/common/Link';
 import { Modal } from 'components/common/Modal';

--- a/components/settings/invites/components/InviteLinks/components/InviteActions.tsx
+++ b/components/settings/invites/components/InviteLinks/components/InviteActions.tsx
@@ -10,7 +10,7 @@ import type { PopupState } from 'material-ui-popup-state/hooks';
 import type { MouseEvent, SyntheticEvent } from 'react';
 import { memo, useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 
 const StyledMenu = styled((props: MenuProps) => (
   <Menu

--- a/components/settings/invites/components/InviteLinks/components/InviteLinkForm.tsx
+++ b/components/settings/invites/components/InviteLinks/components/InviteLinkForm.tsx
@@ -7,7 +7,7 @@ import Typography from '@mui/material/Typography';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import FieldLabel from 'components/common/form/FieldLabel';
 import { DialogTitle } from 'components/common/Modal';
 import PrimaryButton from 'components/common/PrimaryButton';

--- a/components/settings/roles/CustomRolesInfoModal.tsx
+++ b/components/settings/roles/CustomRolesInfoModal.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import { useSettingsDialog } from 'hooks/useSettingsDialog';
 

--- a/components/settings/roles/RoleSettings.tsx
+++ b/components/settings/roles/RoleSettings.tsx
@@ -4,7 +4,7 @@ import { Box, CircularProgress, Divider, Menu, Typography } from '@mui/material'
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useRef, useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import Legend from 'components/settings/Legend';
 import ImportGuildRolesMenuItem from 'components/settings/roles/components/ImportGuildRolesMenuItem';
 import { useIsAdmin } from 'hooks/useIsAdmin';

--- a/components/settings/roles/components/CreateRoleForm.tsx
+++ b/components/settings/roles/components/CreateRoleForm.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { InputSearchMemberMultiple } from 'components/common/form/InputSearchMember';
 import { useMembers } from 'hooks/useMembers';
 import type { ISystemError } from 'lib/utilities/errors';

--- a/components/settings/roles/components/ImportGuildRolesMenuItem.tsx
+++ b/components/settings/roles/components/ImportGuildRolesMenuItem.tsx
@@ -5,13 +5,12 @@ import { useEffect, useState } from 'react';
 import { mutate } from 'swr';
 
 import charmClient from 'charmClient';
+import { Button, StyledSpinner } from 'components/common/Button';
 import { ScrollableModal } from 'components/common/Modal';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { useUser } from 'hooks/useUser';
 import GuildXYZIcon from 'public/images/guild_logo.svg';
-
-import { PimpedButton, StyledSpinner } from '../../../common/Button';
 
 import GuildsAutocomplete from './GuildsAutocomplete';
 
@@ -114,7 +113,7 @@ export default function ImportGuildRolesMenuItem({ onClose }: { onClose: () => v
                 selectedGuildIds={selectedGuildIds}
                 guilds={guilds}
               />
-              <PimpedButton
+              <Button
                 loading={importingRoles}
                 sx={{
                   mt: 2
@@ -123,7 +122,7 @@ export default function ImportGuildRolesMenuItem({ onClose }: { onClose: () => v
                 onClick={importRoles}
               >
                 Import Roles
-              </PimpedButton>
+              </Button>
             </Box>
           )}
         </Box>

--- a/components/settings/roles/components/RoleForm.tsx
+++ b/components/settings/roles/components/RoleForm.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useRoles } from 'hooks/useRoles';
 import type { ISystemError } from 'lib/utilities/errors';
 

--- a/components/settings/roles/components/RolePermissions/RolePermissions.tsx
+++ b/components/settings/roles/components/RolePermissions/RolePermissions.tsx
@@ -8,7 +8,7 @@ import useSWR from 'swr/immutable';
 import { v4 as uuid } from 'uuid';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { PostCategoryRolePermissionRow } from 'components/forum/components/PostCategoryPermissions/components/PostCategoryPermissionRow';
 import { ProposalCategoryRolePermissionRow } from 'components/proposals/components/permissions/components/ProposalCategoryPermissionRow';
 import { useProposalCategories } from 'components/proposals/hooks/useProposalCategories';

--- a/components/settings/roles/components/RolePermissions/components/DefaultPagePermissions.tsx
+++ b/components/settings/roles/components/RolePermissions/components/DefaultPagePermissions.tsx
@@ -5,7 +5,7 @@ import { bindMenu, bindTrigger, usePopupState } from 'material-ui-popup-state/ho
 import { useState } from 'react';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { StyledListItemText } from 'components/common/StyledListItemText';
 import { CustomRolesInfoModal } from 'components/settings/roles/CustomRolesInfoModal';
 import { UpgradeWrapper } from 'components/settings/subscription/UpgradeWrapper';

--- a/components/settings/roles/components/RoleRowBase.tsx
+++ b/components/settings/roles/components/RoleRowBase.tsx
@@ -21,7 +21,7 @@ import { usePopupState } from 'material-ui-popup-state/hooks';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { InputSearchMemberMultiple } from 'components/common/form/InputSearchMember';
 import Modal from 'components/common/Modal';
 import type { Props as UpgradeProps } from 'components/settings/subscription/UpgradeWrapper';

--- a/components/settings/space/SpaceSettings.tsx
+++ b/components/settings/space/SpaceSettings.tsx
@@ -9,7 +9,7 @@ import { useForm, Controller } from 'react-hook-form';
 import * as yup from 'yup';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import FieldLabel from 'components/common/form/FieldLabel';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import ConnectSnapshot from 'components/common/PageActions/components/SnapshotAction/ConnectSnapshot';

--- a/components/settings/space/components/SetupCustomDomain.tsx
+++ b/components/settings/space/components/SetupCustomDomain.tsx
@@ -23,7 +23,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import FieldLabel from 'components/common/form/FieldLabel';
 import Link from 'components/common/Link';
 import LoadingComponent from 'components/common/LoadingComponent';

--- a/components/settings/subscription/ChangeCardDetails.tsx
+++ b/components/settings/subscription/ChangeCardDetails.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import useSWRMutation from 'swr/mutation';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import UpdateCardModal from 'components/common/Modal/ModalWithButtons';
 import { useSnackbar } from 'hooks/useSnackbar';
 import type { CreatePaymentMethodRequest } from 'lib/subscription/createPaymentMethod';

--- a/components/settings/subscription/CheckoutForm.tsx
+++ b/components/settings/subscription/CheckoutForm.tsx
@@ -12,7 +12,7 @@ import useSWRMutation from 'swr/mutation';
 import * as yup from 'yup';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { useSnackbar } from 'hooks/useSnackbar';
 import type { SubscriptionPeriod } from 'lib/subscription/constants';

--- a/components/settings/subscription/CreateSubscriptionInformation.tsx
+++ b/components/settings/subscription/CreateSubscriptionInformation.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { subscriptionDetails } from 'lib/subscription/constants';
 import type { SpaceSubscriptionWithStripeData } from 'lib/subscription/getActiveSpaceSubscription';

--- a/components/settings/subscription/OrderSummary.tsx
+++ b/components/settings/subscription/OrderSummary.tsx
@@ -1,7 +1,7 @@
 import { Divider, Stack, Typography } from '@mui/material';
 import type { FormEvent, ReactNode } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import type { SubscriptionPeriod } from 'lib/subscription/constants';
 import { generatePriceDetails } from 'lib/subscription/generatePriceDetails';
 import type { CouponDetails } from 'lib/subscription/getCouponDetails';

--- a/components/settings/subscription/SubscriptionActions.tsx
+++ b/components/settings/subscription/SubscriptionActions.tsx
@@ -1,7 +1,7 @@
 import Stack from '@mui/material/Stack';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import type { SpaceSubscriptionWithStripeData } from 'lib/subscription/getActiveSpaceSubscription';
 

--- a/components/settings/subscription/SubscriptionInformation.tsx
+++ b/components/settings/subscription/SubscriptionInformation.tsx
@@ -9,7 +9,7 @@ import useSWRMutation from 'swr/mutation';
 import * as yup from 'yup';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import ModalWithButtons from 'components/common/Modal/ModalWithButtons';
 import Legend from 'components/settings/Legend';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';

--- a/components/u/components/IdentityModal.tsx
+++ b/components/u/components/IdentityModal.tsx
@@ -8,7 +8,7 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { DialogTitle, Modal } from 'components/common/Modal';
 import { useSettingsDialog } from 'hooks/useSettingsDialog';

--- a/components/u/components/Integration.tsx
+++ b/components/u/components/Integration.tsx
@@ -4,7 +4,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import { Box, Divider, Grid, Tooltip, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 
 const IntegrationName = styled(Typography)`
   background-color: ${({ theme }) => theme.palette.background.dark};

--- a/components/u/components/UserDetails/UserDetailsForm.tsx
+++ b/components/u/components/UserDetails/UserDetailsForm.tsx
@@ -15,7 +15,7 @@ import useSWRImmutable from 'swr/immutable';
 import useSWRMutation from 'swr/mutation';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { hoverIconsStyle } from 'components/common/Icons/hoverIconsStyle';
 import Link from 'components/common/Link';
 import { useIdentityTypes } from 'components/settings/account/components/useIdentityTypes';

--- a/components/u/components/UserPathModal.tsx
+++ b/components/u/components/UserPathModal.tsx
@@ -7,7 +7,7 @@ import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { DialogTitle, Modal } from 'components/common/Modal';
 import debouncePromise from 'lib/utilities/debouncePromise';
 

--- a/components/u/components/UserSpacesList/UserSpacesList.tsx
+++ b/components/u/components/UserSpacesList/UserSpacesList.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import { useRouter } from 'next/router';
 import { useMemo, useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { MemberPropertiesForm } from 'components/common/UserProfile/components/MemberPropertiesForm';
 import { useMemberPropertyValues } from 'components/common/UserProfile/hooks/useMemberPropertyValues';

--- a/components/votes/components/CreateVoteModal.tsx
+++ b/components/votes/components/CreateVoteModal.tsx
@@ -19,7 +19,7 @@ import { DateTime } from 'luxon';
 import type { Dispatch, SetStateAction } from 'react';
 import { useEffect, useState } from 'react';
 
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import FieldLabel from 'components/common/form/FieldLabel';
 import Modal from 'components/common/Modal';

--- a/components/votes/components/NewProposalButton.tsx
+++ b/components/votes/components/NewProposalButton.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { KeyedMutator } from 'swr';
 
 import charmClient from 'charmClient';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import { TemplatesMenu } from 'components/common/TemplatesMenu';
 import { useProposalDialog } from 'components/proposals/components/ProposalDialog/hooks/useProposalDialog';
 import { useProposalCategories } from 'components/proposals/hooks/useProposalCategories';

--- a/pages/join.tsx
+++ b/pages/join.tsx
@@ -7,7 +7,7 @@ import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
 import getBaseLayout from 'components/common/BaseLayout/BaseLayout';
-import Button from 'components/common/Button';
+import { Button } from 'components/common/Button';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { DialogTitle } from 'components/common/Modal';
 import { SpaceAccessGate } from 'components/common/SpaceAccessGate/SpaceAccessGate';


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db32c01</samp>

This pull request refactors the usage of button components in various files to improve consistency and avoid conflicts. It replaces the default export of `Button` from `components/common/Button` with a named export and updates the corresponding imports in all files that use it. It also updates the `BountyProperties` component to use the button components from `components/common/BoardEditor/focalboard/src/widgets/buttons/button` instead of custom ones.

### WHY
I believe the time has come. It was alway confusing for me on how should we use our button, or should we use MUI etc. Previously we had options:

1) using PimpedButton `import { PimpedButton } from 'components/common/Button';`
2) using default export which wraps PiompedButton with href functionality `import AnyButtonNameyouLike  from 'components/common/Button';` 
3) Using PrimaryButton component 
4) Using MUI button

I decided to refactor this a bit to have one single source of a button:

`import { Button } from 'components/common/Button';`

Just like that. Smae name everywhere (although we can discuss on naming if you prefer to call it i.e. `CharmedButton` but personally I like generic name)

We should stop using PrimaryButton (now called DeprecatedButton) or any otehr way of importing button. Lets make it clear and simple.
