### PR TITLE
wait for proposal to be refreshed before moving to rubric answers

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -106,8 +106,8 @@ export function ProposalProperties({
     }
   }
 
-  async function onSaveRubricCriteriaAnswers() {
-    refreshProposal();
+  function onSaveRubricCriteriaAnswers() {
+    return refreshProposal();
   }
 
   async function onChangeRubricCriteria(rubricCriteria: ProposalPropertiesInput['rubricCriteria']) {

--- a/components/proposals/components/ProposalProperties/ProposalProperties.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalProperties.tsx
@@ -233,8 +233,8 @@ export function ProposalProperties({
     setIsVoteModalOpen(true);
   }
 
-  function onSubmitEvaluation() {
-    onSaveRubricCriteriaAnswers?.();
+  async function onSubmitEvaluation() {
+    await onSaveRubricCriteriaAnswers?.();
     // Set view to "Results tab", assuming Results is the 2nd tab, ie value: 1
     setRubricView(1);
   }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed2e6b3</samp>

Fixed a bug where rubric criteria answers were not saved before showing the evaluation results. Changed the `onSaveRubricCriteriaAnswers` function to return a promise and used `await` on it in the `onSubmitEvaluation` function.

### WHY
<!-- author to complete -->
