### PR TITLE
Add shortcut for table of contents

### DIFF
--- a/components/common/CharmEditor/components/inlinePalette/editorItems/advancedBlocks.tsx
+++ b/components/common/CharmEditor/components/inlinePalette/editorItems/advancedBlocks.tsx
@@ -140,6 +140,7 @@ export function items({ view: currentView, enableVoting }: AdvancedItemsProps): 
   editorItems.push({
     uid: 'table-of-contents',
     title: 'Table of contents',
+    keywords: ['table', 'contents', 'toc'],
     icon: (
       <FormatListBulleted
         sx={{


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ce1517</samp>

Add keywords for Table of Contents block in `inlinePalette`. This improves the discoverability and usability of the new block in the charm editor.

### WHY
<!-- author to complete -->
