### PR TITLE
Persist last visited board view

### DIFF
--- a/components/[pageId]/SharedPage/SharedPage.tsx
+++ b/components/[pageId]/SharedPage/SharedPage.tsx
@@ -6,7 +6,7 @@ import DocumentPage from 'components/[pageId]/DocumentPage';
 import { updateBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import { addCard } from 'components/common/BoardEditor/focalboard/src/store/cards';
 import { useAppDispatch } from 'components/common/BoardEditor/focalboard/src/store/hooks';
-import { addView, setCurrent } from 'components/common/BoardEditor/focalboard/src/store/views';
+import { addView } from 'components/common/BoardEditor/focalboard/src/store/views';
 import ErrorPage from 'components/common/errors/ErrorPage';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { useBounties } from 'hooks/useBounties';
@@ -48,7 +48,6 @@ export function SharedPage({ publicPage }: Props) {
     setTitleState(rootPage.title);
     setCurrentPageId(rootPage.id);
 
-    dispatch(setCurrent(rootPage.id));
     cards.forEach((card) => {
       dispatch(addCard(card));
     });

--- a/components/common/BoardEditor/focalboard/src/store/views.ts
+++ b/components/common/BoardEditor/focalboard/src/store/views.ts
@@ -12,18 +12,14 @@ import type { RootState } from './index';
  * @loadedBoardViews is a map of boardIds for which we have loaded views
  */
 type ViewsState = {
-  current: string;
   views: { [key: string]: BoardView };
   loadedBoardViews: { [key: string]: boolean };
 };
 
 const viewsSlice = createSlice({
   name: 'views',
-  initialState: { views: {}, current: '', loadedBoardViews: {} } as ViewsState,
+  initialState: { views: {}, loadedBoardViews: {} } as ViewsState,
   reducers: {
-    setCurrent: (state, action: PayloadAction<string>) => {
-      state.current = action.payload;
-    },
     addView: (state, action: PayloadAction<BoardView>) => {
       state.views[action.payload.id] = action.payload;
     },
@@ -70,7 +66,7 @@ const viewsSlice = createSlice({
   }
 });
 
-export const { updateViews, setCurrent, updateView, addView, deleteViews } = viewsSlice.actions;
+export const { updateViews, updateView, addView, deleteViews } = viewsSlice.actions;
 export const { reducer } = viewsSlice;
 
 export const getViews = (state: RootState): { [key: string]: BoardView } => state.views.views;
@@ -105,13 +101,5 @@ export const getCurrentBoardViews = createSelector(
       .filter((v) => v.parentId === boardId)
       .sort((a, b) => a.title.localeCompare(b.title))
       .map((v) => createBoardView(v));
-  }
-);
-
-export const getCurrentView = createSelector(
-  getViews,
-  (state: RootState) => state.views.current,
-  (views, viewId) => {
-    return views[viewId];
   }
 );

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -11,6 +11,7 @@ import { initialDatabaseLoad } from 'components/common/BoardEditor/focalboard/sr
 import { useAppDispatch, useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import { getSortedViews, getView } from 'components/common/BoardEditor/focalboard/src/store/views';
 import FocalBoardPortal from 'components/common/BoardEditor/FocalBoardPortal';
+import { useFocalboardViews } from 'hooks/useFocalboardViews';
 import { usePage } from 'hooks/usePage';
 import { usePagePermissions } from 'hooks/usePagePermissions';
 import debouncePromise from 'lib/utilities/debouncePromise';
@@ -90,9 +91,11 @@ export function InlineDatabase({ containerWidth, readOnly: readOnlyOverride, nod
   const allViews = useAppSelector(getSortedViews);
   const router = useRouter();
   const dispatch = useAppDispatch();
-
+  const { focalboardViewsRecord, setFocalboardViewsRecord } = useFocalboardViews();
   const views = useMemo(() => allViews.filter((view) => view.parentId === pageId), [pageId, allViews]);
-  const [currentViewId, setCurrentViewId] = useState<string | null>(views[0]?.id || null);
+  const [currentViewId, setCurrentViewId] = useState<string | null>(
+    focalboardViewsRecord[pageId] ?? (views[0]?.id || null)
+  );
 
   useEffect(() => {
     if (!currentViewId && views.length > 0) {
@@ -126,6 +129,11 @@ export function InlineDatabase({ containerWidth, readOnly: readOnlyOverride, nod
     e.stopPropagation();
   }
 
+  function showView(viewId: string) {
+    setCurrentViewId(viewId);
+    setFocalboardViewsRecord((prev) => ({ ...prev, [pageId]: viewId }));
+  }
+
   const readOnly =
     typeof readOnlyOverride === 'undefined' ? currentPagePermissions?.edit_content !== true : readOnlyOverride;
 
@@ -153,7 +161,7 @@ export function InlineDatabase({ containerWidth, readOnly: readOnlyOverride, nod
         <CenterPanel
           currentRootPageId={pageId}
           disableUpdatingUrl
-          showView={setCurrentViewId}
+          showView={showView}
           onDeleteView={deleteView}
           hideBanner
           readOnly={readOnly}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e861bd5</samp>

Refactored and simplified the code for managing focalboard views and local storage in various components. Removed unused and redundant code from the `viewsSlice` and the `SharedPage` component. Added a feature to remember the last viewed view for each board in the charm editor.

### WHY
[Card](https://app.charmverse.io/charmverse/page-9404902857241855)