### PR TITLE
have elastic beanstalk ignore 400 errors

### DIFF
--- a/.cdk/staging-stack.ts
+++ b/.cdk/staging-stack.ts
@@ -39,10 +39,10 @@ export class CdkDeployStack extends Stack {
       Rules: {
         Environment: {
           Application: {
-            ApplicationRequests4xx: { Enabled: true }
+            ApplicationRequests4xx: { Enabled: false }
           },
           ELB: {
-            ELBRequests4xx: { Enabled: true }
+            ELBRequests4xx: { Enabled: false }
           }
         }
       },

--- a/.cdk/staging-stack.ts
+++ b/.cdk/staging-stack.ts
@@ -35,6 +35,20 @@ export class CdkDeployStack extends Stack {
     // Make sure that Elastic Beanstalk app exists before creating an app version
     appVersionProps.addDependency(ebApp);
 
+    const healthReportingSystemConfig = {
+      Rules: {
+        Environment: {
+          Application: {
+            ApplicationRequests4xx: { Enabled: 'true' }
+          },
+          ELB: {
+            ELBRequests4xx: { Enabled: 'true' }
+          }
+        }
+      },
+      Version: 1
+    }
+
     // list of all options: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html
     const optionSettingProperties: elasticbeanstalk.CfnEnvironment.OptionSettingProperty[] = [
       {
@@ -51,6 +65,16 @@ export class CdkDeployStack extends Stack {
         namespace: 'aws:elasticbeanstalk:environment',
         optionName: 'LoadBalancerType',
         value: 'application'
+      },
+      {
+        namespace: 'aws:elasticbeanstalk:healthreporting:system',
+        optionName: 'SystemType',
+        value: 'enhanced'
+      },
+      {
+        namespace: 'aws:elasticbeanstalk:healthreporting:system',
+        optionName: 'ConfigDocument',
+        value: JSON.stringify(healthReportingSystemConfig)
       },
       {
         namespace: 'aws:elbv2:listener:443',

--- a/.cdk/staging-stack.ts
+++ b/.cdk/staging-stack.ts
@@ -39,10 +39,10 @@ export class CdkDeployStack extends Stack {
       Rules: {
         Environment: {
           Application: {
-            ApplicationRequests4xx: { Enabled: 'true' }
+            ApplicationRequests4xx: { Enabled: true }
           },
           ELB: {
-            ELBRequests4xx: { Enabled: 'true' }
+            ELBRequests4xx: { Enabled: true }
           }
         }
       },

--- a/.ebextensions/01_env_health_ignore_400.config
+++ b/.ebextensions/01_env_health_ignore_400.config
@@ -1,0 +1,13 @@
+option_settings:
+  aws:elasticbeanstalk:healthreporting:system:
+    SystemType: enhanced
+    ConfigDocument:
+      Rules:
+        Environment:
+          Application:
+            ApplicationRequests4xx:
+              Enabled: true
+          ELB:
+            ELBRequests4xx:
+              Enabled: true
+      Version: 1

--- a/.ebextensions/01_env_health_ignore_400.config
+++ b/.ebextensions/01_env_health_ignore_400.config
@@ -6,8 +6,8 @@ option_settings:
         Environment:
           Application:
             ApplicationRequests4xx:
-              Enabled: true
+              Enabled: false
           ELB:
             ELBRequests4xx:
-              Enabled: true
+              Enabled: false
       Version: 1

--- a/.ebextensions_cron/01_env_health_ignore_400.config
+++ b/.ebextensions_cron/01_env_health_ignore_400.config
@@ -1,0 +1,13 @@
+option_settings:
+  aws:elasticbeanstalk:healthreporting:system:
+    SystemType: enhanced
+    ConfigDocument:
+      Rules:
+        Environment:
+          Application:
+            ApplicationRequests4xx:
+              Enabled: true
+          ELB:
+            ELBRequests4xx:
+              Enabled: true
+      Version: 1

--- a/.ebextensions_cron/01_env_health_ignore_400.config
+++ b/.ebextensions_cron/01_env_health_ignore_400.config
@@ -6,8 +6,8 @@ option_settings:
         Environment:
           Application:
             ApplicationRequests4xx:
-              Enabled: true
+              Enabled: false
           ELB:
             ELBRequests4xx:
-              Enabled: true
+              Enabled: false
       Version: 1

--- a/.ebextensions_websockets/01_env_health_ignore_400.config
+++ b/.ebextensions_websockets/01_env_health_ignore_400.config
@@ -1,0 +1,13 @@
+option_settings:
+  aws:elasticbeanstalk:healthreporting:system:
+    SystemType: enhanced
+    ConfigDocument:
+      Rules:
+        Environment:
+          Application:
+            ApplicationRequests4xx:
+              Enabled: true
+          ELB:
+            ELBRequests4xx:
+              Enabled: true
+      Version: 1

--- a/.ebextensions_websockets/01_env_health_ignore_400.config
+++ b/.ebextensions_websockets/01_env_health_ignore_400.config
@@ -6,8 +6,8 @@ option_settings:
         Environment:
           Application:
             ApplicationRequests4xx:
-              Enabled: true
+              Enabled: false
           ELB:
             ELBRequests4xx:
-              Enabled: true
+              Enabled: false
       Version: 1


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8aeb65</samp>

This pull request adds an option setting to ignore 4xx errors in the enhanced health reporting for the Elastic Beanstalk environments. This affects the main environment configuration file and the specific files for the cron and websockets environments.

### WHY
<!-- author to complete -->
