### PR TITLE
Recover from socket close + close web sockets on sigterm

### DIFF
--- a/background/initWebsockets.ts
+++ b/background/initWebsockets.ts
@@ -4,7 +4,7 @@ import { log } from '@charmverse/core/log';
 
 import { appEnv } from 'config/constants';
 
-import { httpServer } from './websockets/app';
+import { httpServer, socketServer } from './websockets/app';
 import { cleanup as originCacheCleanup } from './websockets/verifyCustomOrigin';
 
 const port = process.env.PORT || 3002;
@@ -16,9 +16,12 @@ log.info(`[server] Websocket server running in ${appEnv} listening to port: ${po
 function cleanup() {
   log.info('[server] Closing Websocket server...');
   originCacheCleanup();
-  httpServer.close(() => {
-    log.info('[server] Exiting process...');
-    process.exit(1);
+  socketServer.close(() => {
+    log.info('[server] Closing HTTP server...');
+    httpServer.close(() => {
+      log.info('[server] Exiting process...');
+      process.exit(1);
+    });
   });
 }
 

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -15,6 +15,7 @@ import { getCardComments } from 'components/common/BoardEditor/focalboard/src/st
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { FrontendParticipant } from 'components/common/CharmEditor/components/fiduswriter/collab';
+import type { ConnectionEvent } from 'components/common/CharmEditor/components/fiduswriter/ws';
 import { SnapshotVoteDetails } from 'components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails';
 import { VoteDetail } from 'components/common/CharmEditor/components/inlineVote/components/VoteDetail';
 import ScrollableWindow from 'components/common/PageLayout/components/ScrollableWindow';
@@ -164,8 +165,13 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
     setPageProps({ participants });
   }
 
-  function onConnectionError(error: Error) {
-    setConnectionError(error);
+  function onConnectionEvent(event: ConnectionEvent) {
+    if (event.type === 'error') {
+      setConnectionError(event.error);
+    } else if (event.type === 'subscribed') {
+      // clear out error in case we re-subscribed
+      setConnectionError(null);
+    }
   }
 
   // reset error whenever page id changes
@@ -230,7 +236,7 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
                   containerWidth={containerWidth}
                   pageType={page.type}
                   pagePermissions={pagePermissions ?? undefined}
-                  onConnectionError={onConnectionError}
+                  onConnectionEvent={onConnectionEvent}
                   snapshotProposalId={page.snapshotProposalId}
                   onParticipantUpdate={onParticipantUpdate}
                   style={{

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -35,6 +35,7 @@ import EmojiSuggest from './components/emojiSuggest/EmojiSuggest.component';
 import type { FrontendParticipant } from './components/fiduswriter/collab';
 import { getSelectedChanges } from './components/fiduswriter/state_plugins/track';
 import fiduswriterStyles from './components/fiduswriter/styles';
+import type { ConnectionEvent } from './components/fiduswriter/ws';
 import { File } from './components/file/File';
 import FloatingMenu from './components/floatingMenu/FloatingMenu';
 import * as iframe from './components/iframe';
@@ -186,7 +187,7 @@ interface CharmEditorProps {
   focusOnInit?: boolean;
   disableRowHandles?: boolean;
   disableNestedPages?: boolean;
-  onConnectionError?: (error: Error) => void;
+  onConnectionEvent?: (event: ConnectionEvent) => void;
   isPollOrVote?: boolean;
   disableMention?: boolean;
 }
@@ -216,7 +217,7 @@ function CharmEditor({
   onParticipantUpdate,
   disableRowHandles = false,
   disableNestedPages = false,
-  onConnectionError,
+  onConnectionEvent,
   isPollOrVote = false,
   disableMention = false
 }: CharmEditorProps) {
@@ -366,7 +367,7 @@ function CharmEditor({
       trackChanges
       readOnly={readOnly}
       enableComments={enableComments}
-      onConnectionError={onConnectionError}
+      onConnectionEvent={onConnectionEvent}
       style={{
         ...(style ?? {}),
         width: '100%',

--- a/components/common/stories/CharmEditor.stories.tsx
+++ b/components/common/stories/CharmEditor.stories.tsx
@@ -26,7 +26,7 @@ function renderEditorWithContent(content: PageContent | undefined) {
       enableVoting={true}
       pageType='page'
       pagePermissions={undefined}
-      onConnectionError={() => {}}
+      onConnectionEvent={() => {}}
       snapshotProposalId={null}
       onParticipantUpdate={() => {}}
       style={{

--- a/components/common/stories/CharmEditor.stories.tsx
+++ b/components/common/stories/CharmEditor.stories.tsx
@@ -85,7 +85,7 @@ export function FullPageEditor() {
       enableVoting={true}
       pageType='page'
       pagePermissions={undefined}
-      onConnectionError={() => {}}
+      onConnectionEvent={() => {}}
       snapshotProposalId={null}
       onParticipantUpdate={() => {}}
       style={{

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "cron:staging": "npx react-env --path .env.staging -- node ./.next/server/cron.js",
     "cron:prod": "node ./.next/server/cron.js",
     "cron:dev": "dotenv -e .env.local -- ts-node --transpileOnly ./background/cron.ts",
-    "sockets": "concurrently --names \"sockets,next\" -c \"yellow,green\" \"npm run sockets:dev\" \"npm run server:sockets\"",
+    "sockets": "concurrently --names \"next,sockets\" -c \"green,yellow\" \"npm run server:sockets\" \"npm run sockets:dev\"",
     "sockets:build": "tsc --project tsconfig.websockets.json && tsc-alias -p tsconfig.websockets.json",
     "sockets:esbuild": "esbuild background/initWebsockets.ts --bundle --outdir=dist --tsconfig=tsconfig.websockets.json",
     "sockets:dev": "cross-env PORT=3002 npx dotenv -e .env -e .env.local -- node --watch ./.next/server/websockets.js",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f73f9e5</samp>

Improved WebSocket server handling in `background/initWebsockets.ts`. Imported `socketServer` and closed it on cleanup.

### WHY
When testing the socket server locally, I noticed it was not closing when i hit CMD+C if i had a document open. This fixes the issue. I think it may have been an issue in prod too, but beanstalk shoots the app dead anyway