### PR TITLE
Page reorder sync between sidebar and content

### DIFF
--- a/lib/websockets/__tests__/spaceEvents.spec.ts
+++ b/lib/websockets/__tests__/spaceEvents.spec.ts
@@ -1,5 +1,6 @@
+import type { Page, User } from '@charmverse/core/prisma-client';
 import { prisma } from '@charmverse/core/prisma-client';
-import { testUtilsUser, testUtilsPages } from '@charmverse/core/test';
+import { testUtilsPages, testUtilsUser } from '@charmverse/core/test';
 import { v4 } from 'uuid';
 
 import { getPagePath } from 'lib/pages';
@@ -20,28 +21,36 @@ jest.mock('../relay', () => {
   };
 });
 
-async function socketSetup({
+async function createPageAndSetupDocRooms({
   participants = false,
-  content
+  content,
+  docRooms,
+  spaceId,
+  user,
+  createChildPage = true
 }: {
+  createChildPage?: boolean;
+  spaceId: string;
+  user: User;
   participants?: boolean;
   content: (childPageId: string) => PageContent;
+  docRooms: Map<string | undefined, DocumentRoom>;
 }) {
-  const { space, user } = await testUtilsUser.generateUserAndSpace({ isAdmin: true });
-  const spaceId = space.id;
   const userId = user.id;
   const childPageId = v4();
   const parentContent = content(childPageId);
   const parentPage = await testUtilsPages.generatePage({ spaceId, createdBy: userId, content: parentContent });
   const socketEmitMockFn = jest.fn();
-  await testUtilsPages.generatePage({
-    id: childPageId,
-    spaceId,
-    createdBy: userId,
-    parentId: parentPage.id
-  });
+  let childPage: Page | null = null;
 
-  const docRooms: Map<string | undefined, DocumentRoom> = new Map();
+  if (createChildPage) {
+    childPage = await testUtilsPages.generatePage({
+      id: childPageId,
+      spaceId,
+      createdBy: userId,
+      parentId: parentPage.id
+    });
+  }
 
   if (participants) {
     docRooms.set(parentPage.id, {
@@ -78,21 +87,57 @@ async function socketSetup({
     parentPageDocRoom.participants.set(userId, documentEvent);
   }
 
+  return {
+    docRooms,
+    socketEmitMockFn,
+    childPageId,
+    parentPage,
+    childPage
+  };
+}
+
+async function socketSetup({
+  participants = false,
+  createChildPage = true,
+  content
+}: {
+  createChildPage?: boolean;
+  participants?: boolean;
+  content: (childPageId: string) => PageContent;
+}) {
+  const { space, user } = await testUtilsUser.generateUserAndSpace({ isAdmin: true });
+
+  const spaceId = space.id;
+  const userId = user.id;
+
+  const { docRooms, childPage, childPageId, parentPage, socketEmitMockFn } = await createPageAndSetupDocRooms({
+    createChildPage,
+    participants,
+    content,
+    docRooms: new Map(),
+    spaceId,
+    user
+  });
+
   const spaceEventHandler = new SpaceEventHandler({} as any, docRooms);
   spaceEventHandler.userId = userId;
 
   return {
+    docRooms,
     socketEmitMockFn,
     spaceId,
     userId,
+    space,
+    user,
     childPageId,
     parentPage,
-    spaceEventHandler
+    spaceEventHandler,
+    childPage
   };
 }
 
-describe.only('page_delete event handler', () => {
-  it.only(`Archive nested pages and remove it from parent document's content when it have the nested page in its content and it is being viewed`, async () => {
+describe('page_delete event handler', () => {
+  it(`Archive nested pages and remove it from parent document's content when it have the nested page in its content and it is being viewed`, async () => {
     const { socketEmitMockFn, childPageId, spaceEventHandler, parentPage } = await socketSetup({
       participants: true,
       content: (_childPageId) => ({
@@ -632,5 +677,392 @@ describe('page_created event handler', () => {
     expect(childPage).toBeTruthy();
     expect(socketEmitMockFn).toHaveBeenCalled();
     expect(relayBroadCastMock).toHaveBeenCalled();
+  });
+});
+
+describe.only('page_reordered event handler', () => {
+  it(`Move page from one parent page to another parent page when both documents are being viewed`, async () => {
+    const { spaceEventHandler, socketEmitMockFn, parentPage, childPageId, docRooms, space, user } = await socketSetup({
+      participants: true,
+      content: (_childPageId) => ({
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 1' }] },
+          {
+            type: 'page',
+            attrs: {
+              track: [],
+              id: _childPageId
+            }
+          },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 2' }] }
+        ]
+      })
+    });
+
+    const { parentPage: parentPage2, socketEmitMockFn: socketEmitMockFn2 } = await createPageAndSetupDocRooms({
+      docRooms,
+      spaceId: space.id,
+      user,
+      participants: true,
+      content: () => ({
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 1' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 2' }] }
+        ]
+      })
+    });
+
+    await spaceEventHandler.onMessage({
+      type: 'page_reordered',
+      payload: {
+        currentParentId: parentPage.id,
+        newIndex: 1,
+        newParentId: parentPage2.id,
+        pageId: childPageId
+      }
+    });
+
+    const previousParentPage = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: parentPage.id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    const newParentPage = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: parentPage2.id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    expect(previousParentPage.content).toStrictEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 1' }],
+          attrs: {
+            track: []
+          }
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 2' }],
+          attrs: {
+            track: []
+          }
+        }
+      ]
+    });
+
+    expect(newParentPage.content).toStrictEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 1' }],
+          attrs: {
+            track: []
+          }
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 2' }],
+          attrs: {
+            track: []
+          }
+        },
+        {
+          type: 'page',
+          attrs: {
+            track: [],
+            id: childPageId,
+            path: null,
+            type: null
+          }
+        },
+        {
+          type: 'paragraph',
+          attrs: {
+            track: []
+          }
+        }
+      ]
+    });
+    expect(socketEmitMockFn).toHaveBeenCalled();
+    expect(socketEmitMockFn2).toHaveBeenCalled();
+  });
+
+  it(`Move page from one parent page to another parent page (with children) when none of the documents are being viewed`, async () => {
+    const { spaceEventHandler, parentPage, childPageId, docRooms, space, user, socketEmitMockFn } = await socketSetup({
+      content: (_childPageId) => ({
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 1' }] },
+          {
+            type: 'page',
+            attrs: {
+              track: [],
+              id: _childPageId
+            }
+          },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 2' }] }
+        ]
+      })
+    });
+
+    const {
+      parentPage: parentPage2,
+      childPageId: childPageId2,
+      socketEmitMockFn: socketEmitMockFn2
+    } = await createPageAndSetupDocRooms({
+      docRooms,
+      spaceId: space.id,
+      user,
+      content: (_childPageId) => ({
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 1' }] },
+          {
+            type: 'page',
+            attrs: {
+              track: [],
+              id: _childPageId
+            }
+          },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 2' }] }
+        ]
+      })
+    });
+
+    await spaceEventHandler.onMessage({
+      type: 'page_reordered',
+      payload: {
+        currentParentId: parentPage.id,
+        newIndex: 1,
+        newParentId: parentPage2.id,
+        pageId: childPageId
+      }
+    });
+
+    const previousParentPage = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: parentPage.id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    const newParentPage = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: parentPage2.id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    expect(previousParentPage.content).toStrictEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 1' }],
+          attrs: {
+            track: []
+          }
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 2' }],
+          attrs: {
+            track: []
+          }
+        }
+      ]
+    });
+
+    expect(newParentPage.content).toStrictEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 1' }],
+          attrs: {
+            track: []
+          }
+        },
+        {
+          type: 'page',
+          attrs: {
+            type: null,
+            path: null,
+            track: [],
+            id: childPageId2
+          }
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 2' }],
+          attrs: {
+            track: []
+          }
+        },
+        {
+          type: 'page',
+          attrs: {
+            track: [],
+            id: childPageId,
+            path: null,
+            type: null
+          }
+        },
+        {
+          type: 'paragraph',
+          attrs: {
+            track: []
+          }
+        }
+      ]
+    });
+    expect(socketEmitMockFn).not.toHaveBeenCalled();
+    expect(socketEmitMockFn2).not.toHaveBeenCalled();
+  });
+
+  it(`Move page from parent page to root level the parent document is being viewed`, async () => {
+    const { spaceEventHandler, parentPage, childPageId, socketEmitMockFn } = await socketSetup({
+      participants: true,
+      content: (_childPageId) => ({
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 1' }] },
+          {
+            type: 'page',
+            attrs: {
+              track: [],
+              id: _childPageId
+            }
+          },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 2' }] }
+        ]
+      })
+    });
+
+    await spaceEventHandler.onMessage({
+      type: 'page_reordered',
+      payload: {
+        currentParentId: parentPage.id,
+        newIndex: 1,
+        newParentId: null,
+        pageId: childPageId
+      }
+    });
+
+    const previousParentPage = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: parentPage.id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    expect(previousParentPage.content).toStrictEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 1' }],
+          attrs: {
+            track: []
+          }
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 2' }],
+          attrs: {
+            track: []
+          }
+        }
+      ]
+    });
+
+    expect(socketEmitMockFn).toHaveBeenCalled();
+  });
+
+  it(`Move page from root level another parent when the parent document is not being viewed`, async () => {
+    const { spaceEventHandler, parentPage, childPageId, socketEmitMockFn } = await socketSetup({
+      content: () => ({
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 1' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Text content 2' }] }
+        ]
+      })
+    });
+
+    await spaceEventHandler.onMessage({
+      type: 'page_reordered',
+      payload: {
+        currentParentId: null,
+        newIndex: 1,
+        newParentId: parentPage.id,
+        pageId: childPageId
+      }
+    });
+
+    const newParentPage = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: parentPage.id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    expect(newParentPage.content).toStrictEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 1' }],
+          attrs: {
+            track: []
+          }
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Text content 2' }],
+          attrs: {
+            track: []
+          }
+        },
+        {
+          type: 'page',
+          attrs: {
+            track: [],
+            id: childPageId,
+            path: null,
+            type: null
+          }
+        },
+        {
+          type: 'paragraph',
+          attrs: {
+            track: []
+          }
+        }
+      ]
+    });
+
+    expect(socketEmitMockFn).not.toHaveBeenCalled();
   });
 });

--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -384,7 +384,7 @@ export class DocumentEventHandler {
   // sendMessageToActor is used when we want to send the diff to all other participants, but not the actor
   async handleDiff(
     message: WrappedSocketMessage<ClientDiffMessage>,
-    { socketEvent }: { socketEvent?: 'page_created' | 'page_restored' | 'page_deleted' | null } = {
+    { socketEvent }: { socketEvent?: 'page_created' | 'page_restored' | 'page_deleted' | 'page_reordered' | null } = {
       socketEvent: null
     }
   ) {
@@ -479,7 +479,7 @@ export class DocumentEventHandler {
           await this.saveDocument();
         }
 
-        if (deletedPageIds.length) {
+        if (deletedPageIds.length && socketEvent !== 'page_reordered') {
           await archivePages({
             pageIds: deletedPageIds,
             userId: session.user.id,
@@ -488,7 +488,7 @@ export class DocumentEventHandler {
           });
         }
 
-        if (restoredPageIds.length) {
+        if (restoredPageIds.length && socketEvent !== 'page_reordered') {
           await archivePages({
             pageIds: restoredPageIds,
             userId: session.user.id,

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -121,6 +121,16 @@ export type PageCreated = {
     >;
 };
 
+type PageReordered = {
+  type: 'page_reordered';
+  payload: {
+    pageId: string;
+    currentParentId: string | null;
+    newParentId: string | null;
+    newIndex: number;
+  };
+};
+
 type SpaceSubscriptionUpdated = {
   type: 'space_subscription';
   payload: {
@@ -151,7 +161,7 @@ type PagesRestored = {
   payload: Resource[];
 };
 
-export type ClientMessage = SubscribeToWorkspace | PageDeleted | PageRestored | PageCreated;
+export type ClientMessage = SubscribeToWorkspace | PageDeleted | PageRestored | PageCreated | PageReordered;
 
 export type ServerMessage =
   | BlocksUpdated


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80c4341</samp>

This pull request enables users to reorder pages in the sidebar of the app using drag and drop. It implements websocket communication for page reordering events between the client and the server, and updates the relevant components and handlers to support this feature. It also fixes some issues with page deletion and restoration events. It modifies the files `components/common/PageLayout/components/PageNavigation/PageNavigation.tsx`, `lib/websockets/documentEvents/documentEvents.ts`, `lib/websockets/interfaces.ts`, and `lib/websockets/spaceEvents.ts`.

### WHY
1. Reordering page from sidebar removes from its current parent and add the content in the new parent's content
