### PR TITLE
Allow using an invite link to elevate guest to member

### DIFF
--- a/lib/middleware/requireSpaceMembership.ts
+++ b/lib/middleware/requireSpaceMembership.ts
@@ -10,6 +10,7 @@ import { AdministratorOnlyError, UserIsNotSpaceMemberError } from '../users/erro
 declare module 'http' {
   interface IncomingMessage {
     isAdmin: boolean;
+    isGuest: boolean;
   }
 }
 
@@ -65,6 +66,7 @@ export function requireSpaceMembership(options: { adminOnly: boolean; spaceIdKey
       throw new AdministratorOnlyError();
     } else {
       req.isAdmin = spaceRole.isAdmin;
+      req.isGuest = !spaceRole.isAdmin && spaceRole.isGuest;
       next();
     }
   };

--- a/pages/api/invites/index.ts
+++ b/pages/api/invites/index.ts
@@ -39,6 +39,10 @@ async function createInviteLinkEndpoint(req: NextApiRequest, res: NextApiRespons
   return res.status(201).json(invite);
 }
 async function getInviteLinks(req: NextApiRequest, res: NextApiResponse<InviteLinkWithRoles[]>) {
+  if (req.isGuest) {
+    return [];
+  }
+
   const invites = await getSpaceInviteLinks({
     spaceId: req.query.spaceId as string
   });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ec2aef</samp>

This pull request improves the invite link feature by fixing a bug, adding more tests, and enforcing the space membership middleware. It renames some variables and refactors some functions in `lib/invites` and adds a `isGuest` property to the request object in `lib/middleware/requireSpaceMembership.ts`. It also prevents guests from creating invite links in `pages/api/invites/index.ts`.

### WHY
Invite link can now be used to promote guest to member
