### PR TITLE
Fix discord link

### DIFF
--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -196,6 +196,7 @@ export function Sidebar({ closeSidebar, navAction }: SidebarProps) {
           />
           <SidebarLink
             active={false}
+            external
             href={charmverseDiscordInvite}
             icon={<QuestionMarkIcon color='secondary' fontSize='small' />}
             label='Support & Feedback'

--- a/components/common/PageLayout/components/Sidebar/components/SidebarButton.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/SidebarButton.tsx
@@ -70,6 +70,7 @@ export function SidebarLink({
   className?: string;
   section?: SpaceSettingsSection;
   children?: ReactNode;
+  external?: boolean;
 }) {
   return (
     <StyledSidebarLink {...props}>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c2c259</samp>

Added support for external links in the sidebar. Modified the `SidebarButton` component and the `SidebarLink` interface to accept the `external` prop and applied it to the "Documentation" link in `Sidebar.tsx`.

### WHY
The link to support in Discord was broken.