### PR TITLE
simplify mocks for browser tests using charm editor

### DIFF
--- a/components/common/CharmEditor/components/columnLayout/__tests__/columnLayout.spec.tsx
+++ b/components/common/CharmEditor/components/columnLayout/__tests__/columnLayout.spec.tsx
@@ -2,28 +2,8 @@ import { CharmEditor } from 'components/common/CharmEditor';
 import { customRenderWithContext } from 'testing/customRender';
 import { jsonDoc, builders as _ } from 'testing/prosemirror/builders';
 
-jest.mock('hooks/useFirebaseAuth', () => ({
-  useFirebaseAuth: {}
-}));
-
-jest.mock('components/proposals/components/SnapshotVoting/hooks/useSnapshotVoting', () => ({}));
-jest.mock('components/settings/account/hooks/useLensProfile', () => ({}));
-
-jest.mock('@lit-protocol/lit-node-client', () => ({
-  humanizeAccessControlConditions: () => {}
-}));
-
-jest.mock('lib/snapshot/getProposal', () => ({
-  getSnapshotProposal: () => ({ proposals: [] })
-}));
-
-jest.mock('lib/snapshot/getSpace', () => ({
-  getSnapshotSpace: () => ({ space: {} })
-}));
-
-jest.mock('lib/snapshot/getVotes', () => ({
-  getSnapshotVotes: () => ({ votes: {} })
-}));
+jest.mock('components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase', () => ({}));
+jest.mock('components/common/CharmEditor/components/poll/PollComponent', () => ({}));
 
 jest.mock('next/router', () => ({
   useRouter: () => ({

--- a/components/common/PageActions/components/SnapshotAction/InputVotingStrategies.tsx
+++ b/components/common/PageActions/components/SnapshotAction/InputVotingStrategies.tsx
@@ -5,7 +5,7 @@ import Select from '@mui/material/Select';
 import { useEffect, useState } from 'react';
 
 import FieldLabel from 'components/common/form/FieldLabel';
-import type { SnapshotVotingStrategy } from 'lib/snapshot';
+import type { SnapshotVotingStrategy } from 'lib/snapshot/interfaces';
 
 export interface Props {
   onChange?: (option: SnapshotVotingStrategy[]) => void;

--- a/components/common/PageActions/components/SnapshotAction/PublishToSnapshot.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishToSnapshot.tsx
@@ -9,8 +9,8 @@ import Link from 'components/common/Link';
 import { LoadingIcon } from 'components/common/LoadingComponent';
 import { Modal } from 'components/common/Modal';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import type { SnapshotProposal } from 'lib/snapshot';
-import { getSnapshotProposal } from 'lib/snapshot';
+import { getSnapshotProposal } from 'lib/snapshot/getProposal';
+import type { SnapshotProposal } from 'lib/snapshot/interfaces';
 
 import { PublishingForm } from './PublishingForm';
 

--- a/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
@@ -25,9 +25,10 @@ import { useMembers } from 'hooks/useMembers';
 import { usePages } from 'hooks/usePages';
 import { useWeb3AuthSig } from 'hooks/useWeb3AuthSig';
 import { generateMarkdown } from 'lib/prosemirror/plugins/markdown/generateMarkdown';
-import type { SnapshotReceipt, SnapshotSpace, SnapshotVotingStrategy } from 'lib/snapshot';
-import { getSnapshotSpace, SnapshotVotingMode } from 'lib/snapshot';
 import { getSnapshotClient } from 'lib/snapshot/getSnapshotClient';
+import { getSnapshotSpace } from 'lib/snapshot/getSpace';
+import { SnapshotVotingMode } from 'lib/snapshot/interfaces';
+import type { SnapshotReceipt, SnapshotSpace, SnapshotVotingStrategy } from 'lib/snapshot/interfaces';
 import { ExternalServiceError, SystemError, UnknownError } from 'lib/utilities/errors';
 import { lowerCaseEqual } from 'lib/utilities/strings';
 

--- a/components/common/comments/__tests__/ComentForm.spec.tsx
+++ b/components/common/comments/__tests__/ComentForm.spec.tsx
@@ -2,36 +2,8 @@ import { customRenderWithContext } from 'testing/customRender';
 
 import { CommentForm } from '../CommentForm';
 
-jest.mock('hooks/useFirebaseAuth', () => ({
-  useFirebaseAuth: {}
-}));
-
-jest.mock('components/proposals/components/SnapshotVoting/hooks/useSnapshotVoting', () => ({}));
-jest.mock('components/settings/account/hooks/useLensProfile', () => ({}));
-
-jest.mock('@lit-protocol/lit-node-client', () => ({
-  humanizeAccessControlConditions: () => {}
-}));
-
-jest.mock('@uauth/js', () => ({
-  UAuth: () => {}
-}));
-
-jest.mock('lib/snapshot/getProposal', () => ({
-  getSnapshotProposal: () => ({ proposals: [] })
-}));
-
-jest.mock('lib/snapshot/getSpace', () => ({
-  getSnapshotSpace: () => ({ space: {} })
-}));
-
-jest.mock('lib/snapshot/getVotes', () => ({
-  getSnapshotVotes: () => ({ votes: {} })
-}));
-
-jest.mock('lib/snapshot/getVotingPower', () => ({
-  getSnapshotVotes: () => ({})
-}));
+jest.mock('components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase', () => ({}));
+jest.mock('components/common/CharmEditor/components/poll/PollComponent', () => ({}));
 
 jest.mock('next/router', () => ({
   useRouter: () => ({

--- a/components/proposals/components/SnapshotVoting/DisplayChoiceScore.tsx
+++ b/components/proposals/components/SnapshotVoting/DisplayChoiceScore.tsx
@@ -1,6 +1,6 @@
 import { Stack, Typography } from '@mui/material';
 
-import type { SnapshotProposal } from 'lib/snapshot';
+import type { SnapshotProposal } from 'lib/snapshot/interfaces';
 import { percent } from 'lib/utilities/numbers';
 
 type Props = {

--- a/components/proposals/components/SnapshotVoting/DraggableRankedItem.tsx
+++ b/components/proposals/components/SnapshotVoting/DraggableRankedItem.tsx
@@ -7,7 +7,7 @@ import { useDrag, useDrop } from 'react-dnd';
 
 import { Button } from 'components/common/Button';
 import { DisplayChoiceScore } from 'components/proposals/components/SnapshotVoting/DisplayChoiceScore';
-import type { SnapshotProposal } from 'lib/snapshot';
+import type { SnapshotProposal } from 'lib/snapshot/interfaces';
 
 type DragItem = {
   index: number;

--- a/components/proposals/components/SnapshotVoting/SnapshotVotingForm.tsx
+++ b/components/proposals/components/SnapshotVoting/SnapshotVotingForm.tsx
@@ -9,7 +9,8 @@ import { RankedVoting } from 'components/proposals/components/SnapshotVoting/Ran
 import { SingleChoiceVoting } from 'components/proposals/components/SnapshotVoting/SingleChoiceVoting';
 import { WeightedVoting } from 'components/proposals/components/SnapshotVoting/WeightedVoting';
 import { useSnackbar } from 'hooks/useSnackbar';
-import type { SnapshotProposal, SnapshotVote, VoteChoice } from 'lib/snapshot';
+import type { SnapshotVote } from 'lib/snapshot/getVotes';
+import type { SnapshotProposal, VoteChoice } from 'lib/snapshot/interfaces';
 
 export type SnapshotVotingProps = {
   snapshotProposal: SnapshotProposal;

--- a/components/proposals/components/SnapshotVoting/hooks/useSnapshotVoting.ts
+++ b/components/proposals/components/SnapshotVoting/hooks/useSnapshotVoting.ts
@@ -3,8 +3,9 @@ import useSWR from 'swr';
 
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useWeb3AuthSig } from 'hooks/useWeb3AuthSig';
-import { getSnapshotProposal, getUserProposalVotes } from 'lib/snapshot';
+import { getSnapshotProposal } from 'lib/snapshot/getProposal';
 import { getSnapshotClient } from 'lib/snapshot/getSnapshotClient';
+import { getUserProposalVotes } from 'lib/snapshot/getVotes';
 import { getVotingPower } from 'lib/snapshot/getVotingPower';
 import type { SnapshotProposal, VoteChoice } from 'lib/snapshot/interfaces';
 import { coerceToMilliseconds, relativeTime } from 'lib/utilities/dates';

--- a/lib/snapshot/index.ts
+++ b/lib/snapshot/index.ts
@@ -1,4 +1,0 @@
-export * from './getProposal';
-export * from './getSpace';
-export * from './getVotes';
-export * from './interfaces';


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
The CharmEditor ends up importing a lot of unrelated stuff due to the InlineDatabase. Similarly, the Poll component uses snapshot and some dependency that breaks browser testing. These components can be mocked for the most part.
