### PR TITLE
remove redundant logic on login page

### DIFF
--- a/components/login/LoginPage.tsx
+++ b/components/login/LoginPage.tsx
@@ -6,7 +6,6 @@ import { Web3Connection } from 'components/_app/Web3ConnectionManager';
 import { getLayout } from 'components/common/BaseLayout/getLayout';
 import { getKey } from 'hooks/useLocalStorage';
 import { usePageTitle } from 'hooks/usePageTitle';
-import { useSettingsDialog } from 'hooks/useSettingsDialog';
 import { useUser } from 'hooks/useUser';
 import { AUTH_CODE_COOKIE } from 'lib/discord/constants';
 import { deleteCookie, getCookie, getSpaceUrl } from 'lib/utilities/browser';
@@ -20,31 +19,9 @@ export function LoginPageView() {
   const [, setTitleState] = usePageTitle();
   const { user, isLoaded: isUserLoaded } = useUser();
   const discordCookie = getCookie(AUTH_CODE_COOKIE);
-  const { onClick: openSettingsModal, open: isSettingsDialogOpen } = useSettingsDialog();
   const isLogInWithDiscord = Boolean(discordCookie);
   const isDataLoaded = triedEager && isUserLoaded;
   const isLoggedIn = !!user;
-
-  useEffect(() => {
-    const account = router.query.account;
-    const subscription = router.query.subscription;
-
-    if (!isSettingsDialogOpen && router.isReady) {
-      if (account) {
-        openSettingsModal('account');
-      }
-      if (subscription) {
-        openSettingsModal('subscription');
-      }
-    }
-  }, [
-    isSettingsDialogOpen,
-    router.isReady,
-    router.query.task,
-    router.query.account,
-    router.query.notifications,
-    openSettingsModal
-  ]);
 
   useEffect(() => {
     setTitleState('Welcome');


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 995d464</samp>

Refactored settings modal logic from `LoginPage` to `AppLayout` component. This improves the user experience and performance of opening the settings modal from different pages.

### WHY
<!-- author to complete -->
