### PR TITLE
dont override random build id from next

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -52,9 +52,6 @@ const config = {
   },
   assetPrefix: process.env.NEXT_PUBLIC_APP_ENV === 'production' ? 'https://cdn.charmverse.io' : undefined,
   productionBrowserSourceMaps: true,
-  async generateBuildId() {
-    return process.env.NEXT_PUBLIC_BUILD_ID || uuid.v4();
-  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
We were only changing the build id when backend changes, but next.js uses this id to write to .next/static/<build_id/
__manifest.json. Because we're caching with a CDN, we need to always have the manifest written to a new file even if frontend files change.

However we still use NEXT_PUBLIC_BUILD_ID to know if the user needs to refresh their frontend because the backend changed.