### PR TITLE
fix proposal header and page icon not being set

### DIFF
--- a/__integration-tests__/server/pages/api/proposals/[id]/index.public.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/[id]/index.public.spec.ts
@@ -5,6 +5,7 @@ import request from 'supertest';
 import { v4 } from 'uuid';
 
 import type { PageWithProposal } from 'lib/pages';
+import { getProposal } from 'lib/proposal/getProposal';
 import type { UpdateProposalRequest } from 'lib/proposal/updateProposal';
 import { baseUrl, loginUser } from 'testing/mockApiCall';
 
@@ -94,14 +95,13 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
       ]
     };
 
-    const updated = (
-      await request(baseUrl)
-        .put(`/api/proposals/${page.proposalId}`)
-        .set('Cookie', adminCookie)
-        .send(updateContent)
-        .expect(200)
-    ).body as PageWithProposal;
+    await request(baseUrl)
+      .put(`/api/proposals/${page.proposalId}`)
+      .set('Cookie', adminCookie)
+      .send(updateContent)
+      .expect(200);
 
+    const updated = await getProposal({ proposalId: page.proposalId! });
     // Make sure update went through
     expect(updated.proposal?.reviewers).toEqual<ProposalReviewer[]>([
       {
@@ -182,15 +182,14 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
       ]
     };
 
-    const updated = (
-      await request(baseUrl)
-        .put(`/api/proposals/${proposalTemplate.id}`)
-        .set('Cookie', adminCookie)
-        .send(updateContent)
-        .expect(200)
-    ).body as PageWithProposal;
+    await request(baseUrl)
+      .put(`/api/proposals/${proposalTemplate.id}`)
+      .set('Cookie', adminCookie)
+      .send(updateContent)
+      .expect(200);
 
     // Make sure update went through
+    const updated = await getProposal({ proposalId: proposalTemplate.id });
     expect(updated.proposal?.reviewers).toHaveLength(2);
     expect(updated.proposal?.reviewers.some((r) => r.roleId === role.id)).toBe(true);
     expect(updated.proposal?.reviewers.some((r) => r.userId === adminUser.id)).toBe(true);

--- a/__integration-tests__/server/pages/api/proposals/[id]/index.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/[id]/index.spec.ts
@@ -7,6 +7,7 @@ import { v4 } from 'uuid';
 
 import type { PageWithProposal } from 'lib/pages';
 import { addSpaceOperations } from 'lib/permissions/spaces/addSpaceOperations';
+import { getProposal } from 'lib/proposal/getProposal';
 import type { UpdateProposalRequest } from 'lib/proposal/updateProposal';
 import { baseUrl, loginUser } from 'testing/mockApiCall';
 import { generateRole } from 'testing/setupDatabase';
@@ -115,15 +116,14 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
       ]
     };
 
-    const updated = (
-      await request(baseUrl)
-        .put(`/api/proposals/${page.proposalId}`)
-        .set('Cookie', adminCookie)
-        .send(updateContent)
-        .expect(200)
-    ).body as PageWithProposal;
+    await request(baseUrl)
+      .put(`/api/proposals/${page.proposalId}`)
+      .set('Cookie', adminCookie)
+      .send(updateContent)
+      .expect(200);
 
     // Make sure update went through
+    const updated = await getProposal({ proposalId: page.proposalId! });
 
     expect(updated.proposal?.reviewers).toHaveLength(1);
     expect(updated.proposal?.reviewers.some((r) => r.userId === adminUser.id)).toBe(true);
@@ -159,15 +159,14 @@ describe('PUT /api/proposals/[id] - Update a proposal', () => {
       ]
     };
 
-    const updated = (
-      await request(baseUrl)
-        .put(`/api/proposals/${proposalTemplate.id}`)
-        .set('Cookie', adminCookie)
-        .send(updateContent)
-        .expect(200)
-    ).body as PageWithProposal;
+    await request(baseUrl)
+      .put(`/api/proposals/${proposalTemplate.id}`)
+      .set('Cookie', adminCookie)
+      .send(updateContent)
+      .expect(200);
 
     // Make sure update went through
+    const updated = await getProposal({ proposalId: proposalTemplate.id });
     expect(updated.proposal?.reviewers).toHaveLength(2);
     expect(updated.proposal?.reviewers.some((r) => r.roleId === role.id)).toBe(true);
     expect(updated.proposal?.reviewers.some((r) => r.userId === adminUser.id)).toBe(true);

--- a/charmClient/apis/proposalsApi.ts
+++ b/charmClient/apis/proposalsApi.ts
@@ -17,7 +17,7 @@ export class ProposalsApi {
   }
 
   updateProposal({ proposalId, ...rest }: UpdateProposalRequest) {
-    return http.PUT<PageWithProposal>(`/api/proposals/${proposalId}`, rest);
+    return http.PUT(`/api/proposals/${proposalId}`, rest);
   }
 
   updateStatus(proposalId: string, newStatus: ProposalStatus) {

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -32,7 +32,7 @@ import BountyProperties from './components/BountyProperties';
 import PageBanner from './components/PageBanner';
 import { PageConnectionBanner } from './components/PageConnectionBanner';
 import PageDeleteBanner from './components/PageDeleteBanner';
-import PageHeader from './components/PageHeader';
+import PageHeader, { getPageTop } from './components/PageHeader';
 import { PageTemplateBanner } from './components/PageTemplateBanner';
 import { ProposalBanner } from './components/ProposalBanner';
 import { ProposalProperties } from './components/ProposalProperties';
@@ -139,15 +139,7 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
 
   const activeView = boardViews[0];
 
-  let pageTop = 100;
-  if (page.headerImage) {
-    pageTop = 50;
-    if (page.icon) {
-      pageTop = 80;
-    }
-  } else if (page.icon) {
-    pageTop = 200;
-  }
+  const pageTop = getPageTop(page);
 
   const comments = useAppSelector(getCardComments(page.cardId ?? page.id));
 

--- a/components/[pageId]/DocumentPage/components/PageBanner.tsx
+++ b/components/[pageId]/DocumentPage/components/PageBanner.tsx
@@ -63,7 +63,7 @@ export function randomBannerImage() {
 interface PageBannerProps {
   focalBoard?: boolean;
   headerImage: string;
-  readOnly: boolean;
+  readOnly?: boolean;
   setPage: (page: { headerImage: string | null }) => void;
 }
 

--- a/components/[pageId]/DocumentPage/components/PageHeader.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeader.tsx
@@ -143,5 +143,17 @@ function PageHeader({ headerImage, icon, readOnly, setPage, title, updatedAt, re
     </>
   );
 }
+export function getPageTop({ headerImage, icon }: Pick<Page, 'headerImage' | 'icon'>) {
+  let pageTop = 100;
+  if (headerImage) {
+    pageTop = 50;
+    if (icon) {
+      pageTop = 80;
+    }
+  } else if (icon) {
+    pageTop = 200;
+  }
+  return pageTop;
+}
 
 export default memo(PageHeader);

--- a/components/[pageId]/DocumentPage/components/PageHeader.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeader.tsx
@@ -54,12 +54,14 @@ const EditorHeader = styled.div`
   }
 `;
 
+type PageHeaderValues = Partial<Pick<Page, 'title' | 'icon' | 'headerImage' | 'updatedAt'>>;
+
 type PageHeaderProps = {
   headerImage: string | null;
   icon: string | null;
   readOnly: boolean;
   title: string;
-  setPage: (p: Partial<Page>) => void;
+  setPage: (p: PageHeaderValues) => void;
   updatedAt: string;
   readOnlyTitle?: boolean;
 };

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -11,7 +11,10 @@ import {
   useGetProposalDetails
 } from 'charmClient/hooks/proposals';
 import { useTasks } from 'components/nexus/hooks/useTasks';
-import type { ProposalFormInputs } from 'components/proposals/components/ProposalProperties/ProposalProperties';
+import type {
+  ProposalValues,
+  ProposalPropertiesValues
+} from 'components/proposals/components/ProposalProperties/ProposalProperties';
 import { ProposalProperties as ProposalPropertiesBase } from 'components/proposals/components/ProposalProperties/ProposalProperties';
 import { useProposalPermissions } from 'components/proposals/hooks/useProposalPermissions';
 import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemplates';
@@ -62,7 +65,7 @@ export function ProposalProperties({
   const canViewRubricAnswers = isAdmin || !!(user?.id && reviewerUserIds?.includes(user.id));
   const isFromTemplateSource = Boolean(proposal?.page?.sourceTemplateId);
 
-  const proposalFormInputs: ProposalFormInputs = {
+  const proposalFormInputs: ProposalValues = {
     categoryId: proposal?.categoryId,
     evaluationType: proposal?.evaluationType || 'vote',
     authors: proposal?.authors.map((author) => author.userId) ?? [],
@@ -91,7 +94,7 @@ export function ProposalProperties({
     refreshProposal();
   }
 
-  async function onChangeRubricCriteria(rubricCriteria: ProposalFormInputs['rubricCriteria']) {
+  async function onChangeRubricCriteria(rubricCriteria: ProposalValues['rubricCriteria']) {
     // @ts-ignore TODO: unify types for rubricCriteria
     await upsertRubricCriteria({ rubricCriteria });
     if (proposal?.status === 'evaluation_active') {
@@ -99,11 +102,18 @@ export function ProposalProperties({
     }
   }
 
-  async function onChangeProperties(values: ProposalFormInputs) {
-    await charmClient.proposals.updateProposal({
-      proposalId,
-      ...values
-    });
+  async function onChangeProperties(values: Partial<ProposalPropertiesValues>) {
+    if (proposal) {
+      await charmClient.proposals.updateProposal({
+        proposalId,
+        authors: proposal.authors.map(({ userId }) => userId),
+        reviewers: proposal.reviewers.map((reviewer) => ({
+          id: reviewer.roleId ?? (reviewer.userId as string),
+          group: reviewer.roleId ? 'role' : 'user'
+        })),
+        ...values
+      });
+    }
     refreshProposal();
     refreshProposalFlowFlags(); // needs to run when reviewers change?
   }

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -11,10 +11,7 @@ import {
   useGetProposalDetails
 } from 'charmClient/hooks/proposals';
 import { useTasks } from 'components/nexus/hooks/useTasks';
-import type {
-  ProposalValues,
-  ProposalPropertiesValues
-} from 'components/proposals/components/ProposalProperties/ProposalProperties';
+import type { ProposalPropertiesInput } from 'components/proposals/components/ProposalProperties/ProposalProperties';
 import { ProposalProperties as ProposalPropertiesBase } from 'components/proposals/components/ProposalProperties/ProposalProperties';
 import { useProposalPermissions } from 'components/proposals/hooks/useProposalPermissions';
 import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemplates';
@@ -65,7 +62,7 @@ export function ProposalProperties({
   const canViewRubricAnswers = isAdmin || !!(user?.id && reviewerUserIds?.includes(user.id));
   const isFromTemplateSource = Boolean(proposal?.page?.sourceTemplateId);
 
-  const proposalFormInputs: ProposalValues = {
+  const proposalFormInputs: ProposalPropertiesInput = {
     categoryId: proposal?.categoryId,
     evaluationType: proposal?.evaluationType || 'vote',
     authors: proposal?.authors.map((author) => author.userId) ?? [],
@@ -94,7 +91,7 @@ export function ProposalProperties({
     refreshProposal();
   }
 
-  async function onChangeRubricCriteria(rubricCriteria: ProposalValues['rubricCriteria']) {
+  async function onChangeRubricCriteria(rubricCriteria: ProposalPropertiesInput['rubricCriteria']) {
     // @ts-ignore TODO: unify types for rubricCriteria
     await upsertRubricCriteria({ rubricCriteria });
     if (proposal?.status === 'evaluation_active') {
@@ -102,7 +99,7 @@ export function ProposalProperties({
     }
   }
 
-  async function onChangeProperties(values: Partial<ProposalPropertiesValues>) {
+  async function onChangeProperties(values: Partial<ProposalPropertiesInput>) {
     if (proposal) {
       await charmClient.proposals.updateProposal({
         proposalId,

--- a/components/common/stories/Proposals.stories.tsx
+++ b/components/common/stories/Proposals.stories.tsx
@@ -6,8 +6,8 @@ import { Provider } from 'react-redux';
 
 import DocumentPage from 'components/[pageId]/DocumentPage/DocumentPage';
 import { mockStateStore } from 'components/common/BoardEditor/focalboard/src/testUtils';
+import type { ProposalPageAndPropertiesInput } from 'components/proposals/components/ProposalDialog/NewProposalPage';
 import { NewProposalPage as ProposalPageComponent } from 'components/proposals/components/ProposalDialog/NewProposalPage';
-import type { ProposalFormInputs } from 'components/proposals/components/ProposalProperties/ProposalProperties';
 import type { ICurrentSpaceContext } from 'hooks/useCurrentSpace';
 import { CurrentSpaceContext } from 'hooks/useCurrentSpace';
 import { MembersProvider } from 'hooks/useMembers';
@@ -56,12 +56,14 @@ function Context({ children }: { children: ReactNode }) {
 
 export function NewProposal() {
   const [contentUpdated, setContentUpdated] = useState(false);
-  const [formInputs, setFormInputs] = useState<ProposalFormInputs>({
+  const [formInputs, setFormInputs] = useState<ProposalPageAndPropertiesInput>({
     authors: [],
     categoryId: null,
     content: null,
     contentText: '',
     evaluationType: 'rubric',
+    headerImage: null,
+    icon: null,
     proposalTemplateId: null,
     reviewers: [],
     rubricCriteria: [

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -23,14 +23,22 @@ import type { PageContent } from 'lib/prosemirror/interfaces';
 import { setUrlWithoutRerender } from 'lib/utilities/browser';
 import { fontClassName } from 'theme/fonts';
 
-import type { ProposalFormInputs } from '../ProposalProperties/ProposalProperties';
+import type { ProposalPropertiesInput } from '../ProposalProperties/ProposalProperties';
 import { ProposalProperties } from '../ProposalProperties/ProposalProperties';
 
 import { useProposalDialog } from './hooks/useProposalDialog';
 
+export type ProposalPageAndPropertiesInput = ProposalPropertiesInput & {
+  title?: string; // title is saved to the same state that's used in ProposalPage
+  content?: PageContent | null;
+  contentText?: string;
+  headerImage: string | null;
+  icon: string | null;
+};
+
 type Props = {
-  setFormInputs: (params: Partial<ProposalFormInputs>) => void;
-  formInputs: ProposalFormInputs;
+  setFormInputs: (params: Partial<ProposalPageAndPropertiesInput>) => void;
+  formInputs: ProposalPageAndPropertiesInput;
   contentUpdated: boolean;
   setContentUpdated: (changed: boolean) => void;
 };
@@ -169,18 +177,14 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
             >
               {/* temporary? disable editing of page title when in suggestion mode */}
               <PageHeader
-                headerImage={null}
-                icon={null}
+                headerImage={formInputs.headerImage}
+                icon={formInputs.icon}
                 readOnly={false}
                 updatedAt={new Date().toString()}
                 title={formInputs.title || ''}
                 // readOnly={readOnly || !!enableSuggestingMode}
                 setPage={(updatedPage) => {
-                  setFormInputs({
-                    headerImage: updatedPage.headerImage,
-                    pageIcon: updatedPage.pageIcon,
-                    title: updatedPage.title
-                  });
+                  setFormInputs(updatedPage);
                 }}
               />
               <div className='focalboard-body font-family-default'>

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -177,6 +177,8 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
                 // readOnly={readOnly || !!enableSuggestingMode}
                 setPage={(updatedPage) => {
                   setFormInputs({
+                    headerImage: updatedPage.headerImage,
+                    pageIcon: updatedPage.pageIcon,
                     title: updatedPage.title
                   });
                 }}

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -6,7 +6,8 @@ import { mutate } from 'swr';
 import { useElementSize } from 'usehooks-ts';
 
 import charmClient from 'charmClient';
-import PageHeader from 'components/[pageId]/DocumentPage/components/PageHeader';
+import PageBanner from 'components/[pageId]/DocumentPage/components/PageBanner';
+import PageHeader, { getPageTop } from 'components/[pageId]/DocumentPage/components/PageHeader';
 import { Container } from 'components/[pageId]/DocumentPage/DocumentPage';
 import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
@@ -101,7 +102,9 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
             content: formInputs.content,
             contentText: formInputs.contentText ?? '',
             title: formInputs.title,
-            sourceTemplateId: formInputs.proposalTemplateId
+            sourceTemplateId: formInputs.proposalTemplateId,
+            headerImage: formInputs.headerImage,
+            icon: formInputs.icon
           },
           evaluationType: formInputs.evaluationType,
           rubricCriteria: formInputs.rubricCriteria as RubricDataInput[],
@@ -151,7 +154,8 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
   return (
     <ScrollableWindow>
       <div className={`document-print-container ${fontClassName}`}>
-        <Container top={50} fullWidth={isSmallScreen}>
+        {formInputs.headerImage && <PageBanner headerImage={formInputs.headerImage} setPage={setFormInputs} />}
+        <Container top={getPageTop(formInputs)} fullWidth={isSmallScreen}>
           <Box minHeight={450}>
             <CharmEditor
               placeholderText={

--- a/components/proposals/components/ProposalDialog/ProposalDialog.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalDialog.tsx
@@ -12,8 +12,7 @@ import { FullPageActionsMenuButton } from 'components/common/PageActions/FullPag
 import { useUser } from 'hooks/useUser';
 import type { PageWithContent } from 'lib/pages';
 
-import type { ProposalFormInputs } from '../ProposalProperties/ProposalProperties';
-
+import type { ProposalPageAndPropertiesInput } from './NewProposalPage';
 import { NewProposalPage } from './NewProposalPage';
 
 interface Props {
@@ -26,17 +25,8 @@ export function ProposalDialog({ page, isLoading, onClose }: Props) {
   const mounted = useRef(false);
   const router = useRouter();
   const { user } = useUser();
-  const [formInputs, setFormInputs] = useState<ProposalFormInputs>({
-    authors: user ? [user.id] : [],
-    categoryId: null,
-    content: null,
-    contentText: '',
-    evaluationType: 'vote',
-    proposalTemplateId: null,
-    reviewers: [],
-    rubricCriteria: [],
-    title: ''
-  });
+  const [formInputs, setFormInputs] = useState<ProposalPageAndPropertiesInput>(emptyState({ userId: user?.id }));
+
   const [contentUpdated, setContentUpdated] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
 
@@ -50,17 +40,7 @@ export function ProposalDialog({ page, isLoading, onClose }: Props) {
 
   function close() {
     onClose();
-    setFormInputs({
-      authors: [],
-      categoryId: null,
-      content: null,
-      contentText: '',
-      evaluationType: 'vote',
-      proposalTemplateId: null,
-      reviewers: [],
-      rubricCriteria: [],
-      title: ''
-    });
+    setFormInputs(emptyState());
     setContentUpdated(false);
     setShowConfirmDialog(false);
   }
@@ -130,4 +110,20 @@ export function ProposalDialog({ page, isLoading, onClose }: Props) {
       />
     </Dialog>
   );
+}
+
+function emptyState({ userId }: { userId?: string } = {}): ProposalPageAndPropertiesInput {
+  return {
+    authors: userId ? [userId] : [],
+    categoryId: null,
+    content: null,
+    contentText: '',
+    headerImage: null,
+    icon: null,
+    evaluationType: 'vote',
+    proposalTemplateId: null,
+    reviewers: [],
+    rubricCriteria: [],
+    title: ''
+  };
 }

--- a/components/proposals/components/ProposalProperties/ProposalProperties.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalProperties.tsx
@@ -35,17 +35,20 @@ import { ProposalStepSummary } from './components/ProposalStepSummary';
 import { ProposalTemplateSelect } from './components/ProposalTemplateSelect';
 import { RubricEvaluationForm } from './components/RubricEvaluationForm';
 
-export type ProposalFormInputs = {
-  title?: string; // title is saved to the same state that's used in ProposalPage
-  content?: PageContent | null;
-  contentText?: string;
-  // id?: string;
+export type ProposalPropertiesValues = {
+  contentText?: string; // required to know if we can overwrite content when selecting a template
   categoryId?: string | null;
   authors: string[];
   reviewers: ProposalReviewerInput[];
   proposalTemplateId?: string | null;
   evaluationType: ProposalEvaluationType;
   rubricCriteria: RangeProposalCriteria[];
+};
+export type ProposalValues = ProposalPropertiesValues & {
+  title?: string; // title is saved to the same state that's used in ProposalPage
+  content?: PageContent | null;
+  contentText?: string;
+  headerImage?: string | null;
 };
 
 type ProposalPropertiesProps = {
@@ -58,7 +61,7 @@ type ProposalPropertiesProps = {
   pageId?: string;
   proposalId?: string;
   proposalFlowFlags?: ProposalFlowPermissionFlags;
-  proposalFormInputs: ProposalFormInputs;
+  proposalFormInputs: ProposalPropertiesValues;
   proposalStatus?: ProposalStatus;
   readOnlyAuthors?: boolean;
   readOnlyReviewers?: boolean;
@@ -66,7 +69,7 @@ type ProposalPropertiesProps = {
   readOnlyRubricCriteria?: boolean;
   rubricAnswers?: ProposalRubricCriteriaAnswerWithTypedResponse[];
   rubricCriteria?: ProposalRubricCriteria[];
-  setProposalFormInputs: (values: ProposalFormInputs) => Promise<void> | void;
+  setProposalFormInputs: (values: Partial<ProposalPropertiesValues>) => Promise<void> | void;
   showStatus?: boolean;
   snapshotProposalId?: string | null;
   userId?: string;
@@ -148,13 +151,11 @@ export function ProposalProperties({
   async function onChangeCategory(updatedCategory: ProposalCategory | null) {
     if (updatedCategory && updatedCategory.id !== proposalFormInputs.categoryId) {
       setProposalFormInputs({
-        ...proposalFormInputs,
         categoryId: updatedCategory.id,
         proposalTemplateId: null
       });
     } else if (!updatedCategory) {
       setProposalFormInputs({
-        ...proposalFormInputs,
         categoryId: null,
         proposalTemplateId: null
       });
@@ -169,10 +170,7 @@ export function ProposalProperties({
       );
       if (proposalTemplate) {
         setProposalFormInputs({
-          ...proposalFormInputs,
           categoryId: proposalTemplate.categoryId,
-          content: proposalTemplate.page.content as PageContent,
-          contentText: proposalTemplate.page.contentText,
           reviewers: proposalTemplate.reviewers.map((reviewer) => ({
             group: reviewer.roleId ? 'role' : 'user',
             id: reviewer.roleId ?? (reviewer.userId as string)
@@ -187,7 +185,6 @@ export function ProposalProperties({
 
   function clearTemplate() {
     setProposalFormInputs({
-      ...proposalFormInputs,
       proposalTemplateId: null
     });
   }
@@ -361,7 +358,6 @@ export function ProposalProperties({
                   readOnly={readOnlyAuthors}
                   onChange={(authors) => {
                     setProposalFormInputs({
-                      ...proposalFormInputs,
                       authors
                     });
                   }}
@@ -381,7 +377,6 @@ export function ProposalProperties({
                 proposalCategoryId={proposalFormInputs.categoryId}
                 onChange={async (options) => {
                   await setProposalFormInputs({
-                    ...proposalFormInputs,
                     reviewers: options.map((option) => ({ group: option.group, id: option.id }))
                   });
                   refreshReviewerIds();
@@ -398,7 +393,6 @@ export function ProposalProperties({
                 value={proposalFormInputs.evaluationType}
                 onChange={(evaluationType) => {
                   setProposalFormInputs({
-                    ...proposalFormInputs,
                     evaluationType
                   });
                 }}

--- a/components/proposals/components/ProposalProperties/ProposalProperties.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalProperties.tsx
@@ -35,7 +35,7 @@ import { ProposalStepSummary } from './components/ProposalStepSummary';
 import { ProposalTemplateSelect } from './components/ProposalTemplateSelect';
 import { RubricEvaluationForm } from './components/RubricEvaluationForm';
 
-export type ProposalPropertiesValues = {
+export type ProposalPropertiesInput = {
   contentText?: string; // required to know if we can overwrite content when selecting a template
   categoryId?: string | null;
   authors: string[];
@@ -43,12 +43,6 @@ export type ProposalPropertiesValues = {
   proposalTemplateId?: string | null;
   evaluationType: ProposalEvaluationType;
   rubricCriteria: RangeProposalCriteria[];
-};
-export type ProposalValues = ProposalPropertiesValues & {
-  title?: string; // title is saved to the same state that's used in ProposalPage
-  content?: PageContent | null;
-  contentText?: string;
-  headerImage?: string | null;
 };
 
 type ProposalPropertiesProps = {
@@ -61,7 +55,7 @@ type ProposalPropertiesProps = {
   pageId?: string;
   proposalId?: string;
   proposalFlowFlags?: ProposalFlowPermissionFlags;
-  proposalFormInputs: ProposalPropertiesValues;
+  proposalFormInputs: ProposalPropertiesInput;
   proposalStatus?: ProposalStatus;
   readOnlyAuthors?: boolean;
   readOnlyReviewers?: boolean;
@@ -69,7 +63,7 @@ type ProposalPropertiesProps = {
   readOnlyRubricCriteria?: boolean;
   rubricAnswers?: ProposalRubricCriteriaAnswerWithTypedResponse[];
   rubricCriteria?: ProposalRubricCriteria[];
-  setProposalFormInputs: (values: Partial<ProposalPropertiesValues>) => Promise<void> | void;
+  setProposalFormInputs: (values: Partial<ProposalPropertiesInput>) => Promise<void> | void;
   showStatus?: boolean;
   snapshotProposalId?: string | null;
   userId?: string;

--- a/lib/proposal/createProposal.ts
+++ b/lib/proposal/createProposal.ts
@@ -17,7 +17,7 @@ import type { RubricDataInput } from './rubric/upsertRubricCriteria';
 import { upsertRubricCriteria } from './rubric/upsertRubricCriteria';
 import { validateProposalAuthorsAndReviewers } from './validateProposalAuthorsAndReviewers';
 
-type PageProps = Partial<Pick<Page, 'title' | 'content' | 'contentText' | 'sourceTemplateId'>>;
+type PageProps = Partial<Pick<Page, 'title' | 'content' | 'contentText' | 'sourceTemplateId' | 'headerImage' | 'icon'>>;
 
 export type CreateProposalInput = {
   pageId?: string;
@@ -101,16 +101,18 @@ export async function createProposal({
     createPage({
       data: {
         content: pageProps?.content ?? undefined,
-        proposalId,
+        createdBy: userId,
         contentText: pageProps?.contentText ?? '',
+        headerImage: pageProps?.headerImage,
+        icon: pageProps?.icon,
+        id: proposalId,
         path: getPagePath(),
+        proposalId,
         sourceTemplateId: pageProps?.sourceTemplateId,
         title: pageProps?.title ?? '',
+        type: 'proposal',
         updatedBy: userId,
-        createdBy: userId,
-        spaceId,
-        id: proposalId,
-        type: 'proposal'
+        spaceId
       }
     }),
     prisma.workspaceEvent.create({

--- a/lib/proposal/updateProposal.ts
+++ b/lib/proposal/updateProposal.ts
@@ -3,7 +3,7 @@ import { prisma } from '@charmverse/core/prisma-client';
 
 import { InvalidStateError } from 'lib/middleware';
 
-import type { ProposalReviewerInput, ProposalWithUsersAndRubric } from './interface';
+import type { ProposalReviewerInput } from './interface';
 
 export type UpdateProposalRequest = {
   proposalId: string;
@@ -19,7 +19,7 @@ export async function updateProposal({
   reviewers,
   categoryId,
   evaluationType
-}: UpdateProposalRequest): Promise<ProposalWithUsersAndRubric> {
+}: UpdateProposalRequest) {
   if (authors.length === 0) {
     throw new InvalidStateError('Proposal must have at least 1 author');
   }
@@ -69,17 +69,4 @@ export async function updateProposal({
       }))
     });
   });
-
-  return prisma.proposal.findUnique({
-    where: {
-      id: proposalId
-    },
-    include: {
-      authors: true,
-      reviewers: true,
-      category: true,
-      rubricAnswers: true,
-      rubricCriteria: true
-    }
-  }) as any as Promise<ProposalWithUsersAndRubric>;
 }

--- a/pages/api/proposals/[id]/index.ts
+++ b/pages/api/proposals/[id]/index.ts
@@ -7,7 +7,6 @@ import { ActionNotPermittedError, NotFoundError, onError, onNoMatch } from 'lib/
 import type { PageWithProposal } from 'lib/pages';
 import { providePermissionClients } from 'lib/permissions/api/permissionsClientMiddleware';
 import { getAllReviewerUserIds } from 'lib/proposal/getAllReviewerIds';
-import { getProposal } from 'lib/proposal/getProposal';
 import type { ProposalWithUsersAndRubric } from 'lib/proposal/interface';
 import type { UpdateProposalRequest } from 'lib/proposal/updateProposal';
 import { updateProposal } from 'lib/proposal/updateProposal';
@@ -73,7 +72,7 @@ async function getProposalController(req: NextApiRequest, res: NextApiResponse<P
   return res.status(200).json(proposal as ProposalWithUsersAndRubric);
 }
 
-async function updateProposalController(req: NextApiRequest, res: NextApiResponse<PageWithProposal>) {
+async function updateProposalController(req: NextApiRequest, res: NextApiResponse) {
   const proposalId = req.query.id as string;
   const userId = req.session.user.id;
 
@@ -166,12 +165,7 @@ async function updateProposalController(req: NextApiRequest, res: NextApiRespons
 
   await updateProposal({ proposalId: proposal.id, authors, reviewers, categoryId, evaluationType });
 
-  const updatedProposal = await getProposal({ proposalId: proposal.id });
-
-  // Don't allow fetching answers here
-  updatedProposal.proposal.rubricAnswers = [];
-
-  return res.status(200).send(updatedProposal);
+  return res.status(200).end();
 }
 
 export default withSessionRoute(handler);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 590ae2f</samp>

Refactored and simplified the code for creating and updating proposals in the app. Separated the type definitions for proposal page and component values. Removed unused fields and data fetching from the `updateProposal` function and its related API methods and controllers. Added support for setting `headerImage` and `pageIcon` fields when creating a new proposal from a template.

### WHY
Also removed unecessary queries in the update methods - we were actually getting the proposal and related docs twice! 

