### PR TITLE
Protect commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,16 +4,22 @@
 npx lint-staged
 
 # List of files to check. These should already be in gitignore, but this provides an additional layer of protection.
-files_to_check=(".env.production" ".env.staging", ".env.blocked")
+# List of banned files to check against
+banned_files=(".env.production" ".env.staging", ".env.blocked")
 
-# Loop over each file in the list and check for the forbidden string
-for file_to_check in "${files_to_check[@]}"; do
-  # Check if the file is staged for commit
-  if git diff --cached --name-only | grep -q "^$file_to_check$"; then
-    if grep -q "env.blocked" "$file_to_check"; then
-      echo "Error: 'env.blocked' found in staged file: $file_to_check"
+# Get list of staged files from git
+staged_files=$(git diff --cached --name-only)
+
+# Loop through each staged file
+for staged_file in $staged_files; do
+  # Loop through each banned file
+  for banned_file in "${banned_files[@]}"; do
+    # Check if the staged file is in the list of banned files
+    if [ "$staged_file" = "$banned_file" ]; then
+      # Check if the banned file contains the forbidden string
+      echo "Error: $banned_file found in staged file: $staged_file"
       echo "Please remove it and try again."
       exit 1
     fi
-  fi
+  done
 done

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,7 @@ npx lint-staged
 
 # List of files to check. These should already be in gitignore, but this provides an additional layer of protection.
 # List of banned files to check against
-banned_files=(".env.production" ".env.staging", ".env.blocked")
+banned_files=(".env.b")
 
 # Get list of staged files from git
 staged_files=$(git diff --cached --name-only)
@@ -14,10 +14,9 @@ staged_files=$(git diff --cached --name-only)
 for staged_file in $staged_files; do
   # Loop through each banned file
   for banned_file in "${banned_files[@]}"; do
-    # Check if the staged file is in the list of banned files
-    if [ "$staged_file" = "$banned_file" ]; then
-      # Check if the banned file contains the forbidden string
-      echo "Error: $banned_file found in staged file: $staged_file"
+    # Check if the staged file contains the banned file pattern
+    if grep -q "$banned_file" <<< "$staged_file"; then
+      echo "Error: Banned file '$staged_file' found in staged files"
       echo "Please remove it and try again."
       exit 1
     fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,7 +4,7 @@
 npx lint-staged
 
 # List of files to check. These should already be in gitignore, but this provides an additional layer of protection.
-files_to_check=(".env.production" ".env.staging")
+files_to_check=(".env.production" ".env.staging", ".env.blocked")
 
 # Loop over each file in the list and check for the forbidden string
 for file_to_check in "${files_to_check[@]}"; do

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,7 @@ npx lint-staged
 
 # List of files to check. These should already be in gitignore, but this provides an additional layer of protection.
 # List of banned files to check against. Any staging (ex. .env.staging, .env.stg) or prod file will be rejected.
-banned_files=(".env.p" ".env.s")
+banned_files=(".env.p" ".env.s" ".env.b")
 
 # Get list of staged files from git
 staged_files=$(git diff --cached --name-only)
@@ -16,8 +16,9 @@ for staged_file in $staged_files; do
   for banned_file in "${banned_files[@]}"; do
     # Check if the staged file contains the banned file pattern
     if grep -q "$banned_file" <<< "$staged_file"; then
-      echo "Error: Banned file '$staged_file' found in staged files"
-      echo "Please remove it and try again."
+      printf "\n"
+      printf "\e[31mError: Banned file \e[1m'$staged_file'\e[0m\e[31m found in staged files\e[0m \n"
+      printf "Please remove it and try again.\n"
       exit 1
     fi
   done

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,18 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
+
+# List of files to check. These should already be in gitignore, but this provides an additional layer of protection.
+files_to_check=(".env.production" ".env.staging")
+
+# Loop over each file in the list and check for the forbidden string
+for file_to_check in "${files_to_check[@]}"; do
+  # Check if the file is staged for commit
+  if git diff --cached --name-only | grep -q "^$file_to_check$"; then
+    if grep -q "env.blocked" "$file_to_check"; then
+      echo "Error: 'env.blocked' found in staged file: $file_to_check"
+      echo "Please remove it and try again."
+      exit 1
+    fi
+  fi
+done

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,8 @@ npx lint-staged
 
 # List of files to check. These should already be in gitignore, but this provides an additional layer of protection.
 # List of banned files to check against. Any staging (ex. .env.staging, .env.stg) or prod file will be rejected.
-banned_files=(".env.p" ".env.s" ".env.b")
+# To test this, try adding a file with the name .env.blocked to your project and add '.env.b' to the banned_files array
+banned_files=(".env.p" ".env.s")
 
 # Get list of staged files from git
 staged_files=$(git diff --cached --name-only)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,8 +4,8 @@
 npx lint-staged
 
 # List of files to check. These should already be in gitignore, but this provides an additional layer of protection.
-# List of banned files to check against
-banned_files=(".env.b")
+# List of banned files to check against. Any staging (ex. .env.staging, .env.stg) or prod file will be rejected.
+banned_files=(".env.p" ".env.s")
 
 # Get list of staged files from git
 staged_files=$(git diff --cached --name-only)


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9436786</samp>

Added a pre-commit hook script to prevent committing sensitive or environment-specific files. The script checks for files that match a list of banned patterns in `.husky/pre-commit` and aborts the commit if any are found.

### WHY
We want to add an additional layer of protection on committing .env files.

This PR will throw an error in precommit hooks if trying to commit a .env file matching .env.p OR .env.s (such as .env.staging / env.stg)

Example below shows trying to commit a file called .env.blocked (during testing .env.b was added to the array)

<img width="593" alt="Screenshot 2023-09-06 at 17 07 01" src="https://github.com/charmverse/app.charmverse.io/assets/18669748/bca28907-9e26-469c-a181-3392b55f543b">

