### PR TITLE
Fix page share url from custom domain

### DIFF
--- a/lib/utilities/browser.ts
+++ b/lib/utilities/browser.ts
@@ -287,7 +287,7 @@ export function getAbsolutePath(path: string, spaceDomain: string | undefined) {
         ? window?.origin.replace(`${subdomain}.`, `${spaceDomain}.`)
         : window.location.origin;
 
-    return origin + getSubdomainPath(absolutePath);
+    return origin + getSubdomainPath(absolutePath, { domain: spaceDomain || '', customDomain: getValidCustomDomain() });
   }
 
   return absolutePath;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 824b9a2</samp>

Updated `getAbsolutePath` and `getSubdomainPath` functions in `lib/utilities/browser.ts` to support custom domains for spaces.

### WHY
<!-- author to complete -->
