### PR TITLE
Conforming to the usual alarm format instead of using my own

### DIFF
--- a/.ebextensions/06_cloudwatch_alarm.config
+++ b/.ebextensions/06_cloudwatch_alarm.config
@@ -3,7 +3,6 @@ Resources:
   EnvHealthAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
-      AlarmName: { "Fn::Join" : [ "-", [ "awseb", { "Ref" : "AWSEBEnvironmentName"}, "EnvHealth" ]] }
       AlarmDescription: "A CloudWatch Alarm that triggers when an Elastic Beanstalk Environment is unhealthy."
       Namespace: "ElasticBeanstalk"
       MetricName: "EnvironmentHealth"

--- a/.ebextensions_cron/06_cloudwatch_alarm.config
+++ b/.ebextensions_cron/06_cloudwatch_alarm.config
@@ -3,7 +3,6 @@ Resources:
   EnvHealthAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
-      AlarmName: { "Fn::Join" : [ "-", [ "awseb", { "Ref" : "AWSEBEnvironmentName"}, "EnvHealth" ]] }
       AlarmDescription: "A CloudWatch Alarm that triggers when an Elastic Beanstalk Environment is unhealthy."
       Namespace: "ElasticBeanstalk"
       MetricName: "EnvironmentHealth"

--- a/.ebextensions_websockets/06_cloudwatch_alarm.config
+++ b/.ebextensions_websockets/06_cloudwatch_alarm.config
@@ -3,7 +3,6 @@ Resources:
   EnvHealthAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
-      AlarmName: { "Fn::Join" : [ "-", [ "awseb", { "Ref" : "AWSEBEnvironmentName"}, "EnvHealth" ]] }
       AlarmDescription: "A CloudWatch Alarm that triggers when an Elastic Beanstalk Environment is unhealthy."
       Namespace: "ElasticBeanstalk"
       MetricName: "EnvironmentHealth"


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
Lambda script attempts to match the name format that elasticbeanstalk creates for alarms. Current format is a creation which doesn't make management easy. So removing the AlarmName and let Cloudformation generate it to conform to the other alarm names.  
