### PR TITLE
add missing page views

### DIFF
--- a/components/bounties/BountiesPage.tsx
+++ b/components/bounties/BountiesPage.tsx
@@ -5,15 +5,14 @@ import BountyIcon from '@mui/icons-material/RequestPageOutlined';
 import { Box, Card, Grid, Tab, Tabs, Typography } from '@mui/material';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { CSVLink } from 'react-csv';
 
 import charmClient from 'charmClient';
 import { Button } from 'components/common/Button';
 import { EmptyStateVideo } from 'components/common/EmptyStateVideo';
 import Link from 'components/common/Link';
-import { PageDialogProvider } from 'components/common/PageDialog/hooks/usePageDialog';
-import { PageDialogGlobal } from 'components/common/PageDialog/PageDialogGlobal';
+import { usePageDialog } from 'components/common/PageDialog/hooks/usePageDialog';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import type { BountyWithDetails } from 'lib/bounties';
 import { sortArrayByObjectProperty } from 'lib/utilities/array';
@@ -24,6 +23,7 @@ import { BountiesKanbanView } from './components/BountiesKanbanView';
 import { BountiesGalleryView } from './components/BountyGalleryView';
 import { MultiPaymentModal } from './components/MultiPaymentModal';
 import { NewBountyButton } from './components/NewBountyButton';
+import { useOnBountyCardClose } from './hooks/useOnBountyCardClose';
 
 const bountyStatuses: BountyStatus[] = ['open', 'inProgress', 'complete', 'paid', 'suggestion'];
 
@@ -49,6 +49,8 @@ const views = [
 
 export function BountiesPage({ publicMode = false, bounties, title }: Props) {
   const { space } = useCurrentSpace();
+  const { showPage } = usePageDialog();
+  const { onClose } = useOnBountyCardClose();
   const router = useRouter();
   const viewFromUrl = router.query.view as (typeof views)[number]['type'];
   const currentView = views.find((v) => v.type === viewFromUrl) ?? views[0];
@@ -89,96 +91,103 @@ export function BountiesPage({ publicMode = false, bounties, title }: Props) {
     }
   }
 
-  return (
-    <PageDialogProvider>
-      <div className='focalboard-body full-page'>
-        <div className='BoardComponent'>
-          <div className='top-head'>
-            <Grid container display='flex' justifyContent='space-between' alignContent='center' mb={3} mt={10}>
-              <Grid display='flex' justifyContent='space-between' item xs={12} mb={2}>
-                <Typography variant='h1' display='flex' alignItems='center' sx={{ height: '100%' }}>
-                  {title}
-                </Typography>
+  useEffect(() => {
+    if (typeof router.query.bountyId === 'string') {
+      showPage({
+        bountyId: router.query.bountyId,
+        readOnly: publicMode,
+        onClose
+      });
+    }
+  }, [router.query.bountyId]);
 
-                {!publicMode && (
-                  <Box width='fit-content' display='flex' gap={1}>
-                    {!!csvData.length && (
-                      <CSVLink
-                        data={csvData}
-                        onClick={recordExportEvent}
-                        filename='Gnosis Safe Airdrop.csv'
-                        style={{ textDecoration: 'none' }}
-                      >
-                        <Button color='secondary' variant='outlined'>
-                          Export to CSV
-                        </Button>
-                      </CSVLink>
-                    )}
-                    <MultiPaymentModal bounties={bounties} />
-                    <NewBountyButton />
-                  </Box>
-                )}
-              </Grid>
+  return (
+    <div className='focalboard-body full-page'>
+      <div className='BoardComponent'>
+        <div className='top-head'>
+          <Grid container display='flex' justifyContent='space-between' alignContent='center' mb={3} mt={10}>
+            <Grid display='flex' justifyContent='space-between' item xs={12} mb={2}>
+              <Typography variant='h1' display='flex' alignItems='center' sx={{ height: '100%' }}>
+                {title}
+              </Typography>
+
+              {!publicMode && (
+                <Box width='fit-content' display='flex' gap={1}>
+                  {!!csvData.length && (
+                    <CSVLink
+                      data={csvData}
+                      onClick={recordExportEvent}
+                      filename='Gnosis Safe Airdrop.csv'
+                      style={{ textDecoration: 'none' }}
+                    >
+                      <Button color='secondary' variant='outlined'>
+                        Export to CSV
+                      </Button>
+                    </CSVLink>
+                  )}
+                  <MultiPaymentModal bounties={bounties} />
+                  <NewBountyButton />
+                </Box>
+              )}
             </Grid>
-            {bounties.length !== 0 && (
-              <Box className='ViewHeader' alignItems='flex-start'>
-                <Tabs
-                  textColor='primary'
-                  indicatorColor='secondary'
-                  value={currentView.type}
-                  sx={{ minHeight: 0, mb: '-6px' }}
-                >
-                  {views.map(({ icon, label, type }) => (
-                    <Tab
-                      data-test={`bounties-view-${type}`}
-                      disableRipple
-                      component={NextLink}
-                      href={getAbsolutePath(`/bounties?view=${type}`, space?.domain)}
-                      key={type}
-                      value={type}
-                      label={
-                        <StyledButton
-                          startIcon={icon}
-                          variant='text'
-                          size='small'
-                          sx={{ p: 0, mb: '5px', width: '100%' }}
-                          color={currentView.type === type ? 'textPrimary' : 'secondary'}
-                        >
-                          {label}
-                        </StyledButton>
-                      }
-                      sx={{ p: 0 }}
-                    />
-                  ))}
-                </Tabs>
-              </Box>
-            )}
-          </div>
-          {bounties.length === 0 ? (
-            <EmptyStateVideo
-              description='Getting started with bounties'
-              videoTitle='Bounties | Getting started with CharmVerse'
-              videoUrl='https://tiny.charmverse.io/bounties'
-            />
-          ) : currentView.type === 'open' && bounties.filter((bounty) => bounty.status === 'open').length === 0 ? (
-            <Card variant='outlined' sx={{ margin: '0 auto', my: 2, width: 'fit-content' }}>
-              <Box p={3} textAlign='center'>
-                <Typography color='secondary'>
-                  There are no open bounties, click <Link href={`/${space?.domain}/bounties?view=all`}>here</Link> to
-                  see all of your existing bounties
-                </Typography>
-              </Box>
-            </Card>
-          ) : currentView.type === 'open' ? (
-            <BountiesGalleryView bounties={bounties} publicMode={publicMode} />
-          ) : (
-            <div className='container-container'>
-              <BountiesKanbanView publicMode={publicMode} bounties={bounties} />
-            </div>
+          </Grid>
+          {bounties.length !== 0 && (
+            <Box className='ViewHeader' alignItems='flex-start'>
+              <Tabs
+                textColor='primary'
+                indicatorColor='secondary'
+                value={currentView.type}
+                sx={{ minHeight: 0, mb: '-6px' }}
+              >
+                {views.map(({ icon, label, type }) => (
+                  <Tab
+                    data-test={`bounties-view-${type}`}
+                    disableRipple
+                    component={NextLink}
+                    href={getAbsolutePath(`/bounties?view=${type}`, space?.domain)}
+                    key={type}
+                    value={type}
+                    label={
+                      <StyledButton
+                        startIcon={icon}
+                        variant='text'
+                        size='small'
+                        sx={{ p: 0, mb: '5px', width: '100%' }}
+                        color={currentView.type === type ? 'textPrimary' : 'secondary'}
+                      >
+                        {label}
+                      </StyledButton>
+                    }
+                    sx={{ p: 0 }}
+                  />
+                ))}
+              </Tabs>
+            </Box>
           )}
         </div>
+        {bounties.length === 0 ? (
+          <EmptyStateVideo
+            description='Getting started with bounties'
+            videoTitle='Bounties | Getting started with CharmVerse'
+            videoUrl='https://tiny.charmverse.io/bounties'
+          />
+        ) : currentView.type === 'open' && bounties.filter((bounty) => bounty.status === 'open').length === 0 ? (
+          <Card variant='outlined' sx={{ margin: '0 auto', my: 2, width: 'fit-content' }}>
+            <Box p={3} textAlign='center'>
+              <Typography color='secondary'>
+                There are no open bounties, click <Link href={`/${space?.domain}/bounties?view=all`}>here</Link> to see
+                all of your existing bounties
+              </Typography>
+            </Box>
+          </Card>
+        ) : currentView.type === 'open' ? (
+          <BountiesGalleryView bounties={bounties} publicMode={publicMode} />
+        ) : (
+          <div className='container-container'>
+            <BountiesKanbanView publicMode={publicMode} bounties={bounties} />
+          </div>
+        )}
       </div>
-      <PageDialogGlobal />
-    </PageDialogProvider>
+    </div>
   );
 }

--- a/components/bounties/components/BountiesKanbanView.tsx
+++ b/components/bounties/components/BountiesKanbanView.tsx
@@ -2,10 +2,7 @@ import type { PageMeta } from '@charmverse/core/pages';
 import type { BountyStatus } from '@charmverse/core/prisma';
 import { Box, Typography } from '@mui/material';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 
-import { useOnBountyCardClose } from 'components/bounties/hooks/useOnBountyCardClose';
-import { usePageDialog } from 'components/common/PageDialog/hooks/usePageDialog';
 import { useBounties } from 'hooks/useBounties';
 import { usePages } from 'hooks/usePages';
 import type { BountyWithDetails } from 'lib/bounties';
@@ -22,10 +19,8 @@ interface Props {
 
 export function BountiesKanbanView({ bounties, publicMode }: Props) {
   const { deletePage, pages } = usePages();
-  const { showPage } = usePageDialog();
   const { setBounties } = useBounties();
   const router = useRouter();
-  const { onClose } = useOnBountyCardClose();
 
   function onClickDelete(pageId: string) {
     setBounties((_bounties) => _bounties.filter((_bounty) => _bounty.page.id !== pageId));
@@ -52,17 +47,6 @@ export function BountiesKanbanView({ bounties, publicMode }: Props) {
       query: { ...router.query, bountyId }
     });
   }
-
-  useEffect(() => {
-    if (router.isReady && typeof router.query.bountyId === 'string') {
-      showPage({
-        bountyId: router.query.bountyId,
-        readOnly: publicMode,
-        onClose
-      });
-    }
-  }, [router.isReady, router.query.bountyId]);
-
   return (
     <div className='Kanban'>
       {/* include ViewHeader to include the horizontal line */}

--- a/components/bounties/components/BountyGalleryView.tsx
+++ b/components/bounties/components/BountyGalleryView.tsx
@@ -1,9 +1,6 @@
 import type { PageMeta } from '@charmverse/core/pages';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 
-import { useOnBountyCardClose } from 'components/bounties/hooks/useOnBountyCardClose';
-import { usePageDialog } from 'components/common/PageDialog/hooks/usePageDialog';
 import { useBounties } from 'hooks/useBounties';
 import { usePages } from 'hooks/usePages';
 import type { BountyWithDetails } from 'lib/bounties';
@@ -17,10 +14,8 @@ interface Props {
 
 export function BountiesGalleryView({ bounties, publicMode }: Props) {
   const { deletePage, pages } = usePages();
-  const { showPage } = usePageDialog();
   const { setBounties } = useBounties();
   const router = useRouter();
-  const { onClose } = useOnBountyCardClose();
 
   const filteredBounties = bounties
     .filter((bounty) => bounty.status === 'open')
@@ -36,17 +31,6 @@ export function BountiesGalleryView({ bounties, publicMode }: Props) {
       query: { ...router.query, bountyId }
     });
   }
-
-  useEffect(() => {
-    if (typeof router.query.bountyId === 'string') {
-      showPage({
-        bountyId: router.query.bountyId,
-        readOnly: publicMode,
-        onClose
-      });
-    }
-  }, [router.query.bountyId]);
-
   return (
     <div data-test='all-bounties-layout' className='Gallery' style={{ overflow: 'visible' }}>
       {filteredBounties.map((bounty) => {

--- a/components/forum/components/PostDialog/PostDialog.tsx
+++ b/components/forum/components/PostDialog/PostDialog.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from 'react';
 import useSWR from 'swr';
 
 import charmClient from 'charmClient';
+import { trackPageView } from 'charmClient/hooks/track';
 import Dialog from 'components/common/BoardEditor/focalboard/src/components/dialog';
 import { Button } from 'components/common/Button';
 import { DialogTitle } from 'components/common/Modal';
@@ -59,6 +60,12 @@ export function PostDialog({ post, isLoading, spaceId, onClose, newPostCategory 
       mounted.current = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (spaceId && post?.id) {
+      trackPageView({ spaceId, postId: post.id, type: 'post' });
+    }
+  }, [post?.id]);
 
   function close() {
     onClose();

--- a/components/proposals/ProposalsPage.tsx
+++ b/components/proposals/ProposalsPage.tsx
@@ -1,7 +1,7 @@
 import { Box, Divider, Grid, Stack, Typography } from '@mui/material';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useRouter } from 'next/router';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import charmClient from 'charmClient';
 import { ViewSortControl } from 'components/common/BoardEditor/components/ViewSortControl';
@@ -79,6 +79,15 @@ export function ProposalsPage({ title }: { title: string }) {
   const onDelete = useCallback(async (proposalId: string) => {
     await charmClient.deletePage(proposalId);
   }, []);
+
+  useEffect(() => {
+    if (typeof router.query.id === 'string') {
+      showProposal({
+        pageId: router.query.id,
+        onClose
+      });
+    }
+  }, [router.query.id]);
 
   if (isLoadingAccess) {
     return null;

--- a/components/proposals/components/ProposalDialog/ProposalDialog.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalDialog.tsx
@@ -5,6 +5,7 @@ import { Box, Stack } from '@mui/material';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { trackPageView } from 'charmClient/hooks/track';
 import DocumentPage from 'components/[pageId]/DocumentPage';
 import Dialog from 'components/common/BoardEditor/focalboard/src/components/dialog';
 import { Button } from 'components/common/Button';
@@ -75,6 +76,12 @@ export function ProposalDialog({ pageId, newProposal, onClose }: Props) {
       publishToLens: !!user?.publishToLensDefault
     }));
   }, [user?.id]);
+
+  useEffect(() => {
+    if (page?.id) {
+      trackPageView({ spaceId: page.spaceId, pageId: page.id, type: page.type });
+    }
+  }, [page?.id]);
 
   function close() {
     onClose();

--- a/pages/[domain]/bounties/index.tsx
+++ b/pages/[domain]/bounties/index.tsx
@@ -1,6 +1,8 @@
 import { useTrackPageView } from 'charmClient/hooks/track';
 import { BountiesPage } from 'components/bounties/BountiesPage';
 import LoadingComponent from 'components/common/LoadingComponent';
+import { PageDialogProvider } from 'components/common/PageDialog/hooks/usePageDialog';
+import { PageDialogGlobal } from 'components/common/PageDialog/PageDialogGlobal';
 import getPageLayout from 'components/common/PageLayout/getLayout';
 import { useBounties } from 'hooks/useBounties';
 import { useFeaturesAndMembers } from 'hooks/useFeaturesAndMemberProfiles';
@@ -23,7 +25,12 @@ export default function BountyPage() {
   if (loadingBounties || !bounties || !accessChecked || isLoadingAccess) {
     return <LoadingComponent isLoading />;
   }
-  return <BountiesPage bounties={bounties} publicMode={!isSpaceMember} title={bountiesTitle} />;
+  return (
+    <PageDialogProvider>
+      <BountiesPage bounties={bounties} publicMode={!isSpaceMember} title={bountiesTitle} />
+      <PageDialogGlobal />
+    </PageDialogProvider>
+  );
 }
 
 BountyPage.getLayout = getPageLayout;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 679669f</samp>

Added analytics tracking to the forum and proposal dialogs. The `PostDialog` and `ProposalDialog` components now send the details of the displayed posts and proposals to the backend using the `trackPageView` hook.

### FIXES
- track page_view when opening a forum post or proposal page
- load dialog on proposals when you open the page with an id set