### PR TITLE
Add links to email notifications

### DIFF
--- a/lib/emails/templates/PendingTasks.tsx
+++ b/lib/emails/templates/PendingTasks.tsx
@@ -260,9 +260,12 @@ function VoteTaskMjml({ task }: { task: VoteTask }) {
   const pageWorkspaceTitle = `${task.pageTitle} | ${task.spaceName}`;
   return (
     <MjmlText>
-      <div style={{ fontWeight: 'bold', marginBottom: 5 }}>
+      <a
+        href={`${charmverseUrl}/${task.spaceDomain}/${task.pagePath}`}
+        style={{ fontWeight: 'bold', marginBottom: 5, display: 'block', color: 'inherit' }}
+      >
         {task.title.length > MAX_CHAR ? `${task.title.slice(0, MAX_CHAR)}...` : task.title}
-      </div>
+      </a>
       <div
         style={{
           fontSize: 16,
@@ -350,13 +353,16 @@ function BountyTaskMjml({ task }: { task: BountyTask }) {
   );
 }
 
-function DiscussionTask({ task: { text, spaceName, pageTitle } }: { task: DiscussionTask }) {
+function DiscussionTask({ task: { text, spaceName, pageTitle, pagePath, spaceDomain } }: { task: DiscussionTask }) {
   const pageWorkspaceTitle = `${pageTitle || 'Untitled'} | ${spaceName}`;
   return (
     <MjmlText>
-      <div style={{ fontWeight: 'bold', marginBottom: 5 }}>
+      <a
+        href={`${charmverseUrl}/${spaceDomain}/${pagePath}`}
+        style={{ fontWeight: 'bold', marginBottom: 5, display: 'block', color: 'inherit' }}
+      >
         {text.length > MAX_CHAR ? `${text.slice(0, MAX_CHAR)}...` : text}
-      </div>
+      </a>
       <div
         style={{
           fontSize: 16,
@@ -371,13 +377,16 @@ function DiscussionTask({ task: { text, spaceName, pageTitle } }: { task: Discus
   );
 }
 
-function ForumTask({ task: { commentText, spaceName, postTitle } }: { task: ForumTask }) {
+function ForumTask({ task: { commentText, spaceName, spaceDomain, postPath, postTitle } }: { task: ForumTask }) {
   const pageWorkspaceTitle = `${postTitle || 'Untitled'} | ${spaceName}`;
   return (
     <MjmlText>
-      <div style={{ fontWeight: 'bold', marginBottom: 5 }}>
+      <a
+        href={`${charmverseUrl}/${spaceDomain}/forum/post/${postPath}`}
+        style={{ fontWeight: 'bold', marginBottom: 5, display: 'block', color: 'inherit' }}
+      >
         {commentText.length > MAX_CHAR ? `${commentText.slice(0, MAX_CHAR)}...` : commentText || 'New Post'}
-      </div>
+      </a>
       <div
         style={{
           fontSize: 16,

--- a/pages/api/email-templates/index.ts
+++ b/pages/api/email-templates/index.ts
@@ -70,7 +70,7 @@ const createForumTask = ({
     spaceName,
     postId: v4(),
     postTitle,
-    postPath: `/forum/post/${getPagePath()}`,
+    postPath: getPagePath(),
     commentText,
     commentId: v4(),
     createdAt: new Date().toISOString(),
@@ -109,7 +109,11 @@ const createVoteTasks = ({
     } as any,
     pageId: v4(),
     spaceId: v4(),
-    title: voteTitle
+    title: voteTitle,
+    pageTitle,
+    spaceName,
+    pagePath: getPagePath(),
+    spaceDomain: randomName()
   } as any;
 };
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dc5850b</samp>

Updated email templates and API functions to generate and display links to app pages for pending tasks. This makes the emails more informative and interactive for the users.

### WHY
[Task](https://app.charmverse.io/charmverse/page-21130249087699737)
