### PR TITLE
Show page icon menu on small screens

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/__snapshots__/comment.spec.tsx.snap
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/__snapshots__/comment.spec.tsx.snap
@@ -94,31 +94,6 @@ exports[`components/cardDetail/comment return comment 1`] = `
                     />
                   </div>
                 </div>
-                <div
-                  class="menu-spacer hideOnWidescreen"
-                />
-                <div
-                  class="menu-options hideOnWidescreen"
-                >
-                  <div
-                    aria-label="Cancel"
-                    class="MenuOption TextOption menu-option menu-cancel"
-                    data-mui-internal-clone-element="true"
-                    role="button"
-                  >
-                    <div
-                      class="noicon"
-                    />
-                    <div
-                      class="menu-name"
-                    >
-                      Cancel
-                    </div>
-                    <div
-                      class="noicon"
-                    />
-                  </div>
-                </div>
               </div>
             </div>
           </div>
@@ -275,31 +250,6 @@ exports[`components/cardDetail/comment return comment and delete comment 1`] = `
                       class="menu-name"
                     >
                       Delete
-                    </div>
-                    <div
-                      class="noicon"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="menu-spacer hideOnWidescreen"
-                />
-                <div
-                  class="menu-options hideOnWidescreen"
-                >
-                  <div
-                    aria-label="Cancel"
-                    class="MenuOption TextOption menu-option menu-cancel"
-                    data-mui-internal-clone-element="true"
-                    role="button"
-                  >
-                    <div
-                      class="noicon"
-                    />
-                    <div
-                      class="menu-name"
-                    >
-                      Cancel
                     </div>
                     <div
                       class="noicon"

--- a/components/common/BoardEditor/focalboard/src/components/dialog.scss
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.scss
@@ -59,13 +59,6 @@
       max-width: 975px;
     }
 
-    @media not screen and (max-width: 975px) {
-      .hideOnWidescreen {
-        /* Hide elements on larger screens */
-        display: none !important;
-      }
-    }
-
     > * {
       flex-shrink: 0;
       overflow-x: hidden;

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/menu.scss
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/menu.scss
@@ -170,11 +170,4 @@
       }
     }
   }
-
-  @media not screen and (max-width: 430px) {
-    .hideOnWidescreen {
-      /* Hide controls (e.g. close button) on larger screens */
-      display: none !important;
-    }
-  }
 }

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/menu.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/menu.tsx
@@ -59,12 +59,6 @@ function Menu({ position = 'bottom-start', children, disablePortal = true }: Pro
       >
         <div className='menu-contents'>
           <div className='menu-options'>{children}</div>
-
-          <div className='menu-spacer hideOnWidescreen' />
-
-          <div className='menu-options hideOnWidescreen'>
-            <Menu.Text id='menu-cancel' name='Cancel' className='menu-cancel' onClick={() => undefined} />
-          </div>
         </div>
       </div>
     </StyledPopper>

--- a/components/common/BoardEditor/focalboard/src/widgets/menu/subMenuOption.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/menu/subMenuOption.tsx
@@ -3,8 +3,6 @@ import ArrowDropDownOutlinedIcon from '@mui/icons-material/ArrowDropDownOutlined
 import Popper from '@mui/material/Popper';
 import React, { useEffect, useRef, useState } from 'react';
 
-import TextOption from './textOption';
-
 type SubMenuOptionProps = {
   id: string;
   name: string;
@@ -77,11 +75,6 @@ function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
         <div ref={popperRef} style={{ maxHeight: maxHeight || 'none' }} className='SubMenu Menu noselect '>
           <div className='menu-contents'>
             <div className='menu-options'>{props.children}</div>
-            <div className='menu-spacer hideOnWidescreen' />
-
-            <div className='menu-options hideOnWidescreen'>
-              <TextOption id='menu-cancel' name='Cancel' className='menu-cancel' onClick={() => undefined} />
-            </div>
           </div>
         </div>
       </StyledPopper>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2d0b4d</samp>

This pull request removes unused and redundant code from the `subMenuOption` component and makes the `dialog` and `menu` components responsive on different screen sizes by removing media queries and hidden elements. These changes improve the user interface and functionality of the app.

### WHY
<!-- author to complete -->
