### PR TITLE
Multiplayer thread comment bug

### DIFF
--- a/components/common/CharmEditor/components/PageThread.tsx
+++ b/components/common/CharmEditor/components/PageThread.tsx
@@ -133,7 +133,6 @@ function AddCommentCharmEditor({
           border: '1px solid var(--input-border)'
         }}
         placeholderText='Reply...'
-        key={thread.comments[thread.comments.length - 1]?.id}
         content={commentContent}
         onContentChange={({ doc }) => {
           setCommentContent(doc);
@@ -290,6 +289,7 @@ const PageThread = forwardRef<HTMLDivElement, PageThreadProps>(
     const view = useEditorViewContext();
     const thread = threadId ? (threads[threadId] as ThreadWithCommentsAndAuthors) : null;
     const isSmallScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
+    const [counter, setCounter] = useState(0);
 
     function resetState() {
       setEditedCommentId(null);
@@ -477,8 +477,8 @@ const PageThread = forwardRef<HTMLDivElement, PageThreadProps>(
         </div>
         {permissions?.comment && (
           <AddCommentCharmEditor
-            key={thread.comments[thread.comments.length - 1]?.id}
             readOnly={Boolean(editedCommentId)}
+            key={counter}
             sx={{
               display: 'flex',
               px: 1,
@@ -496,6 +496,7 @@ const PageThread = forwardRef<HTMLDivElement, PageThreadProps>(
               setIsMutating(true);
               cb();
               resetState();
+              setCounter(counter + 1);
             }}
           />
         )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9800066</samp>

Fixed a comment rendering bug in `PageThread` component. Used a key prop to re-render `AddCommentCharmEditor` component after adding a new comment.

### WHY
* Keep current comment content intact when new comments have been added through ws. Previously it used to reset the comment content

[Card](https://app.charmverse.io/charmverse/page-27951586228886915)