### PR TITLE
Fixed issue with deleting column block nodes

### DIFF
--- a/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
+++ b/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
@@ -51,10 +51,13 @@ function Component({ menuState }: { menuState: PluginState }) {
     // calculate the node at the mouse position. do it on click in case the content has changed
     let topPos = view.state.doc.resolve(menuState.rowPos);
     // Skip stepping up the document tree if the current node is columnBlock, it will calculate the child in the next step
-    if (topPos.node().type.name !== 'columnBlock') {
-      while (topPos.depth > 1 || (topPos.depth === 1 && topPos.parentOffset > 0)) {
-        const parentOffset = topPos.pos - (topPos.parentOffset > 0 ? topPos.parentOffset : 1); // if parentOffset is 0, step back by 1
-        topPos = view.state.doc.resolve(parentOffset);
+    while (topPos.depth > 1 || (topPos.depth === 1 && topPos.parentOffset > 0)) {
+      const parentOffset = topPos.pos - (topPos.parentOffset > 0 ? topPos.parentOffset : 1); // if parentOffset is 0, step back by 1
+      const parentOffsetNode = view.state.doc.resolve(parentOffset);
+      if (parentOffsetNode.node().type.name !== 'columnBlock') {
+        topPos = parentOffsetNode;
+      } else {
+        break;
       }
     }
 

--- a/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
+++ b/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
@@ -23,8 +23,6 @@ import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
 import { isMac } from 'lib/utilities/browser';
 
-import { nodeViewUpdateStore } from '../@bangle.dev/react/node-view-helpers';
-
 import type { PluginState } from './rowActions';
 
 const menuPosition: Partial<MenuProps> = {
@@ -52,9 +50,12 @@ function Component({ menuState }: { menuState: PluginState }) {
 
     // calculate the node at the mouse position. do it on click in case the content has changed
     let topPos = view.state.doc.resolve(menuState.rowPos);
-    while (topPos.depth > 1 || (topPos.depth === 1 && topPos.parentOffset > 0)) {
-      const parentOffset = topPos.pos - (topPos.parentOffset > 0 ? topPos.parentOffset : 1); // if parentOffset is 0, step back by 1
-      topPos = view.state.doc.resolve(parentOffset);
+    // Skip stepping up the document tree if the current node is columnBlock, it will calculate the child in the next step
+    if (topPos.node().type.name !== 'columnBlock') {
+      while (topPos.depth > 1 || (topPos.depth === 1 && topPos.parentOffset > 0)) {
+        const parentOffset = topPos.pos - (topPos.parentOffset > 0 ? topPos.parentOffset : 1); // if parentOffset is 0, step back by 1
+        topPos = view.state.doc.resolve(parentOffset);
+      }
     }
 
     // console.log('Position of row', topPos, { node: topPos.node() });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fce33f5</samp>

Fixed a bug in the row actions menu for column blocks in the `CharmEditor` component. The bug affected the node calculation in the `_getNode` function in `RowActionsMenu.tsx`.

### WHY
<!-- author to complete -->
