### PR TITLE
Custom emoji picker for callout block

### DIFF
--- a/components/[pageId]/DocumentPage/components/PageHeader.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeader.tsx
@@ -11,11 +11,11 @@ import { BlockIcons } from 'components/common/BoardEditor/focalboard/src/blockIc
 import { randomEmojiList } from 'components/common/BoardEditor/focalboard/src/emojiList';
 import Menu from 'components/common/BoardEditor/focalboard/src/widgets/menu';
 import MenuWrapper from 'components/common/BoardEditor/focalboard/src/widgets/menuWrapper';
+import { CustomEmojiPicker } from 'components/common/CustomEmojiPicker';
 import EmojiIcon from 'components/common/Emoji';
 import { randomIntFromInterval } from 'lib/utilities/random';
 
 import { randomBannerImage } from './PageBanner';
-import { PageHeaderIcon } from './PageHeaderIcon';
 import { PageTitleInput } from './PageTitleInput';
 
 const PageControlItem = styled(ListItemButton)`
@@ -103,8 +103,8 @@ function PageHeader({ headerImage, icon, readOnly, setPage, title, updatedAt, re
                     }}
                   />
                   <Menu.SubMenu id='pick' icon={<EmojiEmotionsOutlinedIcon />} name='Pick icon'>
-                    <PageHeaderIcon
-                      updatePageIcon={(emoji) => {
+                    <CustomEmojiPicker
+                      onUpdate={(emoji) => {
                         updatePageIcon(emoji);
                       }}
                     />

--- a/components/common/BoardEditor/focalboard/src/components/blockIconSelector.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/blockIconSelector.tsx
@@ -5,11 +5,10 @@ import EmojiEmotionsOutlinedIcon from '@mui/icons-material/EmojiEmotionsOutlined
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { PageHeaderIcon } from 'components/[pageId]/DocumentPage/components/PageHeaderIcon';
+import { CustomEmojiPicker } from 'components/common/CustomEmojiPicker';
 import PageIcon from 'components/common/Emoji';
 
 import { BlockIcons } from '../blockIcons';
-import EmojiPicker from '../widgets/emojiPicker';
 import Menu from '../widgets/menu';
 import MenuWrapper from '../widgets/menuWrapper';
 
@@ -49,8 +48,8 @@ const BlockIconSelector = React.memo((props: Props) => {
               icon={<EmojiEmotionsOutlinedIcon />}
               name={intl.formatMessage({ id: 'ViewTitle.pick-icon', defaultMessage: 'Pick icon' })}
             >
-              <PageHeaderIcon
-                updatePageIcon={(icon) => {
+              <CustomEmojiPicker
+                onUpdate={(icon) => {
                   setPage({ icon });
                 }}
               />

--- a/components/common/CharmEditor/components/callout/components/Callout.tsx
+++ b/components/common/CharmEditor/components/callout/components/Callout.tsx
@@ -1,11 +1,9 @@
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Box, IconButton, Menu } from '@mui/material';
-import type { BaseEmoji } from 'emoji-mart';
-import { Picker } from 'emoji-mart';
 import type { MouseEvent, ReactNode } from 'react';
 import { useState } from 'react';
 
+import { CustomEmojiPicker } from 'components/common/CustomEmojiPicker';
 import { getTwitterEmoji } from 'components/common/Emoji';
 
 import type { CharmNodeViewProps } from '../../nodeView/nodeView';
@@ -59,8 +57,9 @@ export default function Callout({
   const handleClose = () => {
     setAnchorEl(null);
   };
-  const theme = useTheme();
-  const twemojiImage = getTwitterEmoji(node.attrs.emoji);
+
+  const emoji = node.attrs.emoji;
+  const twemojiImage = emoji?.startsWith('http') ? emoji : getTwitterEmoji(emoji);
 
   return (
     <Box py={0.5}>
@@ -89,7 +88,10 @@ export default function Callout({
               <img
                 style={{
                   cursor: 'pointer',
-                  transition: 'background 100ms ease-in-out'
+                  transition: 'background 100ms ease-in-out',
+                  objectFit: 'cover',
+                  width: 22,
+                  height: 22
                 }}
                 src={twemojiImage}
               />
@@ -105,11 +107,10 @@ export default function Callout({
             )}
           </IconButton>
           <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
-            <Picker
-              theme={theme.palette.mode}
-              onSelect={(emoji: BaseEmoji) => {
+            <CustomEmojiPicker
+              onUpdate={(_emoji) => {
                 updateAttrs({
-                  emoji: emoji.native
+                  emoji: _emoji
                 });
                 handleClose();
               }}

--- a/components/common/CustomEmojiPicker.tsx
+++ b/components/common/CustomEmojiPicker.tsx
@@ -21,7 +21,12 @@ export function CustomEmojiPicker({ onUpdate }: { onUpdate: (icon: string) => vo
             onSelect={(emoji) => {
               onUpdate(emoji);
             }}
-          />
+          />,
+          {
+            sx: {
+              p: 0
+            }
+          }
         ],
         [
           'Custom',

--- a/components/common/CustomEmojiPicker.tsx
+++ b/components/common/CustomEmojiPicker.tsx
@@ -6,7 +6,7 @@ import { Button } from 'components/common/Button';
 import { ImageUploadButton } from 'components/common/ImageSelector/ImageUploadButton';
 import MultiTabs from 'components/common/MultiTabs';
 
-export function PageHeaderIcon({ updatePageIcon }: { updatePageIcon: (icon: string) => void }) {
+export function CustomEmojiPicker({ onUpdate }: { onUpdate: (icon: string) => void }) {
   const [imageLink, setImageLink] = useState('');
   return (
     <MultiTabs
@@ -16,7 +16,7 @@ export function PageHeaderIcon({ updatePageIcon }: { updatePageIcon: (icon: stri
           <EmojiPicker
             key='upload'
             onSelect={(emoji) => {
-              updatePageIcon(emoji);
+              onUpdate(emoji);
             }}
           />
         ],
@@ -33,7 +33,7 @@ export function PageHeaderIcon({ updatePageIcon }: { updatePageIcon: (icon: stri
               />
               <Button
                 onClick={() => {
-                  updatePageIcon(imageLink);
+                  onUpdate(imageLink);
                 }}
                 disabled={imageLink.length === 0}
               >
@@ -46,7 +46,7 @@ export function PageHeaderIcon({ updatePageIcon }: { updatePageIcon: (icon: stri
                 width: '100%'
               }}
               uploadDisclaimer='Recommended size is 280 × 280 pixels'
-              setImage={updatePageIcon}
+              setImage={onUpdate}
             />
           </Stack>
         ]

--- a/components/common/CustomEmojiPicker.tsx
+++ b/components/common/CustomEmojiPicker.tsx
@@ -10,6 +10,9 @@ export function CustomEmojiPicker({ onUpdate }: { onUpdate: (icon: string) => vo
   const [imageLink, setImageLink] = useState('');
   return (
     <MultiTabs
+      tabPanelSx={{
+        p: 1
+      }}
       tabs={[
         [
           'Emojis',

--- a/components/common/MultiTabs.tsx
+++ b/components/common/MultiTabs.tsx
@@ -9,18 +9,19 @@ interface TabPanelProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   value: React.ReactNode;
   index: number;
+  label: string;
   sx?: SxProps;
 }
 
 function TabPanel(props: TabPanelProps) {
-  const { children, value, index, sx = {}, ...other } = props;
+  const { children, value, index, label, sx = {}, ...other } = props;
 
   return (
     <div
       role='tabpanel'
       hidden={value !== index}
-      id={`simple-tabpanel-${index}`}
-      aria-labelledby={`simple-tab-${index}`}
+      id={`tabpanel-${label}-${index}`}
+      aria-labelledby={`tab-${label}-${index}`}
       {...other}
     >
       {value === index && (
@@ -66,9 +67,9 @@ export default function MultiTabs(props: MultiTabsProps) {
           ))}
         </Tabs>
       </Box>
-      {tabs.map(([_, tabComponent], tabIndex) => (
+      {tabs.map(([tabLabel, tabComponent], tabIndex) => (
         /* eslint-disable-next-line */
-        <TabPanel value={value} sx={tabPanelSx} index={tabIndex} key={tabIndex}>
+        <TabPanel value={value} label={tabLabel} sx={tabPanelSx} index={tabIndex} key={tabIndex}>
           {tabComponent}
         </TabPanel>
       ))}

--- a/components/common/MultiTabs.tsx
+++ b/components/common/MultiTabs.tsx
@@ -1,3 +1,4 @@
+import type { SxProps } from '@mui/material';
 import Box from '@mui/material/Box';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
@@ -8,10 +9,11 @@ interface TabPanelProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   value: React.ReactNode;
   index: number;
+  sx?: SxProps;
 }
 
 function TabPanel(props: TabPanelProps) {
-  const { children, value, index, ...other } = props;
+  const { children, value, index, sx = {}, ...other } = props;
 
   return (
     <div
@@ -22,7 +24,7 @@ function TabPanel(props: TabPanelProps) {
       {...other}
     >
       {value === index && (
-        <Box sx={{ p: 2 }}>
+        <Box sx={{ p: 3, ...sx }}>
           <Typography component='div'>{children}</Typography>
         </Box>
       )}
@@ -33,11 +35,12 @@ function TabPanel(props: TabPanelProps) {
 interface MultiTabsProps {
   tabs: [string, React.ReactNode][];
   disabled?: boolean;
+  tabPanelSx?: SxProps;
 }
 
 export default function MultiTabs(props: MultiTabsProps) {
   const [value, setValue] = React.useState(0);
-  const { tabs, disabled = false } = props;
+  const { tabs, disabled = false, tabPanelSx = {} } = props;
   const handleChange = (_: React.SyntheticEvent<Element, Event>, newValue: number) => {
     setValue(newValue);
   };
@@ -65,7 +68,7 @@ export default function MultiTabs(props: MultiTabsProps) {
       </Box>
       {tabs.map(([_, tabComponent], tabIndex) => (
         /* eslint-disable-next-line */
-        <TabPanel value={value} index={tabIndex} key={tabIndex}>
+        <TabPanel value={value} sx={tabPanelSx} index={tabIndex} key={tabIndex}>
           {tabComponent}
         </TabPanel>
       ))}

--- a/components/common/MultiTabs.tsx
+++ b/components/common/MultiTabs.tsx
@@ -34,7 +34,7 @@ function TabPanel(props: TabPanelProps) {
 }
 
 interface MultiTabsProps {
-  tabs: [string, React.ReactNode][];
+  tabs: [string, React.ReactNode, { sx?: SxProps }?][];
   disabled?: boolean;
   tabPanelSx?: SxProps;
 }
@@ -67,12 +67,15 @@ export default function MultiTabs(props: MultiTabsProps) {
           ))}
         </Tabs>
       </Box>
-      {tabs.map(([tabLabel, tabComponent], tabIndex) => (
-        /* eslint-disable-next-line */
-        <TabPanel value={value} label={tabLabel} sx={tabPanelSx} index={tabIndex} key={tabIndex}>
-          {tabComponent}
-        </TabPanel>
-      ))}
+      {tabs.map(([tabLabel, tabComponent, _props], tabIndex) => {
+        const sxProps = _props?.sx ?? ({} as SxProps);
+        return (
+          /* eslint-disable-next-line */
+          <TabPanel value={value} label={tabLabel} sx={{ ...tabPanelSx, ...sxProps } as SxProps} index={tabIndex} key={tabIndex}>
+            {tabComponent}
+          </TabPanel>
+        );
+      })}
     </Box>
   );
 }

--- a/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/PageTreeItem.tsx
@@ -17,10 +17,9 @@ import React, { forwardRef, memo, useCallback, useMemo, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
-import { PageHeaderIcon } from 'components/[pageId]/DocumentPage/components/PageHeaderIcon';
 import { getSortedBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
-import EmojiPicker from 'components/common/BoardEditor/focalboard/src/widgets/emojiPicker';
+import { CustomEmojiPicker } from 'components/common/CustomEmojiPicker';
 import Link from 'components/common/Link';
 import { AddToFavoritesAction } from 'components/common/PageActions/components/AddToFavoritesAction';
 import { CopyPageLinkAction } from 'components/common/PageActions/components/CopyPageLinkAction';
@@ -281,7 +280,7 @@ function EmojiMenu({ popupState, pageId }: { popupState: any; pageId: string }) 
         e.stopPropagation();
       }}
     >
-      <PageHeaderIcon updatePageIcon={onSelectEmoji} />
+      <CustomEmojiPicker onUpdate={onSelectEmoji} />
     </Menu>
   );
 }

--- a/theme/styles.scss
+++ b/theme/styles.scss
@@ -42,6 +42,11 @@ blockquote .bangle-nv-child-container {
   width: 100%;
 }
 
+// remove horizontal padding for emoji picker inside tab panel
+[id^="tabpanel-Emojis"] > div {
+  padding: 8px 0;
+}
+
 // fix for Autofill by Safari turning background yellow - https://stackoverflow.com/questions/41871618/how-to-change-safari-autofill-yellow-background-color
 // Note: we use --bg-gray instead of --bg-input since it is an opaque color
 input:-webkit-autofill,

--- a/theme/styles.scss
+++ b/theme/styles.scss
@@ -42,11 +42,6 @@ blockquote .bangle-nv-child-container {
   width: 100%;
 }
 
-// remove horizontal padding for emoji picker inside tab panel
-[id^="tabpanel-Emojis"] > div {
-  padding: 8px 0;
-}
-
 // fix for Autofill by Safari turning background yellow - https://stackoverflow.com/questions/41871618/how-to-change-safari-autofill-yellow-background-color
 // Note: we use --bg-gray instead of --bg-input since it is an opaque color
 input:-webkit-autofill,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 62725eb</samp>

Renamed and moved `PageHeaderIcon` component to `CustomEmojiPicker` component and made it reusable for various UI elements that require icon or emoji selection. This improves code reusability and consistency across the app. Modified several components to use the new `CustomEmojiPicker` component.

### WHY
[Card](https://app.charmverse.io/charmverse/page-18954968884603662)
