### PR TITLE
Add tooltip when proposal props are disabled due to template

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -142,6 +142,7 @@ export function ProposalProperties({
       proposalLensLink={proposal?.lensPostLink ?? undefined}
       archived={!!proposal?.archived}
       disabledCategoryInput={!proposalPermissions?.edit || !!proposal?.page?.sourceTemplateId}
+      isFromTemplate={!!proposal?.page?.sourceTemplateId}
       proposalFlowFlags={proposalFlowFlags}
       proposalStatus={proposal?.status}
       proposalId={proposal?.id}

--- a/components/common/BoardEditor/components/properties/TagSelect/TagSelect.tsx
+++ b/components/common/BoardEditor/components/properties/TagSelect/TagSelect.tsx
@@ -90,6 +90,7 @@ const StyledSelect = styled(SelectField)<ContainerProps>`
 
 type Props = {
   readOnly?: boolean;
+  readOnlyMessage?: string;
   canEditOptions?: boolean; // TODO: allow editing options
   multiselect?: boolean;
   noOptionsText?: string;
@@ -106,6 +107,7 @@ type Props = {
 
 export function TagSelect({
   readOnly,
+  readOnlyMessage,
   canEditOptions = false,
   options,
   propertyValue,
@@ -171,6 +173,7 @@ export function TagSelect({
       <SelectPreviewContainer data-test={dataTest} onClick={onEdit} displayType={displayType} readOnly={readOnly}>
         <SelectPreview
           readOnly={readOnly}
+          readOnlyMessage={readOnlyMessage}
           sx={{ height: '100%' }}
           wrapColumn={wrapColumn}
           value={selectValue}

--- a/components/common/BoardEditor/components/properties/TextInput.tsx
+++ b/components/common/BoardEditor/components/properties/TextInput.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { InputBase } from '@mui/material';
+import { InputBase, Tooltip } from '@mui/material';
 import React, { forwardRef, useRef } from 'react';
 
 import type { PropertyValueDisplayType } from 'components/common/BoardEditor/interfaces';
@@ -11,6 +11,7 @@ import { useEditable } from '../../focalboard/src/widgets/editable';
 export type TextInputProps = EditableProps & {
   multiline?: boolean;
   displayType?: PropertyValueDisplayType;
+  readOnlyMessage?: string;
   fullWidth?: boolean;
   wrapColumn?: boolean;
   columnRef?: React.RefObject<HTMLDivElement>;
@@ -44,7 +45,17 @@ const StyledInput = styled(InputBase)`
 `;
 
 function Editable(
-  { multiline, columnRef, wrapColumn, displayType, fullWidth = true, sx, inputProps = {}, ..._props }: TextInputProps,
+  {
+    multiline,
+    columnRef,
+    wrapColumn,
+    displayType,
+    fullWidth = true,
+    sx,
+    inputProps = {},
+    readOnlyMessage,
+    ..._props
+  }: TextInputProps,
   ref: React.Ref<Focusable>
 ): JSX.Element {
   _props.className = 'octo-propertyvalue';
@@ -60,16 +71,18 @@ function Editable(
   // Keep it as before for card modal view
   if (displayType === 'details') {
     return (
-      <StyledInput
-        inputProps={{
-          ...inputProps,
-          className
-        }}
-        fullWidth={fullWidth}
-        sx={sx}
-        {...props}
-        multiline={multiline}
-      />
+      <Tooltip title={readOnlyMessage}>
+        <StyledInput
+          inputProps={{
+            ...inputProps,
+            className
+          }}
+          fullWidth={fullWidth}
+          sx={sx}
+          {...props}
+          multiline={multiline}
+        />
+      </Tooltip>
     );
   }
 

--- a/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
+++ b/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import CloseIcon from '@mui/icons-material/Close';
-import { Alert, Autocomplete, Box, Chip, IconButton, Stack, TextField } from '@mui/material';
+import { Alert, Autocomplete, Box, Chip, IconButton, Stack, TextField, Tooltip } from '@mui/material';
 import { useCallback, useMemo, useState } from 'react';
 
 import { useGetReviewerPool } from 'charmClient/hooks/proposals';
@@ -124,6 +124,7 @@ type Props = {
   onChange: (value: GroupedOptionPopulated[]) => void;
   proposalCategoryId?: string | null;
   readOnly?: boolean;
+  readOnlyMessage?: string;
   showEmptyPlaceholder?: boolean;
   value: GroupedOption[];
   variant?: 'outlined' | 'standard';
@@ -135,6 +136,7 @@ export function UserAndRoleSelect({
   onChange,
   proposalCategoryId,
   readOnly,
+  readOnlyMessage,
   showEmptyPlaceholder = true,
   variant = 'standard',
   value: inputValue,
@@ -226,7 +228,9 @@ export function UserAndRoleSelect({
           {applicableValues.length === 0 ? (
             showEmptyPlaceholder && <EmptyPlaceholder>Empty</EmptyPlaceholder>
           ) : (
-            <SelectedReviewers wrapColumn readOnly value={populatedValue} onRemove={removeReviewer} />
+            <Tooltip title={readOnlyMessage}>
+              <SelectedReviewers wrapColumn readOnly value={populatedValue} onRemove={removeReviewer} />
+            </Tooltip>
           )}
         </Stack>
       </SelectPreviewContainer>

--- a/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
+++ b/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
@@ -59,63 +59,73 @@ const StyledUserPropertyContainer = styled(Box, {
 function SelectedReviewers({
   value,
   readOnly,
+  readOnlyMessage,
   onRemove,
   wrapColumn
 }: {
   wrapColumn: boolean;
   readOnly: boolean;
+  readOnlyMessage?: string;
   value: GroupedOptionPopulated[];
   onRemove: (reviewerId: string) => void;
 }) {
   return (
-    <Stack flexDirection='row' gap={1} flexWrap={wrapColumn ? 'wrap' : 'nowrap'}>
-      {value.map((reviewer) => {
-        return (
-          <Stack
-            alignItems='center'
-            flexDirection='row'
-            key={reviewer.id}
-            gap={0.5}
-            sx={wrapColumn ? { justifyContent: 'space-between', overflowX: 'hidden' } : { overflowX: 'hidden' }}
-          >
-            {reviewer.group === 'user' && (
-              <>
-                <UserDisplay fontSize={14} avatarSize='xSmall' user={reviewer} wrapName={wrapColumn} />
-                {!readOnly && (
-                  <IconButton size='small' onClick={() => onRemove(reviewer.id)}>
+    <Tooltip title={readOnlyMessage}>
+      <Stack
+        display='inline-flex'
+        width='min-content'
+        flexDirection='row'
+        gap={1}
+        flexWrap={wrapColumn ? 'wrap' : 'nowrap'}
+      >
+        {value.map((reviewer) => {
+          return (
+            <Stack
+              alignItems='center'
+              flexDirection='row'
+              key={reviewer.id}
+              gap={0.5}
+              sx={wrapColumn ? { justifyContent: 'space-between', overflowX: 'hidden' } : { overflowX: 'hidden' }}
+            >
+              {reviewer.group === 'user' && (
+                <>
+                  <UserDisplay fontSize={14} avatarSize='xSmall' user={reviewer} wrapName={wrapColumn} />
+                  {!readOnly && (
+                    <IconButton size='small' onClick={() => onRemove(reviewer.id)}>
+                      <CloseIcon
+                        sx={{
+                          fontSize: 14
+                        }}
+                        cursor='pointer'
+                        color='secondary'
+                      />
+                    </IconButton>
+                  )}
+                </>
+              )}
+              {reviewer.group === 'role' && (
+                <Chip
+                  sx={{ px: 0.5, cursor: readOnly ? 'text' : 'pointer' }}
+                  label={reviewer.name}
+                  // color={reviewer.color}
+                  key={reviewer.id}
+                  size='small'
+                  onDelete={readOnly ? undefined : () => onRemove(reviewer.id)}
+                  deleteIcon={
                     <CloseIcon
                       sx={{
                         fontSize: 14
                       }}
                       cursor='pointer'
-                      color='secondary'
                     />
-                  </IconButton>
-                )}
-              </>
-            )}
-            {reviewer.group === 'role' && (
-              <Chip
-                sx={{ px: 0.5, cursor: readOnly ? 'text' : 'pointer' }}
-                label={reviewer.name}
-                // color={reviewer.color}
-                key={reviewer.id}
-                size='small'
-                onDelete={readOnly ? undefined : () => onRemove(reviewer.id)}
-                deleteIcon={
-                  <CloseIcon
-                    sx={{
-                      fontSize: 14
-                    }}
-                    cursor='pointer'
-                  />
-                }
-              />
-            )}
-          </Stack>
-        );
-      })}
-    </Stack>
+                  }
+                />
+              )}
+            </Stack>
+          );
+        })}
+      </Stack>
+    </Tooltip>
   );
 }
 
@@ -228,9 +238,13 @@ export function UserAndRoleSelect({
           {applicableValues.length === 0 ? (
             showEmptyPlaceholder && <EmptyPlaceholder>Empty</EmptyPlaceholder>
           ) : (
-            <Tooltip title={readOnlyMessage}>
-              <SelectedReviewers wrapColumn readOnly value={populatedValue} onRemove={removeReviewer} />
-            </Tooltip>
+            <SelectedReviewers
+              readOnlyMessage={readOnlyMessage}
+              wrapColumn
+              readOnly
+              value={populatedValue}
+              onRemove={removeReviewer}
+            />
           )}
         </Stack>
       </SelectPreviewContainer>

--- a/components/common/form/fields/Select/SelectPreview.tsx
+++ b/components/common/form/fields/Select/SelectPreview.tsx
@@ -1,5 +1,5 @@
 import type { SxProps } from '@mui/material';
-import { Chip, Stack, Typography } from '@mui/material';
+import { Chip, Stack, Tooltip, Typography } from '@mui/material';
 
 import { EmptyPlaceholder } from 'components/common/BoardEditor/components/properties/EmptyPlaceholder';
 import type { SelectOptionType } from 'components/common/form/fields/Select/interfaces';
@@ -12,10 +12,21 @@ type Props = {
   showEmpty?: boolean;
   wrapColumn?: boolean;
   readOnly?: boolean;
+  readOnlyMessage?: string;
   sx?: SxProps;
 };
 
-export function SelectPreview({ sx, wrapColumn, value, options = [], name, size, readOnly, showEmpty }: Props) {
+export function SelectPreview({
+  sx,
+  wrapColumn,
+  value,
+  options = [],
+  name,
+  size,
+  readOnly,
+  readOnlyMessage,
+  showEmpty
+}: Props) {
   const values: string[] = Array.isArray(value) ? value : [value].filter(Boolean);
   const valueOptions = values
     .map((v) => options?.find((o) => (o as SelectOptionType).id === v))
@@ -27,19 +38,21 @@ export function SelectPreview({ sx, wrapColumn, value, options = [], name, size,
           {name}
         </Typography>
       )}
-      <Stack gap={0.5} flexDirection='row' flexWrap={wrapColumn ? 'wrap' : 'nowrap'} overflow='hidden'>
-        {valueOptions.length !== 0
-          ? valueOptions.map((valueOption) => (
-              <Chip
-                sx={{ px: 0.5, cursor: readOnly ? 'text' : 'pointer' }}
-                label={valueOption.name}
-                color={valueOption.color}
-                key={valueOption.name}
-                size='small'
-              />
-            ))
-          : showEmpty && <EmptyPlaceholder>Empty</EmptyPlaceholder>}
-      </Stack>
+      <Tooltip title={readOnlyMessage}>
+        <Stack gap={0.5} flexDirection='row' flexWrap={wrapColumn ? 'wrap' : 'nowrap'} overflow='hidden'>
+          {valueOptions.length !== 0
+            ? valueOptions.map((valueOption) => (
+                <Chip
+                  sx={{ px: 0.5, cursor: readOnly ? 'text' : 'pointer' }}
+                  label={valueOption.name}
+                  color={valueOption.color}
+                  key={valueOption.name}
+                  size='small'
+                />
+              ))
+            : showEmpty && <EmptyPlaceholder>Empty</EmptyPlaceholder>}
+        </Stack>
+      </Tooltip>
     </Stack>
   );
 }

--- a/components/common/form/fields/Select/SelectPreview.tsx
+++ b/components/common/form/fields/Select/SelectPreview.tsx
@@ -39,7 +39,14 @@ export function SelectPreview({
         </Typography>
       )}
       <Tooltip title={readOnlyMessage}>
-        <Stack gap={0.5} flexDirection='row' flexWrap={wrapColumn ? 'wrap' : 'nowrap'} overflow='hidden'>
+        <Stack
+          display='inline-flex'
+          width='min-content'
+          gap={0.5}
+          flexDirection='row'
+          flexWrap={wrapColumn ? 'wrap' : 'nowrap'}
+          overflow='hidden'
+        >
           {valueOptions.length !== 0
             ? valueOptions.map((valueOption) => (
                 <Chip

--- a/components/proposals/components/NewProposalButton.tsx
+++ b/components/proposals/components/NewProposalButton.tsx
@@ -1,11 +1,9 @@
-import type { ProposalWithUsers } from '@charmverse/core/proposals';
 import { KeyboardArrowDown } from '@mui/icons-material';
 import type { Theme } from '@mui/material';
 import { Box, ButtonGroup, Tooltip, useMediaQuery } from '@mui/material';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useRouter } from 'next/router';
 import { useRef } from 'react';
-import type { KeyedMutator } from 'swr';
 
 import charmClient from 'charmClient';
 import { Button } from 'components/common/Button';
@@ -15,6 +13,7 @@ import { useIsAdmin } from 'hooks/useIsAdmin';
 import { usePages } from 'hooks/usePages';
 import type { PageContent } from 'lib/prosemirror/interfaces';
 import { setUrlWithoutRerender } from 'lib/utilities/browser';
+import { isTruthy } from 'lib/utilities/types';
 
 import { useProposalCategories } from '../hooks/useProposalCategories';
 import { useProposalTemplates } from '../hooks/useProposalTemplates';
@@ -27,7 +26,7 @@ export function NewProposalButton() {
   const { showProposal } = useProposalDialog();
   const { proposalCategoriesWithCreatePermission, getDefaultCreateCategory } = useProposalCategories();
   const isAdmin = useIsAdmin();
-  const { mutatePage } = usePages();
+  const { pages, mutatePage } = usePages();
   const isXsScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
 
   // MUI Menu specific content
@@ -37,7 +36,8 @@ export function NewProposalButton() {
   const { proposalTemplates, deleteProposalTemplate, isLoadingTemplates } = useProposalTemplates();
 
   const canCreateProposal = proposalCategoriesWithCreatePermission.length > 0;
-  const proposalTemplatePages = proposalTemplates?.map((template) => template.page);
+  // grab page data from context so that title is always up-to-date
+  const proposalTemplatePages = proposalTemplates?.map((template) => pages[template.page.id]).filter(isTruthy);
 
   async function createProposalFromTemplate(templateId: string) {
     const proposalTemplate = proposalTemplates?.find((proposal) => proposal.id === templateId);

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -186,6 +186,7 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
               <div className='focalboard-body font-family-default'>
                 <div className='CardDetail content'>
                   <ProposalProperties
+                    isFromTemplate={isFromTemplateSource}
                     readOnlyRubricCriteria={isFromTemplateSource}
                     readOnlyReviewers={readOnlyReviewers}
                     readOnlyProposalEvaluationType={isFromTemplateSource}

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -135,8 +135,6 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
   let disabledTooltip = '';
   if (!formInputs.title) {
     disabledTooltip = 'Title is required';
-  } else if (checkIsContentEmpty(formInputs.content)) {
-    disabledTooltip = 'Content is required';
   } else if (!formInputs.categoryId) {
     disabledTooltip = 'Category is required';
   } else if (currentSpace?.requireProposalTemplate && !formInputs.proposalTemplateId) {

--- a/components/proposals/components/ProposalProperties/ProposalProperties.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalProperties.tsx
@@ -60,6 +60,7 @@ type ProposalPropertiesProps = {
   canAnswerRubric?: boolean;
   canViewRubricAnswers?: boolean;
   disabledCategoryInput?: boolean;
+  isFromTemplate?: boolean;
   onChangeRubricCriteria: (criteria: RangeProposalCriteria[]) => void;
   onChangeRubricCriteriaAnswer?: () => void;
   pageId?: string;
@@ -87,6 +88,7 @@ export function ProposalProperties({
   canAnswerRubric,
   canViewRubricAnswers,
   disabledCategoryInput,
+  isFromTemplate,
   onChangeRubricCriteria,
   onChangeRubricCriteriaAnswer,
   proposalFormInputs,
@@ -334,7 +336,8 @@ export function ProposalProperties({
               <PropertyLabel readOnly>Category</PropertyLabel>
               <Box display='flex' flex={1}>
                 <ProposalCategorySelect
-                  disabled={disabledCategoryInput}
+                  readOnly={disabledCategoryInput}
+                  readOnlyMessage={isFromTemplate ? 'Cannot change category when using template' : undefined}
                   options={proposalCategoriesWithCreatePermission || []}
                   value={proposalCategory ?? null}
                   onChange={onChangeCategory}
@@ -401,6 +404,7 @@ export function ProposalProperties({
               <PropertyLabel readOnly>Reviewer</PropertyLabel>
               <UserAndRoleSelect
                 data-test='proposal-reviewer-select'
+                readOnlyMessage={isFromTemplate ? 'Cannot change category when using template' : undefined}
                 readOnly={readOnlyReviewers}
                 value={proposalReviewers}
                 proposalCategoryId={proposalFormInputs.categoryId}

--- a/components/proposals/components/ProposalProperties/ProposalProperties.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalProperties.tsx
@@ -404,7 +404,7 @@ export function ProposalProperties({
               <PropertyLabel readOnly>Reviewer</PropertyLabel>
               <UserAndRoleSelect
                 data-test='proposal-reviewer-select'
-                readOnlyMessage={isFromTemplate ? 'Cannot change category when using template' : undefined}
+                readOnlyMessage={isFromTemplate ? 'Cannot change reviewers when using template' : undefined}
                 readOnly={readOnlyReviewers}
                 value={proposalReviewers}
                 proposalCategoryId={proposalFormInputs.categoryId}
@@ -422,7 +422,8 @@ export function ProposalProperties({
             <Box display='flex' height='fit-content' flex={1} className='octo-propertyrow'>
               <PropertyLabel readOnly>Type</PropertyLabel>
               <ProposalEvaluationTypeSelect
-                disabled={readOnlyProposalEvaluationType}
+                readOnly={readOnlyProposalEvaluationType}
+                readOnlyMessage={isFromTemplate ? 'Cannot change evaluation type when using template' : undefined}
                 value={proposalFormInputs.evaluationType}
                 onChange={(evaluationType) => {
                   setProposalFormInputs({
@@ -490,6 +491,7 @@ export function ProposalProperties({
                 <Box display='flex' flex={1} flexDirection='column'>
                   <ProposalRubricCriteriaInput
                     readOnly={readOnlyRubricCriteria}
+                    readOnlyMessage={isFromTemplate ? 'Cannot change rubric criteria when using template' : undefined}
                     value={proposalFormInputs.rubricCriteria}
                     onChange={onChangeRubricCriteria}
                     proposalStatus={proposalStatus}

--- a/components/proposals/components/ProposalProperties/components/ProposalCategorySelect.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalCategorySelect.tsx
@@ -2,13 +2,14 @@ import { TagSelect } from 'components/common/BoardEditor/components/properties/T
 import type { ProposalCategory } from 'lib/proposal/interface';
 
 type Props = {
-  disabled?: boolean;
+  readOnly?: boolean;
+  readOnlyMessage?: string;
   options: ProposalCategory[];
   value: ProposalCategory | null;
   onChange: (value: ProposalCategory | null) => void;
 };
 
-export function ProposalCategorySelect({ disabled, options, value, onChange }: Props) {
+export function ProposalCategorySelect({ readOnly, readOnlyMessage, options, value, onChange }: Props) {
   const propertyOptions = options.map((option) => ({
     id: option.id,
     value: option.title,
@@ -30,7 +31,8 @@ export function ProposalCategorySelect({ disabled, options, value, onChange }: P
     <TagSelect
       data-test='proposal-category-select'
       wrapColumn
-      readOnly={disabled}
+      readOnly={readOnly}
+      readOnlyMessage={readOnlyMessage}
       options={propertyOptions}
       propertyValue={propertyValue}
       onChange={onValueChange}

--- a/components/proposals/components/ProposalProperties/components/ProposalEvaluationTypeSelect.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalEvaluationTypeSelect.tsx
@@ -4,7 +4,8 @@ import { TagSelect } from 'components/common/BoardEditor/components/properties/T
 import type { IPropertyOption } from 'lib/focalboard/board';
 
 type Props = {
-  disabled?: boolean;
+  readOnly?: boolean;
+  readOnlyMessage?: string;
   value: ProposalEvaluationType;
   onChange: (value: ProposalEvaluationType) => void;
 };
@@ -22,7 +23,7 @@ const options: IPropertyOption<ProposalEvaluationType>[] = [
   }
 ];
 
-export function ProposalEvaluationTypeSelect({ disabled, value, onChange }: Props) {
+export function ProposalEvaluationTypeSelect({ readOnly, readOnlyMessage, value, onChange }: Props) {
   function onValueChange(values: string | string[]) {
     const newValue = Array.isArray(values) ? values[0] : values;
     if (newValue) {
@@ -30,5 +31,14 @@ export function ProposalEvaluationTypeSelect({ disabled, value, onChange }: Prop
     }
   }
 
-  return <TagSelect wrapColumn readOnly={disabled} options={options} propertyValue={value} onChange={onValueChange} />;
+  return (
+    <TagSelect
+      wrapColumn
+      readOnly={readOnly}
+      readOnlyMessage={readOnlyMessage}
+      options={options}
+      propertyValue={value}
+      onChange={onValueChange}
+    />
+  );
 }

--- a/components/proposals/components/ProposalProperties/components/ProposalRubricCriteriaInput.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalRubricCriteriaInput.tsx
@@ -23,6 +23,7 @@ export type RangeProposalCriteria = {
 
 type Props = {
   readOnly?: boolean;
+  readOnlyMessage?: string;
   proposalStatus?: ProposalStatus;
   value: RangeProposalCriteria[];
   onChange: (criteria: RangeProposalCriteria[]) => void;
@@ -55,7 +56,14 @@ export const CriteriaRow = styled(Box)`
   }
 `;
 
-export function ProposalRubricCriteriaInput({ readOnly, value, onChange, proposalStatus, answers }: Props) {
+export function ProposalRubricCriteriaInput({
+  readOnly,
+  readOnlyMessage,
+  value,
+  onChange,
+  proposalStatus,
+  answers
+}: Props) {
   const [criteriaList, setCriteriaList] = useState<RangeProposalCriteria[]>([]);
 
   const [rubricCriteriaIdToDelete, setRubricCriteriaIdToDelete] = useState<string | null>(null);
@@ -142,6 +150,7 @@ export function ProposalRubricCriteriaInput({ readOnly, value, onChange, proposa
                   onChange={(title) => setCriteriaProperty(criteria.id, { title })}
                   placeholderText='Add a label...'
                   readOnly={readOnly}
+                  readOnlyMessage={readOnlyMessage}
                   value={criteria.title}
                 />
                 <TextInput
@@ -164,6 +173,7 @@ export function ProposalRubricCriteriaInput({ readOnly, value, onChange, proposa
                             });
                           }}
                           readOnly={readOnly}
+                          readOnlyMessage={readOnlyMessage}
                           value={criteria.parameters.min}
                         />
                         <Typography
@@ -189,6 +199,7 @@ export function ProposalRubricCriteriaInput({ readOnly, value, onChange, proposa
                             });
                           }}
                           readOnly={readOnly}
+                          readOnlyMessage={readOnlyMessage}
                           value={criteria.parameters.max}
                         />
                         <Typography
@@ -242,6 +253,7 @@ export function IntegerInput({
   value,
   onChange,
   readOnly,
+  readOnlyMessage,
   inputProps,
   maxWidth,
   sx
@@ -249,6 +261,7 @@ export function IntegerInput({
   value?: number | string | null;
   onChange: (num: number | null) => void;
   readOnly?: boolean;
+  readOnlyMessage?: string;
   inputProps?: any;
   maxWidth?: number;
   sx?: any;
@@ -260,6 +273,7 @@ export function IntegerInput({
       inputProps={{ type: 'number', ...inputProps }}
       onChange={(newValue) => onChange(getNumberFromString(newValue))}
       readOnly={readOnly}
+      readOnlyMessage={readOnlyMessage}
       sx={{
         input: { textAlign: 'center', minWidth: '2.5em !important', maxWidth },
         ...sx

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -325,6 +325,7 @@ export const createThemeLightSensitive = (mode: PaletteMode) => {
       MuiTooltip: {
         defaultProps: {
           arrow: true,
+          enterDelay: 1000,
           placement: 'top'
         }
       },


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6090c81</samp>

This pull request adds tooltips to various components in the app to improve the user feedback and experience when they are in read-only mode. It also makes some minor improvements to the proposal creation and rendering logic. The main components affected are `TagSelect`, `TextInput`, `UserAndRoleSelect`, `SelectPreview`, `NewProposalButton`, `NewProposalPage`, `ProposalCategorySelect`, `ProposalEvaluationTypeSelect`, `ProposalRubricCriteriaInput`, and `ProposalProperties`. The files modified are `components/common/BoardEditor/components/properties/TagSelect/TagSelect.tsx`, `components/common/BoardEditor/components/properties/TextInput.tsx`, `components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx`, `components/common/form/fields/Select/SelectPreview.tsx`, `components/proposals/components/NewProposalButton.tsx`, `components/proposals/components/ProposalDialog/NewProposalPage.tsx`, `components/proposals/components/ProposalProperties/components/ProposalCategorySelect.tsx`, `components/proposals/components/ProposalProperties/components/ProposalEvaluationTypeSelect.tsx`, `components/proposals/components/ProposalProperties/components/ProposalRubricCriteriaInput.tsx`, `components/proposals/components/ProposalProperties/ProposalProperties.tsx`, `components/[pageId]/DocumentPage/components/ProposalProperties.tsx`, and `theme/index.ts`.

### WHY
<!-- author to complete -->
