### PR TITLE
add a hack to hide lens from cyberconnect space for now

### DIFF
--- a/components/settings/account/hooks/useLensProfile.ts
+++ b/components/settings/account/hooks/useLensProfile.ts
@@ -3,6 +3,7 @@ import { RPC } from 'connectors/index';
 import useSWR from 'swr';
 
 import charmClient from 'charmClient';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useUser } from 'hooks/useUser';
 import { useWeb3AuthSig } from 'hooks/useWeb3AuthSig';
 import { switchActiveNetwork } from 'lib/blockchain/switchNetwork';
@@ -15,6 +16,7 @@ async function switchNetwork() {
 export function useLensProfile() {
   const { account, library, chainId } = useWeb3AuthSig();
   const { user } = useUser();
+  const { space } = useCurrentSpace();
 
   const {
     data: lensProfileState = {
@@ -49,7 +51,12 @@ export function useLensProfile() {
   }
 
   return {
-    ...lensProfileState,
+    isAuthenticated: lensProfileState.isAuthenticated,
+    lensProfile: !isCyberConnect(space?.domain) && lensProfileState.lensProfile,
     setupLensProfile
   };
+}
+
+function isCyberConnect(domain?: string) {
+  return domain === 'cyberconnect';
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10c878d</samp>

Updated `useLensProfile` hook to disable lens profile settings for cyberconnect space. This prevents users from changing their lens profile in a space that does not support it.

### WHY
<!-- author to complete -->
