### PR TITLE
Change how missing datapoint is treated

### DIFF
--- a/.ebextensions/06_cloudwatch_alarm.config
+++ b/.ebextensions/06_cloudwatch_alarm.config
@@ -1,6 +1,6 @@
 # Adding alarm for degraded state
 Resources:
-  CloudWatchAlarm:
+  EnvHealthAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       AlarmName: { "Fn::Join" : [ "-", [ "awseb", { "Ref" : "AWSEBEnvironmentName"}, "EnvHealth" ]] }
@@ -19,4 +19,4 @@ Resources:
         - "arn:aws:sns:us-east-1:310849459438:Production-Alerts"
       OKActions:
         - "arn:aws:sns:us-east-1:310849459438:Production-Alerts"
-      TreatMissingData: "ignore"
+      TreatMissingData: "notBreaching"

--- a/.ebextensions_cron/06_cloudwatch_alarm.config
+++ b/.ebextensions_cron/06_cloudwatch_alarm.config
@@ -1,6 +1,6 @@
 # Adding alarm for degraded state
 Resources:
-  CloudWatchAlarm:
+  EnvHealthAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       AlarmName: { "Fn::Join" : [ "-", [ "awseb", { "Ref" : "AWSEBEnvironmentName"}, "EnvHealth" ]] }
@@ -19,4 +19,4 @@ Resources:
         - "arn:aws:sns:us-east-1:310849459438:Production-Alerts"
       OKActions:
         - "arn:aws:sns:us-east-1:310849459438:Production-Alerts"
-      TreatMissingData: "ignore"
+      TreatMissingData: "notBreaching"

--- a/.ebextensions_websockets/06_cloudwatch_alarm.config
+++ b/.ebextensions_websockets/06_cloudwatch_alarm.config
@@ -1,6 +1,6 @@
 # Adding alarm for degraded state
 Resources:
-  CloudWatchAlarm:
+  EnvHealthAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       AlarmName: { "Fn::Join" : [ "-", [ "awseb", { "Ref" : "AWSEBEnvironmentName"}, "EnvHealth" ]] }
@@ -19,4 +19,4 @@ Resources:
         - "arn:aws:sns:us-east-1:310849459438:Production-Alerts"
       OKActions:
         - "arn:aws:sns:us-east-1:310849459438:Production-Alerts"
-      TreatMissingData: "ignore"
+      TreatMissingData: "notBreaching"


### PR DESCRIPTION


### WHAT
copilot:summary

### WHY
Marking missing datapoint as ignore will make the alert in forever insufficient data mode. Fixing it back to notBreaching. 
