### PR TITLE
Fix safari video playback

### DIFF
--- a/components/common/CharmEditor/components/video/VideoNodeView.tsx
+++ b/components/common/CharmEditor/components/video/VideoNodeView.tsx
@@ -126,6 +126,7 @@ export function VideoNodeView({
       return (
         <BlockAligner readOnly={readOnly} onDelete={deleteNode}>
           <MuxVideo
+            playsInline
             style={{ height: '100%', maxWidth: '100%', width: '100%' }}
             playbackId={playbackIdWithToken} // asset.playbackId includes signed token
             // for analytics

--- a/lib/utilities/domains/getValidCustomDomain.ts
+++ b/lib/utilities/domains/getValidCustomDomain.ts
@@ -2,6 +2,10 @@ import { getValidDefaultHost } from 'lib/utilities/domains/getValidDefaultHost';
 import { isLocalhostAlias } from 'lib/utilities/domains/isLocalhostAlias';
 
 export function getValidCustomDomain(host?: string | null) {
+  if (process.env.DISABLE_SUBDOMAINS === 'true') {
+    return null;
+  }
+
   if (!host && typeof window !== 'undefined') {
     // On client side, get the host from window
     host = window.location.host;

--- a/lib/utilities/getValidSubdomain.ts
+++ b/lib/utilities/getValidSubdomain.ts
@@ -3,6 +3,10 @@ import { getValidDefaultHost } from 'lib/utilities/domains/getValidDefaultHost';
 import { isLocalhostAlias } from 'lib/utilities/domains/isLocalhostAlias';
 
 export function getValidSubdomain(host?: string | null) {
+  if (process.env.DISABLE_SUBDOMAINS === 'true') {
+    return null;
+  }
+
   if (!host && typeof window !== 'undefined') {
     // On client side, get the host from window
     host = window.location.host;

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@mui/material": "^5.11.7",
         "@mui/x-date-pickers": "^5.0.16",
         "@mux/mux-node": "^7.0.0",
-        "@mux/mux-video-react": "^0.7.1",
+        "@mux/mux-video-react": "^0.7.15",
         "@mux/upchunk": "^3.0.0",
         "@next/bundle-analyzer": "^12.0.7",
         "@notionhq/client": "^2.2.2",
@@ -13157,11 +13157,11 @@
       }
     },
     "node_modules/@mux/mux-video-react": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video-react/-/mux-video-react-0.7.4.tgz",
-      "integrity": "sha512-5MvYwZb5VxxQ176YlcDCR4a7DNDV7gCzUHaZD2NkUu1M3mbxgWvFuOvzQMVwby4V8zbnEYReQ1SXI0keNpZT5w==",
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video-react/-/mux-video-react-0.7.15.tgz",
+      "integrity": "sha512-qWbr5QwJoxBuwY6hb6YSaGHK1S4wa433lo6O9cID/u2wyp9F6eykNhKAmZ/RrxY5d3t/UQIw9OXGn44aG0eDJQ==",
       "dependencies": {
-        "@mux/playback-core": "0.16.0",
+        "@mux/playback-core": "0.18.5",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -13179,12 +13179,12 @@
       }
     },
     "node_modules/@mux/playback-core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.16.0.tgz",
-      "integrity": "sha512-DTnc0WVKtVd9V1qmN+oj6W7IAr4GArOWIm5hdfTc0tLS5UpAt/UZk5pSrHrwwo5DxhQTdC1lfM4EeDkSEAV3Dw==",
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.18.5.tgz",
+      "integrity": "sha512-uMBEaCcCv60z1YYF5f9hnx8w/rGPY++ShvD5uZmBM/4YveccBhHj4xqeSTbBkrcwgisF5Uz3IK3IKap2wY23WQ==",
       "dependencies": {
-        "hls.js": "1.3.1",
-        "mux-embed": "^4.14.0"
+        "hls.js": "^1.4.8",
+        "mux-embed": "^4.24.0"
       }
     },
     "node_modules/@mux/upchunk": {
@@ -32709,9 +32709,9 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.3.1.tgz",
-      "integrity": "sha512-6f4Qyrfj9sNUWMzNFKruqeD2KdisOwQ1GQJqnWAgMQ1hequlFK7e2dmF9qQD3mF/RI76hvztCMBptlPb+HcDow=="
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.4.10.tgz",
+      "integrity": "sha512-wAVSj4Fm2MqOHy5+BlYnlKxXvJlv5IuZHjlzHu18QmjRzSDFQiUDWdHs5+NsFMQrgKEBwuWDcyvaMC9dUzJ5Uw=="
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
@@ -40378,9 +40378,9 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/mux-embed": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-4.18.0.tgz",
-      "integrity": "sha512-9tgHLg8plmJAOiOzG2Tvi1MO7LO44DaC4V9W67kxrfzqco37UmreiKBwvrykncW4VUwU7+nectz8AUjcYBCz4g=="
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-4.26.0.tgz",
+      "integrity": "sha512-SvQahoUAe/WL+c4zyTb7dnO381x/MwlSfFHKirco/FyZAPirD8WnF/Ry+GxTQzucJFY2CMw8PsmPgy/ckkC2ZQ=="
     },
     "node_modules/mylas": {
       "version": "2.1.13",
@@ -61140,21 +61140,21 @@
       }
     },
     "@mux/mux-video-react": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video-react/-/mux-video-react-0.7.4.tgz",
-      "integrity": "sha512-5MvYwZb5VxxQ176YlcDCR4a7DNDV7gCzUHaZD2NkUu1M3mbxgWvFuOvzQMVwby4V8zbnEYReQ1SXI0keNpZT5w==",
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video-react/-/mux-video-react-0.7.15.tgz",
+      "integrity": "sha512-qWbr5QwJoxBuwY6hb6YSaGHK1S4wa433lo6O9cID/u2wyp9F6eykNhKAmZ/RrxY5d3t/UQIw9OXGn44aG0eDJQ==",
       "requires": {
-        "@mux/playback-core": "0.16.0",
+        "@mux/playback-core": "0.18.5",
         "prop-types": "^15.7.2"
       }
     },
     "@mux/playback-core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.16.0.tgz",
-      "integrity": "sha512-DTnc0WVKtVd9V1qmN+oj6W7IAr4GArOWIm5hdfTc0tLS5UpAt/UZk5pSrHrwwo5DxhQTdC1lfM4EeDkSEAV3Dw==",
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.18.5.tgz",
+      "integrity": "sha512-uMBEaCcCv60z1YYF5f9hnx8w/rGPY++ShvD5uZmBM/4YveccBhHj4xqeSTbBkrcwgisF5Uz3IK3IKap2wY23WQ==",
       "requires": {
-        "hls.js": "1.3.1",
-        "mux-embed": "^4.14.0"
+        "hls.js": "^1.4.8",
+        "mux-embed": "^4.24.0"
       }
     },
     "@mux/upchunk": {
@@ -76380,9 +76380,9 @@
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
     },
     "hls.js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.3.1.tgz",
-      "integrity": "sha512-6f4Qyrfj9sNUWMzNFKruqeD2KdisOwQ1GQJqnWAgMQ1hequlFK7e2dmF9qQD3mF/RI76hvztCMBptlPb+HcDow=="
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.4.10.tgz",
+      "integrity": "sha512-wAVSj4Fm2MqOHy5+BlYnlKxXvJlv5IuZHjlzHu18QmjRzSDFQiUDWdHs5+NsFMQrgKEBwuWDcyvaMC9dUzJ5Uw=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -82338,9 +82338,9 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "mux-embed": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-4.18.0.tgz",
-      "integrity": "sha512-9tgHLg8plmJAOiOzG2Tvi1MO7LO44DaC4V9W67kxrfzqco37UmreiKBwvrykncW4VUwU7+nectz8AUjcYBCz4g=="
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-4.26.0.tgz",
+      "integrity": "sha512-SvQahoUAe/WL+c4zyTb7dnO381x/MwlSfFHKirco/FyZAPirD8WnF/Ry+GxTQzucJFY2CMw8PsmPgy/ckkC2ZQ=="
     },
     "mylas": {
       "version": "2.1.13",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@mui/material": "^5.11.7",
     "@mui/x-date-pickers": "^5.0.16",
     "@mux/mux-node": "^7.0.0",
-    "@mux/mux-video-react": "^0.7.1",
+    "@mux/mux-video-react": "^0.7.15",
     "@mux/upchunk": "^3.0.0",
     "@next/bundle-analyzer": "^12.0.7",
     "@notionhq/client": "^2.2.2",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6436365</samp>

This pull request adds the `playsInline` attribute to the video element in the `CharmEditor` component, and introduces a feature flag to disable the use of subdomains for web app hosting. These changes improve the video playback experience and the flexibility of the web app hosting options.

### WHY
<!-- author to complete -->
