### PR TITLE
Improved Notion Import UX

### DIFF
--- a/components/common/BoardEditor/FocalBoardProvider.tsx
+++ b/components/common/BoardEditor/FocalBoardProvider.tsx
@@ -1,4 +1,3 @@
-import { log } from '@charmverse/core/log';
 import { useCallback, useEffect } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 

--- a/components/common/Snackbar.tsx
+++ b/components/common/Snackbar.tsx
@@ -16,7 +16,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
 });
 
 interface CustomizedSnackbarProps {
-  autoHideDuration?: number;
+  autoHideDuration?: number | null;
   severity?: AlertColor;
   message?: string;
   actions?: ReactNode[];

--- a/components/common/Snackbar.tsx
+++ b/components/common/Snackbar.tsx
@@ -26,7 +26,16 @@ interface CustomizedSnackbarProps {
 }
 
 export default function CustomizedSnackbar(props: CustomizedSnackbarProps) {
-  const { setIsOpen, severity, message, actions, origin, handleClose, isOpen } = useSnackbar();
+  const {
+    setIsOpen,
+    severity,
+    message,
+    actions,
+    origin,
+    handleClose,
+    isOpen,
+    autoHideDuration = props.autoHideDuration ?? 5000
+  } = useSnackbar();
   const router = useRouter();
 
   // Close the snackbar if we change url
@@ -40,8 +49,7 @@ export default function CustomizedSnackbar(props: CustomizedSnackbarProps) {
     isOpen: isOpenProp,
     message: messageProp,
     origin: originProp,
-    severity: severityProp,
-    autoHideDuration = 5000
+    severity: severityProp
   } = props;
 
   return (

--- a/components/common/Snackbar.tsx
+++ b/components/common/Snackbar.tsx
@@ -40,8 +40,11 @@ export default function CustomizedSnackbar(props: CustomizedSnackbarProps) {
 
   // Close the snackbar if we change url
   useEffect(() => {
-    setIsOpen(false);
-  }, [router.asPath]);
+    // When autoHideDuration is null, we don't want to close the snackbar automatically and instead wait for close action
+    if (autoHideDuration !== null) {
+      setIsOpen(false);
+    }
+  }, [router.asPath, autoHideDuration]);
 
   const {
     actions: actionsProp,

--- a/hooks/useNotionImport.tsx
+++ b/hooks/useNotionImport.tsx
@@ -165,6 +165,13 @@ export function NotionProvider({ children }: Props) {
         autoHideDuration={null}
         isOpen={!!notionState.error || !!notionState.warning || notionState.failedImports.length !== 0}
         message={notionState.error ?? notionState.warning}
+        handleClose={() => {
+          setNotionState({
+            error: undefined,
+            warning: undefined,
+            failedImports: []
+          });
+        }}
         actions={
           notionState.failedImports.length !== 0 && !notionState.loading
             ? [

--- a/hooks/useSnackbar.tsx
+++ b/hooks/useSnackbar.tsx
@@ -14,9 +14,13 @@ type IContext = {
   setActions: Dispatch<SetStateAction<ReactNode[]>>;
   showMessage: (msg: string, newSeverity?: AlertColor) => void;
   handleClose: SnackbarProps['onClose'];
+  autoHideDuration?: number | null;
+  setAutoHideDuration?: Dispatch<SetStateAction<number | null>>;
+  resetState: () => void;
 };
 
 export const SnackbarContext = createContext<Readonly<IContext>>({
+  resetState: () => {},
   handleClose: () => {},
   isOpen: false,
   actions: [],
@@ -27,7 +31,9 @@ export const SnackbarContext = createContext<Readonly<IContext>>({
   setSeverity: () => {},
   severity: 'info',
   showMessage: () => {},
-  setActions: () => {}
+  setActions: () => {},
+  autoHideDuration: 5000,
+  setAutoHideDuration: () => {}
 });
 
 export function SnackbarProvider({ children }: { children: ReactNode }) {
@@ -36,21 +42,34 @@ export function SnackbarProvider({ children }: { children: ReactNode }) {
   const [origin, setOrigin] = useState<SnackbarOrigin>({ vertical: 'bottom', horizontal: 'left' });
   const [severity, setSeverity] = useState<AlertColor>('info');
   const [message, setMessage] = useState<null | string>(null);
+  const [autoHideDuration, setAutoHideDuration] = useState<null | number>(5000);
 
   const handleClick = () => {
     setIsOpen(true);
+  };
+
+  const resetState = () => {
+    setIsOpen(false);
+    setActions([]);
+    setOrigin({ vertical: 'bottom', horizontal: 'left' });
+    setSeverity('info');
+    setMessage(null);
+    setAutoHideDuration(5000);
   };
 
   const handleClose: SnackbarProps['onClose'] = (_, reason) => {
     if (reason === 'clickaway') {
       return;
     }
-    setIsOpen(false);
+    resetState();
   };
 
   const value = useMemo<IContext>(
     () => ({
+      autoHideDuration,
+      setAutoHideDuration,
       isOpen,
+      resetState,
       handleClose,
       showMessage: (msg: string, newSeverity?: AlertColor, anchorOrigin?: SnackbarOrigin) => {
         newSeverity = newSeverity ?? 'info';

--- a/hooks/useSnackbar.tsx
+++ b/hooks/useSnackbar.tsx
@@ -6,16 +6,16 @@ type IContext = {
   isOpen: boolean;
   actions?: ReactNode[];
   setIsOpen: Dispatch<SetStateAction<boolean>>;
-  message: string | null;
+  message: ReactNode;
   origin: SnackbarOrigin;
-  setMessage: Dispatch<SetStateAction<string | null>>;
+  setMessage: Dispatch<SetStateAction<ReactNode>>;
   severity: AlertColor;
   setSeverity: Dispatch<SetStateAction<AlertColor>>;
   setActions: Dispatch<SetStateAction<ReactNode[]>>;
-  showMessage: (msg: string, newSeverity?: AlertColor) => void;
+  showMessage: (msg: ReactNode, newSeverity?: AlertColor) => void;
   handleClose: SnackbarProps['onClose'];
-  autoHideDuration?: number | null;
-  setAutoHideDuration?: Dispatch<SetStateAction<number | null>>;
+  autoHideDuration: number | null;
+  setAutoHideDuration: Dispatch<SetStateAction<number | null>>;
 };
 
 export const SnackbarContext = createContext<Readonly<IContext>>({
@@ -39,20 +39,16 @@ export function SnackbarProvider({ children }: { children: ReactNode }) {
   const [actions, setActions] = useState<ReactNode[]>([]);
   const [origin, setOrigin] = useState<SnackbarOrigin>({ vertical: 'bottom', horizontal: 'left' });
   const [severity, setSeverity] = useState<AlertColor>('info');
-  const [message, setMessage] = useState<null | string>(null);
+  const [message, setMessage] = useState<null | ReactNode>(null);
   const [autoHideDuration, setAutoHideDuration] = useState<null | number>(5000);
-
-  const handleClick = () => {
-    setIsOpen(true);
-  };
 
   const resetState = () => {
     setIsOpen(false);
     setActions([]);
     setOrigin({ vertical: 'bottom', horizontal: 'left' });
-    setSeverity('info');
     setMessage(null);
     setAutoHideDuration(5000);
+    setSeverity('info');
   };
 
   const handleClose: SnackbarProps['onClose'] = (_, reason) => {
@@ -68,9 +64,9 @@ export function SnackbarProvider({ children }: { children: ReactNode }) {
       setAutoHideDuration,
       isOpen,
       handleClose,
-      showMessage: (msg: string, newSeverity?: AlertColor, anchorOrigin?: SnackbarOrigin) => {
+      showMessage: (msg: ReactNode, newSeverity?: AlertColor, anchorOrigin?: SnackbarOrigin) => {
         newSeverity = newSeverity ?? 'info';
-        handleClick();
+        setIsOpen(true);
         if (anchorOrigin) {
           setOrigin(anchorOrigin);
         }

--- a/hooks/useSnackbar.tsx
+++ b/hooks/useSnackbar.tsx
@@ -16,11 +16,9 @@ type IContext = {
   handleClose: SnackbarProps['onClose'];
   autoHideDuration?: number | null;
   setAutoHideDuration?: Dispatch<SetStateAction<number | null>>;
-  resetState: () => void;
 };
 
 export const SnackbarContext = createContext<Readonly<IContext>>({
-  resetState: () => {},
   handleClose: () => {},
   isOpen: false,
   actions: [],
@@ -69,7 +67,6 @@ export function SnackbarProvider({ children }: { children: ReactNode }) {
       autoHideDuration,
       setAutoHideDuration,
       isOpen,
-      resetState,
       handleClose,
       showMessage: (msg: string, newSeverity?: AlertColor, anchorOrigin?: SnackbarOrigin) => {
         newSeverity = newSeverity ?? 'info';

--- a/lib/notion/NotionImporter/NotionCache.ts
+++ b/lib/notion/NotionImporter/NotionCache.ts
@@ -5,7 +5,7 @@ import { RateLimit } from 'async-sema';
 
 import type { IPropertyTemplate } from 'lib/focalboard/board';
 
-import type { BlocksRecord, CreatePageInput } from '../types';
+import type { BlocksRecord, CreatePageInput, FailedImportsError } from '../types';
 
 export type RegularPageItem = {
   charmversePage?: Page;
@@ -34,15 +34,7 @@ export class NotionCache {
 
   pagesWithoutIntegrationAccess: Set<string> = new Set();
 
-  failedImportsRecord: Record<
-    string,
-    {
-      pageId: string;
-      type: 'page' | 'database';
-      title: string;
-      blocks: [string, string][];
-    }
-  > = {};
+  failedImportsRecord: Record<string, FailedImportsError> = {};
 
   // key: blockId, value: pageId
   blockPageIdRecord: Map<string, string> = new Map();

--- a/lib/notion/NotionImporter/NotionImporter.ts
+++ b/lib/notion/NotionImporter/NotionImporter.ts
@@ -92,6 +92,7 @@ export class NotionImporter {
 
     const workspacePageId = v4();
 
+    // Create a root level page for the notion workspace
     await createPrismaPage({
       createdBy: this.userId,
       spaceId: this.spaceId,

--- a/lib/notion/NotionImporter/NotionImporter.ts
+++ b/lib/notion/NotionImporter/NotionImporter.ts
@@ -3,6 +3,8 @@ import { Client } from '@notionhq/client';
 import type { DatabaseObjectResponse, PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import { v4 } from 'uuid';
 
+import { relay } from 'lib/websockets/relay';
+
 import { createPrismaPage } from '../createPrismaPage';
 
 import { NotionCache } from './NotionCache';
@@ -93,13 +95,21 @@ export class NotionImporter {
     const workspacePageId = v4();
 
     // Create a root level page for the notion workspace
-    await createPrismaPage({
+    const rootPage = await createPrismaPage({
       createdBy: this.userId,
       spaceId: this.spaceId,
       id: workspacePageId,
       title: workspaceName,
       icon: workspaceIcon
     });
+
+    relay.broadcast(
+      {
+        type: 'pages_created',
+        payload: [rootPage]
+      },
+      this.spaceId
+    );
 
     const notionPage = new NotionPage({
       blocksPerRequest: this.blocksPerRequest,

--- a/lib/notion/createPrismaPage.ts
+++ b/lib/notion/createPrismaPage.ts
@@ -2,7 +2,7 @@ import type { Prisma } from '@charmverse/core/prisma';
 
 import { getPagePath } from 'lib/pages';
 import { createPage } from 'lib/pages/server/createPage';
-import { checkSpaceSpaceSubscriptionInfo, premiumPermissionsApiClient } from 'lib/permissions/api/routers';
+import { premiumPermissionsApiClient } from 'lib/permissions/api/routers';
 
 import type { CreatePageInput } from './types';
 

--- a/lib/notion/importFromWorkspace.ts
+++ b/lib/notion/importFromWorkspace.ts
@@ -31,12 +31,15 @@ export async function importFromWorkspace({
   const pagesRecordValues = Array.from(notionImporter.cache.pagesRecord.values());
   const totalNotionPages = pagesRecordValues.filter((value) => value.notionPage).length;
   const totalImportedPages = pagesRecordValues.filter((value) => value.charmversePage).length;
+  const failedImports = Object.values(notionImporter.cache.failedImportsRecord).slice(0, 25);
+
   relay.broadcast(
     {
       type: 'notion_import_completed',
       payload: {
         totalImportedPages,
-        totalPages: totalNotionPages
+        totalPages: totalNotionPages,
+        failedImports
       }
     },
     spaceId
@@ -45,7 +48,7 @@ export async function importFromWorkspace({
   log.info('[notion] Completed import of Notion pages', {
     'Notion pages': totalNotionPages,
     'Created CharmVerse pages (incl. cards)': totalImportedPages,
-    'Failed import pages': Object.values(notionImporter.cache.failedImportsRecord).slice(0, 25),
+    'Failed import pages': failedImports,
     'Pages without integration access': notionImporter.cache.pagesWithoutIntegrationAccess
   });
 

--- a/lib/notion/types.ts
+++ b/lib/notion/types.ts
@@ -18,7 +18,7 @@ export interface FailedImportsError {
   pageId: string;
   type: 'page' | 'database';
   title: string;
-  blocks: [string, number][][];
+  blocks: [string, string][][];
 }
 
 export type CreatePageInput = {

--- a/lib/notion/types.ts
+++ b/lib/notion/types.ts
@@ -18,7 +18,7 @@ export interface FailedImportsError {
   pageId: string;
   type: 'page' | 'database';
   title: string;
-  blocks: [string, string][][];
+  blocks: [string, string][];
 }
 
 export type CreatePageInput = {

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -109,6 +109,14 @@ type SpaceSubscriptionUpdated = {
   };
 };
 
+export type NotionImportCompleted = {
+  type: 'notion_import_completed';
+  payload: {
+    totalImportedPages: number;
+    totalPages: number;
+  };
+};
+
 export type ClientMessage = SubscribeToWorkspace;
 
 export type ServerMessage =
@@ -125,7 +133,8 @@ export type ServerMessage =
   | PostPublished
   | PostUpdated
   | PostDeleted
-  | SpaceSubscriptionUpdated;
+  | SpaceSubscriptionUpdated
+  | NotionImportCompleted;
 
 export type WebSocketMessage = ClientMessage | ServerMessage;
 

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -4,6 +4,7 @@ import type { PageMeta } from '@charmverse/core/pages';
 import type { Page, SubscriptionTier } from '@charmverse/core/prisma';
 
 import type { Block } from 'lib/focalboard/block';
+import type { FailedImportsError } from 'lib/notion/types';
 import type { ExtendedVote, VoteTask } from 'lib/votes/interfaces';
 
 export type Resource = { id: string };
@@ -114,6 +115,7 @@ export type NotionImportCompleted = {
   payload: {
     totalImportedPages: number;
     totalPages: number;
+    failedImports: FailedImportsError[];
   };
 };
 

--- a/testing/customRender.tsx
+++ b/testing/customRender.tsx
@@ -51,6 +51,8 @@ export const customRenderWithContext = (ui: ReactNode, { value, ...renderOptions
           >
             <SnackbarContext.Provider
               value={{
+                autoHideDuration: 5000,
+                setAutoHideDuration: () => {},
                 isOpen: false,
                 handleClose: () => {},
                 showMessage: () => {},


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4394c67</samp>

Added a feature to import boards from Notion and show the import status and errors to the user. Refactored the code to use web socket broadcasting and relay module to communicate the notion import events and results. Fixed some types and removed some unused imports.

### WHY
[Card](https://app.charmverse.io/charmverse/page-49366552253645923?viewId=50d940bb-fdbd-40ba-9816-616d6138a663&cardId=aa14ccea-2a10-4e71-9db4-179f6bff417f)
