### PR TITLE
Markdown export fix

### DIFF
--- a/components/common/CharmEditor/components/emojiSuggest/emojiSuggest.specs.ts
+++ b/components/common/CharmEditor/components/emojiSuggest/emojiSuggest.specs.ts
@@ -52,10 +52,12 @@ function emojiSpec({ defaultEmoji = '😃' }: { defaultEmoji?: string } = {}): R
     },
     markdown: {
       toMarkdown: (state, node) => {
-        try {
-          state.text(node.attrs.emoji);
-        } catch (err) {
-          log.warn('Conversion err', err);
+        if (node.attrs?.emoji) {
+          try {
+            state.text(node.attrs.emoji);
+          } catch (err) {
+            log.warn('Conversion err', err);
+          }
         }
       }
     }
@@ -71,6 +73,14 @@ function specMark({
 
   return {
     ..._spec,
+    markdown: {
+      toMarkdown: {
+        open: '',
+        close: '',
+        mixable: false,
+        expelEnclosingWhitespace: true
+      }
+    },
     options: {
       trigger
     }

--- a/components/common/CharmEditor/components/nestedPage/nestedPage.utils.ts
+++ b/components/common/CharmEditor/components/nestedPage/nestedPage.utils.ts
@@ -14,7 +14,7 @@ export function encloseNestedPage(pageId: string): string {
  * Returns a list of page IDs
  */
 function parseNestedPagesToReplace(convertedToMarkdown: string): string[] {
-  return convertedToMarkdown.match(new RegExp(`_${nestedPageMarkdownEnclosure}\\((?:[a-f]|\\d|-){1,}\\)_`)) ?? [];
+  return convertedToMarkdown.match(new RegExp(`_${nestedPageMarkdownEnclosure}\\((?:[a-f]|\\d|-){1,}\\)_`, 'g')) ?? [];
 }
 
 function extractPageId(matchedMarkdownEnclosure: string): string {
@@ -25,8 +25,6 @@ function extractPageId(matchedMarkdownEnclosure: string): string {
     .split(')')
     .filter((str) => !!str)[0];
 }
-
-// function produceLinkMarkdown()
 
 /**
  * Returns markdown content with page data interpolated

--- a/components/common/CharmEditor/specRegistry.ts
+++ b/components/common/CharmEditor/specRegistry.ts
@@ -1,4 +1,4 @@
-import { bold, code, hardBreak, italic, strike, underline } from '@bangle.dev/base-components';
+import { bold, code, italic, strike, underline } from '@bangle.dev/base-components';
 import { SpecRegistry } from '@bangle.dev/core';
 
 import type { PageContent } from 'lib/prosemirror/interfaces';
@@ -38,6 +38,7 @@ import { spec as tableOfContentSpec } from './components/tableOfContents/tableOf
 import * as textColor from './components/textColor/textColorSpec';
 import * as tweet from './components/tweet/tweetSpec';
 import * as video from './components/video/videoSpec';
+import { hardBreakSpec } from './specs/hardBreakSpec';
 
 export interface ICharmEditorOutput {
   doc: PageContent;
@@ -57,7 +58,7 @@ export const specRegistry = new SpecRegistry([
   inlineVote.spec(),
   bold.spec(), // OK
   bulletList.spec(), // OK
-  hardBreak.spec(), // OK
+  hardBreakSpec(), // OK
   horizontalRule.spec(), // OK
   italic.spec(), // OK
   linkSpec(), // OK

--- a/components/common/CharmEditor/specs/hardBreakSpec.ts
+++ b/components/common/CharmEditor/specs/hardBreakSpec.ts
@@ -1,0 +1,20 @@
+import { hardBreak } from '@bangle.dev/base-components';
+import type { BaseRawNodeSpec } from '@bangle.dev/core';
+
+export function hardBreakSpec() {
+  const nativeSpec = hardBreak.spec() as BaseRawNodeSpec;
+
+  const charmHardBreakSpec: BaseRawNodeSpec = {
+    ...nativeSpec,
+    markdown: {
+      toMarkdown: (state) => {
+        state.write('\n');
+      },
+      parseMarkdown: {
+        hardbreak: { node: 'hardBreak' }
+      }
+    }
+  };
+
+  return charmHardBreakSpec;
+}

--- a/lib/prosemirror/plugins/markdown/__tests__/generateMarkdown.spec.ts
+++ b/lib/prosemirror/plugins/markdown/__tests__/generateMarkdown.spec.ts
@@ -1,3 +1,7 @@
+import { testUtilsPages, testUtilsUser } from '@charmverse/core/test';
+
+import { baseUrl } from 'config/constants';
+
 import { generateMarkdown } from '../generateMarkdown';
 
 describe('generateMarkdown', () => {
@@ -149,6 +153,121 @@ describe('generateMarkdown', () => {
   - First nested bullet list item
 
   - Second nested bullet list item`
+    );
+  });
+
+  it('should convert urls and nested pages to markdown links', async () => {
+    const { user, space } = await testUtilsUser.generateUserAndSpace();
+
+    const page1 = await testUtilsPages.generatePage({ createdBy: user.id, spaceId: space.id, title: 'Page 1' });
+    const page2 = await testUtilsPages.generatePage({ createdBy: user.id, spaceId: space.id, title: 'Page 2' });
+
+    const inputData = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { id: null, level: 1, track: [], collapseContent: null },
+          content: [
+            {
+              text: 'Header',
+              type: 'text',
+              marks: [
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-07-08T01:23:00.000Z',
+                    user: '8e54b253-eeca-420d-9727-4598521d8121',
+                    approved: true,
+                    username: 'Admin'
+                  }
+                }
+              ]
+            },
+            {
+              text: ':',
+              type: 'text',
+              marks: [
+                { type: 'emojiSuggest', attrs: { trigger: ':' } },
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-07-08T01:23:00.000Z',
+                    user: '8e54b253-eeca-420d-9727-4598521d8121',
+                    approved: true,
+                    username: 'Admin'
+                  }
+                }
+              ]
+            },
+            {
+              text: ' ',
+              type: 'text',
+              marks: [
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-07-08T01:23:00.000Z',
+                    user: '8e54b253-eeca-420d-9727-4598521d8121',
+                    approved: true,
+                    username: 'Admin'
+                  }
+                },
+                { type: 'text-color', attrs: { color: null, bgColor: null } }
+              ]
+            }
+          ]
+        },
+        {
+          type: 'paragraph',
+          attrs: { track: [] },
+          content: [
+            {
+              text: 'Wikipedia - Ethereum',
+              type: 'text',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://en.wikipedia.org/wiki/Ethereum'
+                  }
+                },
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-07-08T01:23:00.000Z',
+                    user: '8e54b253-eeca-420d-9727-4598521d8121',
+                    approved: true,
+                    username: 'Admin'
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        { type: 'paragraph', attrs: { track: [] } },
+        {
+          type: 'page',
+          attrs: { id: page1.id, track: [] }
+        },
+        { type: 'paragraph', attrs: { track: [] } },
+        { type: 'page', attrs: { id: page2.id, track: [] } },
+        { type: 'paragraph', attrs: { track: [] } },
+        { type: 'paragraph', attrs: { track: [] } }
+      ]
+    };
+    const exported = await generateMarkdown({ content: inputData });
+
+    expect(exported).toEqual(
+      // eslint-disable-next-line prettier/prettier
+`# Header: 
+
+[Wikipedia - Ethereum](https://en.wikipedia.org/wiki/Ethereum)
+
+[Page 1](${baseUrl}/${space.domain}/${page1.path})
+
+[Page 2](${baseUrl}/${space.domain}/${page2.path})
+`
     );
   });
 });

--- a/lib/prosemirror/plugins/markdown/__tests__/generateMarkdown.spec.ts
+++ b/lib/prosemirror/plugins/markdown/__tests__/generateMarkdown.spec.ts
@@ -270,4 +270,145 @@ describe('generateMarkdown', () => {
 `
     );
   });
+
+  it('should convert hard breaks to newlines', async () => {
+    const inputData = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          attrs: { track: [] },
+          content: [
+            {
+              text: 'Content',
+              type: 'text',
+              marks: [
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-08-15T13:50:00.000Z',
+                    user: 'ed1a3f61-0d02-4ed2-831a-ed12c188aee6',
+                    approved: true,
+                    username: 'member'
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          type: 'paragraph',
+          attrs: { track: [] },
+          content: [
+            {
+              type: 'hardBreak',
+              marks: [
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-08-15T13:50:00.000Z',
+                    user: 'ed1a3f61-0d02-4ed2-831a-ed12c188aee6',
+                    approved: true,
+                    username: 'member'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'hardBreak',
+              marks: [
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-08-15T13:50:00.000Z',
+                    user: 'ed1a3f61-0d02-4ed2-831a-ed12c188aee6',
+                    approved: true,
+                    username: 'member'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'hardBreak',
+              marks: [
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-08-15T13:50:00.000Z',
+                    user: 'ed1a3f61-0d02-4ed2-831a-ed12c188aee6',
+                    approved: true,
+                    username: 'member'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'hardBreak',
+              marks: [
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-08-15T13:50:00.000Z',
+                    user: 'ed1a3f61-0d02-4ed2-831a-ed12c188aee6',
+                    approved: true,
+                    username: 'member'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'hardBreak',
+              marks: [
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-08-15T13:50:00.000Z',
+                    user: 'ed1a3f61-0d02-4ed2-831a-ed12c188aee6',
+                    approved: true,
+                    username: 'member'
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          type: 'paragraph',
+          attrs: { track: [] },
+          content: [
+            {
+              text: 'Second',
+              type: 'text',
+              marks: [
+                {
+                  type: 'insertion',
+                  attrs: {
+                    date: '2023-08-15T13:50:00.000Z',
+                    user: 'ed1a3f61-0d02-4ed2-831a-ed12c188aee6',
+                    approved: true,
+                    username: 'member'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const exported = await generateMarkdown({ content: inputData });
+
+    expect(exported).toEqual(
+      // eslint-disable-next-line prettier/prettier
+`Content
+
+
+
+
+
+
+
+Second`
+    );
+  });
 });

--- a/lib/prosemirror/plugins/markdown/__tests__/generateMarkdown.spec.ts
+++ b/lib/prosemirror/plugins/markdown/__tests__/generateMarkdown.spec.ts
@@ -1,0 +1,154 @@
+import { generateMarkdown } from '../generateMarkdown';
+
+describe('generateMarkdown', () => {
+  it('should generate markdown from a header', async () => {
+    const h1Data = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 1, collapseContent: null },
+          content: [{ text: 'Description', type: 'text' }]
+        }
+      ]
+    };
+
+    const exportedH1 = await generateMarkdown({ content: h1Data });
+
+    expect(exportedH1).toEqual(`# Description`);
+
+    const h2Data = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2, collapseContent: null },
+          content: [{ text: 'Description', type: 'text' }]
+        }
+      ]
+    };
+
+    const exportedH2 = await generateMarkdown({ content: h2Data });
+
+    expect(exportedH2).toEqual(`## Description`);
+
+    const h3Data = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 3, collapseContent: null },
+          content: [{ text: 'Description', type: 'text' }]
+        }
+      ]
+    };
+
+    const exportedH3 = await generateMarkdown({ content: h3Data });
+
+    expect(exportedH3).toEqual(`### Description`);
+  });
+
+  it('should handle text and ignore the emojiSuggest mark', async () => {
+    const inputData = {
+      type: 'doc',
+      content: [
+        {
+          text: ':',
+          type: 'text',
+          marks: [{ type: 'emojiSuggest', attrs: { trigger: ':' } }]
+        }
+      ]
+    };
+    const exported = await generateMarkdown({ content: inputData });
+
+    expect(exported).toEqual(`:`);
+  });
+  it('should generate handle a bullet list', async () => {
+    const inputData = {
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          attrs: { tight: false },
+          content: [
+            {
+              type: 'listItem',
+              attrs: { track: [], todoChecked: null },
+              content: [
+                {
+                  type: 'paragraph',
+                  attrs: { track: [] },
+                  content: [{ text: 'First list item', type: 'text' }]
+                }
+              ]
+            },
+            {
+              type: 'listItem',
+              attrs: { track: [], todoChecked: null },
+              content: [
+                {
+                  type: 'paragraph',
+                  attrs: { track: [] },
+                  content: [
+                    { text: 'Second list item part 1', type: 'text' },
+                    { text: 'Second list item part 2', type: 'text' }
+                  ]
+                },
+                {
+                  type: 'bulletList',
+                  attrs: { tight: false },
+                  content: [
+                    {
+                      type: 'listItem',
+                      attrs: { track: [], todoChecked: null },
+                      content: [
+                        {
+                          type: 'paragraph',
+                          attrs: { track: [] },
+                          content: [
+                            {
+                              text: 'First nested bullet list item',
+                              type: 'text'
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      type: 'listItem',
+                      attrs: { track: [], todoChecked: null },
+                      content: [
+                        {
+                          type: 'paragraph',
+                          attrs: { track: [] },
+                          content: [
+                            {
+                              type: 'text',
+                              text: 'Second nested bullet list item'
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    const exported = await generateMarkdown({ content: inputData });
+
+    expect(exported).toEqual(
+      // eslint-disable-next-line prettier/prettier
+`- First list item
+
+- Second list item part 1Second list item part 2
+
+  - First nested bullet list item
+
+  - Second nested bullet list item`
+    );
+  });
+});


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f5b0f7</samp>

This pull request enhances the markdown conversion and export features of the `CharmEditor` component and adds unit tests for the `generateMarkdown` function. It fixes a bug in the nested page export, improves the `emojiSuggest` feature, and removes unused code. It affects the files `components/common/CharmEditor/components/emojiSuggest/emojiSuggest.specs.ts`, `components/common/CharmEditor/components/nestedPage/nestedPage.utils.ts`, and `lib/prosemirror/plugins/markdown/__tests__/generateMarkdown.spec.ts`.

### WHY
Fix exporting text to markdown