### PR TITLE
update to how we save rubric answers

### DIFF
--- a/__integration-tests__/server/pages/api/proposals/[id]/rubric-answers.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/[id]/rubric-answers.spec.ts
@@ -50,13 +50,18 @@ describe('PUT /api/proposals/[id]/rubric-answers - Update proposal rubric criter
       answers: [{ rubricCriteriaId: rubricCriteria.id, response: { score: 5 }, comment: 'opinion' }]
     };
 
-    const updated = (
-      await request(baseUrl)
-        .put(`/api/proposals/${proposal.id}/rubric-answers`)
-        .set('Cookie', reviewerCookie)
-        .send(answerContent)
-        .expect(200)
-    ).body as ProposalRubricCriteriaAnswerWithTypedResponse[];
+    await request(baseUrl)
+      .put(`/api/proposals/${proposal.id}/rubric-answers`)
+      .set('Cookie', reviewerCookie)
+      .send(answerContent)
+      .expect(200);
+
+    const updated = await prisma.proposalRubricCriteriaAnswer.findMany({
+      where: {
+        userId: reviewer.id,
+        proposalId: proposal.id
+      }
+    });
 
     expect(updated).toHaveLength(1);
 

--- a/__integration-tests__/server/pages/api/proposals/[id]/rubric-answers.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/[id]/rubric-answers.spec.ts
@@ -125,13 +125,11 @@ describe('DELETE /api/proposals/[id]/rubric-answers - Delete proposal rubric cri
     };
 
     // Submit answers first
-    const updated = (
-      await request(baseUrl)
-        .put(`/api/proposals/${proposal.id}/rubric-answers`)
-        .set('Cookie', reviewerCookie)
-        .send(answerContent)
-        .expect(200)
-    ).body as ProposalRubricCriteriaWithTypedParams[];
+    await request(baseUrl)
+      .put(`/api/proposals/${proposal.id}/rubric-answers`)
+      .set('Cookie', reviewerCookie)
+      .send(answerContent)
+      .expect(200);
 
     await request(baseUrl)
       .delete(`/api/proposals/${proposal.id}/rubric-answers`)

--- a/lib/proposal/rubric/upsertRubricAnswers.ts
+++ b/lib/proposal/rubric/upsertRubricAnswers.ts
@@ -18,11 +18,7 @@ export type RubricAnswerUpsert = {
   answers: RubricAnswerData[];
 };
 
-export async function upsertRubricAnswers({
-  answers,
-  userId,
-  proposalId
-}: RubricAnswerUpsert): Promise<ProposalRubricCriteriaAnswerWithTypedResponse[]> {
+export async function upsertRubricAnswers({ answers, userId, proposalId }: RubricAnswerUpsert) {
   if (!stringUtils.isUUID(proposalId)) {
     throw new InvalidInputError(`Valid proposalId is required`);
   } else if (!stringUtils.isUUID(userId)) {
@@ -57,29 +53,21 @@ export async function upsertRubricAnswers({
     }
   }
 
-  const updatedAnswers = await prisma.$transaction(
-    answers.map((a) =>
-      prisma.proposalRubricCriteriaAnswer.upsert({
-        where: {
-          userId_rubricCriteriaId: {
-            rubricCriteriaId: a.rubricCriteriaId,
-            userId
-          }
-        },
-        create: {
-          response: a.response,
-          userId,
-          comment: a.comment,
-          proposal: { connect: { id: proposalId } },
-          rubricCriteria: { connect: { id: a.rubricCriteriaId } }
-        },
-        update: {
-          response: a.response,
-          comment: a.comment
-        }
-      })
-    )
-  );
-
-  return updatedAnswers as ProposalRubricCriteriaAnswerWithTypedResponse[];
+  return prisma.$transaction([
+    prisma.proposalRubricCriteriaAnswer.deleteMany({
+      where: {
+        proposalId,
+        userId
+      }
+    }),
+    prisma.proposalRubricCriteriaAnswer.createMany({
+      data: answers.map((a) => ({
+        proposalId,
+        response: a.response,
+        userId,
+        comment: a.comment,
+        rubricCriteriaId: a.rubricCriteriaId
+      }))
+    })
+  ]);
 }

--- a/pages/api/proposals/[id]/rubric-answers.ts
+++ b/pages/api/proposals/[id]/rubric-answers.ts
@@ -36,13 +36,13 @@ async function upsertProposalAnswersController(
 
   const { answers } = req.body as RubricAnswerUpsert;
 
-  const updatedCriteria = await upsertRubricAnswers({
+  await upsertRubricAnswers({
     proposalId,
     answers,
     userId
   });
 
-  res.status(200).send(updatedCriteria);
+  res.status(200).end();
 }
 
 async function deleteRubricAnswer(req: NextApiRequest, res: NextApiResponse) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ecb59a</samp>

This pull request refactors the code and tests related to the `upsertRubricAnswers` function and the `/api/proposals/[id]/rubric-answers` endpoint. It improves the code readability, efficiency, and test coverage by using simpler and more consistent methods and removing unnecessary data and variables.

### WHY
Right now there's a bug because I want the user to be able to remove previous answers. The UI always sends back the full list of answers from the user. The backend can just override everything.
