### PR TITLE
Skip socket server event for creating root pages

### DIFF
--- a/lib/pages/addPage.ts
+++ b/lib/pages/addPage.ts
@@ -84,7 +84,11 @@ export async function addPage(
 
   // Only emit socket message if we are creating a board or page from the sidebar
   // Adding condition for checking page type since card pages can also be added from the sidebar but it should be created via the api
-  if ((page.type === 'board' || page.type === 'page' || page.type === 'linked_board') && trigger === 'sidebar') {
+  if (
+    (page.type === 'board' || page.type === 'page' || page.type === 'linked_board') &&
+    trigger === 'sidebar' &&
+    page.parentId
+  ) {
     emitSocketMessage<PageWithPermissions>(
       {
         type: 'page_created',

--- a/lib/websockets/spaceEvents.ts
+++ b/lib/websockets/spaceEvents.ts
@@ -219,6 +219,9 @@ export class SpaceEventHandler {
         });
 
         if (!parentId) {
+          if (typeof callback === 'function') {
+            callback(createdPage);
+          }
           return null;
         }
 


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
1. Skip socket server event for creating root pages from sidebar
2. Call the callback function with the created page even if created page is a root page (fail safe)
