### PR TITLE
changing js map version to match build id

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -281,7 +281,7 @@ jobs:
           npm install @datadog/datadog-ci
           npx datadog-ci sourcemaps upload .next/static   \
             --service=webapp                              \
-            --release-version=${{ steps.docker_build_push.outputs.img_tag }}  \
+            --release-version=${{ needs.build-test-env.outputs.build_id }}  \
             --minified-path-prefix=https://app.charmverse.io/_next/static
 
       - name: Deploy Background to Beanstalk


### PR DESCRIPTION

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c269de</samp>

Changed the `release-version` argument for sourcemaps upload to use a unique `build_id` instead of the branch-based `img_tag`. This improves the accuracy of release tracking in Datadog.

### WHY
for better correlation in datadog.