### PR TITLE
Silence test errors

### DIFF
--- a/jes.setup.browser.ts
+++ b/jes.setup.browser.ts
@@ -1,3 +1,0 @@
-// Used for __tests__/testing-library.js
-// Learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -6,10 +6,16 @@ afterAll(() => {
   prisma.$disconnect();
 });
 
+// Mock external requests globally
+
 jest.mock('lib/blockchain/getENSName', () => ({
   ...jest.requireActual('lib/blockchain/getENSName'),
   __esModule: true,
-  default: jest.fn().mockImplementation(() => {
-    return Promise.resolve(null);
-  })
+  default: jest.fn().mockImplementation(() => Promise.resolve(null))
+}));
+
+jest.mock('lib/alchemy/getNFTs', () => ({
+  ...jest.requireActual('lib/alchemy/getNFTs'),
+  __esModule: true,
+  getNFTs: jest.fn().mockImplementation(() => Promise.resolve([]))
 }));


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
When looking at output of CI actions, it is spammed with api key errors. If I skip the exception, we'd still make an API call. So instead I'm trying to just stub it out globally for now:
<img width="1153" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/06a811b8-5b08-454b-9b96-0d112fa9a5b3">

