### PR TITLE
brighten up contrast on login page

### DIFF
--- a/components/common/BaseLayout/BaseLayout.tsx
+++ b/components/common/BaseLayout/BaseLayout.tsx
@@ -1,11 +1,12 @@
 import type { ReactElement } from 'react';
 
 import Header from './components/Header';
+import type { PageWrapperOptions } from './components/PageWrapper';
 import PageWrapper from './components/PageWrapper';
 
-export default function getLayout(page: ReactElement) {
+export default function getLayout(page: ReactElement, options: PageWrapperOptions = {}) {
   return (
-    <PageWrapper>
+    <PageWrapper bgcolor={options.bgcolor}>
       <Header />
       {page}
     </PageWrapper>

--- a/components/common/BaseLayout/components/PageWrapper.tsx
+++ b/components/common/BaseLayout/components/PageWrapper.tsx
@@ -1,10 +1,13 @@
 import styled from '@emotion/styled';
 
-const PageWrapper = styled.div`
+export type PageWrapperOptions = { bgcolor?: 'default' | 'light' };
+
+const PageWrapper = styled.div<PageWrapperOptions>`
   display: flex;
   flex-direction: column;
   min-height: 100%;
-  background-color: ${({ theme }) => theme.palette.background.light};
+  background-color: ${({ bgcolor, theme }) =>
+    bgcolor ? theme.palette.background[bgcolor] : theme.palette.background.light};
 `;
 
 export default PageWrapper;

--- a/components/login/Footer.tsx
+++ b/components/login/Footer.tsx
@@ -15,7 +15,7 @@ import DiscordIcon from 'public/images/discord_logo.svg';
 import { Container } from './components/LoginLayout';
 
 const Background = styled(Box)`
-  background-color: ${({ theme }) => theme.palette.background.dark};
+  background-color: ${({ theme }) => theme.palette.background.light};
   flex-grow: 1;
 `;
 

--- a/components/login/LoginPage.tsx
+++ b/components/login/LoginPage.tsx
@@ -100,7 +100,8 @@ export function LoginPageView() {
         <>
           <LoginPageContent />
           <Footer />
-        </>
+        </>,
+        { bgcolor: 'default' }
       );
 }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43f913e</samp>

The pull request adds the ability to customize the background color of the `PageWrapper` component for different pages using an `options` parameter in the `getLayout` function. The login page uses a darker background color than the other pages to create a contrast and a focus for the login form.

### WHY
I may have to take a photo but on my monitor, the 'blue' background looks really bad with the pure-grey footer on login:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/da3eb4e1-368c-4de2-979f-adf27af4ea05)

