### PR TITLE
Set notion cookie without domain

### DIFF
--- a/pages/api/discord/callback.ts
+++ b/pages/api/discord/callback.ts
@@ -10,8 +10,6 @@ import { updateGuildRolesForUser } from 'lib/guild-xyz/server/updateGuildRolesFo
 import { extractSignupAnalytics } from 'lib/metrics/mixpanel/utilsSignup';
 import { onError, onNoMatch } from 'lib/middleware';
 import { withSessionRoute } from 'lib/session/withSession';
-import { getAppApexDomain } from 'lib/utilities/domains/getAppApexDomain';
-import { isLocalhostAlias } from 'lib/utilities/domains/isLocalhostAlias';
 import { DisabledAccountError } from 'lib/utilities/errors';
 import { getValidSubdomain } from 'lib/utilities/getValidSubdomain';
 
@@ -31,19 +29,18 @@ handler.get(async (req, res) => {
   const redirect = subdomain ? redirectPath : redirectUrl.pathname + redirectUrl.search;
 
   const tempAuthCode = req.query.code;
-  const domain = isLocalhostAlias(req.headers.host) ? undefined : getAppApexDomain();
+
   if (req.query.error || typeof tempAuthCode !== 'string') {
     log.warn('Error importing from notion', req.query);
     cookies.set(AUTH_ERROR_COOKIE, 'There was an error from Discord. Please try again', {
       httpOnly: false,
-      sameSite: 'strict',
-      domain
+      sameSite: 'strict'
     });
     res.redirect(`${redirect}?discord=2&type=${type}`);
     return;
   }
 
-  cookies.set(AUTH_CODE_COOKIE, tempAuthCode, { httpOnly: false, sameSite: 'strict', domain });
+  cookies.set(AUTH_CODE_COOKIE, tempAuthCode, { httpOnly: false, sameSite: 'strict' });
 
   if (type === 'login') {
     try {

--- a/pages/api/notion/callback.ts
+++ b/pages/api/notion/callback.ts
@@ -4,8 +4,6 @@ import nc from 'next-connect';
 
 import { onError, onNoMatch } from 'lib/middleware';
 import { AUTH_CODE_COOKIE, AUTH_ERROR_COOKIE } from 'lib/notion/constants';
-import { getAppApexDomain } from 'lib/utilities/domains/getAppApexDomain';
-import { isLocalhostAlias } from 'lib/utilities/domains/isLocalhostAlias';
 
 const handler = nc({
   onError,
@@ -25,18 +23,15 @@ handler.get(async (req, res) => {
     return;
   }
 
-  // use cookies to pass response to frontend because they're easier to delete than query params
-  const domain = isLocalhostAlias(req.headers.host) ? undefined : getAppApexDomain();
   const cookies = new Cookies(req, res);
 
   if (typeof tempAuthCode === 'string') {
-    cookies.set(AUTH_CODE_COOKIE, tempAuthCode, { httpOnly: false, sameSite: 'strict', domain });
+    cookies.set(AUTH_CODE_COOKIE, tempAuthCode, { httpOnly: false, sameSite: 'strict' });
   } else {
     log.warn('Error importing from notion', req.query);
     cookies.set(AUTH_ERROR_COOKIE, 'There was an error from Notion. Please try again', {
       httpOnly: false,
-      sameSite: 'strict',
-      domain
+      sameSite: 'strict'
     });
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d90c2d</samp>

Removed the `domain` option from the cookie settings in the Discord and Notion callback handlers to fix cross-domain cookie issues on some browsers. Cleaned up the code by deleting unused imports in `pages/api/discord/callback.ts` and `pages/api/notion/callback.ts`.

### WHY
<!-- author to complete -->
