### PR TITLE
Analytics/block quota

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,6 +42,7 @@ jobs:
         uses: ./.github/actions/install
         with: 
           core_pkg_version: ${{ inputs.core_pkg_version }}
+          use_github_core_branch: analytics/block-quota
 
       - name: Build app
         uses: ./.github/actions/build

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,7 +42,6 @@ jobs:
         uses: ./.github/actions/install
         with: 
           core_pkg_version: ${{ inputs.core_pkg_version }}
-          use_github_core_branch: analytics/block-quota
 
       - name: Build app
         uses: ./.github/actions/build

--- a/components/settings/subscription/BlockCounts.tsx
+++ b/components/settings/subscription/BlockCounts.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { getTimeDifference } from 'lib/utilities/dates';
 
 import { BlocksExplanationModal } from './BlocksExplanation';
@@ -19,6 +20,7 @@ import { UpgradeChip } from './UpgradeWrapper';
 export function BlockCounts() {
   const theme = useTheme();
   const { spaceSubscription } = useSpaceSubscription();
+  const { space } = useCurrentSpace();
   const { blockCount } = useBlockCount();
 
   const {
@@ -31,8 +33,8 @@ export function BlockCounts() {
     return null;
   }
 
-  const blockQuota = (spaceSubscription?.blockQuota || 0) * 1000;
-  const passedBlockQuota = blockCount.count > blockQuota;
+  const blockQuota = (spaceSubscription?.blockQuota ?? space?.blockQuota ?? 0) * 1000;
+  const passedBlockQuota = !!blockQuota && blockCount.count > blockQuota;
 
   return (
     <Box width='100%' display='block' justifyContent='space-between' alignItems='center'>
@@ -49,7 +51,7 @@ export function BlockCounts() {
         <Typography variant='caption' color={passedBlockQuota ? 'error' : undefined}>
           {blockCount.count.toLocaleString()}
         </Typography>
-        /{blockQuota.toLocaleString()}
+        {!!blockQuota && `/${blockQuota.toLocaleString()}`}
         <HelpOutlineIcon
           onClick={openExplanationModal}
           color={theme.palette.background.default as any}

--- a/lib/metrics/mixpanel/interfaces/SubscriptionEvent.ts
+++ b/lib/metrics/mixpanel/interfaces/SubscriptionEvent.ts
@@ -7,7 +7,7 @@ type StripeBaseEvent = BaseEvent & {
 };
 
 export type CreateSubscriptionEvent = StripeBaseEvent & {
-  blockQuota: number;
+  blockQuota?: number;
   period: SubscriptionPeriod;
 };
 
@@ -24,7 +24,7 @@ export type UpdateSubscriptionEvent = StripeBaseEvent & {
 
 export type SubscriptionPaymentEvent = StripeBaseEvent & {
   paymentMethod: 'card' | 'ach' | 'crypto';
-  blockQuota: number;
+  blockQuota?: number;
   period: SubscriptionPeriod;
   status: 'success' | 'failure';
 };

--- a/lib/metrics/mixpanel/updateTrackGroupProfile.ts
+++ b/lib/metrics/mixpanel/updateTrackGroupProfile.ts
@@ -8,6 +8,7 @@ type MixPanelSpaceProfile = {
   $name: string;
   'Space Created By': string;
   'Space Updated At': string | Date;
+  'Space Block Quota': number;
   'Space Origin'?: string;
 };
 
@@ -24,7 +25,8 @@ export function getTrackGroupProfile(space: Space, spaceOrigin?: string) {
     $created: space.createdAt,
     $name: space.name,
     'Space Created By': space.createdBy,
-    'Space Updated At': space.updatedAt
+    'Space Updated At': space.updatedAt,
+    'Space Block Quota': space.blockQuota
   };
 
   if (spaceOrigin) {

--- a/lib/spaces/createSpace.ts
+++ b/lib/spaces/createSpace.ts
@@ -15,7 +15,7 @@ import { generateFirstDiff } from 'lib/pages/server/generateFirstDiff';
 import { setupDefaultPaymentMethods } from 'lib/payment-methods/defaultPaymentMethods';
 import { updateSpacePermissionConfigurationMode } from 'lib/permissions/meta';
 import { generateDefaultProposalCategoriesInput } from 'lib/proposal/generateDefaultProposalCategoriesInput';
-import { communityProduct } from 'lib/subscription/constants';
+import { communityProduct, defaultFreeTrialBlockQuota } from 'lib/subscription/constants';
 import { createProSubscription } from 'lib/subscription/createProSubscription';
 import type { WorkspaceExport } from 'lib/templates/exportWorkspacePages';
 import { importWorkspacePages } from 'lib/templates/importWorkspacePages';
@@ -96,6 +96,7 @@ export async function createWorkspace({
       webhookSigningSecret: signingSecret,
       updatedBy: spaceData.updatedBy ?? userId,
       author: { connect: { id: userId } },
+      blockQuota: defaultFreeTrialBlockQuota,
       spaceRoles: {
         createMany: {
           data: userList.map((_userId) => ({
@@ -240,7 +241,7 @@ export async function createWorkspace({
       spaceId: space.id,
       name: spaceData.name,
       freeTrial: true,
-      blockQuota: 30
+      blockQuota: defaultFreeTrialBlockQuota
     });
   } catch (err) {
     log.error('Error creating pro subscription', {

--- a/lib/subscription/upgradeProSubscription.ts
+++ b/lib/subscription/upgradeProSubscription.ts
@@ -28,7 +28,7 @@ export async function upgradeProSubscription({
 
   await stripeClient.subscriptions.update(subscription.id, {
     cancel_at_period_end: false,
-    proration_behavior: 'create_prorations',
+    proration_behavior: 'always_invoice',
     items: [
       {
         id: subscription.items.data[0].id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@bangle.dev/tooltip": "^0.31.6",
         "@bangle.dev/utils": "^0.31.6",
         "@beam-australia/react-env": "^3.1.1",
-        "@charmverse/core": "^0.2.6",
+        "@charmverse/core": "^0.2.7",
         "@column-resizer/core": "^1.0.2",
         "@datadog/browser-logs": "^4.42.2",
         "@datadog/browser-rum": "^4.42.2",
@@ -6930,9 +6930,9 @@
       "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
     },
     "node_modules/@charmverse/core": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@charmverse/core/-/core-0.2.6.tgz",
-      "integrity": "sha512-4PoxdpDd9K148/Mx5Kxy/UEVFOVYseTImQ/bGHOCrOZobrSc9sFyU1iwNXS4VsADROCl60C4uR+OIG0CzU3wVQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@charmverse/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-lJZwH7Mn/qEDxc42BHfoH3ammG6U3ZxIEZPXTXkrpujQDRbERB3C43de92QmyZqadAnslghTWZT6LswhhvyRIA==",
       "hasInstallScript": true,
       "dependencies": {
         "@datadog/browser-logs": "^4.42.2",
@@ -56552,9 +56552,9 @@
       "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
     },
     "@charmverse/core": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@charmverse/core/-/core-0.2.6.tgz",
-      "integrity": "sha512-4PoxdpDd9K148/Mx5Kxy/UEVFOVYseTImQ/bGHOCrOZobrSc9sFyU1iwNXS4VsADROCl60C4uR+OIG0CzU3wVQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@charmverse/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-lJZwH7Mn/qEDxc42BHfoH3ammG6U3ZxIEZPXTXkrpujQDRbERB3C43de92QmyZqadAnslghTWZT6LswhhvyRIA==",
       "requires": {
         "@datadog/browser-logs": "^4.42.2",
         "@prisma/client": "4.13.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@bangle.dev/tooltip": "^0.31.6",
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
-    "@charmverse/core": "^0.2.6",
+    "@charmverse/core": "^0.2.7",
     "@column-resizer/core": "^1.0.2",
     "@datadog/browser-logs": "^4.42.2",
     "@datadog/browser-rum": "^4.42.2",

--- a/pages/api/v1/webhooks/stripe/index.ts
+++ b/pages/api/v1/webhooks/stripe/index.ts
@@ -100,7 +100,7 @@ export async function stripePayment(req: NextApiRequest, res: NextApiResponse): 
           deletedAt: null
         };
 
-        const blockQuota = stripeSubscription.items.data[0]?.quantity as number;
+        const blockQuota = stripeSubscription.items.data[0]?.quantity;
 
         await prisma.$transaction([
           prisma.stripeSubscription.upsert({

--- a/pages/api/v1/webhooks/stripe/index.ts
+++ b/pages/api/v1/webhooks/stripe/index.ts
@@ -100,6 +100,8 @@ export async function stripePayment(req: NextApiRequest, res: NextApiResponse): 
           deletedAt: null
         };
 
+        const blockQuota = stripeSubscription.items.data[0]?.quantity as number;
+
         await prisma.$transaction([
           prisma.stripeSubscription.upsert({
             where: {
@@ -117,13 +119,11 @@ export async function stripePayment(req: NextApiRequest, res: NextApiResponse): 
               id: space.id
             },
             data: {
-              paidTier: paidTier === 'enterprise' ? 'enterprise' : 'community'
+              paidTier: paidTier === 'enterprise' ? 'enterprise' : 'community',
+              blockQuota: blockQuota && space.blockQuota !== blockQuota ? blockQuota : undefined
             }
           })
         ]);
-
-        const blockQuota = stripeSubscription.items.data[0]?.quantity as number;
-
         if (invoice.billing_reason === 'subscription_create' && invoice.payment_intent) {
           // The subscription automatically activates after successful payment
           // Set the payment method used to pay the first invoice

--- a/scripts/migrations/2023_07_31_importStripeBlockQuotas.ts
+++ b/scripts/migrations/2023_07_31_importStripeBlockQuotas.ts
@@ -1,0 +1,98 @@
+import { prisma } from '@charmverse/core/prisma-client';
+import { stringUtils } from '@charmverse/core/utilities';
+import { updateTrackGroupProfile } from 'lib/metrics/mixpanel/updateTrackGroupProfile';
+import { communityProduct } from 'lib/subscription/constants';
+import {stripeClient} from 'lib/subscription/stripe'
+import type Stripe from 'stripe';
+
+
+async function importStripeBlockQuotas({status}: {status: Stripe.Subscription.Status}) {
+
+  let hasMore = true;
+  let cursor: string | undefined = undefined;
+  let page = 0;
+
+  let totalSpacesProcessed = 0;
+
+  console.log('\r\n------ Processing subscriptions with status:', status)
+
+
+  while (hasMore) {
+    page += 1;
+
+    const subscriptions = await stripeClient.subscriptions.list({
+      starting_after: cursor,
+      status,
+      limit: 10
+    }) as Stripe.Response<Stripe.ApiList<Stripe.Subscription>>;
+
+    cursor = subscriptions.data[0]?.id
+
+    if (!cursor) {
+      hasMore = false;
+    }
+
+
+    const filteredSubs = subscriptions.data
+    .filter(sub => {
+      // Only process subscriptions for community product
+      return sub.items.data[0].plan.product === communityProduct.id &&
+      stringUtils.isUUID(sub.metadata['spaceId'])
+    }).map(sub => ({
+      subscriptionId: sub.id,
+      spaceId: sub.metadata['spaceId'],
+      blockQuota: sub.items.data[0].quantity,
+    } as {spaceId: string; subscriptionId: string; blockQuota: number}));
+
+    if (filteredSubs.length > 0) {
+
+      const spacesToUpdate = await prisma.space.findMany({
+        where: {
+          id: {
+            in: filteredSubs.map(sub => sub.spaceId)
+          }
+        },
+        select: {
+          id: true
+        }
+      });
+
+      const updatedSpaces = await prisma.$transaction(spacesToUpdate.map(space => (
+        prisma.space.update({
+          where: {
+            id: space.id
+          },
+          data: {
+            blockQuota: filteredSubs.find(sub => sub.spaceId === space.id)?.blockQuota
+          }
+        })
+      )))
+
+    
+      await Promise.all(updatedSpaces.map(space => updateTrackGroupProfile(space)))
+
+      totalSpacesProcessed += updatedSpaces.length;
+
+      console.log(`Updated ${updatedSpaces.length} space(s) in page`, page)
+    } else {
+      console.log(`No spaces to update in page`, page)
+    }
+
+
+    console.log(`Processed page ${page}`, {cursor, hasMore, status}, '\r\n\r\n')
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000)
+    })
+  }
+
+  console.log('Processed', totalSpacesProcessed, 'space subscriptions with', status, 'status')
+}
+
+// Just in case a space has a trial sub and active sub, this will prevent overwriting paid plan data with trial plan data
+importStripeBlockQuotas({status: 'trialing'})
+.then()
+.then(() => importStripeBlockQuotas({status: 'active'}))
+.then((spacesProcessed) => {
+  console.log('Processed', spacesProcessed, 'spaces')
+})


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 031acaf</samp>

This pull request implements the block quota feature for spaces, which limits the number of blocks that a space can have based on its Stripe subscription. It adds a new metric to track the block quota in Mixpanel, updates the logic to set or update the block quota when creating or updating subscriptions, and adds a script to import the block quotas from Stripe to the database and Mixpanel. It also modifies the GitHub action to use a specific branch of the core repository that contains related changes.

### WHY
Adding the script and data for block quota