### PR TITLE
FIx callback url in staging apps

### DIFF
--- a/lib/oauth/getCallbackDomain.ts
+++ b/lib/oauth/getCallbackDomain.ts
@@ -1,4 +1,4 @@
-import { appSubdomain, isDevEnv, isProdEnv, isStagingEnv } from 'config/constants';
+import { appSubdomain, baseUrl, isDevEnv, isProdEnv, isStagingEnv } from 'config/constants';
 import { getAppApexDomain } from 'lib/utilities/domains/getAppApexDomain';
 import { getValidCustomDomain } from 'lib/utilities/domains/getValidCustomDomain';
 import { getAppOriginURL } from 'lib/utilities/getAppOriginURL';
@@ -20,6 +20,11 @@ export function getCallbackDomain(host?: string | undefined) {
   }
 
   const subdomain = getValidSubdomain(host);
+
+  if (!subdomain && isStagingEnv) {
+    return baseUrl;
+  }
+
   const callbackDomain = subdomain ? `${protocol}${host?.replace(subdomain, 'app')}` : `${protocol}${host}`;
 
   return callbackDomain;

--- a/lib/oauth/getCallbackDomain.ts
+++ b/lib/oauth/getCallbackDomain.ts
@@ -22,7 +22,7 @@ export function getCallbackDomain(host?: string | undefined) {
   const subdomain = getValidSubdomain(host);
 
   if (!subdomain && isStagingEnv) {
-    return baseUrl;
+    return baseUrl || host || '';
   }
 
   const callbackDomain = subdomain ? `${protocol}${host?.replace(subdomain, 'app')}` : `${protocol}${host}`;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5bc5a43</samp>

Improved OAuth callback domain handling for staging environment. Used `baseUrl` as a fallback value in `lib/oauth/getCallbackDomain.ts` when subdomain is empty.

### WHY
<!-- author to complete -->
