### PR TITLE
Allow editing select options

### DIFF
--- a/components/common/BoardEditor/components/properties/TagSelect/TagSelect.tsx
+++ b/components/common/BoardEditor/components/properties/TagSelect/TagSelect.tsx
@@ -78,6 +78,7 @@ const StyledSelect = styled(SelectField)<ContainerProps>`
 
 type Props = {
   readOnly?: boolean;
+  canEditOptions?: boolean;
   multiselect?: boolean;
   noOptionsText?: string;
   options: IPropertyOption[];
@@ -92,6 +93,7 @@ type Props = {
 
 export function TagSelect({
   readOnly,
+  canEditOptions,
   options,
   propertyValue,
   multiselect = false,
@@ -168,7 +170,7 @@ export function TagSelect({
 
   return (
     <StyledSelect
-      canEditOptions={false} // TODO: allow editing options
+      canEditOptions={canEditOptions} // TODO: allow editing options
       placeholder='Search for an option...'
       noOptionsText={noOptionsText}
       autoOpen

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -105,6 +105,7 @@ function PropertyValueElement(props: Props) {
   ) {
     propertyValueElement = (
       <TagSelect
+        canEditOptions={!readOnly && !proposalPropertyTypesList.includes(propertyTemplate.type as any)}
         wrapColumn={displayType !== 'table' ? true : props.wrapColumn ?? false}
         multiselect={propertyTemplate.type === 'multiSelect'}
         readOnly={readOnly || proposalPropertyTypesList.includes(propertyTemplate.type as any)}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6c5a76</samp>

Added option editing feature for tag select properties in board editor. Modified `TagSelect` component to accept a `canEditOptions` prop and passed it from `PropertyValueElement` component based on property type and read-only status.

### WHY
Fix regression where options could not be edited