### PR TITLE
Reorganize features and profiles logic

### DIFF
--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -20,6 +20,7 @@ import { charmverseDiscordInvite } from 'config/constants';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
 import { useFavoritePages } from 'hooks/useFavoritePages';
+import { useFeaturesAndMembers } from 'hooks/useFeaturesAndMemberProfiles';
 import { useForumCategories } from 'hooks/useForumCategories';
 import { useHasMemberLevel } from 'hooks/useHasMemberLevel';
 import useKeydownPress from 'hooks/useKeydownPress';
@@ -39,8 +40,6 @@ import TrashModal from '../TrashModal';
 
 import { sidebarItemStyles, SidebarLink } from './SidebarButton';
 import SidebarSubmenu from './SidebarSubmenu';
-import type { FeatureJson } from './utils/staticPages';
-import { STATIC_PAGES_RECORD } from './utils/staticPages';
 
 const WorkspaceLabel = styled.div`
   display: flex;
@@ -236,6 +235,8 @@ export function Sidebar({ closeSidebar, navAction }: SidebarProps) {
     );
   }, [favoritePageIds, userSpacePermissions, navAction, addPage, showMemberFeatures]);
 
+  const { features } = useFeaturesAndMembers();
+
   return (
     <SidebarContainer>
       <Box display='flex' flexDirection='column' sx={{ height: '100%', flexGrow: 1, width: 'calc(100% - 57px)' }}>
@@ -282,25 +283,23 @@ export function Sidebar({ closeSidebar, navAction }: SidebarProps) {
                     />
                   )}
                   <Divider sx={{ mx: 2, my: 1 }} />
-                  {(space.features as FeatureJson[])
-                    .filter((mp) => !mp.isHidden)
-                    .map(({ id }) => {
-                      const page = STATIC_PAGES_RECORD[id];
+                  {features
+                    .filter((feat) => !feat.isHidden)
+                    .map((feat) => {
                       if (
-                        page &&
-                        (showMemberFeatures ||
-                          // Always show forum to space members. Show it to guests if they have access to at least 1 category
-                          (page.path === 'forum' && categories.length > 0))
+                        showMemberFeatures ||
+                        // Always show forum to space members. Show it to guests if they have access to at least 1 category
+                        (feat.path === 'forum' && categories.length > 0)
                       ) {
                         return (
                           <SidebarLink
-                            key={page.path}
-                            href={`/${space.domain}/${page.path}`}
-                            active={router.pathname.startsWith(`/[domain]/${page.path}`)}
-                            icon={<PageIcon icon={null} pageType={page.path} />}
-                            label={page.title}
+                            key={feat.path}
+                            href={`/${space.domain}/${feat.path}`}
+                            active={router.pathname.startsWith(`/[domain]/${feat.path}`)}
+                            icon={<PageIcon icon={null} pageType={feat.path} />}
+                            label={feat.title}
                             onClick={navAction}
-                            data-test={`sidebar-link-${page.path}`}
+                            data-test={`sidebar-link-${feat.path}`}
                           />
                         );
                       }

--- a/components/common/PageLayout/components/Sidebar/utils/staticPages.tsx
+++ b/components/common/PageLayout/components/Sidebar/utils/staticPages.tsx
@@ -26,8 +26,3 @@ export const STATIC_PAGES: StaticPage[] = [
   { path: 'bounties', title: 'Bounties', feature: 'bounties' },
   { path: 'forum', title: 'Forum', feature: 'forum' }
 ];
-
-export const STATIC_PAGES_RECORD = STATIC_PAGES.reduce((acc, page) => {
-  acc[page.feature] = page;
-  return acc;
-}, {} as Record<Feature, StaticPage>);

--- a/components/common/UserProfile/components/ProfileWidgets/ProfileWidgets.tsx
+++ b/components/common/UserProfile/components/ProfileWidgets/ProfileWidgets.tsx
@@ -4,7 +4,7 @@ import useSWR from 'swr';
 import charmClient from 'charmClient';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import type { MemberProfileJson } from 'lib/profile/memberProfiles';
+import { useFeaturesAndMembers } from 'hooks/useFeaturesAndMemberProfiles';
 
 import { useMemberCollections } from '../../hooks/useMemberCollections';
 import { useMemberPropertyValues } from '../../hooks/useMemberPropertyValues';
@@ -18,6 +18,7 @@ import { SummonProfileWidget } from './SummonProfileWidget';
 export function ProfileWidgets({ userId }: { userId: string }) {
   const { space } = useCurrentSpace();
   const { memberPropertyValues = [], isLoading: isLoadingMemberPropertiesValues } = useMemberPropertyValues(userId);
+  const { memberProfiles } = useFeaturesAndMembers();
 
   const { data: ensProfile, isLoading: isLoadingEnsProfile } = useSWR(`public/profile/${userId}/ens`, () =>
     charmClient.publicProfile.getEnsProfile(userId)
@@ -48,8 +49,6 @@ export function ProfileWidgets({ userId }: { userId: string }) {
   if (isLoading) {
     return <LoadingComponent isLoading />;
   }
-
-  const memberProfiles = space?.memberProfiles as MemberProfileJson[] | undefined;
 
   return (
     <Grid container spacing={4}>

--- a/components/settings/space/SpaceSettings.tsx
+++ b/components/settings/space/SpaceSettings.tsx
@@ -32,22 +32,17 @@ import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import ConnectSnapshot from 'components/common/PageActions/components/SnapshotAction/ConnectSnapshot';
 import DraggableListItem from 'components/common/PageLayout/components/DraggableListItem';
 import { PageIcon } from 'components/common/PageLayout/components/PageIcon';
-import {
-  type Feature,
-  type FeatureJson,
-  STATIC_PAGES_RECORD
-} from 'components/common/PageLayout/components/Sidebar/utils/staticPages';
+import type { Feature } from 'components/common/PageLayout/components/Sidebar/utils/staticPages';
 import { getDefaultWorkspaceUrl } from 'components/login/LoginPage';
 import Legend from 'components/settings/Legend';
 import { SetupCustomDomain } from 'components/settings/space/components/SetupCustomDomain';
+import { useFeaturesAndMembers } from 'hooks/useFeaturesAndMemberProfiles';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { usePreventReload } from 'hooks/usePreventReload';
 import { useSpaces } from 'hooks/useSpaces';
-import type { MemberProfileJson, MemberProfileName } from 'lib/profile/memberProfiles';
-import { memberProfileLabels } from 'lib/profile/memberProfiles';
+import type { MemberProfileName } from 'lib/profile/memberProfiles';
 import { getSpaceUrl, getSubdomainPath } from 'lib/utilities/browser';
 import { getValidSubdomain } from 'lib/utilities/getValidSubdomain';
-import { capitalize } from 'lib/utilities/strings';
 
 import Avatar from './components/LargeAvatar';
 import SettingsItem from './components/SettingsItem';
@@ -67,23 +62,17 @@ const schema = yup.object({
 
 type FormValues = yup.InferType<typeof schema>;
 
-const featureLabels: Record<Feature, string> = {
-  bounties: 'Bounties',
-  forum: 'Forum',
-  member_directory: 'Member Directory',
-  proposals: 'Proposals'
-};
-
 export function SpaceSettings({ space }: { space: Space }) {
   const router = useRouter();
   const { spaces, setSpace, setSpaces } = useSpaces();
   const isAdmin = useIsAdmin();
+  const { features: allFeatures, memberProfiles: allMemberProfiles } = useFeaturesAndMembers();
   const workspaceRemoveModalState = usePopupState({ variant: 'popover', popupId: 'workspace-remove' });
   const workspaceLeaveModalState = usePopupState({ variant: 'popover', popupId: 'workspace-leave' });
   const unsavedChangesModalState = usePopupState({ variant: 'popover', popupId: 'unsaved-changes' });
   const memberProfilesPopupState = usePopupState({ variant: 'popover', popupId: 'member-profiles' });
-  const [features, setFeatures] = useState(space.features as FeatureJson[]);
-  const [memberProfiles, setMemberProfiles] = useState(space.memberProfiles as MemberProfileJson[]);
+  const [features, setFeatures] = useState(allFeatures);
+  const [memberProfiles, setMemberProfiles] = useState(allMemberProfiles);
   const {
     register,
     handleSubmit,
@@ -168,7 +157,7 @@ export function SpaceSettings({ space }: { space: Space }) {
 
   async function changeOptionsOrder(draggedProperty: Feature, droppedOnProperty: Feature) {
     const newOrder = [...features];
-    const propIndex = newOrder.findIndex((_feat) => draggedProperty === _feat.id); // find the property that was dragged
+    const propIndex = newOrder.findIndex((_feat) => _feat.id === draggedProperty); // find the property that was dragged
     const deletedElements = newOrder.splice(propIndex, 1); // remove the dragged property from the array
     const droppedOnIndex = newOrder.findIndex((_feat) => _feat.id === droppedOnProperty); // find the index of the space that was dropped on
     newOrder.splice(droppedOnIndex, 0, deletedElements[0]); // add the property to the new index
@@ -177,7 +166,7 @@ export function SpaceSettings({ space }: { space: Space }) {
 
   async function changeMembersOrder(draggedProperty: MemberProfileName, droppedOnProperty: MemberProfileName) {
     const newOrder = [...memberProfiles];
-    const propIndex = newOrder.findIndex((_feat) => draggedProperty === _feat.id); // find the property that was dragged
+    const propIndex = newOrder.findIndex((_feat) => _feat.id === draggedProperty); // find the property that was dragged
     const deletedElements = newOrder.splice(propIndex, 1); // remove the dragged property from the array
     const droppedOnIndex = newOrder.findIndex((_feat) => _feat.id === droppedOnProperty); // find the index of the space that was dropped on
     newOrder.splice(droppedOnIndex, 0, deletedElements[0]); // add the property to the new index
@@ -272,8 +261,7 @@ export function SpaceSettings({ space }: { space: Space }) {
               exist, but it won't be visible in the sidebar.
             </Typography>
             <Stack>
-              {features.map(({ id, isHidden }) => {
-                const page = STATIC_PAGES_RECORD[id];
+              {features.map(({ id, isHidden, title, path }) => {
                 return (
                   <DraggableListItem
                     key={id}
@@ -295,7 +283,7 @@ export function SpaceSettings({ space }: { space: Space }) {
                             setFeatures((prevState) => {
                               const newState = [...prevState];
                               const index = newState.findIndex((_feat) => _feat.id === id);
-                              newState[index] = { id, isHidden: !newState[index].isHidden };
+                              newState[index] = { ...newState[index], isHidden: !newState[index].isHidden };
                               return [...newState];
                             });
                           }}
@@ -307,8 +295,8 @@ export function SpaceSettings({ space }: { space: Space }) {
                       hidden={isHidden}
                       text={
                         <Box display='flex' gap={1}>
-                          {!!page && <PageIcon icon={null} pageType={page.path} />}
-                          {featureLabels[id]}
+                          <PageIcon icon={null} pageType={path} />
+                          {title}
                         </Box>
                       }
                     />
@@ -325,11 +313,11 @@ export function SpaceSettings({ space }: { space: Space }) {
             <Stack gap={1}>
               {memberProfiles
                 .filter((mp) => !mp.isHidden)
-                .map((mp) => (
+                .map(({ id, title }) => (
                   <DraggableListItem
-                    key={mp.id}
+                    key={id}
                     name='memberProfileItem'
-                    itemId={mp.id}
+                    itemId={id}
                     disabled={!isAdmin}
                     changeOrderHandler={async (draggedProperty: string, droppedOnProperty: string) =>
                       changeMembersOrder(draggedProperty as MemberProfileName, droppedOnProperty as MemberProfileName)
@@ -337,16 +325,16 @@ export function SpaceSettings({ space }: { space: Space }) {
                   >
                     <SettingsItem
                       sx={{ gap: 0 }}
-                      data-test={`settings-profiles-item-${mp.id}`}
+                      data-test={`settings-profiles-item-${id}`}
                       actions={[
                         <MenuItem
-                          key={mp.id}
+                          key='1'
                           data-test='settings-profiles-option-hide'
                           onClick={() => {
                             setMemberProfiles((prevState) => {
                               const newState = [...prevState];
-                              const index = newState.findIndex((prevMp) => mp.id === prevMp.id);
-                              newState[index] = { id: mp.id, isHidden: true };
+                              const index = newState.findIndex((prevMp) => prevMp.id === id);
+                              newState[index] = { id, title, isHidden: true };
                               return [...newState];
                             });
                           }}
@@ -357,8 +345,8 @@ export function SpaceSettings({ space }: { space: Space }) {
                       disabled={!isAdmin}
                       text={
                         <Box display='flex' alignItems='center' gap={1}>
-                          <Image width={25} height={25} alt={mp.id} src={getProfileWidgetLogo(mp.id)} />
-                          <Typography>{memberProfileLabels[mp.id]}</Typography>
+                          <Image width={25} height={25} alt={id} src={getProfileWidgetLogo(id)} />
+                          <Typography>{title}</Typography>
                         </Box>
                       }
                     />
@@ -456,17 +444,21 @@ export function SpaceSettings({ space }: { space: Space }) {
         <List>
           {memberProfiles
             .filter((mp) => mp.isHidden)
-            .map((mp) => (
+            .map(({ id, title }) => (
               <ListItem
-                key={mp.id}
+                key={id}
                 secondaryAction={
                   <Button
-                    data-test={`add-profile-button-${mp.id}`}
+                    data-test={`add-profile-button-${id}`}
                     onClick={() => {
                       setMemberProfiles((prevState) => {
                         const prevMemberProfiles = [...prevState];
-                        const targetedMemberProfileIndex = prevMemberProfiles.findIndex((_mp) => _mp.id === mp.id);
-                        prevMemberProfiles[targetedMemberProfileIndex] = { id: mp.id, isHidden: false };
+                        const targetedMemberProfileIndex = prevMemberProfiles.findIndex((_mp) => _mp.id === id);
+                        prevMemberProfiles[targetedMemberProfileIndex] = {
+                          id,
+                          title,
+                          isHidden: false
+                        };
                         if (prevMemberProfiles.every((_mp) => _mp.isHidden === false)) {
                           memberProfilesPopupState.close();
                         }
@@ -479,9 +471,9 @@ export function SpaceSettings({ space }: { space: Space }) {
                 }
               >
                 <ListItemIcon>
-                  <Image width={25} height={25} alt={mp.id} src={getProfileWidgetLogo(mp.id)} />
+                  <Image width={25} height={25} alt={id} src={getProfileWidgetLogo(id)} />
                 </ListItemIcon>
-                <ListItemText primary={memberProfileLabels[mp.id]} />
+                <ListItemText primary={title} />
               </ListItem>
             ))}
         </List>

--- a/hooks/useFeaturesAndMemberProfiles.tsx
+++ b/hooks/useFeaturesAndMemberProfiles.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+
+import type { FeatureJson } from 'components/common/PageLayout/components/Sidebar/utils/staticPages';
+import { STATIC_PAGES } from 'components/common/PageLayout/components/Sidebar/utils/staticPages';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import type { MemberProfileJson } from 'lib/profile/memberProfiles';
+import { memberProfileLabels, memberProfileNames } from 'lib/profile/memberProfiles';
+import { sortArrayByObjectProperty } from 'lib/utilities/array';
+
+export const useFeaturesAndMembers = () => {
+  const { space } = useCurrentSpace();
+
+  const features = useMemo(() => {
+    const dbFeatures = Object.fromEntries(((space?.features || []) as FeatureJson[]).map((_feat) => [_feat.id, _feat]));
+
+    const sortedFeatures = sortArrayByObjectProperty(
+      STATIC_PAGES,
+      'feature',
+      ((space?.features || []) as FeatureJson[]).map((feat) => feat.id)
+    );
+
+    const extendedFeatures = sortedFeatures.map(({ feature, ...restFeat }) => ({
+      ...restFeat,
+      id: feature,
+      isHidden: !!dbFeatures[feature]?.isHidden
+    }));
+
+    return extendedFeatures;
+  }, [space?.features]);
+
+  const memberProfiles = useMemo(() => {
+    const dbMemberProfiles = Object.fromEntries(
+      ((space?.memberProfiles || []) as MemberProfileJson[]).map((_feat) => [_feat.id, _feat])
+    );
+
+    const sortedMemberProfiles = sortArrayByObjectProperty(
+      memberProfileNames.map((n) => ({ id: n, title: memberProfileLabels[n] })),
+      'id',
+      ((space?.memberProfiles || []) as FeatureJson[]).map((feat) => feat.id)
+    );
+
+    const extendedMemberProfiles = sortedMemberProfiles.map((feat) => ({
+      ...feat,
+      isHidden: !!dbMemberProfiles[feat.id]?.isHidden
+    }));
+    return extendedMemberProfiles;
+  }, [space?.memberProfiles]);
+
+  return { features, memberProfiles };
+};


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b649ce1</samp>

This pull request introduces a custom hook `useFeaturesAndMembers` that fetches and formats the features and member profiles data for various components that use them. It also refactors the sidebar, profile widgets, and space settings components to use this hook and simplifies their code. It also removes some unused code and imports.

### WHY
Reorganised the logic so we don't need to check the db for the lists of profiles and features.

- if the user doesn't have any features or memberProfiles in the db it will see the whole list.
- for example, if the user has 4 features and we add another one, we don't need to make a migration, the new feature will be added at the end of the list.