### PR TITLE
send user an error when we cant process their message

### DIFF
--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -180,6 +180,7 @@ export class DocumentEventHandler {
         message,
         ...logData
       });
+      this.sendError('There was an error saving changes do your document. Please reload and try again.');
     }
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d0cf29f</samp>

Handle database save errors in document editing websocket events. Send error message to client using `sendError` method of `DocumentEventHandler` in `lib/websockets/documentEvents/documentEvents.ts`.

### WHY
<!-- author to complete -->
