### PR TITLE
Notion import: don't show error message on 504

### DIFF
--- a/hooks/useNotionImport.tsx
+++ b/hooks/useNotionImport.tsx
@@ -102,12 +102,7 @@ export function NotionProvider({ children }: Props) {
         setNotionState({
           loading: false
         });
-        if (err.status === 504) {
-          showMessage(
-            'It can take up to an hour to import large Notion spaces. Your data will appear on the left navigation when the import is completed.',
-            'warning'
-          );
-        } else {
+        if (err.status !== 504) {
           showMessage(
             notionError || err.message || err.error || 'Something went wrong with your notion import. Please try again',
             'error'

--- a/hooks/useNotionImport.tsx
+++ b/hooks/useNotionImport.tsx
@@ -118,7 +118,6 @@ export function NotionProvider({ children }: Props) {
     failedImports
   }: NotionImportCompleted['payload']) {
     setAutoHideDuration(null);
-    // Only show this message if the import was not triggered by the user
     if (totalImportedPages === totalPages && failedImports.length === 0) {
       showMessage('Notion workspace successfully imported', 'success');
       setNotionState({


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d90ec9</samp>

Simplify error handling and notification for Notion import feature. Remove outdated comment in `useNotionImport.tsx`.

### WHY
[Card](https://app.charmverse.io/charmverse/page-49366552253645923?viewId=b72dd329-8b1b-4980-9c81-0ec60bd02c45&cardId=680e2faf-a440-436f-96a5-ab975a7b4030)
