### PR TITLE
Show loading screen during loading notifications

### DIFF
--- a/components/common/PageLayout/components/Header/components/NotificationPreview/NotificationModal.tsx
+++ b/components/common/PageLayout/components/Header/components/NotificationPreview/NotificationModal.tsx
@@ -10,6 +10,7 @@ import TaskOutlinedIcon from '@mui/icons-material/TaskOutlined';
 import { Badge, Box, Dialog, DialogContent, Divider, IconButton, Tab, Tabs, Tooltip, Typography } from '@mui/material';
 import { Fragment } from 'react';
 
+import LoadingComponent from 'components/common/LoadingComponent';
 import { MobileDialog } from 'components/common/MobileDialog/MobileDialog';
 import type { NotificationDisplayType } from 'components/common/PageLayout/components/Header/components/NotificationPreview/useNotifications';
 import { useNotifications } from 'components/common/PageLayout/components/Header/components/NotificationPreview/useNotifications';
@@ -56,7 +57,8 @@ export function NotificationModal() {
     unmarkedNotificationPreviews: unmarked,
     closeNotificationsModal,
     openNotificationsModal,
-    markAsRead
+    markAsRead,
+    isLoading
   } = useNotifications();
   const isMobile = useSmallScreen();
   const DialogComponent = isMobile ? MobileDialog : Dialog;
@@ -208,45 +210,47 @@ export function NotificationModal() {
               </Tabs>
             </Box>
             <DialogContent sx={{ height: 'calc(100% - 145px)', px: { xs: 0, md: 3 } }}>
-              {unmarkedNotifications.map((notification) => (
-                <Fragment key={notification.taskId}>
-                  <NotificationPreview
-                    large
-                    unmarked
-                    notification={notification}
-                    markAsRead={markAsRead}
-                    onClose={closeNotificationsModal}
-                  />
-                  <Divider />
-                </Fragment>
-              ))}
-              {markedNotifications.map((notification) => (
-                <Fragment key={notification.taskId}>
-                  <NotificationPreview
-                    large
-                    notification={notification}
-                    markAsRead={markAsRead}
-                    onClose={closeNotificationsModal}
-                  />
-                  <Divider />
-                </Fragment>
-              ))}
+              <LoadingComponent isLoading={isLoading} label='Fetching your notifications' size={24}>
+                {unmarkedNotifications.map((notification) => (
+                  <Fragment key={notification.taskId}>
+                    <NotificationPreview
+                      large
+                      unmarked
+                      notification={notification}
+                      markAsRead={markAsRead}
+                      onClose={closeNotificationsModal}
+                    />
+                    <Divider />
+                  </Fragment>
+                ))}
+                {markedNotifications.map((notification) => (
+                  <Fragment key={notification.taskId}>
+                    <NotificationPreview
+                      large
+                      notification={notification}
+                      markAsRead={markAsRead}
+                      onClose={closeNotificationsModal}
+                    />
+                    <Divider />
+                  </Fragment>
+                ))}
 
-              {unmarkedNotifications.length < 1 && markedNotifications.length < 1 && (
-                <Box
-                  display='flex'
-                  justifyContent='center'
-                  alignItems='center'
-                  flexDirection='row'
-                  height='calc(100% - 70px)'
-                  gap={1}
-                >
-                  <Typography variant='h5' color='secondary'>
-                    You are up to date!
-                  </Typography>
-                  <CelebrationIcon color='secondary' fontSize='large' />
-                </Box>
-              )}
+                {unmarkedNotifications.length < 1 && markedNotifications.length < 1 && (
+                  <Box
+                    display='flex'
+                    justifyContent='center'
+                    alignItems='center'
+                    flexDirection='row'
+                    height='calc(100% - 70px)'
+                    gap={1}
+                  >
+                    <Typography variant='h5' color='secondary'>
+                      You are up to date!
+                    </Typography>
+                    <CelebrationIcon color='secondary' fontSize='large' />
+                  </Box>
+                )}
+              </LoadingComponent>
             </DialogContent>
           </Box>
         </Box>

--- a/components/common/PageLayout/components/Header/components/NotificationPreview/NotificationPreviewPopover.tsx
+++ b/components/common/PageLayout/components/Header/components/NotificationPreview/NotificationPreviewPopover.tsx
@@ -2,6 +2,7 @@ import CelebrationIcon from '@mui/icons-material/Celebration';
 import { Box, Card, Divider, Typography } from '@mui/material';
 import { Fragment, useMemo } from 'react';
 
+import LoadingComponent from 'components/common/LoadingComponent';
 import { useNotifications } from 'components/common/PageLayout/components/Header/components/NotificationPreview/useNotifications';
 
 import { NotificationPreview } from './NotificationPreview';
@@ -9,7 +10,7 @@ import { NotificationPreview } from './NotificationPreview';
 const MAX_COUNT = 5;
 
 export function NotificationPreviewPopover({ close }: { close: VoidFunction }) {
-  const { unmarkedNotificationPreviews, markAsRead, markedNotificationPreviews, openNotificationsModal } =
+  const { isLoading, unmarkedNotificationPreviews, markAsRead, markedNotificationPreviews, openNotificationsModal } =
     useNotifications();
 
   const latestNotifications = useMemo(() => {
@@ -26,31 +27,34 @@ export function NotificationPreviewPopover({ close }: { close: VoidFunction }) {
         </Typography>
       </Card>
       <Divider />
-      <Box maxHeight={500} sx={{ overflowY: 'auto', overflowX: 'hidden' }}>
-        {latestNotifications.length > 0 ? (
-          latestNotifications.map((notification) => (
-            <Fragment key={notification.taskId}>
-              <NotificationPreview notification={notification} markAsRead={markAsRead} onClose={close} />
-              <Divider />
-            </Fragment>
-          ))
-        ) : (
-          <Box
-            display='flex'
-            justifyContent='center'
-            alignItems='center'
-            flexDirection='row'
-            height='100%'
-            my={2}
-            gap={1}
-          >
-            <Typography variant='h6' color='secondary'>
-              You are up to date!
-            </Typography>
-            <CelebrationIcon color='secondary' fontSize='medium' />
-          </Box>
-        )}
-      </Box>
+      <LoadingComponent isLoading={isLoading} label='Fetching your notifications' size={24}>
+        <Box maxHeight={500} sx={{ overflowY: 'auto', overflowX: 'hidden' }}>
+          {latestNotifications.length > 0 ? (
+            latestNotifications.map((notification) => (
+              <Fragment key={notification.taskId}>
+                <NotificationPreview notification={notification} markAsRead={markAsRead} onClose={close} />
+                <Divider />
+              </Fragment>
+            ))
+          ) : (
+            <Box
+              display='flex'
+              justifyContent='center'
+              alignItems='center'
+              flexDirection='row'
+              height='100%'
+              my={2}
+              gap={1}
+            >
+              <Typography variant='h6' color='secondary'>
+                You are up to date!
+              </Typography>
+              <CelebrationIcon color='secondary' fontSize='medium' />
+            </Box>
+          )}
+        </Box>
+      </LoadingComponent>
+
       <Card>
         <Box
           onClick={() => {

--- a/components/common/PageLayout/components/Header/components/NotificationPreview/useNotifications.tsx
+++ b/components/common/PageLayout/components/Header/components/NotificationPreview/useNotifications.tsx
@@ -45,6 +45,7 @@ type Context = {
   notificationDisplayType: NotificationDisplayType | null;
   openNotificationsModal: (type?: NotificationDisplayType) => void;
   closeNotificationsModal: () => void;
+  isLoading: boolean;
 };
 
 const NotificationsContext = createContext<Readonly<Context>>({
@@ -53,11 +54,12 @@ const NotificationsContext = createContext<Readonly<Context>>({
   markAsRead: async () => {},
   notificationDisplayType: null,
   openNotificationsModal: () => {},
-  closeNotificationsModal: () => {}
+  closeNotificationsModal: () => {},
+  isLoading: false
 });
 
 export function NotificationsProvider({ children }: { children: ReactNode }) {
-  const { tasks, mutate: mutateTasks } = useTasks();
+  const { tasks, mutate: mutateTasks, isLoading } = useTasks();
   const { user } = useUser();
   const currentUserId = user?.id;
   const { query, isReady } = useRouter();
@@ -146,6 +148,7 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo(
     () => ({
+      isLoading,
       unmarkedNotificationPreviews,
       markedNotificationPreviews,
       markAsRead,
@@ -154,6 +157,7 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
       closeNotificationsModal
     }),
     [
+      isLoading,
       unmarkedNotificationPreviews,
       markedNotificationPreviews,
       markAsRead,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7782051</samp>

Added loading feedback to notification components. Used a common `LoadingComponent` to show a loading indicator and label in the `NotificationModal` and `NotificationPreviewPopover` components. Added an `isLoading` state variable to the `useNotifications` hook and context to track the loading status of notifications data.

### WHY
[Card](https://app.charmverse.io/charmverse/page-4651833491179498)
