### PR TITLE
Prevent duplicate proposal cards

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -13,7 +13,7 @@ inputs:
       If set core_pkg_version and commit_core_pkg_upgrade will be ignored. 
       Add your branch to this variable below to install your custom branch.
     required: false
-    default: 
+    default: prevent-duplicate-proposal-cards
 
 runs:
   using: 'composite'

--- a/lib/focalboard/__tests__/updateCardsFromProposals.spec.ts
+++ b/lib/focalboard/__tests__/updateCardsFromProposals.spec.ts
@@ -3,7 +3,6 @@ import { prisma } from '@charmverse/core/prisma-client';
 import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
 import { v4 } from 'uuid';
 
-import type { BoardView } from 'lib/focalboard/boardView';
 import { InvalidStateError } from 'lib/middleware';
 import { generateBoard } from 'testing/setupDatabase';
 

--- a/lib/focalboard/createCardsFromProposals.ts
+++ b/lib/focalboard/createCardsFromProposals.ts
@@ -12,13 +12,19 @@ import type {
 import type { BoardPropertyValue } from 'lib/public-api';
 import { relay } from 'lib/websockets/relay';
 
-import { createCardPage } from '../pages/createCardPage';
-
 import type { BoardFields } from './board';
 import type { BoardViewFields } from './boardView';
 import { extractDatabaseProposalProperties } from './extractDatabaseProposalProperties';
 import { generateResyncedProposalEvaluationForCard } from './generateResyncedProposalEvaluationForCard';
 import { setDatabaseProposalProperties } from './setDatabaseProposalProperties';
+import { upsertProposalCardPage } from './upsertProposalCardPage';
+
+const baseFields = {
+  contentOrder: [],
+  headerImage: null,
+  icon: '',
+  isTemplate: false
+};
 
 export async function createCardsFromProposals({
   boardId,
@@ -181,7 +187,7 @@ export async function createCardsFromProposals({
 
       const updatedCardShape = generateResyncedProposalEvaluationForCard({
         proposalEvaluationType: pageProposal.proposal.evaluationType,
-        cardProps: { fields: properties },
+        cardProps: { fields: { properties } },
         databaseProperties: databaseProposalProps,
         rubricCriteria: criteria as ProposalRubricCriteriaWithTypedParams[],
         rubricAnswers: answers as ProposalRubricCriteriaAnswerWithTypedResponse[]
@@ -190,13 +196,16 @@ export async function createCardsFromProposals({
       properties = updatedCardShape.fields;
     }
 
-    const _card = await createCardPage({
+    const _card = await upsertProposalCardPage({
       title: pageProposal.title,
       boardId,
       spaceId: pageProposal.spaceId,
       createdAt,
-      createdBy: userId,
-      properties: properties as any,
+      userId,
+      fields: {
+        ...baseFields,
+        properties
+      },
       hasContent: pageProposal.hasContent,
       content: pageProposal.content,
       contentText: pageProposal.contentText,

--- a/lib/focalboard/upsertProposalCardPage.ts
+++ b/lib/focalboard/upsertProposalCardPage.ts
@@ -1,0 +1,100 @@
+import type { Page } from '@charmverse/core/prisma-client';
+import { prisma } from '@charmverse/core/prisma-client';
+
+import { getPagePath } from 'lib/pages/utils';
+
+type ProposalCardPageUpsert = Pick<Page, 'title' | 'spaceId' | 'hasContent' | 'content' | 'contentText'> & {
+  fields: any;
+  syncWithPageId: string;
+  boardId: string;
+  userId: string;
+  // If fields is provided, properties will be ignored
+} & Partial<Pick<Page, 'updatedAt' | 'deletedAt' | 'createdAt'>>;
+
+export async function upsertProposalCardPage({
+  boardId,
+  syncWithPageId,
+  content,
+  contentText,
+  createdAt,
+  updatedAt,
+  userId,
+  hasContent,
+  spaceId,
+  title,
+  deletedAt,
+  fields
+}: ProposalCardPageUpsert) {
+  return prisma.$transaction(async (tx) => {
+    const upsertedPage = await tx.page.upsert({
+      // @ts-ignore
+      where: {
+        parentId_syncWithPageId: {
+          parentId: boardId,
+          syncWithPageId
+        }
+      },
+      create: {
+        path: getPagePath(),
+        type: 'card',
+        parentId: boardId,
+        syncWithPageId,
+        content: content as any,
+        contentText,
+        createdAt,
+        updatedAt: createdAt,
+        hasContent,
+        title,
+        author: { connect: { id: userId } },
+        updatedBy: userId,
+        space: { connect: { id: spaceId } }
+      },
+      update: {
+        updatedAt,
+        updatedBy: userId,
+        deletedAt,
+        title,
+        hasContent,
+        content: content as any,
+        contentText
+      }
+    });
+
+    const upsertedBlock = await tx.block.upsert({
+      where: {
+        id: upsertedPage.id
+      },
+      create: {
+        id: upsertedPage.id,
+        user: {
+          connect: { id: userId }
+        },
+        space: {
+          connect: { id: spaceId }
+        },
+        updatedBy: userId,
+        parentId: boardId,
+        rootId: boardId,
+        schema: 1,
+        type: 'card',
+        title,
+        fields,
+        page: {
+          connect: {
+            id: upsertedPage.id
+          }
+        }
+      },
+      update: {
+        title,
+        updatedAt,
+        fields
+      }
+    });
+
+    return {
+      page: upsertedPage,
+      block: upsertedBlock
+    };
+  });
+}

--- a/lib/pages/createCardPage.ts
+++ b/lib/pages/createCardPage.ts
@@ -1,5 +1,5 @@
 import { DataNotFoundError } from '@charmverse/core/errors';
-import type { Page, Block } from '@charmverse/core/prisma';
+import type { Block, Page } from '@charmverse/core/prisma';
 import { prisma } from '@charmverse/core/prisma-client';
 import { v4 } from 'uuid';
 
@@ -7,11 +7,10 @@ import { createPage } from 'lib/pages/server/createPage';
 import { getPagePath } from 'lib/pages/utils';
 import type { BoardPropertyValue } from 'lib/public-api';
 
-export async function createCardPage(
-  pageInfo: Record<keyof Pick<Page, 'title' | 'boardId' | 'createdBy' | 'spaceId'>, string> & {
-    properties: Record<string, BoardPropertyValue>;
-  } & Partial<Pick<Page, 'content' | 'hasContent' | 'contentText' | 'syncWithPageId' | 'createdAt'>>
-): Promise<{ page: Page; block: Block }> {
+export type CardPageCreateInput = Record<keyof Pick<Page, 'title' | 'boardId' | 'createdBy' | 'spaceId'>, string> & {
+  properties: Record<string, BoardPropertyValue>;
+} & Partial<Pick<Page, 'content' | 'hasContent' | 'contentText' | 'syncWithPageId' | 'createdAt'>>;
+export async function createCardPage(pageInfo: CardPageCreateInput): Promise<{ page: Page; block: Block }> {
   const board = await prisma.block.findFirst({
     where: {
       type: 'board',

--- a/scripts/cleanupDuplicateProposalCards.ts
+++ b/scripts/cleanupDuplicateProposalCards.ts
@@ -23,7 +23,7 @@ async function cleanupDuplicateProposalCards() {
       parentId: {
         not: null
       }
-      //spaceId: space.id
+      // spaceId: space.id
     },
     select: {
       id: true,
@@ -56,7 +56,7 @@ async function cleanupDuplicateProposalCards() {
     await prisma.$transaction(async tx => {
       await tx.page.deleteMany({
         where: {
-//          spaceId: space.id,
+        // spaceId: space.id,
           type: 'card',
           id: {
             in: cardsToDelete.cardIdsToDelete
@@ -65,7 +65,7 @@ async function cleanupDuplicateProposalCards() {
       });
       await tx.block.deleteMany({
         where: {
-          // spaceId: space.id,
+          //spaceId: space.id,
           type: 'card',
           id: {
             in: cardsToDelete.cardIdsToDelete

--- a/scripts/seedProposalsData.ts
+++ b/scripts/seedProposalsData.ts
@@ -1,0 +1,50 @@
+import { InvalidInputError } from "@charmverse/core/errors";
+import { prisma } from "@charmverse/core/prisma-client";
+import { testUtils, testUtilsProposals } from "@charmverse/core/test";
+import { emptyDocument } from "lib/prosemirror/constants";
+
+
+
+
+async function seedProposals({spaceDomain, count}: {spaceDomain: string, count: number}) {
+
+  if (!spaceDomain) {
+    throw new InvalidInputError(`spaceDomain is required`)
+  }
+
+  // await prisma.proposal.deleteMany({
+  //   where: {
+  //     space: {
+  //       domain: spaceDomain
+  //     }
+  //   }
+  // })
+  const space = await prisma.space.findUniqueOrThrow({
+    where: {
+      domain: spaceDomain
+    }
+  });
+
+  const category = await prisma.proposalCategory.findFirstOrThrow({
+    where: {
+      spaceId: space.id
+    }
+  })
+  
+  for (let i = 0; i <count; i++) {
+    await testUtilsProposals.generateProposal({
+      spaceId: space.id,
+      userId: space.createdBy,
+      proposalStatus: 'discussion',
+      content: {...emptyDocument},
+      categoryId: category.id,
+      title: `Proposal ${i + 1}`
+    })
+
+    console.log('Generated proposal', i +1, '/', count, 'in space', space.domain)
+  }
+}
+
+seedProposals({count: 150, spaceDomain: 'blank-alpha-butterfly'}).then(() => console.log('Done'));
+
+


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e2376a</samp>

The pull request adds and updates logic to create and update cards from proposals in the Focalboard module. It also adds a new function `upsertProposalCardPage` to perform the card page and block upsert operation, and a new script `seedProposalsData.ts` to generate mock proposals for testing. It also fixes some formatting and import issues in some files.

### WHY
Back-end fix to prevent race conditions in creating and updating proposal cards

Known issue: Getting 52 cards vs 50 in race condition test