### PR TITLE
fix styling for callout components

### DIFF
--- a/components/common/CharmEditor/components/callout/components/Callout.tsx
+++ b/components/common/CharmEditor/components/callout/components/Callout.tsx
@@ -20,6 +20,14 @@ const StyledCallout = styled.div`
   ${({ theme }) => theme.breakpoints.down('sm')} {
     flex-wrap: wrap;
   }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5 {
+    margin: 0 !important; // override global editor styles
+  }
 `;
 
 const CalloutEmoji = styled.div`
@@ -116,7 +124,7 @@ export default function Callout({
             />
           </Menu>
         </CalloutEmoji>
-        {children}
+        <Box my={0.5}>{children}</Box>
       </StyledCallout>
     </Box>
   );


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6940f3</samp>

Improve callout component styling in `CharmEditor`. Adjust margin of headings and `Box` in `Callout.tsx`.

### WHY
- removes margin when using headings (altho maybe we should disable headings altogther like Notion)
- Fixed a weird spacing thing that happens when you have more than one line of content

![image](https://github.com/charmverse/app.charmverse.io/assets/305398/b8c37fe4-4687-4514-98cd-e70da935f853)

