### PR TITLE
Fix CSV import bugs

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions/useSourceOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions/useSourceOptions.tsx
@@ -111,7 +111,7 @@ export function useSourceOptions({ rootBoard, showView, activeView }: Props) {
             showMessage('Importing your csv file...', 'info');
 
             try {
-              const view = await onCreateDatabase({ sourceType: 'board_page' });
+              const view = activeView ?? (await onCreateDatabase({ sourceType: 'board_page' }));
               await addNewCards({
                 board: rootBoard,
                 members,
@@ -127,8 +127,10 @@ export function useSourceOptions({ rootBoard, showView, activeView }: Props) {
               showMessage('Your csv file was imported successfully', 'success');
             } catch (error) {
               log.error('CSV import failed', { spaceId, pageId, error });
-              showMessage((error as Error).message || 'Import failed', 'error');
+              showMessage((error as Error).message || 'There was an error importing your csv file.', 'warning');
             }
+          } else {
+            showMessage('There was an error importing your csv file.', 'warning');
           }
         }
       });

--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions/viewSourceOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions/viewSourceOptions.tsx
@@ -158,7 +158,19 @@ export function ViewSourceOptions(props: ViewSourceOptionsProps) {
 
             {allowedSourceOptions.includes('csv') && (
               <SourceType active={false} component='label' htmlFor='dbcsvfile'>
-                <input hidden type='file' id='dbcsvfile' name='dbcsvfile' accept='.csv' onChange={onCsvImport} />
+                <input
+                  hidden
+                  type='file'
+                  id='dbcsvfile'
+                  name='dbcsvfile'
+                  accept='.csv'
+                  onChange={(event) => {
+                    if (event.target.files && event.target.files[0]) {
+                      onCsvImport(event);
+                    }
+                    event.target.value = '';
+                  }}
+                />
                 <BsFiletypeCsv style={{ fontSize: 24 }} />
                 Import CSV
               </SourceType>

--- a/components/common/PageActions/utils/databasePageOptions.ts
+++ b/components/common/PageActions/utils/databasePageOptions.ts
@@ -309,8 +309,10 @@ export function transformApiPageKeysCsvData(
 export function transformCsvResults(results: ParseResult<Record<string, string>>, customTitle?: string) {
   const csvData = results.data.map((csvRow) => {
     const [key, value] = Object.entries(csvRow)[0];
-    csvRow[titleColumnName] = customTitle || value;
-    delete csvRow[key];
+    if (key !== titleColumnName) {
+      csvRow[titleColumnName] = customTitle || value;
+      delete csvRow[key];
+    }
     return csvRow;
   });
   const headers = results.meta.fields || [];


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 158739c</samp>

This pull request improves the CSV import feature for `focalboard` views in `app.charmverse.io`. It allows importing CSV files into existing views, fixes a bug with multiple imports, and preserves the original title column of the CSV data.

### WHY
Fix multiple issues on CSV import

1. If the column was called "Title" it was ignored
2. If using "import CSV" after a database already exists, it would create a new view
3. If reimporting the CSV file, nothing would happen