### PR TITLE
Fix formatting of proposal links

### DIFF
--- a/__e2e__/database/databaseProposalsAsSource.spec.ts
+++ b/__e2e__/database/databaseProposalsAsSource.spec.ts
@@ -7,6 +7,8 @@ import { DatabasePage } from '__e2e__/po/databasePage.po';
 import { DocumentPage } from '__e2e__/po/document.po';
 import { PagesSidebarPage } from '__e2e__/po/pagesSiderbar.po';
 
+import { baseUrl } from 'config/constants';
+
 import { loginBrowserUser } from '../utils/mocks';
 
 type Fixtures = {
@@ -147,6 +149,18 @@ test.describe.serial('Database with proposals as datasource', async () => {
       const statusSelect = selectProps[1];
 
       expect((await statusSelect.allInnerTexts())[0]).toEqual('Feedback');
+
+      const syncedProposalUrl = databasePage.getTablePropertyProposalUrlLocator({ cardId: card.id });
+      const proposalPage = await prisma.page.findUniqueOrThrow({
+        where: {
+          id: card.syncWithPageId as string
+        },
+        select: {
+          path: true
+        }
+      });
+
+      expect(await syncedProposalUrl.getAttribute('href')).toEqual(`${baseUrl}/${space.domain}/${proposalPage.path}`);
     }
 
     // Make sure the UI only displays 3 cards

--- a/__e2e__/po/databasePage.po.ts
+++ b/__e2e__/po/databasePage.po.ts
@@ -48,4 +48,11 @@ export class DatabasePage extends GlobalPage {
       openSelect: this.page.locator(`data-test=database-row-${cardId}`).locator('data-test=autocomplete').first()
     };
   }
+
+  getTablePropertyProposalUrlLocator({ cardId }: { cardId: string }) {
+    return this.page
+      .locator(`data-test=database-row-${cardId}`)
+      .locator('data-test=property-proposal-url')
+      .locator('a');
+  }
 }

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -257,8 +257,12 @@ function PropertyValueElement(props: Props) {
       propertyValueElement = <TextInput {...commonProps} />;
     }
   } else if (propertyTemplate.type === 'proposalUrl' && typeof displayValue === 'string') {
-    const proposalUrl = getAbsolutePath(`/${displayValue}`, domain);
-    propertyValueElement = <URLProperty {...commonProps} value={proposalUrl} validator={() => true} />;
+    const proposalUrl = getAbsolutePath(`/${propertyValue as string}`, domain);
+    propertyValueElement = (
+      <div data-test='property-proposal-url'>
+        <URLProperty {...commonProps} value={proposalUrl} validator={() => true} />
+      </div>
+    );
   } else if (propertyValueElement === null) {
     propertyValueElement = (
       <div className='octo-propertyvalue'>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 934b0d2</samp>

This pull request enhances the testing and functionality of the database proposals as source feature. It adds a new method to the `databasePage` page object, a new `data-test` attribute to the `URLProperty` component, and fixes a bug in `propertyValueElement.tsx`.

### WHY
Fix how links are rendered for synced proposal, add an E2E test to ensure correct format