### PR TITLE
Fix upgrade label was showing on enterprise plan

### DIFF
--- a/components/settings/SettingsDialog.tsx
+++ b/components/settings/SettingsDialog.tsx
@@ -172,7 +172,7 @@ export function SpaceSettingsDialog() {
                 active={activePath === tab.path}
                 section={tab.path}
               >
-                {tab.path === 'subscription' && passedBlockQuota ? (
+                {tab.path === 'subscription' && passedBlockQuota && currentSpace.paidTier !== 'enterprise' ? (
                   <UpgradeChip forceDisplay upgradeContext='upgrade' />
                 ) : null}
               </SidebarLink>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96989be</samp>

Hide upgrade chip for enterprise spaces in settings dialog. This change modifies `SettingsDialog.tsx` to only show the upgrade chip in the subscription tab if the current space is not an enterprise tier.

### WHY
The upgrade label was showing on enterprise plan because it had quantity 1 and many blocks.
The idea of the upgrade label was to show it only for users that have block quota.
