### PR TITLE
Hide inline comments without document reference

### DIFF
--- a/components/[pageId]/DocumentPage/components/CommentsSidebar.tsx
+++ b/components/[pageId]/DocumentPage/components/CommentsSidebar.tsx
@@ -9,9 +9,11 @@ import type { ReactNode } from 'react';
 import React, { memo, useLayoutEffect, useMemo, useState } from 'react';
 
 import PageThread from 'components/common/CharmEditor/components/PageThread';
+import { specRegistry } from 'components/common/CharmEditor/specRegistry';
 import { usePageActionDisplay } from 'hooks/usePageActionDisplay';
 import { useThreads } from 'hooks/useThreads';
 import { useUser } from 'hooks/useUser';
+import { extractThreadIdsFromDoc } from 'lib/prosemirror/plugins/inlineComments/extractDeletedThreadIds';
 import { findTotalInlineComments } from 'lib/prosemirror/plugins/inlineComments/findTotalInlineComments';
 import type { ThreadWithCommentsAndAuthors } from 'lib/threads/interfaces';
 import { highlightDomElement, setUrlWithoutRerender } from 'lib/utilities/browser';
@@ -76,13 +78,15 @@ function CommentsSidebarComponent({ inline, permissions }: { inline?: boolean; p
   }
 
   const view = useEditorViewContext();
+  const extractedThreadIds = extractThreadIdsFromDoc(view.state.doc, specRegistry.schema);
+
   // Making sure the position sort doesn't filter out comments that are not in the view
   const inlineThreadsIds = Array.from(
     new Set([
       ...findTotalInlineComments(view.state.schema, view.state.doc, threads, true).threadIds,
       ...allThreads.map((thread) => thread?.id)
     ])
-  );
+  ).filter((id) => extractedThreadIds.has(id));
 
   const threadListSet = new Set(threadList.map((thread) => thread.id));
   const sortedThreadList = inlineThreadsIds

--- a/lib/prosemirror/plugins/inlineComments/extractDeletedThreadIds.ts
+++ b/lib/prosemirror/plugins/inlineComments/extractDeletedThreadIds.ts
@@ -18,13 +18,15 @@ function extractThreadIds(inlineCommentNodes: NodeWithPos[]) {
   return threadIds;
 }
 
-export function extractDeletedThreadIds(schema: Schema, curDoc: Node, prevDoc: Node) {
+export function extractThreadIdsFromDoc(doc: Node, schema: Schema) {
   const inlineCommentMarkSchema = schema.marks['inline-comment'] as MarkType;
-  const currentDocInlineCommentNodes = findChildrenByMark(curDoc, inlineCommentMarkSchema);
-  const prevDocInlineCommentNodes = findChildrenByMark(prevDoc, inlineCommentMarkSchema);
+  const inlineCommentNodes = findChildrenByMark(doc, inlineCommentMarkSchema);
+  return extractThreadIds(inlineCommentNodes);
+}
 
-  const prevDocThreadIds = extractThreadIds(prevDocInlineCommentNodes);
-  const curDocThreadIds = extractThreadIds(currentDocInlineCommentNodes);
+export function extractDeletedThreadIds(schema: Schema, curDoc: Node, prevDoc: Node) {
+  const prevDocThreadIds = extractThreadIdsFromDoc(prevDoc, schema);
+  const curDocThreadIds = extractThreadIdsFromDoc(curDoc, schema);
 
   const deletedThreadIds: string[] = [];
   prevDocThreadIds.forEach((prevDocThreadId) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a444379</samp>

The pull request refactors the code for extracting and filtering inline comment threads from a document. It exports a new module `extractThreadIdsFromDoc` from `lib/prosemirror/plugins/inlineComments/extractDeletedThreadIds.ts` and uses it in `components/[pageId]/DocumentPage/components/CommentsSidebar.tsx` to display only the relevant threads.

### WHY
Hide inline comments from the sidebar if there are no corresponding comment marks in the document. 