### PR TITLE
adding back ebextensions file for staging tests

### DIFF
--- a/.ebextensions/06_cloudwatch_alarm.config
+++ b/.ebextensions/06_cloudwatch_alarm.config
@@ -4,7 +4,7 @@ Resources:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       AlarmDescription: "A CloudWatch Alarm that triggers when an Elastic Beanstalk Environment is unhealthy."
-      Namespace: "ElasticBeanstalk"
+      Namespace: "AWS/ElasticBeanstalk"
       MetricName: "EnvironmentHealth"
       Dimensions:
         - Name: EnvironmentName

--- a/.ebextensions_cron/06_cloudwatch_alarm.config
+++ b/.ebextensions_cron/06_cloudwatch_alarm.config
@@ -4,7 +4,7 @@ Resources:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       AlarmDescription: "A CloudWatch Alarm that triggers when an Elastic Beanstalk Environment is unhealthy."
-      Namespace: "ElasticBeanstalk"
+      Namespace: "AWS/ElasticBeanstalk"
       MetricName: "EnvironmentHealth"
       Dimensions:
         - Name: EnvironmentName

--- a/.ebextensions_websockets/06_cloudwatch_alarm.config
+++ b/.ebextensions_websockets/06_cloudwatch_alarm.config
@@ -4,7 +4,7 @@ Resources:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       AlarmDescription: "A CloudWatch Alarm that triggers when an Elastic Beanstalk Environment is unhealthy."
-      Namespace: "ElasticBeanstalk"
+      Namespace: "AWS/ElasticBeanstalk"
       MetricName: "EnvironmentHealth"
       Dimensions:
         - Name: EnvironmentName

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, opened, synchronize]
 
 env:
-  SELECTED_PERMISSION_API_TAG: testing-with-real-payload
+  SELECTED_PERMISSION_API_TAG:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -74,7 +74,7 @@ jobs:
           #   sed -i 's/Production-Alerts/lambda-test-debug/g' $conf_file
           # done
 
-          rm .ebextensions*/06_cloudwatch_alarm.config
+          #rm .ebextensions*/06_cloudwatch_alarm.config
 
       - name: Set the docker compose env variables
         uses: mikefarah/yq@master

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -69,10 +69,10 @@ jobs:
             sed -i 's/production/staging/g' $conf_file
           done
 
-          # below commented out since, instaging, removing cloudwatch alerts is more preferable
-          # for conf_file in .ebextensions*/06_cloudwatch_alarm.config; do
-          #   sed -i 's/Production-Alerts/lambda-test-debug/g' $conf_file
-          # done
+          #below commented out since, instaging, removing cloudwatch alerts is more preferable
+          for conf_file in .ebextensions*/06_cloudwatch_alarm.config; do
+            sed -i 's/Production-Alerts/lambda-test-debug/g' $conf_file
+          done
 
           #rm .ebextensions*/06_cloudwatch_alarm.config
 

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, opened, synchronize]
 
 env:
-  SELECTED_PERMISSION_API_TAG:
+  SELECTED_PERMISSION_API_TAG: testing-with-real-payload
 
 jobs:
   deploy:


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a1e9ff1</samp>

Re-enabled the cloudwatch alarm for the staging environment by uncommenting the line that removes the `cloudwatch_alarm_config.json` file in the `.github/workflows/deploy_staging.yml` workflow. This change allows the alarm to monitor the health and performance of the staging app.

### WHY
<!-- author to complete -->
