### PR TITLE
Bug/duplicate proposal cards

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -34,8 +34,6 @@ import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useMembers } from 'hooks/useMembers';
 import { usePage } from 'hooks/usePage';
 import { usePages } from 'hooks/usePages';
-import { useSnackbar } from 'hooks/useSnackbar';
-import { useUser } from 'hooks/useUser';
 import type { Block } from 'lib/focalboard/block';
 import type { Board, BoardGroup, IPropertyOption, IPropertyTemplate } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';
@@ -101,10 +99,8 @@ function CenterPanel(props: Props) {
 
   const router = useRouter();
   const { space } = useCurrentSpace();
-  const { pages, refreshPage, updatePage } = usePages();
+  const { pages, refreshPage } = usePages();
   const { members } = useMembers();
-  const { showMessage } = useSnackbar();
-  const { user } = useUser();
 
   const isEmbedded = !!props.embeddedBoardPath;
   const boardPageType = boardPage?.type;

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
@@ -85,7 +85,7 @@ function ViewHeader(props: Props) {
     if (currentRootPageId && activeBoard?.fields.sourceType === 'proposals' && activeBoard?.id === currentRootPageId) {
       updateProposalSource({ pageId: currentRootPageId });
     }
-  }, [currentRootPageId, activeBoard?.fields.sourceType, activeBoard?.id]);
+  }, [currentRootPageId, activeBoard?.id]);
 
   const withDisplayBy = activeView?.fields.viewType === 'calendar';
   const withSortBy = activeView?.fields.viewType !== 'calendar';

--- a/lib/focalboard/updateCardsFromProposals.ts
+++ b/lib/focalboard/updateCardsFromProposals.ts
@@ -41,7 +41,7 @@ export async function updateCardsFromProposals({
   });
   // Ideally all the views should have sourceType proposal when created, but there are views which doesn't have sourceType proposal even though they are created from proposal source
   if ((database.fields as any as BoardFields).sourceType !== 'proposals') {
-    throw new InvalidStateError('Board does not have a proposals view');
+    throw new InvalidStateError('Database not configured to use proposals as a source');
   }
 
   const pageProposals = await prisma.page.findMany({

--- a/scripts/cleanupDuplicateProposalCards.ts
+++ b/scripts/cleanupDuplicateProposalCards.ts
@@ -1,0 +1,77 @@
+import { Page, prisma } from "@charmverse/core/prisma-client";
+
+
+
+
+async function cleanupDuplicateProposalCards() {
+  const targetSpace = 'blank-alpha-butterfly';
+
+  const space = await prisma.space.findUniqueOrThrow({
+    where: {
+      domain: targetSpace
+    },
+    select: {
+      id: true
+    }
+  })
+
+  const proposalCards = await prisma.page.findMany({
+    where: {
+      syncWithPageId: {
+        not: null
+      }
+    },
+    select: {
+      id: true,
+      syncWithPageId: true,
+      parentId: true,
+    },
+    orderBy: {
+      createdBy: 'asc'
+    }
+  }) as {[key in keyof Pick<Page, 'id' | 'syncWithPageId' | 'parentId'>]: NonNullable<Page[key]>}[];
+
+  const cardsToDelete = proposalCards.reduce((acc, card) => {
+
+    // Cards in different boards can have the same syncWithPageId, so we need to also dedupe by parent board id
+    const key = `${card.parentId}-${card.syncWithPageId}`
+
+    if (!acc.cardMap[key]) {
+      acc.cardMap[key] = card.id;
+    } else {
+      acc.cardIdsToDelete.push(card.id);
+    }
+
+    return acc;
+
+  }, {cardMap: {} as Record<string, string>, cardIdsToDelete: [] as string[]});
+
+
+  if (cardsToDelete.cardIdsToDelete.length > 0) {
+    await prisma.$transaction(async tx => {
+      await tx.page.deleteMany({
+        where: {
+          spaceId: space.id,
+          type: 'card',
+          id: {
+            in: cardsToDelete.cardIdsToDelete
+          }
+        }
+      });
+      await tx.block.deleteMany({
+        where: {
+          spaceId: space.id,
+          type: 'card',
+          id: {
+            in: cardsToDelete.cardIdsToDelete
+          }
+        }
+      });
+    })
+    console.log('Deleted', cardsToDelete.cardIdsToDelete.length, 'duplicate cards');
+  }
+
+}
+cleanupDuplicateProposalCards().then(() => {
+  console.log('Done')
+})


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f1f191</samp>

Refactored the logic of updating cards from proposals in the `focalboard` component to simplify the code and remove unnecessary dependencies. Added a script `cleanupDuplicateProposalCards.ts` to delete any duplicate cards that were created from proposals in a given space.

### WHY
Fix duplicate proposals