### PR TITLE
Change copy of proposal category permission labels

### DIFF
--- a/components/proposals/components/ProposalViewOptions/components/ProposalCategoryPermissionsDialog/shared.ts
+++ b/components/proposals/components/ProposalViewOptions/components/ProposalCategoryPermissionsDialog/shared.ts
@@ -6,7 +6,7 @@ export type BulkRoleProposalCategoryPermissionUpsert = {
 };
 
 export const proposalCategoryPermissionLabels: Record<ProposalCategoryPermissionLevel, string> = {
-  full_access: 'Propose, Vote & Decide',
+  full_access: 'Propose, Comment & Decide',
   create_comment: 'Propose & Comment',
   view_comment_vote: 'Vote & Comment',
   view_comment: 'Comment',


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 105941f</samp>

Changed the label for the `full_access` permission level in the `ProposalCategoryPermissionsDialog` component. This improves the clarity and accuracy of the UI for managing proposal categories.

### WHY
<!-- author to complete -->
