### PR TITLE
Only call permissions API when necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@bangle.dev/tooltip": "^0.31.6",
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
-    "@charmverse/core": "^0.3.13",
+    "@charmverse/core": "^0.3.16",
     "@column-resizer/core": "^1.0.2",
     "@datadog/browser-logs": "^4.42.2",
     "@datadog/browser-rum": "^4.42.2",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 31fade6</samp>

Improved type safety and error handling of `getVoteTasks` function. Added a type import and an edge case check in `lib/votes/getVoteTasks.ts`.

### WHY
Simplify calls to permissions API