### PR TITLE
hide comments for proposal templates

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -322,7 +322,7 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
                   </div>
                 </CharmEditor>
 
-                {proposalId && <PageComments page={page} permissions={pagePermissions} />}
+                {page.type === 'proposal' && <PageComments page={page} permissions={pagePermissions} />}
               </Container>
             </div>
           </ScrollContainer>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85bd7fb</samp>

Fixed a bug where comments were missing for some proposal pages. Changed the rendering condition for `PageComments` to use `page.type` instead of `proposalId` in `components/[pageId]/DocumentPage/DocumentPage.tsx`.

### WHY
<!-- author to complete -->
