### PR TITLE
Confirmation for Proposal Steps

### DIFF
--- a/components/common/Modal/ModalWithButtons.tsx
+++ b/components/common/Modal/ModalWithButtons.tsx
@@ -13,6 +13,7 @@ type Props = Pick<ModalProps, 'onClose' | 'open' | 'size'> & {
   secondaryButtonText?: string;
   onClose: () => void;
   disabled?: boolean;
+  hideCancelButton?: boolean;
 };
 
 export default function ModalWithButtons({
@@ -24,7 +25,8 @@ export default function ModalWithButtons({
   onConfirm,
   size,
   secondaryButtonText = 'Cancel',
-  disabled
+  disabled,
+  hideCancelButton
 }: Props) {
   async function _onConfirm() {
     await onConfirm();
@@ -49,10 +51,11 @@ export default function ModalWithButtons({
         >
           {buttonText}
         </Button>
-
-        <Button color='secondary' variant='outlined' onClick={onClose}>
-          {secondaryButtonText}
-        </Button>
+        {!hideCancelButton && (
+          <Button color='secondary' variant='outlined' onClick={onClose}>
+            {secondaryButtonText}
+          </Button>
+        )}
       </Box>
     </Modal>
   );

--- a/components/common/Modal/ModalWithButtons.tsx
+++ b/components/common/Modal/ModalWithButtons.tsx
@@ -36,11 +36,16 @@ export default function ModalWithButtons({
   return (
     <Modal open={open} onClose={onClose} title={title} size={size}>
       {children}
-      <Box sx={{ columnSpacing: 2, mt: 3, display: 'flex' }}>
+      <Box sx={{ gap: 2, mt: 3, display: 'flex', justifyContent: 'flex-end' }}>
+        {!hideCancelButton && (
+          <Button color='secondary' variant='outlined' onClick={onClose}>
+            {secondaryButtonText}
+          </Button>
+        )}
         <Button
           color='primary'
           sx={{
-            mr: 2,
+            mr: 0.5,
             fontWeight: 'bold',
             display: 'block',
             overflow: 'hidden',
@@ -51,11 +56,6 @@ export default function ModalWithButtons({
         >
           {buttonText}
         </Button>
-        {!hideCancelButton && (
-          <Button color='secondary' variant='outlined' onClick={onClose}>
-            {secondaryButtonText}
-          </Button>
-        )}
       </Box>
     </Modal>
   );

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -225,7 +225,7 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
             >
               <Typography>
                 The chosen Reviewer will perform a final examination, ensuring the proposal is ready for the
-                organization's vote.
+                organization's {formInputs.evaluationType === 'vote' ? 'Vote' : 'Review'}.
               </Typography>
             </ModalWithButtons>
           </Stack>

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -1,5 +1,6 @@
 import type { Theme } from '@mui/material';
-import { Box, Stack, useMediaQuery } from '@mui/material';
+import { Box, Stack, Typography, useMediaQuery } from '@mui/material';
+import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { mutate } from 'swr';
@@ -11,6 +12,7 @@ import { Container } from 'components/[pageId]/DocumentPage/DocumentPage';
 import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
+import ModalWithButtons from 'components/common/Modal/ModalWithButtons';
 import { ScrollableWindow } from 'components/common/PageLayout';
 import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemplates';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
@@ -49,6 +51,8 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
   const { proposalTemplates } = useProposalTemplates();
 
   const router = useRouter();
+
+  const confirmationPopup = usePopupState({ variant: 'popover', popupId: 'create-proposal-confirmation' });
 
   const [isCreatingProposal, setIsCreatingProposal] = useState(false);
 
@@ -207,10 +211,23 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
             <Button
               disabled={Boolean(disabledTooltip) || !contentUpdated || isCreatingProposal}
               disabledTooltip={disabledTooltip}
-              onClick={createProposal}
+              onClick={formInputs.reviewers.length < 1 ? confirmationPopup.open : createProposal}
             >
               Create
             </Button>
+            <ModalWithButtons
+              open={confirmationPopup.isOpen}
+              onClose={confirmationPopup.close}
+              buttonText='Ok'
+              onConfirm={confirmationPopup.close}
+              hideCancelButton
+              title='Assign a Reviewer to proceed'
+            >
+              <Typography>
+                The chosen Reviewer will perform a final examination, ensuring the proposal is ready for the
+                organization's vote.
+              </Typography>
+            </ModalWithButtons>
           </Stack>
         </Container>
       </div>

--- a/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
@@ -5,8 +5,10 @@ import { ArrowBackIos } from '@mui/icons-material';
 import ArrowForwardIos from '@mui/icons-material/ArrowForwardIos';
 import { Stack, Typography } from '@mui/material';
 import Chip from '@mui/material/Chip';
+import { usePopupState } from 'material-ui-popup-state/hooks';
 
 import { Button } from 'components/common/Button';
+import ModalWithButtons from 'components/common/Modal/ModalWithButtons';
 import {
   proposalStatusDetails,
   getProposalStatuses,
@@ -34,6 +36,62 @@ export function ProposalStepSummary({
   const currentStatusIndex = proposalStatus ? statuses.indexOf(proposalStatus) : -1;
   const nextStatus = statuses[currentStatusIndex + 1];
   const previousStatus = statuses[currentStatusIndex - 1];
+  const previousConfirmationPopup = usePopupState({
+    variant: 'popover',
+    popupId: 'previous-proposal-status-change-confirmation'
+  });
+  const nextConfirmationPopup = usePopupState({
+    variant: 'popover',
+    popupId: 'next-proposal-status-change-confirmation'
+  });
+
+  function handleProposalStatusUpdate(newStatus: ProposalStatus) {
+    switch (newStatus) {
+      case 'draft':
+      case 'discussion':
+      case 'review':
+      case 'vote_active':
+      case 'reviewed':
+        if (newStatus === previousStatus) {
+          previousConfirmationPopup.open();
+        } else if (newStatus === nextStatus) {
+          nextConfirmationPopup.open();
+        }
+        break;
+      default:
+        updateProposalStatus?.(newStatus);
+        break;
+    }
+  }
+
+  function previousProposalStatusUpdateMessage(status: ProposalStatus) {
+    switch (status) {
+      case 'draft':
+        return 'In the Draft stage, only authors and administrators can view and edit the proposal.';
+      case 'discussion':
+        return 'Rejecting this proposal will return it to the Discussion stage for further consideration.';
+      default:
+        return null;
+    }
+  }
+
+  function nextProposalStatusUpdateMessage(status: ProposalStatus) {
+    switch (status) {
+      case 'discussion':
+        return 'In the Feedback stage, all Members can view and provide feedback on the proposal.';
+      case 'review':
+        return 'In the Review stage, the Proposal is visible to all organization members, but disables feedback. Reviewer approval is required to proceed to the voting stage.';
+      case 'vote_active':
+        return 'Proceeding with this action will transition the proposal into the Voting stage.';
+      case 'reviewed':
+        return 'By approving this proposal, you authorize its advancement to the voting stage, to be initiated by an author.';
+      default:
+        return null;
+    }
+  }
+
+  const previousConfirmationMessage = previousProposalStatusUpdateMessage(previousStatus);
+  const nextConfirmationMessage = nextProposalStatusUpdateMessage(nextStatus);
 
   return (
     <Stack flex={1}>
@@ -56,44 +114,56 @@ export function ProposalStepSummary({
 
         <Stack gap={0.5} direction='row' fontSize='10px'>
           {!!previousStatus && (
-            <Button
-              sx={{ whiteSpace: 'nowrap' }}
-              size='small'
-              color='secondary'
-              startIcon={<ArrowBackIos fontSize='inherit' />}
-              disabled={!proposalFlowFlags?.[previousStatus]}
-              disableElevation
-              variant='outlined'
-              onClick={() => {
-                if (previousStatus) {
-                  updateProposalStatus?.(previousStatus);
-                }
-              }}
-            >
-              {PROPOSAL_STATUS_LABELS[previousStatus]}
-            </Button>
+            <>
+              <Button
+                sx={{ whiteSpace: 'nowrap' }}
+                size='small'
+                color='secondary'
+                startIcon={<ArrowBackIos fontSize='inherit' />}
+                disabled={!proposalFlowFlags?.[previousStatus]}
+                disableElevation
+                variant='outlined'
+                onClick={() => handleProposalStatusUpdate(previousStatus)}
+              >
+                {PROPOSAL_STATUS_LABELS[previousStatus]}
+              </Button>
+              <ModalWithButtons
+                open={previousConfirmationPopup.isOpen && !!previousConfirmationMessage}
+                onClose={previousConfirmationPopup.close}
+                onConfirm={() => updateProposalStatus?.(previousStatus)}
+              >
+                <Typography>{previousConfirmationMessage}</Typography>
+              </ModalWithButtons>
+            </>
           )}
           {!!nextStatus && (
-            <Button
-              disabledTooltip={nextStatus === 'discussion' ? 'Select a reviewer to proceed' : undefined}
-              size='small'
-              color='primary'
-              disableElevation
-              sx={{ whiteSpace: 'nowrap' }}
-              endIcon={<ArrowForwardIos fontSize='inherit' />}
-              disabled={!proposalFlowFlags?.[nextStatus]}
-              onClick={() => {
-                if (nextStatus) {
+            <>
+              <Button
+                disabledTooltip={nextStatus === 'discussion' ? 'Select a reviewer to proceed' : undefined}
+                size='small'
+                color='primary'
+                disableElevation
+                sx={{ whiteSpace: 'nowrap' }}
+                endIcon={<ArrowForwardIos fontSize='inherit' />}
+                disabled={!proposalFlowFlags?.[nextStatus]}
+                onClick={() => handleProposalStatusUpdate(nextStatus)}
+              >
+                {PROPOSAL_STATUS_LABELS[nextStatus]}
+              </Button>
+              <ModalWithButtons
+                open={nextConfirmationPopup.isOpen && !!nextConfirmationMessage}
+                onClose={nextConfirmationPopup.close}
+                onConfirm={() => {
                   if (nextStatus === 'vote_active') {
                     openVoteModal?.();
                   } else {
                     updateProposalStatus?.(nextStatus);
                   }
-                }
-              }}
-            >
-              {PROPOSAL_STATUS_LABELS[nextStatus]}
-            </Button>
+                }}
+              >
+                <Typography>{nextConfirmationMessage}</Typography>
+              </ModalWithButtons>
+            </>
           )}
         </Stack>
       </Stack>

--- a/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
@@ -80,7 +80,7 @@ export function ProposalStepSummary({
   function nextProposalStatusUpdateMessage(status: ProposalStatus) {
     switch (status) {
       case 'discussion':
-        return 'In the Feedback stage, all Members can view and provide feedback on the proposal.';
+        return 'In the Feedback stage, Members can view and provide feedback on the proposal.';
       case 'review':
         return 'In the Review stage, the Proposal is visible to all organization members. Reviewer approval is required to proceed to the voting stage.';
       case 'vote_active':

--- a/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
@@ -129,6 +129,7 @@ export function ProposalStepSummary({
               </Button>
               <ModalWithButtons
                 open={previousConfirmationPopup.isOpen && !!previousConfirmationMessage}
+                buttonText='Continue'
                 onClose={previousConfirmationPopup.close}
                 onConfirm={() => updateProposalStatus?.(previousStatus)}
               >
@@ -153,6 +154,7 @@ export function ProposalStepSummary({
               <ModalWithButtons
                 open={nextConfirmationPopup.isOpen && !!nextConfirmationMessage}
                 onClose={nextConfirmationPopup.close}
+                buttonText='Continue'
                 onConfirm={() => {
                   if (nextStatus === 'vote_active') {
                     openVoteModal?.();

--- a/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
@@ -90,7 +90,7 @@ export function ProposalStepSummary({
       case 'evaluation_closed':
         return 'This will close the Evaluation. No additional Rubric answers will be accepted.';
       case 'reviewed':
-        return 'By approving this proposal, you authorize its advancement to the voting stage, to be initiated by an author.';
+        return "By approving this proposal, you authorize its advancement to the voting stage. Voting is initiated by one of the proposal's authors.";
       default:
         return null;
     }

--- a/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
@@ -82,7 +82,7 @@ export function ProposalStepSummary({
       case 'discussion':
         return 'In the Feedback stage, Members can view and provide feedback on the proposal.';
       case 'review':
-        return 'In the Review stage, the Proposal is visible to all organization members. Reviewer approval is required to proceed to the voting stage.';
+        return 'In the Review stage, the Proposal is visible to Members. Reviewer approval is required to proceed to the voting stage.';
       case 'vote_active':
         return 'Proceeding with this action will transition the proposal into the Voting stage.';
       case 'evaluation_active':

--- a/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx
@@ -51,6 +51,8 @@ export function ProposalStepSummary({
       case 'discussion':
       case 'review':
       case 'vote_active':
+      case 'evaluation_active':
+      case 'evaluation_closed':
       case 'reviewed':
         if (newStatus === previousStatus) {
           previousConfirmationPopup.open();
@@ -80,9 +82,13 @@ export function ProposalStepSummary({
       case 'discussion':
         return 'In the Feedback stage, all Members can view and provide feedback on the proposal.';
       case 'review':
-        return 'In the Review stage, the Proposal is visible to all organization members, but disables feedback. Reviewer approval is required to proceed to the voting stage.';
+        return 'In the Review stage, the Proposal is visible to all organization members. Reviewer approval is required to proceed to the voting stage.';
       case 'vote_active':
         return 'Proceeding with this action will transition the proposal into the Voting stage.';
+      case 'evaluation_active':
+        return 'Proceeding with this action will transition the proposal into the Evaluation stage.';
+      case 'evaluation_closed':
+        return 'This will close the Evaluation. No additional Rubric answers will be accepted.';
       case 'reviewed':
         return 'By approving this proposal, you authorize its advancement to the voting stage, to be initiated by an author.';
       default:


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ebf3454</samp>

This pull request adds confirmation popups for some actions related to proposals, using the `ModalWithButtons` component and the `usePopupState` hook. It also enhances the `ModalWithButtons` component to allow hiding the secondary button. The affected files are `components/common/Modal/ModalWithButtons.tsx`, `components/proposals/components/ProposalDialog/NewProposalPage.tsx`, and `components/proposals/components/ProposalProperties/components/ProposalStepSummary.tsx`.

### WHY
[Task](https://app.charmverse.io/charmverse/page-7807730316365582)
