### PR TITLE
Switch reviewer pool to categoryID

### DIFF
--- a/__integration-tests__/server/pages/api/proposals/[id]/index.public.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/[id]/index.public.spec.ts
@@ -79,15 +79,9 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
     });
     const adminCookie = await loginUser(adminUser.id);
 
-    const role = await testUtilsMembers.generateRole({
-      spaceId: adminSpace.id,
-      createdBy: adminUser.id
-    });
-
     const { page } = await testUtilsProposals.generateProposal({
       userId: adminUser.id,
-      spaceId: adminSpace.id,
-      categoryId: proposalCategory.id
+      spaceId: adminSpace.id
     });
 
     const updateContent: Partial<UpdateProposalRequest> = {
@@ -213,8 +207,7 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
 
     const { page } = await testUtilsProposals.generateProposal({
       userId: proposalAuthor.id,
-      spaceId: adminSpace.id,
-      categoryId: proposalCategory.id
+      spaceId: adminSpace.id
     });
 
     const updateContent: Partial<UpdateProposalRequest> = {

--- a/__integration-tests__/server/pages/api/proposals/[id]/index.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/[id]/index.spec.ts
@@ -95,10 +95,14 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
     const { user: adminUser, space: adminSpace } = await testUtilsUser.generateUserAndSpace({ isAdmin: true });
     const adminCookie = await loginUser(adminUser.id);
 
+    const category = await testUtilsProposals.generateProposalCategory({
+      spaceId: adminSpace.id
+    });
+
     const { page } = await testUtilsProposals.generateProposal({
       userId: adminUser.id,
       spaceId: adminSpace.id,
-      categoryId: proposalCategory.id
+      categoryId: category.id
     });
 
     const updateContent: Partial<UpdateProposalRequest> = {
@@ -131,10 +135,14 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
 
     const role = await testUtilsMembers.generateRole({ createdBy: adminUser.id, spaceId: adminSpace.id });
 
+    const category = await testUtilsProposals.generateProposalCategory({
+      spaceId: adminSpace.id
+    });
+
     const proposalTemplate = await testUtilsProposals.generateProposalTemplate({
       spaceId: adminSpace.id,
       userId: adminUser.id,
-      categoryId: proposalCategory.id
+      categoryId: category.id
     });
 
     const updateContent: Partial<UpdateProposalRequest> = {
@@ -171,10 +179,14 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
 
     const proposalAuthor = await testUtilsUser.generateSpaceUser({ isAdmin: false, spaceId: adminSpace.id });
 
+    const category = await testUtilsProposals.generateProposalCategory({
+      spaceId: adminSpace.id
+    });
+
     const { page } = await testUtilsProposals.generateProposal({
       userId: proposalAuthor.id,
       spaceId: adminSpace.id,
-      categoryId: proposalCategory.id,
+      categoryId: category.id,
       proposalStatus: 'discussion'
     });
 
@@ -220,10 +232,14 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
       operations: ['createPage']
     });
 
+    const category = await testUtilsProposals.generateProposalCategory({
+      spaceId: adminSpace.id
+    });
+
     const { page } = await testUtilsProposals.generateProposal({
       userId: proposalAuthor.id,
       spaceId: adminSpace.id,
-      categoryId: proposalCategory.id,
+      categoryId: category.id,
       proposalStatus: 'discussion',
       reviewers: [{ group: 'user', id: userWithRole.id }]
     });

--- a/__integration-tests__/server/pages/api/proposals/reviewer-pool.public.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/reviewer-pool.public.spec.ts
@@ -40,14 +40,14 @@ describe('GET /api/proposals/reviewer-pool - Return eligible reviewers - public 
 
     const pool = (
       await request(baseUrl)
-        .get(`/api/proposals/reviewer-pool?resourceId=${proposal.id}`)
+        .get(`/api/proposals/reviewer-pool?resourceId=${proposal.categoryId}`)
         .set('Cookie', nonAdminCookie)
         .send()
         .expect(200)
     ).body as ProposalReviewerPool;
 
     const computed = await publicPermissionsClient.proposals.getProposalReviewerPool({
-      resourceId: proposal.id
+      resourceId: proposal.categoryId as string
     });
 
     expect(pool.userIds).toEqual(expect.arrayContaining(computed.userIds));
@@ -61,7 +61,7 @@ describe('GET /api/proposals/reviewer-pool - Return eligible reviewers - public 
     const outsideUserCookie = await loginUser(outsideUser.id);
 
     await request(baseUrl)
-      .get(`/api/proposals/reviewer-pool?resourceId=${proposal.id}`)
+      .get(`/api/proposals/reviewer-pool?resourceId=${proposal.categoryId}`)
       .set('Cookie', outsideUserCookie)
       .send()
       .expect(401);

--- a/__integration-tests__/server/pages/api/proposals/reviewer-pool.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/reviewer-pool.spec.ts
@@ -47,7 +47,7 @@ describe('GET /api/proposals/reviewer-pool - Return eligible reviewers', () => {
     ).body as ProposalReviewerPool;
 
     const computed = await premiumPermissionsApiClient.proposals.getProposalReviewerPool({
-      resourceId: proposal.id
+      resourceId: proposal.categoryId as string
     });
 
     expect(pool.userIds).toEqual(expect.arrayContaining(computed.userIds));

--- a/__integration-tests__/server/pages/api/proposals/reviewer-pool.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/reviewer-pool.spec.ts
@@ -40,7 +40,7 @@ describe('GET /api/proposals/reviewer-pool - Return eligible reviewers', () => {
 
     const pool = (
       await request(baseUrl)
-        .get(`/api/proposals/reviewer-pool?resourceId=${proposal.id}`)
+        .get(`/api/proposals/reviewer-pool?resourceId=${proposal.categoryId}`)
         .set('Cookie', nonAdminCookie)
         .send()
         .expect(200)
@@ -61,7 +61,7 @@ describe('GET /api/proposals/reviewer-pool - Return eligible reviewers', () => {
     const outsideUserCookie = await loginUser(outsideUser.id);
 
     await request(baseUrl)
-      .get(`/api/proposals/reviewer-pool?resourceId=${proposal.id}`)
+      .get(`/api/proposals/reviewer-pool?resourceId=${proposal.categoryId}`)
       .set('Cookie', outsideUserCookie)
       .send()
       .expect(401);

--- a/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
+++ b/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
@@ -125,7 +125,7 @@ function SelectedReviewers({
 type Props = {
   displayType?: 'details';
   onChange: (value: GroupedOptionPopulated[]) => void;
-  proposalId?: string;
+  proposalCategoryId?: string | null;
   readOnly?: boolean;
   showEmptyPlaceholder?: boolean;
   value: GroupedOption[];
@@ -135,7 +135,7 @@ type Props = {
 export function UserAndRoleSelect({
   displayType = 'details',
   onChange,
-  proposalId,
+  proposalCategoryId,
   readOnly,
   showEmptyPlaceholder = true,
   variant = 'standard',
@@ -146,7 +146,7 @@ export function UserAndRoleSelect({
   const { members } = useMembers();
   const { isFreeSpace } = useIsFreeSpace();
   // TODO: Make this component agnostic to 'reviewers' by defining the options outside of it
-  const { data: reviewerPool } = useGetReviewerPool(proposalId);
+  const { data: reviewerPool } = useGetReviewerPool(proposalCategoryId);
 
   // For public spaces, we don't want to show reviewer roles
   const applicableValues = isFreeSpace
@@ -167,9 +167,9 @@ export function UserAndRoleSelect({
   }, [reviewerPool]);
 
   let options: GroupedOptionPopulated[] = [];
-  if (proposalId && isFreeSpace) {
+  if (proposalCategoryId && isFreeSpace) {
     options = reviewerPool ? mappedMembers.filter((member) => !!mappedProposalUsers[member.id]) : [];
-  } else if (proposalId && !isFreeSpace) {
+  } else if (proposalCategoryId && !isFreeSpace) {
     options = [
       // For proposals we only want current space members and roles that are allowed to review proposals
       ...(reviewerPool ? mappedMembers.filter((member) => !!mappedProposalUsers[member.id]) : []),
@@ -184,7 +184,7 @@ export function UserAndRoleSelect({
   }
   // Will only happen in the case of proposals
   const noReviewersAvailable = Boolean(
-    proposalId && reviewerPool && reviewerPool.userIds.length === 0 && reviewerPool.roleIds.length === 0
+    proposalCategoryId && reviewerPool && reviewerPool.userIds.length === 0 && reviewerPool.roleIds.length === 0
   );
   const populatedValue = inputValue.map(({ id }) => options.find((opt) => opt.id === id)).filter(isTruthy);
 
@@ -234,7 +234,7 @@ export function UserAndRoleSelect({
         }}
         groupBy={(option) => `${option.group[0].toUpperCase() + option.group.slice(1)}s`}
         isOptionEqualToValue={(option, val) => option.id === val.id}
-        loading={!roles || members.length === 0 || (!!proposalId && !reviewerPool)}
+        loading={!roles || members.length === 0 || (!!proposalCategoryId && !reviewerPool)}
         multiple
         noOptionsText='No more options available'
         onChange={(e, value) => onChange(value)}

--- a/components/proposals/components/ProposalProperties/ProposalProperties.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalProperties.tsx
@@ -378,6 +378,7 @@ export function ProposalProperties({
               <UserAndRoleSelect
                 readOnly={readOnlyReviewers}
                 value={proposalReviewers}
+                proposalCategoryId={proposalFormInputs.categoryId}
                 onChange={async (options) => {
                   await setProposalFormInputs({
                     ...proposalFormInputs,

--- a/lib/permissions/api/__tests__/getPermissionsClient.spec.ts
+++ b/lib/permissions/api/__tests__/getPermissionsClient.spec.ts
@@ -18,6 +18,7 @@ describe('getPermissionsClient', () => {
 
     expect(clientInfo.client).toBeInstanceOf(PublicPermissionsClient);
     expect(clientInfo.type).toBe('free');
+    expect(clientInfo.spaceId).toBe(space.id);
   });
 
   it('should return the premium client for a space with pro, cancelled or enterprise tier', async () => {
@@ -37,6 +38,7 @@ describe('getPermissionsClient', () => {
 
       expect(clientInfo.client).toBeInstanceOf(PermissionsApiClient);
       expect(clientInfo.type).toBe('premium');
+      expect(clientInfo.spaceId).toBe(space.id);
     }
   });
 });

--- a/lib/permissions/api/permissionsClientMiddleware.ts
+++ b/lib/permissions/api/permissionsClientMiddleware.ts
@@ -51,6 +51,8 @@ export function providePermissionClients({ key, location, resourceIdType }: Midd
 
     req.spacePermissionsEngine = clientWithInfo.type;
 
+    req.authorizedSpaceId = clientWithInfo.spaceId;
+
     // Allows using this as a middleware, or inside another middleware which should not pass the next function
     next?.();
   };

--- a/lib/permissions/api/routers.ts
+++ b/lib/permissions/api/routers.ts
@@ -409,6 +409,7 @@ export async function checkSpaceSpaceSubscriptionInfo({
 export type SpacePermissionsClient = {
   type: PermissionsEngine;
   client: PermissionsClient | PremiumPermissionsClient;
+  spaceId: string;
 };
 
 /**
@@ -424,8 +425,8 @@ export async function getPermissionsClient({
   });
 
   if (spaceInfo.tier !== 'free') {
-    return { type: 'premium', client: premiumPermissionsApiClient };
+    return { type: 'premium', client: premiumPermissionsApiClient, spaceId: spaceInfo.spaceId };
   } else {
-    return { type: 'free', client: publicClient };
+    return { type: 'free', client: publicClient, spaceId: spaceInfo.spaceId };
   }
 }

--- a/lib/proposal/__tests__/getProposalReviewerPool.spec.ts
+++ b/lib/proposal/__tests__/getProposalReviewerPool.spec.ts
@@ -1,4 +1,4 @@
-import { ProposalNotFoundError } from '@charmverse/core/errors';
+import { DataNotFoundError } from '@charmverse/core/errors';
 import type { ProposalReviewerPool } from '@charmverse/core/permissions';
 import { testUtilsMembers, testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
 import { v4 } from 'uuid';
@@ -29,7 +29,7 @@ describe('getProposalReviewerPool', () => {
     });
 
     const reviewerPool: ProposalReviewerPool = await getProposalReviewerPool({
-      resourceId: proposal.id
+      resourceId: proposal.categoryId as string
     });
 
     expect(reviewerPool.userIds).toEqual(expect.arrayContaining([user.id, extraUser.id]));
@@ -38,6 +38,6 @@ describe('getProposalReviewerPool', () => {
 
   it('should throw an error if the proposal does not exist', async () => {
     const id = v4();
-    await expect(getProposalReviewerPool({ resourceId: id })).rejects.toMatchObject(new ProposalNotFoundError(id));
+    await expect(getProposalReviewerPool({ resourceId: id })).rejects.toBeInstanceOf(DataNotFoundError);
   });
 });

--- a/lib/proposal/getProposalReviewerPool.ts
+++ b/lib/proposal/getProposalReviewerPool.ts
@@ -1,9 +1,9 @@
-import { ProposalNotFoundError } from '@charmverse/core/errors';
+import { DataNotFoundError } from '@charmverse/core/errors';
 import type { ProposalReviewerPool, Resource } from '@charmverse/core/permissions';
 import { prisma } from '@charmverse/core/prisma-client';
 
 export async function getProposalReviewerPool({ resourceId }: Resource): Promise<ProposalReviewerPool> {
-  const proposal = await prisma.proposal.findUnique({
+  const category = await prisma.proposalCategory.findUnique({
     where: {
       id: resourceId
     },
@@ -12,13 +12,15 @@ export async function getProposalReviewerPool({ resourceId }: Resource): Promise
     }
   });
 
-  if (!proposal) {
-    throw new ProposalNotFoundError(resourceId);
+  if (!category) {
+    throw new DataNotFoundError(`Proposal category with id ${resourceId} not found`);
   }
+
+  const spaceId = category.spaceId;
 
   const spaceRoles = await prisma.spaceRole.findMany({
     where: {
-      spaceId: proposal.spaceId
+      spaceId
     },
     select: {
       userId: true

--- a/pages/api/proposals/[id]/index.ts
+++ b/pages/api/proposals/[id]/index.ts
@@ -134,10 +134,9 @@ async function updateProposalController(req: NextApiRequest, res: NextApiRespons
             : proposalReviewer.userId === updatedReviewer.id;
         })
     );
-
     if (newReviewers.length > 0) {
       const reviewerPool = await req.basePermissionsClient.proposals.getProposalReviewerPool({
-        resourceId: proposal.id
+        resourceId: proposal.categoryId as string
       });
       for (const reviewer of newReviewers) {
         if (reviewer.group === 'role' && !reviewerPool.roleIds.includes(reviewer.id)) {

--- a/pages/api/proposals/reviewer-pool.ts
+++ b/pages/api/proposals/reviewer-pool.ts
@@ -1,7 +1,5 @@
-import { ProposalNotFoundError } from '@charmverse/core/errors';
 import type { ProposalReviewerPool, Resource } from '@charmverse/core/permissions';
 import { hasAccessToSpace } from '@charmverse/core/permissions';
-import { prisma } from '@charmverse/core/prisma-client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
@@ -14,27 +12,13 @@ const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler
   .use(requireUser)
-  .use(providePermissionClients({ key: 'resourceId', location: 'query', resourceIdType: 'proposal' }))
+  .use(providePermissionClients({ key: 'resourceId', location: 'query', resourceIdType: 'proposalCategory' }))
   .get(getReviewerPoolController);
 
 async function getReviewerPoolController(req: NextApiRequest, res: NextApiResponse<ProposalReviewerPool>) {
   const { resourceId } = req.query as Resource;
-
-  const proposal = await prisma.proposal.findUnique({
-    where: {
-      id: resourceId
-    },
-    select: {
-      spaceId: true
-    }
-  });
-
-  if (!proposal) {
-    throw new ProposalNotFoundError(resourceId);
-  }
-
   const { spaceRole } = await hasAccessToSpace({
-    spaceId: proposal.spaceId,
+    spaceId: req.authorizedSpaceId,
     userId: req.session.user.id
   });
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 49bc8d3</samp>

Refactored the reviewer pool logic and components to use proposal categories instead of proposals as the resource for querying and filtering reviewers. Improved the error handling, performance, and type safety of the permissions and proposal APIs. Added a middleware to provide the authorized space id to the request object. Updated the `UserAndRoleSelect` and `ProposalProperties` components to use the new reviewer pool logic.

### WHY
Always get proposal reviewer pool
