### PR TITLE
Fix scrolling behaviour for inline comments

### DIFF
--- a/components/common/CharmEditor/components/inlineComment/inlineComment.utils.ts
+++ b/components/common/CharmEditor/components/inlineComment/inlineComment.utils.ts
@@ -113,22 +113,6 @@ export function scrollToThread(threadId: string) {
   // Find the inline-comment with the threadId and scroll into view
   const threadDocument = document.getElementById(`inline-comment.${threadId}`);
   if (threadDocument) {
-    let parentElement: HTMLElement | null = null;
-    let element: HTMLElement | null = threadDocument;
-    // Check for highest 5 levels of depth
-    for (let i = 0; i < 10; i++) {
-      element = element?.parentElement ?? null;
-      // Get the first paragraph parent element
-      const tagName = element?.tagName.toLowerCase() || '';
-      if (tagName === 'p' || tagName.startsWith('h')) {
-        parentElement = element;
-        break;
-      }
-    }
-
-    if (parentElement) {
-      createHighlightDomElement(parentElement);
-      parentElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
+    threadDocument.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a8022ce</samp>

Simplified the logic for scrolling and highlighting the thread document in the `inlineComment` component. Fixed a bug that affected the inline comment feature in `CharmEditor`.

### WHY
Fix scrolling bug

**Before**
https://www.loom.com/share/6dfd8272f79745d88415c64c15462b9e?sid=95fcb7d6-452f-4fe3-9604-9130677e2285

**After**
https://www.loom.com/share/b43f2ad2e2d240279effaa14982dd91d?sid=39a64238-5437-42e5-bb08-daf33e597f0f
