### PR TITLE
UX Improvements for lens publication

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -76,7 +76,7 @@ export function ProposalProperties({
     evaluationType: proposal?.evaluationType || 'vote',
     authors: proposal?.authors.map((author) => author.userId) ?? [],
     rubricCriteria: proposal?.rubricCriteria ?? [],
-    publishToLens: proposal?.publishToLens ?? !!user?.publishToLensDefault,
+    publishToLens: proposal ? proposal.publishToLens ?? false : !!user?.publishToLensDefault,
     reviewers:
       proposal?.reviewers.map((reviewer) => ({
         group: reviewer.roleId ? 'role' : 'user',
@@ -87,7 +87,8 @@ export function ProposalProperties({
   async function updateProposalStatus(newStatus: ProposalStatus) {
     if (proposal && newStatus !== proposal.status) {
       await charmClient.proposals.updateStatus(proposal.id, newStatus);
-      if (newStatus === 'discussion' && proposalPage && proposal.publishToLens) {
+      // If proposal is being published for the first time and publish to lens is enabled, create a lens post
+      if (newStatus === 'discussion' && proposalPage && proposal.publishToLens && !proposal.lensPostLink) {
         await createLensPost({
           proposalContent: proposalPage.content as PageContent
         });

--- a/components/common/comments/CommentForm.tsx
+++ b/components/common/comments/CommentForm.tsx
@@ -1,4 +1,4 @@
-import { Stack, Box } from '@mui/material';
+import { Stack, Box, Typography, Switch } from '@mui/material';
 import { useMemo, useState } from 'react';
 
 import { Button } from 'components/common/Button';
@@ -18,12 +18,18 @@ const defaultCharmEditorOutput: ICharmEditorOutput = {
 };
 
 export function CommentForm({
+  showPublishToLens,
   handleCreateComment,
   initialValue,
   inlineCharmEditor,
   disabled,
-  placeholder
+  placeholder,
+  setPublishToLens,
+  publishToLens
 }: {
+  publishToLens?: boolean;
+  setPublishToLens?: (publishToLens: boolean) => void;
+  showPublishToLens?: boolean;
   inlineCharmEditor?: boolean;
   initialValue?: ICharmEditorOutput;
   handleCreateComment: (comment: CommentContent) => Promise<void>;
@@ -88,16 +94,19 @@ export function CommentForm({
         <UserDisplay user={user} hideName={true} />
         {editor}
       </Box>
-      <Button
-        data-test='post-comment-button'
-        sx={{
-          alignSelf: 'flex-end'
-        }}
-        disabled={!postContent.rawText || disabled}
-        onClick={createPostComment}
-      >
-        Comment
-      </Button>
+      <Stack flexDirection='row' justifyContent={showPublishToLens ? 'space-between' : 'flex-end'}>
+        {showPublishToLens && (
+          <Stack flexDirection='row' gap={1} alignItems='center'>
+            <Typography variant='caption' color='text.secondary'>
+              Publish to Lens
+            </Typography>
+            <Switch size='small' checked={publishToLens} onChange={(e) => setPublishToLens?.(e.target.checked)} />
+          </Stack>
+        )}
+        <Button data-test='post-comment-button' disabled={!postContent.rawText || disabled} onClick={createPostComment}>
+          Comment
+        </Button>
+      </Stack>
     </Stack>
   );
 }


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
* Fixed publish to lens proposal properties to show the correct value
* Only publish a proposal to lens if it hasn't already been published (feedback -> draft -> feedback)
* Auto-connect lens profile during publishing post and comments to Lens if the lens profile is not foind
* Separate publish to lens button for proposal comments
