### PR TITLE
e2e to assert the visibility of page inline threads

### DIFF
--- a/__e2e__/pageInlineComment.spec.ts
+++ b/__e2e__/pageInlineComment.spec.ts
@@ -33,23 +33,21 @@ test.describe.serial('Create a inline comment thread and check if the page actio
         id: generatedPage.id
       },
       data: {
-        content: [
-          {
-            type: 'doc',
-            content: [
-              {
-                type: 'paragraph',
-                content: [
-                  {
-                    type: 'text',
-                    text: 'Comment',
-                    marks: [{ type: 'inline-comment', attrs: { id: threadId, resolved: false } }]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'Comment',
+                  marks: [{ type: 'inline-comment', attrs: { id: threadId, resolved: false } }]
+                }
+              ]
+            }
+          ]
+        }
       }
     });
 

--- a/__e2e__/pageInlineComment.spec.ts
+++ b/__e2e__/pageInlineComment.spec.ts
@@ -1,0 +1,95 @@
+import { prisma } from '@charmverse/core/prisma-client';
+import { test as base, expect } from '@playwright/test';
+
+import { emptyDocument } from 'lib/prosemirror/constants';
+import { createThread, toggleThreadStatus } from 'lib/threads';
+
+import { DocumentPage } from './po/document.po';
+import { generateUserAndSpace, loginBrowserUser } from './utils/mocks';
+
+type Fixtures = {
+  documentPage: DocumentPage;
+};
+
+const test = base.extend<Fixtures>({
+  documentPage: async ({ page }, use) => use(new DocumentPage(page))
+});
+
+test.describe.serial('Create a inline comment thread and check if the page action sidebar toggles', async () => {
+  const { space, user, page: generatedPage } = await generateUserAndSpace({ isAdmin: true });
+
+  const thread = await createThread({
+    comment: emptyDocument,
+    context: 'Context',
+    pageId: generatedPage.id,
+    userId: user.id
+  });
+
+  const threadId = thread.id;
+
+  test('Check if the inline comment thread is visible after adding comment to text', async ({ documentPage }) => {
+    await prisma.page.update({
+      where: {
+        id: generatedPage.id
+      },
+      data: {
+        content: [
+          {
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [
+                  {
+                    type: 'text',
+                    text: 'Comment',
+                    marks: [{ type: 'inline-comment', attrs: { id: threadId, resolved: false } }]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    await loginBrowserUser({
+      browserPage: documentPage.page,
+      userId: user.id
+    });
+
+    await documentPage.goToPage({
+      domain: space.domain,
+      path: generatedPage.path
+    });
+
+    await expect(documentPage.charmEditor).toBeVisible();
+
+    const threadBoxLocator = documentPage.page.locator(`data-test=thread.${threadId}`);
+
+    await expect(threadBoxLocator).toBeVisible();
+  });
+
+  test('Check if the inline comment thread is not visible after resolving it', async ({ documentPage }) => {
+    await toggleThreadStatus({
+      id: threadId,
+      status: 'closed'
+    });
+
+    await loginBrowserUser({
+      browserPage: documentPage.page,
+      userId: user.id
+    });
+
+    await documentPage.goToPage({
+      domain: space.domain,
+      path: generatedPage.path
+    });
+
+    await expect(documentPage.charmEditor).toBeVisible();
+
+    const threadBoxLocator = documentPage.page.locator(`data-test=thread.${threadId}`);
+
+    await expect(threadBoxLocator).not.toBeVisible();
+  });
+});

--- a/components/common/CharmEditor/components/PageThread.tsx
+++ b/components/common/CharmEditor/components/PageThread.tsx
@@ -345,7 +345,13 @@ const PageThread = forwardRef<HTMLDivElement, PageThreadProps>(
     }
 
     return (
-      <StyledPageThread inline={inline.toString()} variant='outlined' id={`thread.${threadId}`} ref={ref}>
+      <StyledPageThread
+        inline={inline.toString()}
+        variant='outlined'
+        data-test={`thread.${threadId}`}
+        id={`thread.${threadId}`}
+        ref={ref}
+      >
         <div>
           {thread.comments.map((comment, commentIndex) => {
             const member = members.find((_member) => _member.id === comment.userId);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d55aff</samp>

This pull request adds a new test file for the page inline comment feature and a data-test attribute to the PageThread component. The test file `__e2e__/pageInlineComment.spec.ts` contains two tests to check the visibility of the inline comment thread after adding and resolving a comment. The data-test attribute in `components/common/CharmEditor/components/PageThread.tsx` helps to locate the thread element in the test file.

### WHY
<!-- author to complete -->
