### PR TITLE
fix state of page titles in editor

### DIFF
--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -56,11 +56,11 @@ export default function NestedPage({ node, currentPageId, getPos }: NodeViewProp
 
   let pageTitle = '';
   if (documentPage || staticPage) {
-    pageTitle = (documentPage || staticPage)?.title || '';
+    pageTitle = (documentPage || staticPage)?.title || 'Untitled';
+  } else if (forumCategoryPage) {
+    pageTitle = `Forum > ${forumCategoryPage?.name || 'Untitled'}`;
   } else if (!loadingPages) {
     pageTitle = 'No access';
-  } else if (forumCategoryPage) {
-    pageTitle = `Forum > ${forumCategoryPage?.name}`;
   }
   const pageId = documentPage?.id || staticPage?.path || forumCategoryPage?.id;
 
@@ -95,7 +95,7 @@ export default function NestedPage({ node, currentPageId, getPos }: NodeViewProp
           isCategoryPage={!!forumCategoryPage}
         />
       </div>
-      <StyledTypography>{pageTitle || 'Untitled'}</StyledTypography>
+      <StyledTypography>{pageTitle}</StyledTypography>
     </NestedPageContainer>
   );
 }

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -46,7 +46,7 @@ const StyledTypography = styled(Typography)`
 export default function NestedPage({ node, currentPageId, getPos }: NodeViewProps & { currentPageId?: string }) {
   const { space } = useCurrentSpace();
   const view = useEditorViewContext();
-  const { pages } = usePages();
+  const { pages, loadingPages } = usePages();
   const { categories } = useForumCategories();
   const documentPage = pages[node.attrs.id];
   const staticPage = STATIC_PAGES.find((c) => c.path === node.attrs.path && node.attrs.type === c.path);
@@ -54,8 +54,14 @@ export default function NestedPage({ node, currentPageId, getPos }: NodeViewProp
 
   const parentPage = documentPage?.parentId ? pages[documentPage.parentId] : null;
 
-  const pageTitle =
-    (documentPage || staticPage)?.title || (forumCategoryPage ? `Forum > ${forumCategoryPage?.name}` : '');
+  let pageTitle = '';
+  if (documentPage || staticPage) {
+    pageTitle = (documentPage || staticPage)?.title || '';
+  } else if (!loadingPages) {
+    pageTitle = 'No access';
+  } else if (forumCategoryPage) {
+    pageTitle = `Forum > ${forumCategoryPage?.name}`;
+  }
   const pageId = documentPage?.id || staticPage?.path || forumCategoryPage?.id;
 
   const pagePath = documentPage ? `${space?.domain}/${documentPage.path}` : '';
@@ -89,7 +95,7 @@ export default function NestedPage({ node, currentPageId, getPos }: NodeViewProp
           isCategoryPage={!!forumCategoryPage}
         />
       </div>
-      <StyledTypography>{typeof pageTitle === 'string' ? pageTitle || 'Untitled' : 'No access'}</StyledTypography>
+      <StyledTypography>{pageTitle || 'Untitled'}</StyledTypography>
     </NestedPageContainer>
   );
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59b34b1</samp>

Enhanced the user experience of editing nested pages in the `CharmEditor` component. Fixed the page title display and added a loading indicator for the `NestedPage` component.

### WHY
<!-- author to complete -->
