### PR TITLE
Show disabled edit modes

### DIFF
--- a/components/common/PageLayout/components/Header/components/EditingModeToggle.tsx
+++ b/components/common/PageLayout/components/Header/components/EditingModeToggle.tsx
@@ -1,3 +1,4 @@
+import type { PagePermissionFlags } from '@charmverse/core/permissions';
 import { ArrowDropDown } from '@mui/icons-material';
 import type { Theme } from '@mui/material';
 import { IconButton, useMediaQuery, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip } from '@mui/material';
@@ -8,23 +9,8 @@ import { Button } from 'components/common/Button';
 import { useCharmEditor, EDIT_MODE_CONFIG } from 'hooks/useCharmEditor';
 import type { EditMode } from 'hooks/useCharmEditor';
 
-const editModeConfig = {
-  editing: {
-    color: 'primary',
-    label: 'Editing'
-  },
-  suggesting: {
-    color: 'success',
-    label: 'Suggesting'
-  },
-  viewing: {
-    color: 'secondary',
-    label: 'Viewing'
-  }
-} as const;
-
 function EditModeToggle() {
-  const { availableEditModes, editMode, setPageProps } = useCharmEditor();
+  const { availableEditModes, permissions, editMode, setPageProps } = useCharmEditor();
   const isLargeScreen = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
 
   function setMode(mode: EditMode) {
@@ -35,7 +21,11 @@ function EditModeToggle() {
     return null;
   }
 
-  const availableModes = availableEditModes.map((mode) => [mode, editModeConfig[mode]] as const);
+  const availableModes = availableEditModes.map((mode) => {
+    return [mode, EDIT_MODE_CONFIG[mode]] as const;
+  });
+
+  const _permissions = permissions || ({} as PagePermissionFlags);
 
   return (
     <PopupState variant='popover' popupId='edit-mode-select'>
@@ -50,9 +40,9 @@ function EditModeToggle() {
                 size='small'
                 disableElevation
                 variant='outlined'
-                color={editModeConfig[editMode].color}
+                color={EDIT_MODE_CONFIG[editMode].color}
               >
-                {editModeConfig[editMode].label}
+                {EDIT_MODE_CONFIG[editMode].label}
               </Button>
             </Tooltip>
           ) : (
@@ -64,18 +54,19 @@ function EditModeToggle() {
             anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
             transformOrigin={{ horizontal: 'right', vertical: 'top' }}
           >
-            {availableModes.map(([mode, { label }]) => (
+            {availableModes.map(([mode, { label, color, icon, permission }]) => (
               <MenuItem
                 key={mode}
                 dense
                 onClick={() => {
-                  setMode(mode as EditMode);
+                  if (_permissions[permission]) {
+                    setMode(mode);
+                  }
                   popupState.close();
                 }}
+                disabled={!_permissions[permission]}
               >
-                <ListItemIcon sx={{ color: editMode === mode ? `${editModeConfig[mode].color}.main` : '' }}>
-                  {EDIT_MODE_CONFIG[mode].icon}
-                </ListItemIcon>
+                <ListItemIcon sx={{ color: editMode === mode ? `${color}.main` : '' }}>{icon}</ListItemIcon>
                 <ListItemText>{label}</ListItemText>
               </MenuItem>
             ))}

--- a/hooks/useCharmEditor.tsx
+++ b/hooks/useCharmEditor.tsx
@@ -5,23 +5,28 @@ import type { Dispatch, ReactNode, SetStateAction, MutableRefObject } from 'reac
 
 import type { FrontendParticipant } from 'components/common/CharmEditor/components/fiduswriter/collab';
 
-const EDIT_MODES = ['editing', 'suggesting', 'viewing'] as const;
-export type EditMode = (typeof EDIT_MODES)[number];
-
 export const EDIT_MODE_CONFIG = {
   editing: {
     permission: 'edit_content',
-    icon: <EditOutlined fontSize='small' />
+    icon: <EditOutlined fontSize='small' />,
+    color: 'primary',
+    label: 'Editing'
   },
   suggesting: {
     permission: 'comment',
-    icon: <RateReviewOutlined fontSize='small' />
+    icon: <RateReviewOutlined fontSize='small' />,
+    color: 'success',
+    label: 'Suggesting'
   },
   viewing: {
     permission: 'read',
-    icon: <VisibilityOutlined fontSize='small' />
+    icon: <VisibilityOutlined fontSize='small' />,
+    color: 'secondary',
+    label: 'Viewing'
   }
 } as const;
+
+export type EditMode = keyof typeof EDIT_MODE_CONFIG;
 
 interface CharmEditorContext {
   isSaving: boolean;
@@ -55,11 +60,7 @@ const CharmEditorContext = createContext<Readonly<CharmEditorContextWithSetter>>
 export function CharmEditorProvider({ children }: { children: ReactNode }) {
   const [props, _setPageProps] = useState<CharmEditorContext>(defaultProps);
 
-  const availableEditModes = Object.entries(EDIT_MODE_CONFIG)
-    .filter(([, config]) => {
-      return !!props.permissions?.[config.permission];
-    })
-    .map(([mode]) => mode as EditMode);
+  const availableEditModes = Object.keys(EDIT_MODE_CONFIG) as EditMode[];
 
   const setPageProps: CharmEditorContextWithSetter['setPageProps'] = (_props) => {
     _setPageProps((prev) => ({ ...prev, ..._props }));


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b615a0b</samp>

This pull request refactors the editing mode configuration and logic for the charm editor, to use a shared constant, check user permissions, and improve the UI and code quality. It affects the `useCharmEditor` hook and the `EditModeToggle` component in `components/common/PageLayout/components/Header`.

### WHY
[Task](https://app.charmverse.io/charmverse/page-8327898797926263)


<img width="1007" alt="Screenshot 2023-09-01 at 15 04 52" src="https://github.com/charmverse/app.charmverse.io/assets/25636858/c756d89f-a208-4939-a2b7-eaeb3e6dc08b">
