### PR TITLE
Fixed snapshot proposal publish issue when voting type is different

### DIFF
--- a/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
@@ -153,6 +153,7 @@ export function PublishingForm({ onSubmit, pageId }: Props) {
     } else if (space.snapshotDomain && !snapshotSpace) {
       const existingSnapshotSpace = await getSnapshotSpace(space.snapshotDomain);
       setSnapshotSpace(existingSnapshotSpace);
+      setSnapshotVoteMode(existingSnapshotSpace?.voting?.type ?? 'single-choice');
     }
 
     if (snapshotSpace) {
@@ -295,6 +296,8 @@ export function PublishingForm({ onSubmit, pageId }: Props) {
     );
   }
 
+  const snapshotVotingType = snapshotSpace?.voting?.type ?? null;
+
   return !checksComplete ? (
     <LoadingIcon />
   ) : configurationError ? (
@@ -314,7 +317,11 @@ export function PublishingForm({ onSubmit, pageId }: Props) {
               <FieldLabel>Voting type</FieldLabel>
               <InputEnumToOption
                 defaultValue={snapshotVoteMode}
-                keyAndLabel={SnapshotVotingMode}
+                keyAndLabel={
+                  snapshotVotingType === null
+                    ? SnapshotVotingMode
+                    : { [snapshotVotingType]: SnapshotVotingMode[snapshotVotingType] }
+                }
                 onChange={(voteMode) => setSnapshotVoteMode(voteMode as SnapshotVotingModeType)}
               />
             </Grid>

--- a/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
@@ -48,6 +48,11 @@ const MAX_SNAPSHOT_PROPOSAL_CHARACTERS = 14400;
 
 const MIN_VOTING_OPTIONS = 2;
 
+/**
+ *
+ * @abstract See this code for restrictions enforced by Snapshot when submitting proposals
+ * https://github.com/snapshot-labs/snapshot-sequencer/blob/24fba742c89790c7d955c520b4d36c96e883a3e9/src/writer/proposal.ts#L83C29-L83C29
+ */
 export function PublishingForm({ onSubmit, pageId }: Props) {
   const { account, library } = useWeb3AuthSig();
 

--- a/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
@@ -315,15 +315,24 @@ export function PublishingForm({ onSubmit, pageId }: Props) {
           <Grid container direction='column' spacing={3}>
             <Grid item>
               <FieldLabel>Voting type</FieldLabel>
-              <InputEnumToOption
-                defaultValue={snapshotVoteMode}
-                keyAndLabel={
-                  snapshotVotingType === null
-                    ? SnapshotVotingMode
-                    : { [snapshotVotingType]: SnapshotVotingMode[snapshotVotingType] }
+              <Tooltip
+                title={
+                  snapshotSpace?.voting.type
+                    ? 'This option is readonly because it is enforced for your space inside Snapshot'
+                    : ''
                 }
-                onChange={(voteMode) => setSnapshotVoteMode(voteMode as SnapshotVotingModeType)}
-              />
+              >
+                <InputEnumToOption
+                  value={snapshotVoteMode}
+                  readOnly={!!snapshotSpace?.voting.type}
+                  keyAndLabel={
+                    snapshotVotingType === null
+                      ? SnapshotVotingMode
+                      : { [snapshotVotingType]: SnapshotVotingMode[snapshotVotingType] }
+                  }
+                  onChange={(voteMode) => setSnapshotVoteMode(voteMode as SnapshotVotingModeType)}
+                />
+              </Tooltip>
             </Grid>
 
             <Grid item>

--- a/lib/snapshot/getSpace.ts
+++ b/lib/snapshot/getSpace.ts
@@ -35,6 +35,7 @@ export async function getSnapshotSpace(spaceDomain: string): Promise<SnapshotSpa
         voting {
           period
           delay
+          type
         }
       }
     }

--- a/lib/snapshot/interfaces.ts
+++ b/lib/snapshot/interfaces.ts
@@ -4,6 +4,19 @@ export interface SnapshotVotingStrategy {
   params: any;
 }
 
+// Comes from snapshot.js https://github.com/snapshot-labs/snapshot/blob/fd1f2ba15543583861df750b0958d1794cc625bb/src/components/Modal/VotingType.vue
+export const SnapshotVotingMode = {
+  'single-choice': 'Single choice',
+  approval: 'Approval',
+  'ranked-choice': 'Ranked choice',
+  quadratic: 'Quadratic',
+  weighted: 'Weighted',
+  custom: 'Custom',
+  basic: 'Basic'
+};
+
+export type SnapshotVotingModeType = keyof typeof SnapshotVotingMode;
+
 /**
  * @id the actual snapshot domain
  */
@@ -28,6 +41,7 @@ export interface SnapshotSpace {
     // Number of seconds proposals are active for
     period: number | null;
     delay: number | null;
+    type: SnapshotVotingModeType | null;
   };
 }
 
@@ -58,16 +72,3 @@ export interface SnapshotReceipt {
     receipt: string;
   };
 }
-
-// Comes from snapshot.js https://github.com/snapshot-labs/snapshot/blob/fd1f2ba15543583861df750b0958d1794cc625bb/src/components/Modal/VotingType.vue
-export const SnapshotVotingMode = {
-  'single-choice': 'Single choice',
-  approval: 'Approval',
-  'ranked-choice': 'Ranked choice',
-  quadratic: 'Quadratic',
-  weighted: 'Weighted',
-  custom: 'Custom',
-  basic: 'Basic'
-};
-
-export type SnapshotVotingModeType = keyof typeof SnapshotVotingMode;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9e6ebae</samp>

This pull request enhances the publishing form for snapshot spaces by setting a default vote mode and filtering the vote modes based on the space voting type. It also introduces the `SnapshotVotingMode` enum and the `SnapshotVotingModeType` type to improve the typing and consistency of the voting modes in `lib/snapshot/interfaces.ts` and `getSnapshotSpace`.

### WHY
<!-- author to complete -->
