### PR TITLE
Fix subscriptions

### DIFF
--- a/pages/api/spaces/[id]/subscription.ts
+++ b/pages/api/spaces/[id]/subscription.ts
@@ -16,8 +16,8 @@ const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler
   .use(requireUser)
+  .get(requireSpaceMembership({ adminOnly: false, spaceIdKey: 'id' }), getSpaceSubscriptionController)
   .use(requireSpaceMembership({ adminOnly: true, spaceIdKey: 'id' }))
-  .get(getSpaceSubscriptionController)
   .delete(deletePaymentSubscription)
   .put(updatePaymentSubscription)
   .post(requireKeys(['period', 'blockQuota', 'billingEmail'], 'body'), createPaymentSubscription);

--- a/pages/api/v1/webhooks/stripe/index.ts
+++ b/pages/api/v1/webhooks/stripe/index.ts
@@ -101,11 +101,16 @@ export async function stripePayment(req: NextApiRequest, res: NextApiResponse): 
         };
 
         await prisma.$transaction([
-          prisma.stripeSubscription.create({
-            data: {
+          prisma.stripeSubscription.upsert({
+            where: {
+              subscriptionId: stripeSubscription.id,
+              spaceId
+            },
+            create: {
               ...newData,
               spaceId
-            }
+            },
+            update: {}
           }),
           prisma.space.update({
             where: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2fb5d54</samp>

Use `upsert` to avoid duplicate subscriptions in `stripeSubscription` table. This improves the reliability and consistency of the webhook handler for Stripe events.

### WHY
Fixed:
- webhook error on enterprise: I was assuming we will only create, but in fact we can create or not, depending on the type of product.
- user can't see block count because he is not an admin