### PR TITLE
Fix page permission row UI

### DIFF
--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/PagePermissionRow.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/PagePermissionRow.tsx
@@ -4,7 +4,7 @@ import type {
   AssignedPagePermission,
   PagePermissionAssignmentByValues
 } from '@charmverse/core/permissions';
-import { Box } from '@mui/material';
+import { Box, Tooltip } from '@mui/material';
 
 import { SmallSelect } from 'components/common/form/InputEnumToOptions';
 import { Typography } from 'components/common/Typography';
@@ -69,8 +69,15 @@ export function PagePermissionRow({ assignee, editable, onChange, onDelete, exis
   return (
     <Box display='block'>
       <Box display='flex' justifyContent='space-between' alignItems='center'>
-        <Typography variant='body2'>{assigneeLabel}</Typography>
-        {isGuest && <GuestChip />}
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+          {/** Only show the tooltip for very long names */}
+          <Tooltip title={assigneeLabel && assigneeLabel.length > 22 ? assigneeLabel : ''}>
+            <Typography sx={{ maxWidth: '190px', textOverflow: 'ellipsis', overflowX: 'hidden' }} variant='body2'>
+              {assigneeLabel}
+            </Typography>
+          </Tooltip>
+          {isGuest && <GuestChip />}
+        </div>
         <div style={{ width: '160px', textAlign: 'right' }}>
           <SmallSelect
             renderValue={(value) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ebc2a0</samp>

Improved the UI and UX of the share button feature by adding tooltips for long assignee names in `PagePermissionRow.tsx`.

### WHY
**Before**
Long names in permissions would overflow
<img width="357" alt="Screenshot 2023-08-25 at 18 31 52" src="https://github.com/charmverse/app.charmverse.io/assets/18669748/37154329-c522-4728-947e-36c58fd7752f">


**After**
Name cuts off, we show the full name in a tooltip, but tooltip only shows for longer names

<img width="410" alt="Screenshot 2023-08-25 at 18 48 07" src="https://github.com/charmverse/app.charmverse.io/assets/18669748/c31e0640-6413-4183-9f10-937230b9be7d">

