### PR TITLE
Add switch to share a public page in the sidebar

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,11 +1,11 @@
-name: "Install dependencies"
+name: 'Install dependencies'
 
 inputs:
   core_pkg_version:
     description: "Optional. Defaults to what's in package.json. Valid options are latest and custom version"
     required: false
   commit_core_pkg_upgrade:
-    description: "Whether commit the update to core package back to branch"
+    description: 'Whether commit the update to core package back to branch'
     required: false
   use_github_core_branch:
     description: |
@@ -13,10 +13,10 @@ inputs:
       If set core_pkg_version and commit_core_pkg_upgrade will be ignored. 
       Add your branch to this variable below to install your custom branch.
     required: false
-    default:
+    default: feat/page-permission-allow-discovery
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - uses: actions/checkout@v3
 
@@ -40,7 +40,7 @@ runs:
       if: steps.cache_node_modules.outputs.cache-hit != 'true'
       run: npm ci --no-audit --no-fund
 
-    # If installing specific version of core via npmjs 
+    # If installing specific version of core via npmjs
     - name: Upgrade Core package to version ${{ inputs.core_pkg_version }}
       shell: bash
       if: inputs.core_pkg_version
@@ -52,8 +52,8 @@ runs:
       if: (github.ref == 'refs/heads/main') && inputs.core_pkg_version && inputs.commit_core_pkg_upgrade
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        file_pattern: "package*.json"
-        commit_message: "Github action: automated Core pk upgrade to ${{ inputs.core_pkg_version }}"
+        file_pattern: 'package*.json'
+        commit_message: 'Github action: automated Core pk upgrade to ${{ inputs.core_pkg_version }}'
 
     # If installing core via github branch
     - name: Install custom core branch

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -13,7 +13,7 @@ inputs:
       If set core_pkg_version and commit_core_pkg_upgrade will be ignored. 
       Add your branch to this variable below to install your custom branch.
     required: false
-    default: feat/page-permission-allow-discovery
+    default:
 
 runs:
   using: 'composite'

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, opened, synchronize]
 
 env:
-  SELECTED_PERMISSION_API_TAG:
+  SELECTED_PERMISSION_API_TAG: 
 
 jobs:
   deploy:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, opened, synchronize]
 
 env:
-  SELECTED_PERMISSION_API_TAG: 
+  SELECTED_PERMISSION_API_TAG: latest
 
 jobs:
   deploy:

--- a/__e2e__/forum/deletePostFromDialog.spec.ts
+++ b/__e2e__/forum/deletePostFromDialog.spec.ts
@@ -82,7 +82,6 @@ test.describe.serial('Delete forum posts from the post dialog, and autoclose dia
     await forumHomePage.postDialogDeleteButton.click();
 
     await expect(forumHomePage.postDialog).not.toBeVisible();
-    await page.pause();
     await expect(postCard).not.toBeVisible();
   });
   test('moderator can delete another user post from the post dialog', async ({ forumHomePage, page }) => {

--- a/__e2e__/forum/editDescription.spec.ts
+++ b/__e2e__/forum/editDescription.spec.ts
@@ -82,9 +82,6 @@ test.describe.serial('Update category permissions', () => {
 
     // Edit text in modal and save
     const newDescription = `Random text ${randomIntFromInterval(0, 100000000)}`;
-
-    await page.pause();
-
     await forumHomePage.categoryDescriptionInput.fill(newDescription);
     await forumHomePage.saveCategoryDescription.click();
 

--- a/__e2e__/po/pagePermissions.po.ts
+++ b/__e2e__/po/pagePermissions.po.ts
@@ -9,9 +9,12 @@ export class PagePermissionsDialog {
 
   pageShareLink: Locator;
 
+  publishTab: Locator;
+
   constructor(page: Page) {
     this.page = page;
     this.permissionDialog = page.locator('data-test=toggle-page-permissions-dialog');
+    this.publishTab = page.locator('data-test=Publish-tab');
     this.publicShareToggle = page.locator('data-test=toggle-public-page');
     this.pageShareLink = page.locator('data-test=share-link').locator('input');
   }

--- a/__e2e__/po/pagePermissions.po.ts
+++ b/__e2e__/po/pagePermissions.po.ts
@@ -11,11 +11,14 @@ export class PagePermissionsDialog {
 
   publishTab: Locator;
 
+  allowDiscoveryToggle: Locator;
+
   constructor(page: Page) {
     this.page = page;
     this.permissionDialog = page.locator('data-test=toggle-page-permissions-dialog');
     this.publishTab = page.locator('data-test=Publish-tab');
     this.publicShareToggle = page.locator('data-test=toggle-public-page');
+    this.allowDiscoveryToggle = page.locator('data-test=toggle-allow-page-discovery');
     this.pageShareLink = page.locator('data-test=share-link').locator('input');
   }
 

--- a/__e2e__/proposals/viewProposal.spec.ts
+++ b/__e2e__/proposals/viewProposal.spec.ts
@@ -134,8 +134,6 @@ test.describe.serial('View proposal', () => {
 
     const categoriesDropDown = proposalListPage.getProposalCategoryListButtonLocator();
 
-    await page.pause();
-
     await expect(categoriesDropDown).toBeVisible();
 
     await categoriesDropDown.click();

--- a/__e2e__/proposals/viewProposal.spec.ts
+++ b/__e2e__/proposals/viewProposal.spec.ts
@@ -217,6 +217,8 @@ test.describe.serial('View proposal', () => {
     // Start sharing flow
     await pagePermissions.permissionDialog.click();
 
+    await pagePermissions.publishTab.click();
+
     await expect(pagePermissions.publicShareToggle).toBeVisible();
 
     await pagePermissions.togglePageIsPublic();

--- a/__e2e__/publicBounties.spec.ts
+++ b/__e2e__/publicBounties.spec.ts
@@ -67,7 +67,8 @@ test.describe.serial('Make a bounties page public and visit it', async () => {
         },
         {
           permissionLevel: 'view',
-          public: true
+          public: true,
+          allowDiscovery: true
         }
       ]
     });

--- a/__e2e__/publicPage.spec.ts
+++ b/__e2e__/publicPage.spec.ts
@@ -64,6 +64,10 @@ test.describe.serial('Make a page public and visit it', async () => {
 
     await permissionDialog.click();
 
+    const publishTab = page.locator('data-test=Publish-tab');
+
+    await publishTab.click();
+
     const publicShareToggle = page.locator('data-test=toggle-public-page');
 
     await publicShareToggle.click();

--- a/__e2e__/publicPage.spec.ts
+++ b/__e2e__/publicPage.spec.ts
@@ -1,22 +1,29 @@
 import type { Page, User } from '@charmverse/core/prisma';
 import { prisma } from '@charmverse/core/prisma-client';
 import type { Browser } from '@playwright/test';
-import { chromium, expect, test } from '@playwright/test';
+import { chromium, expect, test as base } from '@playwright/test';
 
 import { baseUrl } from 'config/constants';
 import { createVote, generateBoard } from 'testing/setupDatabase';
 
+import { PagePermissionsDialog } from './po/pagePermissions.po';
 import { generateUserAndSpace } from './utils/mocks';
 import { generatePage } from './utils/pages';
 import { login } from './utils/session';
 
 let browser: Browser;
+type Fixtures = {
+  pagePermissions: PagePermissionsDialog;
+};
+
+const test = base.extend<Fixtures>({
+  pagePermissions: ({ page }, use) => use(new PagePermissionsDialog(page))
+});
 
 test.beforeAll(async () => {
   // Set headless to false in chromium.launch to visually debug the test
   browser = await chromium.launch({});
 });
-
 test.describe.serial('Make a page public and visit it', async () => {
   // Will be set by the first test
   let shareUrl = '';
@@ -24,10 +31,9 @@ test.describe.serial('Make a page public and visit it', async () => {
   let cardPage: Page;
   let spaceUser: User;
 
-  test('make a page public', async () => {
+  test('make a page public', async ({ pagePermissions, page }) => {
     // Arrange ------------------
     const userContext = await browser.newContext({ permissions: ['clipboard-read', 'clipboard-write'] });
-    const page = await userContext.newPage();
 
     const { space, user } = await generateUserAndSpace();
     boardPage = await generateBoard({
@@ -60,27 +66,28 @@ test.describe.serial('Make a page public and visit it', async () => {
     await expect(page.locator(`data-test=gallery-card-${cardPage.id}`)).toBeVisible();
 
     // 2. Open the share dialog and make the page public
-    const permissionDialog = page.locator('data-test=toggle-page-permissions-dialog');
+    const permissionDialog = pagePermissions.permissionDialog;
 
     await permissionDialog.click();
 
-    const publishTab = page.locator('data-test=Publish-tab');
+    const publishTab = pagePermissions.publishTab;
 
-    await publishTab.click();
+    await expect(publishTab).toBeVisible();
 
-    const publicShareToggle = page.locator('data-test=toggle-public-page');
+    await publishTab.click({ force: true });
 
-    await publicShareToggle.click();
+    await pagePermissions.publicShareToggle.click();
+
     shareUrl = `${baseUrl}/${domain}/${boardPage.path}`;
 
     await page.waitForResponse(/\/api\/permissions/);
+
+    await pagePermissions.allowDiscoveryToggle.click();
 
     // 3. Copy the public link to the clipboard
     const shareLinkInput = page.locator('data-test=share-link').locator('input');
 
     await expect(shareLinkInput).toBeVisible();
-
-    await page.pause();
 
     const inputValue = await shareLinkInput.inputValue();
 

--- a/__e2e__/publicPageLink.spec.ts
+++ b/__e2e__/publicPageLink.spec.ts
@@ -34,7 +34,7 @@ test('click on link for another public page in same workspace and make sure that
     title: 'First Page',
     pagePermissions: [
       { permissionLevel: 'view', spaceId: space.id },
-      { permissionLevel: 'view', public: true }
+      { permissionLevel: 'view', public: true, allowDiscovery: true }
     ],
     linkedPageId: secondPageId
   });
@@ -46,7 +46,7 @@ test('click on link for another public page in same workspace and make sure that
     title: 'Second Page',
     pagePermissions: [
       { permissionLevel: 'view', spaceId: space.id },
-      { permissionLevel: 'view', public: true }
+      { permissionLevel: 'view', public: true, allowDiscovery: true }
     ],
     linkedPageId: firstPageId
   });

--- a/charmClient/apis/permissions/pagesApi.ts
+++ b/charmClient/apis/permissions/pagesApi.ts
@@ -1,3 +1,4 @@
+import type { UpdatePagePermissionDiscoverabilityRequest } from '@charmverse/core/pages';
 import type { PagePermissionFlags } from '@charmverse/core/permissions';
 
 import * as http from 'adapters/http';
@@ -8,5 +9,9 @@ export class PagePermissionsApi {
     return http.POST<PagePermissionFlags>(`/api/permissions/pages/compute-page-permissions`, {
       resourceId: !spaceDomain ? pageIdOrPath : `${spaceDomain}/${pageIdOrPath}`
     } as PermissionCompute);
+  }
+
+  updatePagePermissionDiscoverability(body: UpdatePagePermissionDiscoverabilityRequest): Promise<void> {
+    return http.PUT('/api/permissions/pages/update-page-discoverability', body);
   }
 }

--- a/charmClient/charmClient.ts
+++ b/charmClient/charmClient.ts
@@ -427,6 +427,10 @@ class CharmClient {
     return http.POST('/api/permissions', permission);
   }
 
+  updatePermission(body: PermissionResource & { pageId: string; allowDiscovery: boolean }): Promise<any> {
+    return http.PUT('/api/permissions', body);
+  }
+
   deletePermission(query: PermissionResource): Promise<boolean> {
     return http.DELETE('/api/permissions', query);
   }

--- a/components/[pageId]/SharedPage/SharedPage.tsx
+++ b/components/[pageId]/SharedPage/SharedPage.tsx
@@ -70,7 +70,7 @@ export function SharedPage({ publicPage }: Props) {
     };
   }, [publicPage?.page.id]);
 
-  const currentPage = pages?.[basePageId];
+  const currentPage = publicPage?.page ?? pages?.[basePageId];
 
   if (!currentPage && publicPage) {
     return <LoadingComponent isLoading />;

--- a/components/common/MultiTabs.tsx
+++ b/components/common/MultiTabs.tsx
@@ -74,6 +74,7 @@ export default function MultiTabs(props: MultiTabsProps) {
               }}
               key={tabLabel}
               label={tabLabel}
+              data-test={`${tabLabel}-tab`}
             />
           ))}
         </Tabs>

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/FreePagePermissions/FreeShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/FreePagePermissions/FreeShareToWeb.tsx
@@ -25,5 +25,13 @@ export default function FreeShareToWeb({ pageId }: Props) {
     // All proposals beyond draft are public
     (currentPage?.type === 'proposal' && proposal?.status !== 'draft');
 
-  return <ShareToWeb disabled pageId={pageId} toggleChecked={isChecked} shareAlertMessage={shareAlertMessage} />;
+  return (
+    <ShareToWeb
+      disabled
+      pageId={pageId}
+      shareChecked={isChecked}
+      discoveryChecked={false}
+      shareAlertMessage={shareAlertMessage}
+    />
+  );
 }

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PagePermissionsContainer.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PagePermissionsContainer.tsx
@@ -1,7 +1,9 @@
 import type { AssignedPagePermission } from '@charmverse/core/permissions';
-import { Box, Divider } from '@mui/material';
+import Box from '@mui/material/Box';
+import { useState } from 'react';
 
 import Loader from 'components/common/Loader';
+import MultiTabs from 'components/common/MultiTabs';
 import { useIsFreeSpace } from 'hooks/useIsFreeSpace';
 import { usePagePermissionsList } from 'hooks/usePagePermissionsList';
 
@@ -15,6 +17,7 @@ type Props = {
 };
 
 export function PagePermissionsContainer({ pageId }: Props) {
+  const [activeTab, setActiveTab] = useState(0);
   const { isFreeSpace } = useIsFreeSpace();
 
   const { pagePermissions, refreshPermissions } = usePagePermissionsList({
@@ -35,26 +38,41 @@ export function PagePermissionsContainer({ pageId }: Props) {
 
   return (
     <Box p={2} pt={1}>
-      {isFreeSpace ? (
-        <FreeShareToWeb pageId={pageId} />
-      ) : (
-        <PaidShareToWeb
-          pageId={pageId}
-          pagePermissions={pagePermissions as AssignedPagePermission[]}
-          refreshPermissions={refreshPermissions}
-        />
-      )}
-
-      <Divider sx={{ my: 1 }} />
-      {isFreeSpace ? (
-        <FreePagePermissions pageId={pageId} />
-      ) : (
-        <PaidPagePermissions
-          pagePermissions={pagePermissions as AssignedPagePermission[]}
-          refreshPermissions={refreshPermissions}
-          pageId={pageId}
-        />
-      )}
+      <MultiTabs
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        tabPanelSx={{ p: '10px 0' }}
+        tabs={[
+          [
+            'Share',
+            <Box key='0'>
+              {isFreeSpace ? (
+                <FreePagePermissions pageId={pageId} />
+              ) : (
+                <PaidPagePermissions
+                  pagePermissions={pagePermissions as AssignedPagePermission[]}
+                  refreshPermissions={refreshPermissions}
+                  pageId={pageId}
+                />
+              )}
+            </Box>
+          ],
+          [
+            'Publish',
+            <Box key='1'>
+              {isFreeSpace ? (
+                <FreeShareToWeb pageId={pageId} />
+              ) : (
+                <PaidShareToWeb
+                  pageId={pageId}
+                  pagePermissions={pagePermissions as AssignedPagePermission[]}
+                  refreshPermissions={refreshPermissions}
+                />
+              )}
+            </Box>
+          ]
+        ]}
+      />
     </Box>
   );
 }

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/PaidShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/PaidShareToWeb.tsx
@@ -49,6 +49,19 @@ export default function PaidShareToWeb({ pageId, pagePermissions, refreshPermiss
     refreshPermissions();
   }
 
+  const isDiscoveryChecked = !!publicPermission?.sourcePermission?.allowDiscovery || !!publicPermission?.allowDiscovery;
+
+  async function handleDiscovery() {
+    if (publicPermission) {
+      await charmClient.updatePermission({
+        permissionId: publicPermission.id,
+        pageId,
+        allowDiscovery: !isDiscoveryChecked
+      });
+      refreshPermissions();
+    }
+  }
+
   // In the case of a space with public proposals, we want to override the manual setting
   const disabledToolip =
     !!space?.publicProposals && currentPage?.type === 'proposal'
@@ -57,7 +70,7 @@ export default function PaidShareToWeb({ pageId, pagePermissions, refreshPermiss
       ? 'You cannot update permissions for this page'
       : null;
 
-  const isChecked =
+  const isShareChecked =
     // If not using space wide proposals, go by the page permissions
     (!space?.publicProposals && !!publicPermission) ||
     (!!space?.publicProposals &&
@@ -65,6 +78,7 @@ export default function PaidShareToWeb({ pageId, pagePermissions, refreshPermiss
       ((currentPage?.type !== 'proposal' && !!publicPermission) ||
         // All proposals beyond draft are public
         (currentPage?.type === 'proposal' && proposal?.status !== 'draft')));
+
   const baseShareAlertMessage = currentPage ? alerts[currentPage.type] : '';
 
   const publicProposalToggleInfo =
@@ -84,15 +98,17 @@ export default function PaidShareToWeb({ pageId, pagePermissions, refreshPermiss
   return (
     <>
       <ShareToWeb
-        toggleChecked={isChecked}
+        shareChecked={isShareChecked}
+        discoveryChecked={isDiscoveryChecked}
         pageId={pageId}
-        onChange={togglePublic}
+        handlePublish={togglePublic}
+        handleDiscovery={handleDiscovery}
         disabled={!!disabledToolip}
         disabledTooltip={disabledToolip}
         shareAlertMessage={shareAlertMessage}
       />
 
-      {isChecked && publicPermission && currentPage?.type !== 'proposal' && (
+      {isShareChecked && publicPermission && currentPage?.type !== 'proposal' && (
         <PermissionInheritedFrom permission={publicPermission} />
       )}
     </>

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/PaidShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/PaidShareToWeb.tsx
@@ -49,13 +49,12 @@ export default function PaidShareToWeb({ pageId, pagePermissions, refreshPermiss
     refreshPermissions();
   }
 
-  const isDiscoveryChecked = !!publicPermission?.sourcePermission?.allowDiscovery || !!publicPermission?.allowDiscovery;
+  const isDiscoveryChecked = !!publicPermission?.allowDiscovery;
 
   async function handleDiscovery() {
     if (publicPermission) {
-      await charmClient.updatePermission({
+      await charmClient.permissions.pages.updatePagePermissionDiscoverability({
         permissionId: publicPermission.id,
-        pageId,
         allowDiscovery: !isDiscoveryChecked
       });
       refreshPermissions();

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/__tests__/PaidShareToWeb.spec.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/__tests__/PaidShareToWeb.spec.tsx
@@ -59,8 +59,8 @@ describe('PaidShareToWeb', () => {
       <PaidShareToWeb pageId={pageId} pagePermissions={[]} refreshPermissions={jest.fn()} />
     );
 
-    let toggle = resultWithPermissions.getByTestId('toggle-public-page', {}).children.item(0);
-    expect(toggle?.getAttribute('type')).toBe('checkbox');
+    let toggle = resultWithPermissions.getByTestId('toggle-public-page', {});
+    expect(toggle?.getAttribute('type')).toBe('button');
 
     // Important part of the test
     expect(toggle).not.toBeChecked();
@@ -86,11 +86,11 @@ describe('PaidShareToWeb', () => {
       />
     );
 
-    toggle = resultWithPermissions.getByTestId('toggle-public-page', {}).children.item(0);
-    expect(toggle?.getAttribute('type')).toBe('checkbox');
+    toggle = resultWithPermissions.getByTestId('toggle-public-page', {});
+    expect(toggle?.getAttribute('type')).toBe('button');
 
     // Important part of the test
-    expect(toggle).toBeChecked();
+    expect(toggle).toHaveTextContent('Unpublish');
     expect(toggle).not.toBeDisabled();
   });
 
@@ -105,8 +105,8 @@ describe('PaidShareToWeb', () => {
       <PaidShareToWeb pageId={pageId} pagePermissions={[]} refreshPermissions={jest.fn()} />
     );
 
-    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {}).children.item(0);
-    expect(toggle?.getAttribute('type')).toBe('checkbox');
+    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {});
+    expect(toggle?.getAttribute('type')).toBe('button');
 
     // Important part of the test
     expect(toggle).not.toBeDisabled();
@@ -123,8 +123,8 @@ describe('PaidShareToWeb', () => {
       <PaidShareToWeb pageId={pageId} pagePermissions={[]} refreshPermissions={jest.fn()} />
     );
 
-    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {}).children.item(0);
-    expect(toggle?.getAttribute('type')).toBe('checkbox');
+    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {});
+    expect(toggle?.getAttribute('type')).toBe('button');
 
     // Important part of the test
     expect(toggle).toBeDisabled();
@@ -158,11 +158,11 @@ describe('PaidShareToWeb', () => {
       <PaidShareToWeb pageId={pageId} pagePermissions={[]} refreshPermissions={jest.fn()} />
     );
 
-    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {}).children.item(0);
-    expect(toggle?.getAttribute('type')).toBe('checkbox');
+    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {});
+    expect(toggle?.getAttribute('type')).toBe('button');
 
     // Important part of the test
-    expect(toggle).not.toBeChecked();
+    expect(toggle).toHaveTextContent('Publish to web');
     expect(toggle).toBeDisabled();
   });
 
@@ -194,11 +194,11 @@ describe('PaidShareToWeb', () => {
       <PaidShareToWeb pageId={pageId} pagePermissions={[]} refreshPermissions={jest.fn()} />
     );
 
-    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {}).children.item(0);
-    expect(toggle?.getAttribute('type')).toBe('checkbox');
+    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {});
+    expect(toggle?.getAttribute('type')).toBe('button');
 
     // Important part of the test
-    expect(toggle).toBeChecked();
+    expect(toggle).toHaveTextContent('Unpublish');
     expect(toggle).toBeDisabled();
   });
 
@@ -225,8 +225,8 @@ describe('PaidShareToWeb', () => {
       <PaidShareToWeb pageId={pageId} pagePermissions={[]} refreshPermissions={jest.fn()} />
     );
 
-    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {}).children.item(0);
-    expect(toggle?.getAttribute('type')).toBe('checkbox');
+    const toggle = resultWithPermissions.getByTestId('toggle-public-page', {});
+    expect(toggle?.getAttribute('type')).toBe('button');
 
     // Important part of the test
     expect(toggle).not.toBeDisabled();

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/common/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/common/ShareToWeb.tsx
@@ -156,7 +156,7 @@ export default function ShareToWeb({
       )}
       <UpgradeWrapper upgradeContext={!disabledTooltip ? 'page_permissions' : undefined}>
         <Tooltip title={disabled && disabledTooltip ? disabledTooltip : ''}>
-          <Button onClick={handlePublish} disabled={disabled}>
+          <Button onClick={handlePublish} disabled={disabled} data-test='toggle-public-page'>
             {shareChecked ? 'Unpublish' : 'Publish to web'}
           </Button>
         </Tooltip>

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/common/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/common/ShareToWeb.tsx
@@ -136,7 +136,7 @@ export default function ShareToWeb({
             </InputLabel>
             <Switch
               id='discovery-toggle'
-              data-test='toggle-discovery-page'
+              data-test='toggle-allow-page-discovery'
               checked={discoveryChecked}
               disabled={disabled}
               onChange={(_, checked) => {

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/common/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/common/ShareToWeb.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
 import InputAdornment from '@mui/material/InputAdornment';
+import InputLabel from '@mui/material/InputLabel';
 import Input from '@mui/material/OutlinedInput';
 import Switch from '@mui/material/Switch';
 import Tooltip from '@mui/material/Tooltip';
@@ -43,18 +44,22 @@ const CopyButton = styled((props: any) => <Button color='secondary' variant='out
 
 export type ShareToWebProps = {
   disabled: boolean;
-  toggleChecked: boolean;
+  shareChecked: boolean;
+  discoveryChecked: boolean;
   pageId: string;
-  onChange?: (newValue: boolean) => void;
+  handlePublish?: (newValue: boolean) => void;
+  handleDiscovery?: (newValue: boolean) => void;
   disabledTooltip?: string | null;
   shareAlertMessage?: string | null;
 };
 
 export default function ShareToWeb({
-  toggleChecked,
+  shareChecked,
+  discoveryChecked,
   disabled,
   pageId,
-  onChange,
+  handlePublish,
+  handleDiscovery,
   shareAlertMessage,
   disabledTooltip
 }: ShareToWebProps) {
@@ -69,7 +74,7 @@ export default function ShareToWeb({
 
   useEffect(() => {
     setShareLink(getShareLink());
-  }, [pageId, !!page, router.query.viewId, toggleChecked]);
+  }, [pageId, !!page, router.query.viewId, shareChecked]);
 
   // Current values of the public permission
 
@@ -79,7 +84,7 @@ export default function ShareToWeb({
   }
 
   function getShareLink() {
-    if (!toggleChecked || !page) {
+    if (!shareChecked || !page) {
       return null;
     } else if (page?.type.match(/board/)) {
       const viewIdToProvide = router.query.viewId;
@@ -98,7 +103,7 @@ export default function ShareToWeb({
           <Typography>Share to web</Typography>
 
           <Typography variant='body2' color='secondary'>
-            {toggleChecked ? 'Anyone with the link can view' : 'Publish and share link with anyone'}
+            {shareChecked ? 'Anyone with the link can view' : 'Publish and share link with anyone'}
           </Typography>
         </Box>
         <UpgradeChip upgradeContext='page_permissions' />
@@ -107,10 +112,10 @@ export default function ShareToWeb({
             <UpgradeWrapper upgradeContext={!disabledTooltip ? 'page_permissions' : undefined}>
               <Switch
                 data-test='toggle-public-page'
-                checked={toggleChecked}
+                checked={shareChecked}
                 disabled={disabled}
                 onChange={(_, checked) => {
-                  onChange?.(checked);
+                  handlePublish?.(checked);
                 }}
               />
             </UpgradeWrapper>
@@ -118,7 +123,7 @@ export default function ShareToWeb({
         </Tooltip>
       </Box>
 
-      <Collapse in={toggleChecked && !!shareLink}>
+      <Collapse in={!!shareChecked && !!shareLink}>
         <Box>
           <StyledInput
             data-test='share-link'
@@ -133,6 +138,26 @@ export default function ShareToWeb({
               </CopyToClipboard>
             }
           />
+        </Box>
+      </Collapse>
+      <Collapse in={!!shareChecked && !!shareLink /* || page.hasGuests */}>
+        <Box>
+          <UpgradeWrapper upgradeContext={!disabledTooltip ? 'page_permissions' : undefined}>
+            <Box display='flex' alignItems='center' justifyContent='space-between' mt={1}>
+              <InputLabel variant='standard' htmlFor='discovery-toggle'>
+                Discoverable
+              </InputLabel>
+              <Switch
+                id='discovery-toggle'
+                data-test='toggle-discovery-page'
+                checked={discoveryChecked}
+                disabled={disabled}
+                onChange={(_, checked) => {
+                  handleDiscovery?.(checked);
+                }}
+              />
+            </Box>
+          </UpgradeWrapper>
         </Box>
       </Collapse>
       {shareAlertMessage && (

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/common/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/common/ShareToWeb.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
+import CircleIcon from '@mui/icons-material/Circle';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Collapse from '@mui/material/Collapse';
+import MuiButton from '@mui/material/Button';
 import InputAdornment from '@mui/material/InputAdornment';
 import InputLabel from '@mui/material/InputLabel';
 import Input from '@mui/material/OutlinedInput';
@@ -13,6 +13,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
+import { Button } from 'components/common/Button';
 import { UpgradeChip, UpgradeWrapper } from 'components/settings/subscription/UpgradeWrapper';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePage } from 'hooks/usePage';
@@ -35,7 +36,7 @@ const StyledInput = styled(Input)`
   }
 `;
 
-const CopyButton = styled((props: any) => <Button color='secondary' variant='outlined' size='small' {...props} />)`
+const CopyButton = styled((props: any) => <MuiButton color='secondary' variant='outlined' size='small' {...props} />)`
   border-radius: 0;
   border-right-color: transparent;
   border-top-color: transparent;
@@ -47,7 +48,7 @@ export type ShareToWebProps = {
   shareChecked: boolean;
   discoveryChecked: boolean;
   pageId: string;
-  handlePublish?: (newValue: boolean) => void;
+  handlePublish?: () => void;
   handleDiscovery?: (newValue: boolean) => void;
   disabledTooltip?: string | null;
   shareAlertMessage?: string | null;
@@ -97,34 +98,25 @@ export default function ShareToWeb({
   }
 
   return (
-    <>
-      <Box display='flex' justifyContent='space-between' alignItems='center' my={1}>
+    <Box my={1} gap={2} display='flex' flexDirection='column'>
+      {!shareChecked && !shareLink ? (
         <Box>
-          <Typography>Share to web</Typography>
-
-          <Typography variant='body2' color='secondary'>
-            {shareChecked ? 'Anyone with the link can view' : 'Publish and share link with anyone'}
-          </Typography>
-        </Box>
-        <UpgradeChip upgradeContext='page_permissions' />
-        <Tooltip title={disabled && disabledTooltip ? disabledTooltip : ''}>
           <Box>
-            <UpgradeWrapper upgradeContext={!disabledTooltip ? 'page_permissions' : undefined}>
-              <Switch
-                data-test='toggle-public-page'
-                checked={shareChecked}
-                disabled={disabled}
-                onChange={(_, checked) => {
-                  handlePublish?.(checked);
-                }}
-              />
-            </UpgradeWrapper>
+            <Typography variant='h6' textAlign='center' mb={1}>
+              Publish to web
+            </Typography>
+            <Typography variant='body2'>
+              Publish a static website of this page. You can allow others to view it.
+            </Typography>
           </Box>
-        </Tooltip>
-      </Box>
-
-      <Collapse in={!!shareChecked && !!shareLink}>
+          <UpgradeChip upgradeContext='page_permissions' />
+        </Box>
+      ) : (
         <Box>
+          <Box display='flex' gap={0.5} mb={2}>
+            <CircleIcon color='primary' fontSize='small' />
+            <Typography variant='body2'>This page is live on the web. Anyone with the link can view it.</Typography>
+          </Box>
           <StyledInput
             data-test='share-link'
             fullWidth
@@ -138,33 +130,37 @@ export default function ShareToWeb({
               </CopyToClipboard>
             }
           />
+          <Box display='flex' alignItems='center' justifyContent='space-between' mt={1}>
+            <InputLabel htmlFor='discovery-toggle' color='primary'>
+              Add to sidebar
+            </InputLabel>
+            <Switch
+              id='discovery-toggle'
+              data-test='toggle-discovery-page'
+              checked={discoveryChecked}
+              disabled={disabled}
+              onChange={(_, checked) => {
+                handleDiscovery?.(checked);
+              }}
+            />
+          </Box>
+          <Typography width={{ xs: '100%', md: '80%' }} variant='body2'>
+            Anyone with access to the space will see this page in the sidebar
+          </Typography>
         </Box>
-      </Collapse>
-      <Collapse in={!!shareChecked && !!shareLink /* || page.hasGuests */}>
-        <Box>
-          <UpgradeWrapper upgradeContext={!disabledTooltip ? 'page_permissions' : undefined}>
-            <Box display='flex' alignItems='center' justifyContent='space-between' mt={1}>
-              <InputLabel variant='standard' htmlFor='discovery-toggle'>
-                Discoverable
-              </InputLabel>
-              <Switch
-                id='discovery-toggle'
-                data-test='toggle-discovery-page'
-                checked={discoveryChecked}
-                disabled={disabled}
-                onChange={(_, checked) => {
-                  handleDiscovery?.(checked);
-                }}
-              />
-            </Box>
-          </UpgradeWrapper>
-        </Box>
-      </Collapse>
+      )}
       {shareAlertMessage && (
         <Alert severity='info' sx={{ whiteSpace: 'break-spaces', mt: 1 }}>
           {shareAlertMessage}
         </Alert>
       )}
-    </>
+      <UpgradeWrapper upgradeContext={!disabledTooltip ? 'page_permissions' : undefined}>
+        <Tooltip title={disabled && disabledTooltip ? disabledTooltip : ''}>
+          <Button onClick={handlePublish} disabled={disabled}>
+            {shareChecked ? 'Unpublish' : 'Publish to web'}
+          </Button>
+        </Tooltip>
+      </UpgradeWrapper>
+    </Box>
   );
 }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@bangle.dev/tooltip": "^0.31.6",
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
-    "@charmverse/core": "0.3.6-rc-feat-page-permi.5",
+    "@charmverse/core": "0.3.6-rc-feat-page-permi.6",
     "@column-resizer/core": "^1.0.2",
     "@datadog/browser-logs": "^4.42.2",
     "@datadog/browser-rum": "^4.42.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@bangle.dev/tooltip": "^0.31.6",
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
-    "@charmverse/core": "0.3.6-rc-feat-page-permi.1",
+    "@charmverse/core": "0.3.6-rc-feat-page-permi.5",
     "@column-resizer/core": "^1.0.2",
     "@datadog/browser-logs": "^4.42.2",
     "@datadog/browser-rum": "^4.42.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@bangle.dev/tooltip": "^0.31.6",
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
-    "@charmverse/core": "^0.3.3",
+    "@charmverse/core": "0.3.6-rc-feat-page-permi.1",
     "@column-resizer/core": "^1.0.2",
     "@datadog/browser-logs": "^4.42.2",
     "@datadog/browser-rum": "^4.42.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@bangle.dev/tooltip": "^0.31.6",
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
-    "@charmverse/core": "0.3.6-rc-feat-page-permi.6",
+    "@charmverse/core": "^0.3.3",
     "@column-resizer/core": "^1.0.2",
     "@datadog/browser-logs": "^4.42.2",
     "@datadog/browser-rum": "^4.42.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@bangle.dev/tooltip": "^0.31.6",
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
-    "@charmverse/core": "^0.3.3",
+    "@charmverse/core": "^0.3.6",
     "@column-resizer/core": "^1.0.2",
     "@datadog/browser-logs": "^4.42.2",
     "@datadog/browser-rum": "^4.42.2",

--- a/pages/api/permissions/index.ts
+++ b/pages/api/permissions/index.ts
@@ -29,10 +29,6 @@ handler
     requirePaidPermissionsSubscription({ key: 'permissionId', resourceIdType: 'pagePermission' }),
     removePagePermission
   )
-  .put(
-    requirePaidPermissionsSubscription({ key: 'permissionId', location: 'body', resourceIdType: 'pagePermission' }),
-    updatePagePermission
-  )
   .use(requireKeys(['pageId'], 'body'))
   .post(
     requirePaidPermissionsSubscription({ key: 'pageId', location: 'body', resourceIdType: 'page' }),
@@ -122,55 +118,6 @@ async function addPagePermission(req: NextApiRequest, res: NextApiResponse<Assig
 
   return res.status(201).json(createdPermission);
 }
-
-async function updatePagePermission(req: NextApiRequest, res: NextApiResponse) {
-  const { permissionId, allowDiscovery, pageId } = req.body as PermissionResource & {
-    allowDiscovery: boolean;
-    pageId: string;
-  };
-
-  const permissionData = await prisma.pagePermission.findUnique({
-    where: { id: permissionId },
-    select: { public: true, pageId: true, allowDiscovery: true }
-  });
-
-  if (!permissionData) {
-    throw new DataNotFoundError(permissionId);
-  }
-
-  const computedPermissions = await req.premiumPermissionsClient.pages.computePagePermissions({
-    resourceId: permissionData.pageId,
-    userId: req.session.user.id
-  });
-
-  if (permissionData.public && computedPermissions.edit_isPublic !== true) {
-    throw new ActionNotPermittedError('You cannot manage permissions for this page');
-  } else if (!permissionData.public && computedPermissions.grant_permissions !== true) {
-    throw new ActionNotPermittedError('You cannot manage permissions for this page');
-  }
-
-  // Will add permissions client here instead of doing it the old way
-  // const permissions = await req.premiumPermissionsClient.pages.updatePagePermissions({
-  //   permissionId,
-  //   allowDiscovery,
-  //   pageId
-  // });
-
-  // Old way. To be deleted
-  // const updated = await prisma.pagePermission.update({
-  //   where: {
-  //     id: permissionId
-  //   },
-  //   data: {
-  //     allowDiscovery: allowDiscovery
-  //   }
-  // });
-
-  updateTrackPageProfile(permissionData.pageId);
-
-  return res.status(200).json({ success: true });
-}
-
 async function removePagePermission(req: NextApiRequest, res: NextApiResponse) {
   const { permissionId } = (req.query || req.body) as PermissionResource;
 

--- a/pages/api/permissions/pages/update-page-discoverability.ts
+++ b/pages/api/permissions/pages/update-page-discoverability.ts
@@ -1,0 +1,53 @@
+import type { UpdatePagePermissionDiscoverabilityRequest } from '@charmverse/core/dist/cjs/pages';
+import { prisma } from '@charmverse/core/prisma-client';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
+
+import { ActionNotPermittedError, onError, onNoMatch, requireKeys } from 'lib/middleware';
+import { requirePaidPermissionsSubscription } from 'lib/middleware/requirePaidPermissionsSubscription';
+import { withSessionRoute } from 'lib/session/withSession';
+import { DataNotFoundError } from 'lib/utilities/errors';
+
+const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+
+handler
+  .use(requireKeys<UpdatePagePermissionDiscoverabilityRequest>(['permissionId', 'allowDiscovery'], 'body'))
+  .put(
+    requirePaidPermissionsSubscription({ key: 'permissionId', location: 'body', resourceIdType: 'pagePermission' }),
+    updateDiscoverability
+  );
+
+//
+async function updateDiscoverability(req: NextApiRequest, res: NextApiResponse<void>) {
+  const input = req.body as UpdatePagePermissionDiscoverabilityRequest;
+
+  const permissionData = await prisma.pagePermission.findUnique({
+    where: { id: input.permissionId },
+    select: { public: true, pageId: true, allowDiscovery: true }
+  });
+
+  if (!permissionData) {
+    throw new DataNotFoundError(input.permissionId);
+  }
+
+  const computedPermissions = await req.premiumPermissionsClient.pages.computePagePermissions({
+    resourceId: permissionData.pageId,
+    userId: req.session.user.id
+  });
+
+  if (
+    (permissionData.public && computedPermissions.edit_isPublic !== true) ||
+    (!permissionData.public && computedPermissions.grant_permissions !== true)
+  ) {
+    throw new ActionNotPermittedError('You cannot manage permissions for this page');
+  }
+
+  await req.premiumPermissionsClient.pages.updatePagePermissionDiscoverability({
+    permissionId: input.permissionId,
+    allowDiscovery: input.allowDiscovery
+  });
+
+  res.status(200).end();
+}
+
+export default withSessionRoute(handler);

--- a/seedData/proposalTemplates.ts
+++ b/seedData/proposalTemplates.ts
@@ -487,7 +487,8 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
         spaceId: null,
         inheritedFromPermission: null,
         public: null,
-        sourcePermission: null
+        sourcePermission: null,
+        allowDiscovery: false
       }
     ],
     children: [],
@@ -1621,7 +1622,8 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
         spaceId: null,
         inheritedFromPermission: null,
         public: null,
-        sourcePermission: null
+        sourcePermission: null,
+        allowDiscovery: false
       }
     ],
     sourceTemplateId: null,
@@ -2041,7 +2043,8 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
         spaceId: null,
         inheritedFromPermission: null,
         public: null,
-        sourcePermission: null
+        sourcePermission: null,
+        allowDiscovery: false
       }
     ],
     sourceTemplateId: null,
@@ -2387,7 +2390,8 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
         spaceId: null,
         inheritedFromPermission: null,
         public: null,
-        sourcePermission: null
+        sourcePermission: null,
+        allowDiscovery: false
       }
     ],
     children: [],
@@ -3077,7 +3081,8 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
         spaceId: null,
         inheritedFromPermission: null,
         public: null,
-        sourcePermission: null
+        sourcePermission: null,
+        allowDiscovery: false
       }
     ],
     children: [],
@@ -3767,7 +3772,8 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
         spaceId: null,
         inheritedFromPermission: null,
         public: null,
-        sourcePermission: null
+        sourcePermission: null,
+        allowDiscovery: false
       }
     ],
     children: [],


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64f4205</samp>

This pull request adds a new feature that allows users with a paid subscription to make their pages discoverable by search engines or other users. It refactors the `ShareToWeb` component and its variants to handle the new `allowDiscovery` property of the page permissions. It also updates the `/api/permissions` endpoint and the `CharmClient` class to support the feature. Finally, it updates the `@charmverse/core` dependency to use a compatible version.

### WHY
[Task](https://app.charmverse.io/charmverse/page-450923839900357)
