### PR TITLE
reset permissions when categories change

### DIFF
--- a/components/forum/ForumFeedPage.tsx
+++ b/components/forum/ForumFeedPage.tsx
@@ -33,7 +33,7 @@ export function ForumPage() {
   const { space: currentSpace } = useCurrentSpace();
   const sort = router.query.sort as PostSortOption | undefined;
   const { createPost, showPost } = usePostDialog();
-  const { categories, isCategoriesLoaded, getPostableCategories } = useForumCategories();
+  const { categories, isLoading: isCategoriesLoading, getPostableCategories } = useForumCategories();
   const [, setTitle] = usePageTitle();
   const [currentCategory, setCurrentCategory] = useState<PostCategory | null>(null);
 
@@ -67,7 +67,7 @@ export function ForumPage() {
     setCurrentCategory(category ?? null);
 
     // User tried to navigate to a category they cannot access or does not exist, redirect them to forum home
-    if (category === undefined && isCategoriesLoaded && currentSpace) {
+    if (category === undefined && !isCategoriesLoading && currentSpace) {
       router.push(`/${currentSpace.domain}/forum`);
     } else if (category && currentSpace) {
       charmClient.track.trackAction('main_feed_filtered', {
@@ -186,7 +186,7 @@ export function ForumPage() {
             disabledTooltip={disabledCreatePostTooltip}
             onClick={showNewPostPopup}
           />
-          {!isCategoriesLoaded ? (
+          {isCategoriesLoading ? (
             <PostSkeleton />
           ) : (
             <ForumPostList search={search} categoryId={currentCategory?.id} sort={sort} />

--- a/components/settings/roles/components/RolePermissions/RolePermissions.tsx
+++ b/components/settings/roles/components/RolePermissions/RolePermissions.tsx
@@ -143,8 +143,8 @@ function reducerWithContext({ id }: { id: string }) {
 export function RolePermissions({ targetGroup, id, callback = () => null }: Props) {
   const { space } = useCurrentSpace();
   const { isFreeSpace } = useIsFreeSpace();
-  const { categories: proposalCategories = [] } = useProposalCategories();
-  const { categories: forumCategories = [] } = useForumCategories();
+  const { categories: proposalCategories = [], isLoading: proposalCategoriesLoading } = useProposalCategories();
+  const { categories: forumCategories = [], isLoading: forumCategoriesLoading } = useForumCategories();
   const isAdmin = useIsAdmin();
   const { showMessage } = useSnackbar();
   // const [assignedPermissions, setAssignedPermissions] = useState<SpacePermissionFlags | null>(null);
@@ -161,7 +161,9 @@ export function RolePermissions({ targetGroup, id, callback = () => null }: Prop
   const categoryIds = [...proposalCategories.map((c) => c.id), ...forumCategories.map((c) => c.id)];
 
   const { data: originalPermissions } = useSWR(
-    currentSpaceId ? `/proposals/list-permissions-${currentSpaceId}-${categoryIds}` : null,
+    currentSpaceId && !forumCategoriesLoading && !proposalCategoriesLoading
+      ? `/proposals/list-permissions-${currentSpaceId}-${categoryIds}`
+      : null,
     () => charmClient.permissions.spaces.listSpacePermissions(currentSpaceId as string)
   );
 

--- a/hooks/useForumCategories.tsx
+++ b/hooks/useForumCategories.tsx
@@ -17,7 +17,7 @@ type IContext = {
   setDefaultPostCategory: (option: PostCategory) => Promise<void>;
   getForumCategoryById: (id?: string | null) => PostCategoryWithPermissions | undefined;
   getPostableCategories: () => PostCategoryWithPermissions[];
-  isCategoriesLoaded: boolean;
+  isLoading: boolean;
   categories: PostCategoryWithPermissions[];
   error: any;
   disabled: boolean;
@@ -30,7 +30,7 @@ export const PostCategoriesContext = createContext<Readonly<IContext>>({
   setDefaultPostCategory: () => Promise.resolve(undefined),
   getForumCategoryById: () => undefined,
   getPostableCategories: () => [],
-  isCategoriesLoaded: false,
+  isLoading: false,
   categories: [],
   error: undefined,
   disabled: false
@@ -132,8 +132,6 @@ export function PostCategoriesProvider({ children }: { children: ReactNode }) {
     return (categories ?? []).filter((c) => c.permissions.create_post);
   }
 
-  const isCategoriesLoaded = !!categories;
-
   const value = useMemo<IContext>(
     () => ({
       createForumCategory,
@@ -142,12 +140,12 @@ export function PostCategoriesProvider({ children }: { children: ReactNode }) {
       setDefaultPostCategory,
       getForumCategoryById,
       getPostableCategories,
-      isCategoriesLoaded,
+      isLoading: !categories,
       categories: categories || [],
       error,
       disabled: isValidating
     }),
-    [isCategoriesLoaded, error, categories, isValidating, currentSpace]
+    [error, categories, isValidating, currentSpace]
   );
 
   return <PostCategoriesContext.Provider value={value}>{children}</PostCategoriesContext.Provider>;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f69b29</samp>

Enhanced the `RolePermissions` component to update and save permissions more reliably. Added data fetching based on categories and error feedback for the save operation.

### WHY
If the categories change while I'm looking at the form, the form state does not update (even tho the categories we display does update)
