### PR TITLE
fix markdown parser

### DIFF
--- a/lib/prosemirror/plugins/markdown/__tests__/parseMarkdown.spec.ts
+++ b/lib/prosemirror/plugins/markdown/__tests__/parseMarkdown.spec.ts
@@ -1,0 +1,13 @@
+import { parseMarkdown } from '../parseMarkdown';
+
+describe('parseMarkdown()', () => {
+  it('Should return a simple sentence', () => {
+    const result = parseMarkdown('Markdown title content');
+    expect(result).toEqual({
+      content: [
+        { attrs: { track: [] }, content: [{ text: 'Markdown title content', type: 'text' }], type: 'paragraph' }
+      ],
+      type: 'doc'
+    });
+  });
+});

--- a/lib/prosemirror/plugins/markdown/parseMarkdown.ts
+++ b/lib/prosemirror/plugins/markdown/parseMarkdown.ts
@@ -45,8 +45,8 @@ const charmParser = new MarkdownParser(specRegistry.schema, markdownit('commonma
 export function parseMarkdown(data: string): PageContent {
   const baseDoc = { type: 'doc', content: [] };
 
-  const parsed = (charmParser.parse(data)?.content as any)?.content;
-
+  const parsedNode = charmParser.parse(data)?.toJSON();
+  const parsed = parsedNode?.content;
   if (parsed) {
     baseDoc.content = parsed;
   }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5cce2a2</samp>

This pull request adds a test file for the `parseMarkdown` function and fixes a bug in the function that caused the test to fail. The bug was related to the way the ProseMirror node was converted into a plain object.

### WHY
the Markdown parser returns a Prosemirror Node, but we are expecting JSON in the api