### PR TITLE
Fix loading spaces for redirection

### DIFF
--- a/components/login/LoginButton.tsx
+++ b/components/login/LoginButton.tsx
@@ -95,7 +95,7 @@ export function LoginButton({ redirectUrl, showSignup, emailOnly }: Props) {
         color={!showSignup ? 'primary' : 'secondary'}
         size='large'
         onClick={handleClickOpen}
-        variant='outlined'
+        variant={showSignup ? 'outlined' : undefined}
       >
         Sign in
       </StyledButton>

--- a/pages/authenticate/index.tsx
+++ b/pages/authenticate/index.tsx
@@ -3,6 +3,7 @@ import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
+import charmClient from 'charmClient';
 import { getLayout } from 'components/common/BaseLayout/getLayout';
 import { Button } from 'components/common/Button';
 import { LoginPageContent } from 'components/login';
@@ -24,13 +25,17 @@ export default function Authenticate() {
   const router = useRouter();
   const emailPopup = usePopupState({ variant: 'popover', popupId: 'emailPopup' });
 
-  function redirectLoggedInUser() {
+  async function redirectLoggedInUser() {
     const redirectPath = typeof router.query.redirectUrl === 'string' ? router.query.redirectUrl : '/';
+
+    // Use spaces might not be loaded yet, this ensures we have up to date data
+    const userSpaces = await charmClient.spaces.getSpaces();
+
     const domainFromRedirect = redirectPath.split('/')[1];
-    if (spaces?.length && domainFromRedirect && spaces.find((s) => s.domain === domainFromRedirect)) {
+    if (userSpaces?.length && domainFromRedirect && userSpaces.find((s) => s.domain === domainFromRedirect)) {
       router.push(redirectPath);
-    } else if (spaces?.length) {
-      router.push(`/${spaces[0].domain}`);
+    } else if (userSpaces?.length) {
+      router.push(`/${userSpaces[0].domain}`);
     } else {
       router.push('/createSpace');
     }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfcbb15</samp>

This pull request improves the authentication flow by using `charmClient` to fetch spaces and handling the `redirectUrl` parameter. It modifies the `pages/authenticate/index.tsx` file.

### WHY
Fix the redirect. We weren't getting spaces in time. Now the smart links will send you to correct location
