### PR TITLE
Add e2e test to ensure archived proposals do not crash tables, ensure archived proposal shows

### DIFF
--- a/__e2e__/po/databasePage.po.ts
+++ b/__e2e__/po/databasePage.po.ts
@@ -55,4 +55,8 @@ export class DatabasePage extends GlobalPage {
       .locator('data-test=property-proposal-url')
       .locator('a');
   }
+
+  getTablePropertyProposalStatusLocator({ cardId }: { cardId: string }) {
+    return this.page.locator(`data-test=database-row-${cardId}`).locator('data-test=proposal-status-badge');
+  }
 }

--- a/components/proposals/components/ProposalStatusBadge.tsx
+++ b/components/proposals/components/ProposalStatusBadge.tsx
@@ -1,19 +1,20 @@
-import type { ProposalStatus } from '@charmverse/core/prisma';
 import styled from '@emotion/styled';
 import BarChartOutlinedIcon from '@mui/icons-material/BarChartOutlined';
 import ChatOutlinedIcon from '@mui/icons-material/ChatOutlined';
 import CheckOutlinedIcon from '@mui/icons-material/CheckOutlined';
 import HowToVoteOutlinedIcon from '@mui/icons-material/HowToVoteOutlined';
+import ArchivedOutlinedIcon from '@mui/icons-material/Inventory2Outlined';
 import ModeEditOutlineOutlinedIcon from '@mui/icons-material/ModeEditOutlineOutlined';
 import ReviewsOutlinedIcon from '@mui/icons-material/ReviewsOutlined';
 import type { ChipProps } from '@mui/material';
 import { Chip } from '@mui/material';
 import type { ReactNode } from 'react';
 
-import { PROPOSAL_STATUS_LABELS } from 'lib/proposal/proposalStatusTransition';
+import type { ProposalStatusWithArchived } from 'lib/proposal/proposalStatusTransition';
+import { PROPOSAL_STATUS_LABELS_WITH_ARCHIVED } from 'lib/proposal/proposalStatusTransition';
 import type { BrandColor } from 'theme/colors';
 
-const PROPOSAL_STATUS_ICONS: Record<ProposalStatus, ReactNode> = {
+const PROPOSAL_STATUS_ICONS: Record<ProposalStatusWithArchived, ReactNode> = {
   draft: <ModeEditOutlineOutlinedIcon />,
   discussion: <ChatOutlinedIcon />,
   review: <ReviewsOutlinedIcon />,
@@ -21,10 +22,11 @@ const PROPOSAL_STATUS_ICONS: Record<ProposalStatus, ReactNode> = {
   vote_active: <HowToVoteOutlinedIcon />,
   vote_closed: <BarChartOutlinedIcon />,
   evaluation_active: <HowToVoteOutlinedIcon />,
-  evaluation_closed: <BarChartOutlinedIcon />
+  evaluation_closed: <BarChartOutlinedIcon />,
+  archived: <ArchivedOutlinedIcon />
 };
 
-export const ProposalStatusColors: Record<ProposalStatus | 'archived', BrandColor> = {
+export const ProposalStatusColors: Record<ProposalStatusWithArchived, BrandColor> = {
   draft: 'gray',
   discussion: 'teal',
   review: 'yellow',
@@ -36,7 +38,7 @@ export const ProposalStatusColors: Record<ProposalStatus | 'archived', BrandColo
   archived: 'gray'
 };
 
-const StyledProposalStatusChip = styled(Chip)<{ status: ProposalStatus }>`
+const StyledProposalStatusChip = styled(Chip)<{ status: ProposalStatusWithArchived }>`
   background-color: ${({ status, theme }) => {
     // @ts-ignore
     return theme.palette[ProposalStatusColors[status]]?.main;
@@ -56,20 +58,26 @@ const StyledProposalStatusChip = styled(Chip)<{ status: ProposalStatus }>`
   }
 `;
 
-export function ProposalStatusChip({ status, size = 'small' }: { size?: ChipProps['size']; status: ProposalStatus }) {
+export function ProposalStatusChip({
+  status,
+  size = 'small'
+}: {
+  size?: ChipProps['size'];
+  status: ProposalStatusWithArchived;
+}) {
   return (
     <StyledProposalStatusChip
       data-test='proposal-status-badge'
       size={size}
       status={status}
-      label={PROPOSAL_STATUS_LABELS[status]}
+      label={PROPOSAL_STATUS_LABELS_WITH_ARCHIVED[status]}
       variant='filled'
       icon={<span>{PROPOSAL_STATUS_ICONS[status]}</span>}
     />
   );
 }
 
-const StyledProposalStatusChipNormalText = styled(Chip)<{ status: ProposalStatus }>`
+const StyledProposalStatusChipNormalText = styled(Chip)<{ status: ProposalStatusWithArchived }>`
   background-color: ${({ status, theme }) => {
     // @ts-ignore
     return theme.palette[ProposalStatusColors[status]]?.main;
@@ -94,14 +102,14 @@ export function ProposalStatusChipTextOnly({
   size = 'small'
 }: {
   size?: ChipProps['size'];
-  status: ProposalStatus;
+  status: ProposalStatusWithArchived;
 }) {
   return (
     <StyledProposalStatusChipNormalText
       data-test='proposal-status-badge'
       size={size}
       status={status}
-      label={PROPOSAL_STATUS_LABELS[status]}
+      label={PROPOSAL_STATUS_LABELS_WITH_ARCHIVED[status]}
       variant='filled'
     />
   );

--- a/lib/focalboard/proposalDbProperties.ts
+++ b/lib/focalboard/proposalDbProperties.ts
@@ -1,8 +1,8 @@
-import type { ProposalStatus } from '@charmverse/core/prisma';
 import { v4 as uuid } from 'uuid';
 
 import type { Constants } from 'components/common/BoardEditor/focalboard/src/constants';
 import type { DatabaseProposalPropertyType, IPropertyTemplate } from 'lib/focalboard/board';
+import type { ProposalStatusWithArchived } from 'lib/proposal/proposalStatusTransition';
 
 export const proposalDbProperties: {
   [key in DatabaseProposalPropertyType]: (id?: string, name?: string) => IPropertyTemplate<key>;
@@ -67,7 +67,7 @@ export const proposalDbProperties: {
  * See components/proposals/components/ProposalStatusBadge.tsx // ProposalStatusColors for the corresponding statuses
  */
 
-export const proposalStatusBoardColors: Record<ProposalStatus | 'archived', keyof (typeof Constants)['menuColors']> = {
+export const proposalStatusBoardColors: Record<ProposalStatusWithArchived, keyof (typeof Constants)['menuColors']> = {
   archived: 'propColorGray',
   draft: 'propColorGray',
   discussion: 'propColorTeal',

--- a/lib/proposal/proposalStatusTransition.ts
+++ b/lib/proposal/proposalStatusTransition.ts
@@ -13,6 +13,8 @@ export const proposalStatusTransitionRecord: Record<ProposalStatus, ProposalStat
 
 export const PROPOSAL_STATUSES = Object.keys(proposalStatusTransitionRecord) as ProposalStatus[];
 
+export type ProposalStatusWithArchived = ProposalStatus | 'archived';
+
 export function getProposalStatuses(evaluationType: ProposalEvaluationType = 'vote'): ProposalStatus[] {
   if (evaluationType === 'rubric') {
     return ['draft', 'discussion', 'evaluation_active', 'evaluation_closed'];
@@ -32,7 +34,7 @@ export const PROPOSAL_STATUS_LABELS: Record<ProposalStatus, string> = {
   evaluation_closed: 'Evaluation Closed'
 };
 
-export const PROPOSAL_STATUS_LABELS_WITH_ARCHIVED: Record<ProposalStatus | 'archived', string> = {
+export const PROPOSAL_STATUS_LABELS_WITH_ARCHIVED: Record<ProposalStatusWithArchived, string> = {
   ...PROPOSAL_STATUS_LABELS,
   archived: 'Archived'
 };


### PR DESCRIPTION

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9892d42</samp>

Added support for archiving proposals in the app and testing it in the end-to-end suite. Modified the `ProposalStatusBadge` component, the proposal status type and mapping, and the `proposalStatusTransition` module to handle the new status. Added a new method to the `databasePage` page object to locate the proposal status badge. Improved the `databaseProposalsAsSource.spec.ts` test to cover the archiving functionality.

### WHY

Adds missing E2E test ensuring archived proposals don't cause a crash.

While adding this test, I noticed the archived badge was empty. Fixed this as well
