### PR TITLE
Improve answers privacy

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -54,7 +54,7 @@ export function ProposalProperties({
   const readOnlyProperties = readOnly || !(pagePermissions?.edit_content || isAdmin);
   const canAnswerRubric = proposalPermissions?.evaluate;
   const canViewRubricAnswers =
-    (user?.id && reviewerUserIds?.includes(user.id)) || proposalPermissions?.evaluate || isAdmin;
+    !!proposalPermissions?.evaluate || isAdmin || !!(user?.id && reviewerUserIds?.includes(user.id));
   const isFromTemplateSource = Boolean(proposal?.page?.sourceTemplateId);
 
   const proposalFormInputs: ProposalFormInputs = {

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -53,8 +53,7 @@ export function ProposalProperties({
   // further restrict readOnly if user cannot update proposal properties specifically
   const readOnlyProperties = readOnly || !(pagePermissions?.edit_content || isAdmin);
   const canAnswerRubric = proposalPermissions?.evaluate;
-  const canViewRubricAnswers =
-    !!proposalPermissions?.evaluate || isAdmin || !!(user?.id && reviewerUserIds?.includes(user.id));
+  const canViewRubricAnswers = isAdmin || !!(user?.id && reviewerUserIds?.includes(user.id));
   const isFromTemplateSource = Boolean(proposal?.page?.sourceTemplateId);
 
   const proposalFormInputs: ProposalFormInputs = {

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -2,6 +2,7 @@ import type { PagePermissionFlags } from '@charmverse/core/permissions';
 import type { ProposalStatus } from '@charmverse/core/prisma';
 import { debounce } from 'lodash';
 import { useCallback } from 'react';
+import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import { useTasks } from 'components/nexus/hooks/useTasks';
@@ -10,6 +11,7 @@ import { ProposalProperties as ProposalPropertiesBase } from 'components/proposa
 import { useProposalDetails } from 'components/proposals/hooks/useProposalDetails';
 import { useProposalFlowFlags } from 'components/proposals/hooks/useProposalFlowFlags';
 import { useProposalPermissions } from 'components/proposals/hooks/useProposalPermissions';
+import { useProposalReviewerIds } from 'components/proposals/hooks/useProposalReviewerIds';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useUser } from 'hooks/useUser';
 
@@ -42,13 +44,17 @@ export function ProposalProperties({
     proposalIdOrPath: proposalId
   });
 
+  const { reviewerUserIds } = useProposalReviewerIds(
+    !!pageId && proposal?.evaluationType === 'rubric' ? pageId : undefined
+  );
   const { permissions: proposalFlowFlags, refresh: refreshProposalFlowFlags } = useProposalFlowFlags({ proposalId });
   const isAdmin = useIsAdmin();
 
   // further restrict readOnly if user cannot update proposal properties specifically
   const readOnlyProperties = readOnly || !(pagePermissions?.edit_content || isAdmin);
   const canAnswerRubric = proposalPermissions?.evaluate;
-  const canViewRubricAnswers = proposalPermissions?.evaluate || isAdmin;
+  const canViewRubricAnswers =
+    (user?.id && reviewerUserIds?.includes(user.id)) || proposalPermissions?.evaluate || isAdmin;
   const isFromTemplateSource = Boolean(proposal?.page?.sourceTemplateId);
 
   const proposalFormInputs: ProposalFormInputs = {

--- a/components/proposals/components/ProposalProperties/ProposalProperties.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalProperties.tsx
@@ -11,7 +11,6 @@ import type { ProposalReviewerInput } from '@charmverse/core/proposals';
 import { KeyboardArrowDown } from '@mui/icons-material';
 import { Box, Card, Collapse, Divider, Grid, IconButton, Stack, Typography } from '@mui/material';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import { PropertyLabel } from 'components/common/BoardEditor/components/properties/PropertyLabel';
@@ -22,6 +21,7 @@ import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import type { TabConfig } from 'components/common/MultiTabs';
 import MultiTabs from 'components/common/MultiTabs';
 import { RubricResults } from 'components/proposals/components/ProposalProperties/components/RubricResults';
+import { useProposalReviewerIds } from 'components/proposals/hooks/useProposalReviewerIds';
 import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemplates';
 import { CreateVoteModal } from 'components/votes/components/CreateVoteModal';
 import { useIsCharmverseSpace } from 'hooks/useIsCharmverseSpace';
@@ -117,9 +117,8 @@ export function ProposalProperties({
 
   const { proposalTemplates } = useProposalTemplates();
 
-  const { data: reviewerUserIds } = useSWR(
-    !!pageId && proposalFormInputs.evaluationType === 'rubric' ? `proposal-reviewers-${pageId}` : null,
-    () => charmClient.proposals.getAllReviewerUserIds(pageId as string)
+  const { reviewerUserIds } = useProposalReviewerIds(
+    !!pageId && proposalFormInputs.evaluationType === 'rubric' ? pageId : undefined
   );
 
   const proposalTemplatePages = useMemo(() => {

--- a/components/proposals/hooks/useProposalReviewerIds.ts
+++ b/components/proposals/hooks/useProposalReviewerIds.ts
@@ -1,0 +1,13 @@
+import useSWR from 'swr';
+
+import charmClient from 'charmClient';
+
+export function useProposalReviewerIds(proposalId?: string) {
+  const { data: reviewerUserIds = [] } = useSWR(proposalId ? `proposal-reviewers-${proposalId}` : null, () =>
+    charmClient.proposals.getAllReviewerUserIds(proposalId as string)
+  );
+
+  return {
+    reviewerUserIds
+  };
+}

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@bangle.dev/tooltip": "^0.31.6",
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
-    "@charmverse/core": "^0.3.2",
+    "@charmverse/core": "^0.3.3",
     "@column-resizer/core": "^1.0.2",
     "@datadog/browser-logs": "^4.42.2",
     "@datadog/browser-rum": "^4.42.2",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e703aba</samp>

Enhance security and privacy of proposal API endpoints. Restrict access to rubric answers and clear them on update. Use `getAllReviewerUserIds` function.

### WHY
Only return rubric answers from GET if user is a reviewer or admin

Don't ever return rubric answers from PUT