### PR TITLE
Bug/properties e2e

### DIFF
--- a/__e2e__/database/editDatabase.spec.ts
+++ b/__e2e__/database/editDatabase.spec.ts
@@ -1,0 +1,76 @@
+import type { Page, User } from '@charmverse/core/prisma';
+import type { Space } from '@charmverse/core/prisma-client';
+import { testUtilsUser } from '@charmverse/core/test';
+import { test as base, expect } from '@playwright/test';
+import { PagesSidebarPage } from '__e2e__/po/pagesSiderbar.po';
+
+import { loginBrowserUser } from '../utils/mocks';
+
+type Fixtures = {
+  pagesSidebar: PagesSidebarPage;
+  databasePage: null;
+};
+
+const test = base.extend<Fixtures>({
+  pagesSidebar: ({ page }, use) => use(new PagesSidebarPage(page))
+});
+
+// Will be set by the first test
+let spaceUser: User;
+let space: Space;
+let databasePagePath: string;
+
+test.beforeAll(async () => {
+  const generated = await testUtilsUser.generateUserAndSpace({
+    isAdmin: true
+  });
+
+  spaceUser = generated.user;
+  space = generated.space;
+});
+
+test.describe.serial('Edit database select properties', async () => {
+  test('create a board', async ({ page, pagesSidebar }) => {
+    // Arrange ------------------
+    await loginBrowserUser({
+      browserPage: page,
+      userId: spaceUser.id
+    });
+
+    await pagesSidebar.goToHomePage(space.domain);
+
+    await expect(pagesSidebar.pagesSidebar).toBeVisible();
+
+    await pagesSidebar.pagesSidebar.hover();
+
+    await pagesSidebar.pagesSidebarAddPageButton.click();
+
+    await expect(pagesSidebar.pagesSidebarSelectAddDatabaseButton).toBeVisible();
+
+    await pagesSidebar.pagesSidebarSelectAddDatabaseButton.click();
+
+    await page.pause();
+
+    await expect(pagesSidebar.databasePage).toBeVisible();
+
+    databasePagePath = page.url();
+  });
+
+  // test('edit a board', async ({ page, globalPage }) => {
+  //   // Arrange ------------------
+  //   await loginBrowserUser({
+  //     browserPage: page,
+  //     userId: spaceUser.id
+  //   });
+
+  //   await expect(globalPage.pagesSidebar).toBeVisible();
+
+  //   await globalPage.pagesSidebar.click();
+
+  //   await expect(globalPage.pagesSidebarSelectAddDatabaseButton).toBeVisible();
+
+  //   await globalPage.pagesSidebarSelectAddDatabaseButton.click();
+
+  //   await expect(globalPage.databasePage).toBeVisible();
+  // });
+});

--- a/__e2e__/po/databasePage.po.ts
+++ b/__e2e__/po/databasePage.po.ts
@@ -1,0 +1,34 @@
+import type { Locator, Page } from '@playwright/test';
+
+import type { PropertyType } from 'lib/focalboard/board';
+
+import { GlobalPage } from './global.po';
+
+export class DatabasePage extends GlobalPage {
+  readonly selectNewDatabaseAsSource: Locator;
+
+  readonly addTablePropButton: Locator;
+
+  readonly addCardFromTableButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    this.selectNewDatabaseAsSource = this.page.locator('data-test=source-new-database');
+
+    this.addTablePropButton = this.page.locator('data-test=add-table-prop');
+    this.addCardFromTableButton = this.page.locator('data-test=table-add-card');
+  }
+
+  getPropertyTypeOptionLocator(type: PropertyType) {
+    return this.page.locator(`data-test=select-property-${type}`);
+  }
+
+  getTablePropertyHeaderLocator(type: PropertyType) {
+    return this.page.locator(`data-test=table-property-${type}`);
+  }
+
+  getTablePropertyValueLocator({ row, propertyType }: { row?: number; propertyType: PropertyType }) {
+    return this.page.locator(`data-test=database-table-row-${row}`).locator(`data-test=property-value-${propertyType}`);
+  }
+}

--- a/__e2e__/po/global.po.ts
+++ b/__e2e__/po/global.po.ts
@@ -7,6 +7,8 @@ export class GlobalPage {
 
   readonly dialog: Locator;
 
+  readonly closeModal: Locator;
+
   readonly openAsPageButton: Locator;
 
   readonly databasePage: Locator;
@@ -14,6 +16,7 @@ export class GlobalPage {
   constructor(page: Page) {
     this.page = page;
     this.dialog = page.locator('data-test=dialog');
+    this.closeModal = page.locator('data-test=close-modal');
     this.openAsPageButton = page.locator('data-test=open-as-page');
     this.databasePage = this.page.locator('data-test=database-page');
   }

--- a/__e2e__/po/pagesSiderbar.po.ts
+++ b/__e2e__/po/pagesSiderbar.po.ts
@@ -2,20 +2,20 @@ import type { Locator, Page } from '@playwright/test';
 
 import { baseUrl } from 'config/constants';
 
-export class GlobalPage {
-  readonly page: Page;
+import { GlobalPage } from './global.po';
 
-  readonly dialog: Locator;
+export class PagesSidebarPage extends GlobalPage {
+  readonly pagesSidebar: Locator;
 
-  readonly openAsPageButton: Locator;
+  readonly pagesSidebarAddPageButton: Locator;
 
-  readonly databasePage: Locator;
+  readonly pagesSidebarSelectAddDatabaseButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-    this.dialog = page.locator('data-test=dialog');
-    this.openAsPageButton = page.locator('data-test=open-as-page');
-    this.databasePage = this.page.locator('data-test=database-page');
+    super(page);
+    this.pagesSidebar = page.locator('data-test=page-sidebar-header');
+    this.pagesSidebarAddPageButton = this.pagesSidebar.locator('data-test=add-page');
+    this.pagesSidebarSelectAddDatabaseButton = this.page.locator('data-test=menu-add-database');
   }
 
   async goToHomePage(domain?: string) {

--- a/components/[pageId]/DatabasePage/DatabasePage.tsx
+++ b/components/[pageId]/DatabasePage/DatabasePage.tsx
@@ -151,7 +151,7 @@ export function DatabasePage({ page, setPage, readOnly = false, pagePermissions 
   if (board) {
     return (
       <>
-        <div className='focalboard-body full-page'>
+        <div data-test='database-page' className='focalboard-body full-page'>
           <CenterPanel
             readOnly={Boolean(readOnlyBoard)}
             readOnlySourceData={readOnlySourceData}

--- a/components/common/BoardEditor/components/properties/TagSelect/TagSelect.tsx
+++ b/components/common/BoardEditor/components/properties/TagSelect/TagSelect.tsx
@@ -78,6 +78,7 @@ const StyledSelect = styled(SelectField)<ContainerProps>`
 
 type Props = {
   readOnly?: boolean;
+  canEditOptions?: boolean;
   multiselect?: boolean;
   noOptionsText?: string;
   options: IPropertyOption[];
@@ -92,6 +93,7 @@ type Props = {
 
 export function TagSelect({
   readOnly,
+  canEditOptions,
   options,
   propertyValue,
   multiselect = false,
@@ -168,7 +170,7 @@ export function TagSelect({
 
   return (
     <StyledSelect
-      canEditOptions={false} // TODO: allow editing options
+      canEditOptions={canEditOptions} // TODO: allow editing options
       placeholder='Search for an option...'
       noOptionsText={noOptionsText}
       autoOpen

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -105,6 +105,7 @@ function PropertyValueElement(props: Props) {
   ) {
     propertyValueElement = (
       <TagSelect
+        canEditOptions={!readOnly && !proposalPropertyTypesList.includes(propertyTemplate.type as any)}
         wrapColumn={displayType !== 'table' ? true : props.wrapColumn ?? false}
         multiselect={propertyTemplate.type === 'multiSelect'}
         readOnly={readOnly || proposalPropertyTypesList.includes(propertyTemplate.type as any)}

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -105,6 +105,7 @@ function PropertyValueElement(props: Props) {
   ) {
     propertyValueElement = (
       <TagSelect
+        data-test={`property-value-${propertyTemplate.type}`}
         canEditOptions={!readOnly && !proposalPropertyTypesList.includes(propertyTemplate.type as any)}
         wrapColumn={displayType !== 'table' ? true : props.wrapColumn ?? false}
         multiselect={propertyTemplate.type === 'multiSelect'}

--- a/components/common/BoardEditor/focalboard/src/components/table/table.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/table.tsx
@@ -287,6 +287,7 @@ function Table(props: Props): JSX.Element {
             !activeView.fields.groupById &&
             !props.disableAddingCards && (
               <div
+                data-test='table-add-card'
                 className='octo-table-cell'
                 onClick={() => {
                   props.addCard('');

--- a/components/common/BoardEditor/focalboard/src/components/table/tableHeaders.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableHeaders.tsx
@@ -184,6 +184,7 @@ function TableHeaders(props: Props): JSX.Element {
         }
         return (
           <TableHeader
+            data-test={`table-property-${template.type}`}
             type={template.type}
             name={template.name}
             sorted={sorted}
@@ -205,7 +206,7 @@ function TableHeaders(props: Props): JSX.Element {
       <div className='octo-table-cell header-cell' style={{ flexGrow: 1, borderRight: '0 none' }}>
         {!props.readOnly && !props.readOnlySourceData && (
           <>
-            <Button {...bindTrigger(addPropertyPopupState)}>
+            <Button data-test='add-table-prop' {...bindTrigger(addPropertyPopupState)}>
               <AddIcon fontSize='small' />
             </Button>
             {isSmallScreen ? (

--- a/components/common/BoardEditor/focalboard/src/components/table/tableRows.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableRows.tsx
@@ -52,8 +52,9 @@ function TableRows(props: Props): JSX.Element {
 
   return (
     <>
-      {cardPages.map(({ page, card }) => (
+      {cardPages.map(({ page, card }, index) => (
         <TableRow
+          data-test={`database-table-row-${index}`}
           key={card.id + card.updatedAt}
           board={board}
           activeView={activeView}

--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions/viewSourceOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions/viewSourceOptions.tsx
@@ -129,7 +129,7 @@ export function ViewSourceOptions(props: ViewSourceOptionsProps) {
               Typeform
             </SourceType>
             {onCreate && (
-              <SourceType onClick={onCreate}>
+              <SourceType data-test='source-new-database' onClick={onCreate}>
                 <AddCircleIcon style={{ fontSize: 24 }} />
                 New database
               </SourceType>

--- a/components/common/BoardEditor/focalboard/src/widgets/propertyTypes.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/propertyTypes.tsx
@@ -23,7 +23,7 @@ export function PropertyTypes({ onClick, isMobile }: { onClick: (type: PropertyT
       {propertyTypesList
         .filter((type) => !proposalPropertyTypesList.includes(type as any))
         .map((type) => (
-          <MenuItem onClick={() => onClick(type)} key={type}>
+          <MenuItem data-test={`select-property-${type}`} onClick={() => onClick(type)} key={type}>
             <ListItemIcon>{iconForPropertyType(type)}</ListItemIcon>
             <Typography>{typeDisplayName(intl, type)}</Typography>
           </MenuItem>

--- a/components/common/PageLayout/components/NewPageMenu.tsx
+++ b/components/common/PageLayout/components/NewPageMenu.tsx
@@ -64,7 +64,7 @@ function NewPageMenu({ addPage, tooltip }: Props) {
   return (
     <>
       <Tooltip disableInteractive title={tooltip} leaveDelay={0} placement='top' arrow>
-        <StyledIconButton onClick={handleClick}>
+        <StyledIconButton data-test='add-page' onClick={handleClick}>
           <AddIcon color='secondary' />
         </StyledIconButton>
       </Tooltip>
@@ -77,7 +77,7 @@ function NewPageMenu({ addPage, tooltip }: Props) {
           <Typography sx={{ fontSize: 15, fontWeight: 600 }}>Add Page</Typography>
         </MenuItem>
         {/* create a linked board page by default, which can be changed to 'board' by the user */}
-        <MenuItem onClick={(e) => createPage(e, { type: 'linked_board' })}>
+        <MenuItem data-test='menu-add-database' onClick={(e) => createPage(e, { type: 'linked_board' })}>
           <ListItemIcon>
             <StyledDatabaseIcon fontSize='small' />
           </ListItemIcon>

--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -185,12 +185,12 @@ export function Sidebar({ closeSidebar, navAction }: SidebarProps) {
             <PageNavigation isFavorites rootPageIds={favoritePageIds} />
           </Box>
         )}
-        <WorkspaceLabel>
+        <WorkspaceLabel data-test='page-sidebar-header'>
           <SectionName>SPACE</SectionName>
           {/** Test component */}
           {userSpacePermissions?.createPage && showMemberFeatures && (
             <div className='add-a-page'>
-              <NewPageMenu tooltip='Add a page' addPage={addPage} />
+              <NewPageMenu data-test='sidebar-add-page' tooltip='Add a page' addPage={addPage} />
             </div>
           )}
         </WorkspaceLabel>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ef1327</samp>

This pull request adds `data-test` attributes to various UI elements in the `app.charmverse.io` web application to enable automated testing using Playwright. It also adds a new test file, `editDatabase.spec.ts`, and several page object classes to implement the test scenarios for editing database select properties.

### WHY
E2E test to prevent board regressions

We had a bad case of not being able to add properties to a board. This e2e test will make sure that's not the case