### PR TITLE
run custom permission api image in staging

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -128,7 +128,14 @@ jobs:
           aws-region: us-east-1
 
       - name: Package
-        run: cat files_to_zip.txt | zip --symlinks -r@ deploy.zip
+        run: |
+          cat files_to_zip.txt | zip --symlinks -r@ deploy.zip
+          mkdir deploy
+          cp deploy.zip deploy
+          cd deploy
+          unzip deploy.zip
+          pwd
+          cat .ebextensions/00_env_vars.config
 
       - name: Deploy to staging
         id: cdk_deploy

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [labeled, opened, synchronize]
 
+env:
+  SELECTED_PERMISSION_API_TAG:
+
 jobs:
   deploy:
     if: |
@@ -66,7 +69,7 @@ jobs:
             yq -I 4 -i '
               with(.option_settings."aws:elasticbeanstalk:application:environment";
                     .COMPOSE_PROJECT_NAME = "pr${{ github.event.number }}" |
-                    .IMGTAG = "${{ github.run_id }}-${{ env.GITHUB_SHA_SHORT }}")
+                    .IMGTAG = "${{ github.run_id }}-${{ env.GITHUB_SHA_SHORT }}"
               ' .ebextensions/00_env_vars.config
 
             yq -I 4 -i '
@@ -78,6 +81,16 @@ jobs:
               with(.option_settings."aws:elasticbeanstalk:application:environment";
                     .IMGTAG = "${{ github.run_id }}-${{ env.GITHUB_SHA_SHORT }}")
               ' .ebextensions_websockets/00_env_vars.config
+
+      - name: Run specific version of permission api if SELECTED_PERMISSION_API_TAG exists
+        if: env.SELECTED_PERMISSION_API_TAG && env.GITHUB_HEAD_REF_SLUG == env.SELECTED_PERMISSION_API_TAG
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            yq -I 4 -i '
+              with(.option_settings."aws:elasticbeanstalk:application:environment";
+                    .PERMISSION_IMGTAG = "${{ env.SELECTED_PERMISSION_API_TAG }}")
+              ' .ebextensions/00_env_vars.config
 
       - name: Parse compose profile to see if we need to enable datadog
         id: get_compose_profiles

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -100,6 +100,7 @@ jobs:
 
       - name: Set STAGE and DDENABLED variable in environment for build and deploy steps
         run: |
+          cat  .ebextensions/00_env_vars.config
           echo "STAGE=pr-${{ github.event.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
 
           COMPOSE_PROFILES=${{ steps.get_compose_profiles.outputs.result }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, opened, synchronize]
 
 env:
-  SELECTED_PERMISSION_API_TAG:
+  SELECTED_PERMISSION_API_TAG: run-custom-branch-of-permission-in-staging
 
 jobs:
   deploy:
@@ -69,7 +69,7 @@ jobs:
             yq -I 4 -i '
               with(.option_settings."aws:elasticbeanstalk:application:environment";
                     .COMPOSE_PROJECT_NAME = "pr${{ github.event.number }}" |
-                    .IMGTAG = "${{ github.run_id }}-${{ env.GITHUB_SHA_SHORT }}"
+                    .IMGTAG = "${{ github.run_id }}-${{ env.GITHUB_SHA_SHORT }}")
               ' .ebextensions/00_env_vars.config
 
             yq -I 4 -i '

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -130,12 +130,6 @@ jobs:
       - name: Package
         run: |
           cat files_to_zip.txt | zip --symlinks -r@ deploy.zip
-          mkdir deploy
-          cp deploy.zip deploy
-          cd deploy
-          unzip deploy.zip
-          pwd
-          cat .ebextensions/00_env_vars.config
 
       - name: Deploy to staging
         id: cdk_deploy

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, opened, synchronize]
 
 env:
-  SELECTED_PERMISSION_API_TAG: run-custom-branch-of-permission-in-staging
+  SELECTED_PERMISSION_API_TAG:
 
 jobs:
   deploy:


### PR DESCRIPTION


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14fabed</samp>

This pull request enables running different versions of the `permission api` service in staging and fixes a bug in the `yq` command.

### WHY
sometimes you need to test in staging a custom branch of permission api. This modification will let you do this.