### PR TITLE
Bug/rubric template flows

### DIFF
--- a/charmClient/hooks/proposals.ts
+++ b/charmClient/hooks/proposals.ts
@@ -1,13 +1,13 @@
 import type {
-  ProposalReviewerPool,
   ProposalCategoryWithPermissions,
-  ProposalFlowPermissionFlags
+  ProposalFlowPermissionFlags,
+  ProposalReviewerPool
 } from '@charmverse/core/permissions';
-import type { Page } from '@charmverse/core/prisma';
 import type { ProposalWithUsers } from '@charmverse/core/proposals';
 
 import type { ListProposalsRequest } from 'lib/proposal/getProposalsBySpace';
 import type { RubricProposalsUserInfo } from 'lib/proposal/getProposalsEvaluatedByUser';
+import type { ProposalTemplate } from 'lib/proposal/getProposalTemplates';
 import type { ProposalWithUsersAndRubric } from 'lib/proposal/interface';
 import type { RubricAnswerUpsert } from 'lib/proposal/rubric/upsertRubricAnswers';
 import type { RubricCriteriaUpsert } from 'lib/proposal/rubric/upsertRubricCriteria';
@@ -38,7 +38,7 @@ export function useGetProposalsBySpace({ spaceId, categoryIds }: Partial<ListPro
 }
 
 export function useGetProposalTemplatesBySpace(spaceId: MaybeString) {
-  return useGET<(ProposalWithUsers & { page: Page })[]>(spaceId ? `/api/spaces/${spaceId}/proposal-templates` : null);
+  return useGET<ProposalTemplate[]>(spaceId ? `/api/spaces/${spaceId}/proposal-templates` : null);
 }
 
 export function useGetProposalCategories(spaceId?: string) {

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -14,6 +14,7 @@ import { useTasks } from 'components/nexus/hooks/useTasks';
 import type { ProposalFormInputs } from 'components/proposals/components/ProposalProperties/ProposalProperties';
 import { ProposalProperties as ProposalPropertiesBase } from 'components/proposals/components/ProposalProperties/ProposalProperties';
 import { useProposalPermissions } from 'components/proposals/hooks/useProposalPermissions';
+import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemplates';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useUser } from 'hooks/useUser';
 
@@ -45,6 +46,8 @@ export function ProposalProperties({
   const { permissions: proposalPermissions, refresh: refreshProposalPermissions } = useProposalPermissions({
     proposalIdOrPath: proposalId
   });
+
+  const { proposalTemplates } = useProposalTemplates({ load: !!proposal?.page?.sourceTemplateId });
 
   const { data: reviewerUserIds } = useGetAllReviewerUserIds(
     !!pageId && proposal?.evaluationType === 'rubric' ? pageId : undefined
@@ -107,6 +110,11 @@ export function ProposalProperties({
 
   const onChangeRubricCriteriaDebounced = useCallback(debounce(onChangeRubricCriteria, 300), [proposal?.status]);
 
+  const readOnlyReviewers =
+    readOnlyProperties ||
+    (isFromTemplateSource &&
+      !!proposalTemplates?.find((t) => t.id === proposal?.page?.sourceTemplateId && t.reviewers.length > 0));
+
   return (
     <ProposalPropertiesBase
       archived={!!proposal?.archived}
@@ -123,9 +131,7 @@ export function ProposalProperties({
         (proposal?.status !== 'draft' && !isTemplate) ||
         isFromTemplateSource
       }
-      readOnlyReviewers={
-        readOnlyProperties || (isFromTemplateSource && proposal?.reviewers && proposal.reviewers.length > 0)
-      }
+      readOnlyReviewers={readOnlyReviewers}
       rubricAnswers={proposal?.rubricAnswers}
       rubricCriteria={proposal?.rubricCriteria}
       showStatus={!isTemplate}

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -118,7 +118,7 @@ export function ProposalProperties({
   return (
     <ProposalPropertiesBase
       archived={!!proposal?.archived}
-      disabledCategoryInput={!proposalPermissions?.edit}
+      disabledCategoryInput={!proposalPermissions?.edit || !!proposal?.page?.sourceTemplateId}
       proposalFlowFlags={proposalFlowFlags}
       proposalStatus={proposal?.status}
       proposalId={proposal?.id}

--- a/components/common/stories/Proposals.stories.tsx
+++ b/components/common/stories/Proposals.stories.tsx
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 
 import DocumentPage from 'components/[pageId]/DocumentPage/DocumentPage';
 import { mockStateStore } from 'components/common/BoardEditor/focalboard/src/testUtils';
-import { ProposalPage as ProposalPageComponent } from 'components/proposals/components/ProposalDialog/ProposalPage';
+import { NewProposalPage as ProposalPageComponent } from 'components/proposals/components/ProposalDialog/NewProposalPage';
 import type { ProposalFormInputs } from 'components/proposals/components/ProposalProperties/ProposalProperties';
 import type { ICurrentSpaceContext } from 'hooks/useCurrentSpace';
 import { CurrentSpaceContext } from 'hooks/useCurrentSpace';

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -92,7 +92,8 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
           pageProps: {
             content: formInputs.content,
             contentText: formInputs.contentText ?? '',
-            title: formInputs.title
+            title: formInputs.title,
+            sourceTemplateId: formInputs.proposalTemplateId
           },
           evaluationType: formInputs.evaluationType,
           rubricCriteria: formInputs.rubricCriteria as RubricDataInput[],

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -12,6 +12,7 @@ import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
 import { ScrollableWindow } from 'components/common/PageLayout';
+import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemplates';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
 import { usePreventReload } from 'hooks/usePreventReload';
@@ -34,7 +35,7 @@ type Props = {
   setContentUpdated: (changed: boolean) => void;
 };
 // Note: this component is only used before a page is saved to the DB
-export function ProposalPage({ setFormInputs, formInputs, contentUpdated, setContentUpdated }: Props) {
+export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, setContentUpdated }: Props) {
   const { space: currentSpace } = useCurrentSpace();
   const { showMessage } = useSnackbar();
   const { showProposal } = useProposalDialog();

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -46,6 +46,8 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
 
   usePreventReload(contentUpdated);
 
+  const { proposalTemplates } = useProposalTemplates();
+
   const router = useRouter();
 
   const [isCreatingProposal, setIsCreatingProposal] = useState(false);
@@ -57,6 +59,10 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
       setReadOnlyEditor(!formInputs.proposalTemplateId);
     }
   }, [formInputs.proposalTemplateId, currentSpace?.requireProposalTemplate]);
+
+  const readOnlyReviewers =
+    isFromTemplateSource &&
+    !!proposalTemplates?.find((t) => t.id === formInputs?.proposalTemplateId && t.reviewers.length > 0);
 
   async function createProposal() {
     if (formInputs.categoryId && currentSpace) {
@@ -178,7 +184,7 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
                 <div className='CardDetail content'>
                   <ProposalProperties
                     readOnlyRubricCriteria={isFromTemplateSource}
-                    readOnlyReviewers={isFromTemplateSource && formInputs.reviewers.length > 0}
+                    readOnlyReviewers={readOnlyReviewers}
                     readOnlyProposalEvaluationType={isFromTemplateSource}
                     proposalStatus='draft'
                     proposalFormInputs={formInputs}

--- a/components/proposals/components/ProposalDialog/ProposalDialog.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalDialog.tsx
@@ -14,7 +14,7 @@ import type { PageWithContent } from 'lib/pages';
 
 import type { ProposalFormInputs } from '../ProposalProperties/ProposalProperties';
 
-import { ProposalPage } from './ProposalPage';
+import { NewProposalPage } from './NewProposalPage';
 
 interface Props {
   isLoading: boolean;
@@ -107,11 +107,11 @@ export function ProposalDialog({ page, isLoading, onClose }: Props) {
       ) : page ? (
         <EditorPage pageId={page.id} />
       ) : (
-        <ProposalPage
+        <NewProposalPage
           formInputs={formInputs}
           setFormInputs={(_formInputs) => {
             setContentUpdated(true);
-            setFormInputs((__formInputs) => ({ ...__formInputs, ..._formInputs }));
+            setFormInputs((existingFormInputs) => ({ ...existingFormInputs, ..._formInputs }));
           }}
           contentUpdated={contentUpdated}
           setContentUpdated={setContentUpdated}

--- a/components/proposals/components/ProposalProperties/ProposalProperties.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalProperties.tsx
@@ -1,12 +1,6 @@
 import type { PageMeta } from '@charmverse/core/pages';
 import type { ProposalFlowPermissionFlags } from '@charmverse/core/permissions';
-import type {
-  Page,
-  Proposal,
-  ProposalEvaluationType,
-  ProposalRubricCriteria,
-  ProposalStatus
-} from '@charmverse/core/prisma';
+import type { ProposalEvaluationType, ProposalRubricCriteria, ProposalStatus } from '@charmverse/core/prisma';
 import type { ProposalReviewerInput } from '@charmverse/core/proposals';
 import { KeyboardArrowDown } from '@mui/icons-material';
 import { Box, Card, Collapse, Divider, Grid, IconButton, Stack, Typography } from '@mui/material';
@@ -24,6 +18,7 @@ import { RubricResults } from 'components/proposals/components/ProposalPropertie
 import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemplates';
 import { CreateVoteModal } from 'components/votes/components/CreateVoteModal';
 import { usePages } from 'hooks/usePages';
+import type { ProposalTemplate } from 'lib/proposal/getProposalTemplates';
 import type { ProposalCategory } from 'lib/proposal/interface';
 import type { ProposalRubricCriteriaAnswerWithTypedResponse } from 'lib/proposal/rubric/interfaces';
 import type { PageContent } from 'lib/prosemirror/interfaces';
@@ -134,7 +129,7 @@ export function ProposalProperties({
   const proposalsRecord = (proposalTemplates ?? []).reduce((acc, _proposal) => {
     acc[_proposal.id] = _proposal;
     return acc;
-  }, {} as Record<string, Proposal & { page: Page }>);
+  }, {} as Record<string, ProposalTemplate>);
 
   const templateOptions = proposalTemplatePages.filter((proposalTemplate) => {
     const _proposal = proposalTemplate.proposalId && proposalsRecord[proposalTemplate.proposalId];
@@ -182,7 +177,9 @@ export function ProposalProperties({
             group: reviewer.roleId ? 'role' : 'user',
             id: reviewer.roleId ?? (reviewer.userId as string)
           })),
-          proposalTemplateId: templatePage.id
+          proposalTemplateId: templatePage.id,
+          evaluationType: proposalTemplate.evaluationType,
+          rubricCriteria: proposalTemplate.rubricCriteria
         });
       }
     }

--- a/components/proposals/hooks/useProposalTemplates.tsx
+++ b/components/proposals/hooks/useProposalTemplates.tsx
@@ -7,12 +7,16 @@ import { useIsAdmin } from 'hooks/useIsAdmin';
 
 import { useProposalCategories } from './useProposalCategories';
 
-export function useProposalTemplates() {
+export function useProposalTemplates({ load } = { load: true }) {
   const { proposalCategoriesWithCreatePermission } = useProposalCategories();
   const { space } = useCurrentSpace();
   const isAdmin = useIsAdmin();
 
-  const { data: proposalTemplates, mutate, isLoading: isLoadingTemplates } = useGetProposalTemplatesBySpace(space?.id);
+  const {
+    data: proposalTemplates,
+    mutate,
+    isLoading: isLoadingTemplates
+  } = useGetProposalTemplatesBySpace(load ? space?.id : null);
   const usableTemplates = isAdmin
     ? proposalTemplates
     : proposalTemplates?.filter((template) =>

--- a/lib/proposal/__tests__/createProposal.spec.ts
+++ b/lib/proposal/__tests__/createProposal.spec.ts
@@ -1,6 +1,7 @@
 import { InsecureOperationError, InvalidInputError } from '@charmverse/core/errors';
 import type { ProposalCategory, Space, User } from '@charmverse/core/prisma';
 import { testUtilsMembers, testUtilsUser } from '@charmverse/core/test';
+import { v4 as uuid } from 'uuid';
 
 import { generateSpaceUser, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
 import { generateProposalCategory } from 'testing/utils/proposals';
@@ -22,7 +23,7 @@ beforeAll(async () => {
 });
 
 describe('Creates a page and proposal with relevant configuration', () => {
-  it('Create a page and proposal in a specific category, accepting page content, reviewers and authors as input', async () => {
+  it('Create a page and proposal in a specific category, accepting page content, reviewers, authors and source template ID as input', async () => {
     const reviewerUser = await generateSpaceUser({
       isAdmin: false,
       spaceId: space.id
@@ -34,10 +35,13 @@ describe('Creates a page and proposal with relevant configuration', () => {
 
     const pageTitle = 'page title 124';
 
+    const templateId = uuid();
+
     const { page, workspaceEvent, proposal } = await createProposal({
       pageProps: {
         contentText: '',
-        title: pageTitle
+        title: pageTitle,
+        sourceTemplateId: templateId
       },
       categoryId: proposalCategory.id,
       userId: user.id,
@@ -54,7 +58,8 @@ describe('Creates a page and proposal with relevant configuration', () => {
     expect(page).toMatchObject(
       expect.objectContaining({
         title: pageTitle,
-        type: 'proposal'
+        type: 'proposal',
+        sourceTemplateId: templateId
       })
     );
 

--- a/lib/proposal/getProposalTemplates.ts
+++ b/lib/proposal/getProposalTemplates.ts
@@ -2,14 +2,17 @@ import { InvalidInputError } from '@charmverse/core/errors';
 import type { SpaceResourcesRequest } from '@charmverse/core/permissions';
 import type { Page } from '@charmverse/core/prisma-client';
 import { prisma } from '@charmverse/core/prisma-client';
-import type { ProposalWithUsers } from '@charmverse/core/proposals';
 import { generateCategoryIdQuery } from '@charmverse/core/proposals';
 import { stringUtils } from '@charmverse/core/utilities';
 
 import { premiumPermissionsApiClient } from 'lib/permissions/api/routers';
 import { hasAccessToSpace } from 'lib/users/hasAccessToSpace';
 
-export async function getProposalTemplates({ spaceId, userId }: SpaceResourcesRequest) {
+import type { ProposalWithUsersAndRubric } from './interface';
+
+export type ProposalTemplate = ProposalWithUsersAndRubric & { page: Page };
+
+export async function getProposalTemplates({ spaceId, userId }: SpaceResourcesRequest): Promise<ProposalTemplate[]> {
   if (!stringUtils.isUUID(spaceId)) {
     throw new InvalidInputError(`SpaceID is required`);
   }
@@ -62,7 +65,8 @@ export async function getProposalTemplates({ spaceId, userId }: SpaceResourcesRe
       authors: true,
       reviewers: true,
       category: true,
-      page: true
+      page: true,
+      rubricCriteria: true
     }
-  }) as Promise<(ProposalWithUsers & { page: Page })[]>;
+  }) as Promise<ProposalTemplate[]>;
 }

--- a/pages/api/spaces/[id]/proposal-templates.ts
+++ b/pages/api/spaces/[id]/proposal-templates.ts
@@ -1,9 +1,9 @@
-import type { ProposalWithUsers } from '@charmverse/core/proposals';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
 import { onError, onNoMatch } from 'lib/middleware';
 import { providePermissionClients } from 'lib/permissions/api/permissionsClientMiddleware';
+import type { ProposalTemplate } from 'lib/proposal/getProposalTemplates';
 import { getProposalTemplates } from 'lib/proposal/getProposalTemplates';
 import { withSessionRoute } from 'lib/session/withSession';
 
@@ -19,7 +19,7 @@ handler
   )
   .get(getProposalTemplatesController);
 
-async function getProposalTemplatesController(req: NextApiRequest, res: NextApiResponse<ProposalWithUsers[]>) {
+async function getProposalTemplatesController(req: NextApiRequest, res: NextApiResponse<ProposalTemplate[]>) {
   const userId = req.session.user?.id;
   const spaceId = req.query.id as string;
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8127f26</samp>

Refactored and updated the proposal template feature to use a new `ProposalTemplate` type and to handle readonly reviewers. Renamed `ProposalPage` component to `NewProposalPage` to avoid confusion with existing proposal page. Added `rubricCriteria` to proposal templates and improved data fetching and display logic.

### WHY
Fix issues related to using templates in the builder