### PR TITLE
Charm editor: show placeholder anywhere in the document when line is empty

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -89,12 +89,7 @@ const StyledReactBangleEditor = styled(ReactBangleEditor)<{
   ${({ colorMode }) =>
     colorMode === 'dark'
       ? `
-          background-color: var(--background-light);
-          .ProseMirror[data-placeholder]::before,
-          .charm-placeholder::before {
-            color: var(--primary-text);
-            opacity: 0.5;
-          }`
+          background-color: var(--background-light);`
       : ''};
 
   ${({ disableRowHandles }) =>

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -90,7 +90,8 @@ const StyledReactBangleEditor = styled(ReactBangleEditor)<{
     colorMode === 'dark'
       ? `
           background-color: var(--background-light);
-          .ProseMirror[data-placeholder]::before {
+          .ProseMirror[data-placeholder]::before,
+          .charm-placeholder::before {
             color: var(--primary-text);
             opacity: 0.5;
           }`

--- a/components/common/CharmEditor/InlineCharmEditor.tsx
+++ b/components/common/CharmEditor/InlineCharmEditor.tsx
@@ -23,7 +23,7 @@ import { plugins as linkPlugins } from './components/link/link.plugins';
 import { spec as linkSpec } from './components/link/link.specs';
 import { LinksPopup } from './components/link/LinksPopup';
 import Mention, { mentionPlugins, mentionSpecs, MentionSuggest, mentionPluginKeyName } from './components/mention';
-import { placeholderPlugin } from './components/placeholder';
+import { placeholderPlugin } from './components/placeholder/placeholder';
 import * as tabIndent from './components/tabIndent';
 
 export interface ICharmEditorOutput {

--- a/components/common/CharmEditor/components/placeholder/__tests__/placeholder.spec.ts
+++ b/components/common/CharmEditor/components/placeholder/__tests__/placeholder.spec.ts
@@ -1,0 +1,65 @@
+import type { EditorView } from 'prosemirror-view';
+
+import { charmEditorPlugins } from 'components/common/CharmEditor/plugins';
+import { specRegistry } from 'components/common/CharmEditor/specRegistry';
+import { builders as _ } from 'testing/prosemirror/builders';
+import { setSelectionNear } from 'testing/prosemirror/helpers';
+import { renderTestEditor } from 'testing/prosemirror/renderTestEditor';
+
+const testEditor = renderTestEditor({
+  specRegistry,
+  plugins: charmEditorPlugins()
+});
+
+describe('Placeholder component', () => {
+  test('appears with empty paragraph', () => {
+    const doc = _.doc(_.p(''));
+    const editor = testEditor(doc);
+    const placeholder = editor.view.dom.getAttribute('data-placeholder');
+    expect(placeholder).not.toBeNull();
+  });
+
+  test('Does not show when there is text', () => {
+    const doc = _.doc(_.p('some text'));
+    const editor = testEditor(doc);
+    const placeholder = editor.view.dom.getAttribute('data-placeholder');
+    expect(placeholder).toBeNull();
+  });
+
+  test('Does not appear on an empty paragraph line with no selection', () => {
+    const doc = _.doc(_.p('some text'), _.p(''));
+    const editor = testEditor(doc);
+    setSelectionNear(editor.view, 4);
+    const placeholder = getPlaceholderAtSelection(editor.view);
+    expect(placeholder).toBeNull();
+  });
+
+  test('Appears on an empty paragraph line with selection', () => {
+    const doc = _.doc(_.p('some text'), _.p(''));
+    const editor = testEditor(doc);
+    setSelectionNear(editor.view, 12);
+    const placeholder = getPlaceholderAtSelection(editor.view);
+    expect(placeholder).not.toBeNull();
+  });
+
+  test('Appears inside a column layout', () => {
+    const doc = _.doc(_.columnLayout(_.columnBlock(_.p(''))));
+    const editor = testEditor(doc);
+    const placeholder = getPlaceholderAtSelection(editor.view);
+    expect(placeholder).not.toBeNull();
+  });
+
+  test('Does not appear inside a table', () => {
+    const doc = _.doc(_.table(_.table_row(_.table_header(_.p('')))));
+    const editor = testEditor(doc);
+    setSelectionNear(editor.view, 4);
+    const placeholder = getPlaceholderAtSelection(editor.view);
+    expect(placeholder).toBeNull();
+  });
+});
+
+function getPlaceholderAtSelection(view: EditorView) {
+  const pos = view.state.selection.from;
+  const selectedDom = view.domAtPos(pos).node as HTMLElement | undefined;
+  return selectedDom?.getAttribute?.('data-placeholder') || null;
+}

--- a/components/common/CharmEditor/components/placeholder/index.ts
+++ b/components/common/CharmEditor/components/placeholder/index.ts
@@ -6,13 +6,11 @@ import { Decoration, DecorationSet } from 'prosemirror-view';
 import { checkIsContentEmpty } from 'lib/prosemirror/checkIsContentEmpty';
 
 const defaultPlaceholderText = "Type '/' for commands";
-
 // source: https://gist.github.com/amk221/1f9657e92e003a3725aaa4cf86a07cc0
 // see also: https://discuss.prosemirror.net/t/how-to-input-like-placeholder-behavior/705/24
 export function placeholderPlugin(text: string = defaultPlaceholderText) {
   const update = (view: EditorView) => {
     const doc = view.state.doc;
-
     // Allow showing a placeholder (often used for permissions) but avoid showing the default edit-focused placeholder when editor is readonly
     if (view.editable || (!view.editable && text !== defaultPlaceholderText)) {
       const hasContent = !checkIsContentEmpty(doc.toJSON() as any);
@@ -37,12 +35,11 @@ export function placeholderPlugin(text: string = defaultPlaceholderText) {
         const selectedNode = state.doc.resolve(selectionPos).parent;
         const selectedNodeIsEmpty = checkIsContentEmpty(selectedNode.toJSON() as any);
         if (selectedNodeIsEmpty) {
+          const resolved = state.doc.resolve(selectionPos);
           return DecorationSet.create(state.doc, [
-            Decoration.widget(selectionPos, () => {
-              return createElement([
-                'div',
-                { contentEditable: false, class: 'charm-placeholder', 'data-placeholder': text }
-              ]);
+            Decoration.node(resolved.before(), resolved.after(), {
+              class: 'charm-placeholder',
+              'data-placeholder': text
             })
           ]);
         }

--- a/components/common/CharmEditor/components/placeholder/index.ts
+++ b/components/common/CharmEditor/components/placeholder/index.ts
@@ -1,4 +1,3 @@
-import { findParentNodeOfType } from '@bangle.dev/utils';
 import type { EditorState } from 'prosemirror-state';
 import { Plugin } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';

--- a/components/common/CharmEditor/components/placeholder/placeholder.ts
+++ b/components/common/CharmEditor/components/placeholder/placeholder.ts
@@ -60,7 +60,7 @@ const parentNodesToShow = ['columnBlock', 'listItem'];
 function shouldShowPlaceholder(state: EditorState) {
   const selectionStart = state.selection.$from;
   const depth = selectionStart.depth;
-  if (depth === 1) {
+  if (depth <= 1) {
     return true;
   }
 

--- a/components/common/CharmEditor/components/rowActions/__tests__/rowActions.spec.ts
+++ b/components/common/CharmEditor/components/rowActions/__tests__/rowActions.spec.ts
@@ -3,7 +3,7 @@ import { specRegistry } from 'components/common/CharmEditor/specRegistry';
 import { builders as _ } from 'testing/prosemirror/builders';
 import { renderTestEditor } from 'testing/prosemirror/renderTestEditor';
 
-import { getNodeForRowPosition, rowNodeAtPos } from '../rowActions';
+import { rowNodeAtPos } from '../rowActions';
 
 const testEditor = renderTestEditor({
   specRegistry,

--- a/components/common/CharmEditor/plugins.ts
+++ b/components/common/CharmEditor/plugins.ts
@@ -32,7 +32,7 @@ import * as nft from './components/nft/nft.plugins';
 import * as orderedList from './components/orderedList';
 import paragraph from './components/paragraph';
 import * as pasteChecker from './components/pasteChecker/pasteChecker';
-import { placeholderPlugin } from './components/placeholder/index';
+import { placeholderPlugin } from './components/placeholder/placeholder';
 import * as rowActions from './components/rowActions/rowActions';
 import { plugins as trackPlugins } from './components/suggestions/suggestions.plugins';
 import * as tabIndent from './components/tabIndent';

--- a/lib/prosemirror/checkIsContentEmpty.ts
+++ b/lib/prosemirror/checkIsContentEmpty.ts
@@ -1,12 +1,17 @@
-import type { PageContent } from 'lib/prosemirror/interfaces';
+import type { BlockNode, TextContent, PageContent } from 'lib/prosemirror/interfaces';
 
-export function checkIsContentEmpty(content: PageContent | null | undefined) {
+export function checkIsContentEmpty(content: PageContent | null | undefined): boolean {
   return (
     !content?.content ||
     content.content.length === 0 ||
-    (content.content.length === 1 &&
-      // These nodes dont contain any content so there is no content field
-      !content.content[0]?.type.match(/(cryptoPrice|columnLayout|image|iframe|mention|page|poll|tableOfContents)/) &&
-      !content.content[0].content?.length)
+    (content.content.length === 1 && isEmptyNode(content.content[0]))
+  );
+}
+
+function isEmptyNode(node: BlockNode): boolean {
+  return (
+    // These nodes dont contain any content so there is no content field
+    !!node.type.match(/(cryptoPrice|columnLayout|image|iframe|mention|page|poll|tableOfContents)/) ||
+    (!node.content?.length && !(node as TextContent).text)
   );
 }

--- a/lib/prosemirror/checkIsContentEmpty.ts
+++ b/lib/prosemirror/checkIsContentEmpty.ts
@@ -1,17 +1,12 @@
-import type { BlockNode, TextContent, PageContent } from 'lib/prosemirror/interfaces';
+import type { PageContent } from 'lib/prosemirror/interfaces';
 
-export function checkIsContentEmpty(content: PageContent | null | undefined): boolean {
+export function checkIsContentEmpty(content: PageContent | null | undefined) {
   return (
     !content?.content ||
     content.content.length === 0 ||
-    (content.content.length === 1 && isEmptyNode(content.content[0]))
-  );
-}
-
-function isEmptyNode(node: BlockNode): boolean {
-  return (
-    // These nodes dont contain any content so there is no content field
-    !!node.type.match(/(cryptoPrice|columnLayout|image|iframe|mention|page|poll|tableOfContents)/) ||
-    (!node.content?.length && !(node as TextContent).text)
+    (content.content.length === 1 &&
+      // These nodes dont contain any content so there is no content field
+      !content.content[0]?.type.match(/(cryptoPrice|columnLayout|image|iframe|mention|page|poll|tableOfContents)/) &&
+      !content.content[0].content?.length)
   );
 }

--- a/testing/prosemirror/helpers.ts
+++ b/testing/prosemirror/helpers.ts
@@ -1,0 +1,7 @@
+import { Selection } from 'prosemirror-state';
+import type { EditorView } from 'prosemirror-view';
+
+export function setSelectionNear(view: EditorView, pos: number) {
+  const tr = view.state.tr;
+  view.dispatch(tr.setSelection(Selection.near(tr.doc.resolve(pos))));
+}

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -511,7 +511,8 @@ ol li {
 }
 
 /** placeholder **/
-.ProseMirror[data-placeholder]::before {
+.ProseMirror[data-placeholder]::before,
+.charm-placeholder::before  {
   display: block;
   height: 0;
   color: var(--bg-gray);

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -515,8 +515,9 @@ ol li {
 .charm-placeholder::before  {
   display: block;
   height: 0;
-  color: var(--bg-gray);
+  color: var(--secondary-text);
   content: attr(data-placeholder);
+  opacity: 0.75;
   pointer-events: none;
   position: relative;
 }

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -519,8 +519,12 @@ ol li {
   content: attr(data-placeholder);
   pointer-events: none;
   position: relative;
+}
+.ProseMirror[data-placeholder]::before  {
   top: 3px;
 }
+
+
 
 /** Begin Resizable columns **/
 


### PR DESCRIPTION


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09d4c69</samp>

This pull request adds a custom placeholder feature for empty lines in the `CharmEditor` component, using a plugin and a widget from the Bangle editor library. It also refactors and simplifies a utility function for checking if a ProseMirror node is empty.

### WHY
Notion does this, and it feels helpful. It also shows up when u select an empty column which is nice.
