### PR TITLE
dont enforce readonly reviewers if 0 provided in template

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -123,7 +123,9 @@ export function ProposalProperties({
         (proposal?.status !== 'draft' && !isTemplate) ||
         isFromTemplateSource
       }
-      readOnlyReviewers={readOnlyProperties || isFromTemplateSource}
+      readOnlyReviewers={
+        readOnlyProperties || (isFromTemplateSource && proposal?.reviewers && proposal.reviewers.length > 0)
+      }
       rubricAnswers={proposal?.rubricAnswers}
       rubricCriteria={proposal?.rubricCriteria}
       showStatus={!isTemplate}

--- a/components/proposals/components/ProposalDialog/ProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalPage.tsx
@@ -177,7 +177,7 @@ export function ProposalPage({ setFormInputs, formInputs, contentUpdated, setCon
                 <div className='CardDetail content'>
                   <ProposalProperties
                     readOnlyRubricCriteria={isFromTemplateSource}
-                    readOnlyReviewers={isFromTemplateSource}
+                    readOnlyReviewers={isFromTemplateSource && formInputs.reviewers.length > 0}
                     readOnlyProposalEvaluationType={isFromTemplateSource}
                     proposalStatus='draft'
                     proposalFormInputs={formInputs}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 56372c8</samp>

This pull request modifies the `readOnlyReviewers` prop of the `ProposalProperties` component to allow editing reviewers when creating a proposal from scratch or from a template without reviewers. It also updates the `ProposalPage` component to pass the form inputs as a source of truth for the reviewers.

### WHY
<!-- author to complete -->
