### PR TITLE
add stub tooltip mark to fix broken docs

### DIFF
--- a/components/common/CharmEditor/components/linkedPage/linkedPage.plugins.ts
+++ b/components/common/CharmEditor/components/linkedPage/linkedPage.plugins.ts
@@ -64,13 +64,9 @@ export function linkedPagePlugins({
         }
       }),
       // add temporary stub to support old mark name
-      suggestTooltip.plugins({
-        key: new PluginKey('suggestTooltipKey-deprecated'),
-        markName: 'nestedPageSuggest',
-        tooltipRenderOpts: {
-          ...tooltipRenderOpts,
-          tooltipDOMSpec
-        }
+      new Plugin({
+        name: 'nestedPageSuggest',
+        type: 'mark'
       }),
       NodeView.createPlugin({
         name: linkedPageNodeName,

--- a/components/common/CharmEditor/components/linkedPage/linkedPage.plugins.ts
+++ b/components/common/CharmEditor/components/linkedPage/linkedPage.plugins.ts
@@ -63,6 +63,15 @@ export function linkedPagePlugins({
           tooltipDOMSpec
         }
       }),
+      // add temporary stub to support old mark name
+      suggestTooltip.plugins({
+        key: suggestTooltipKey,
+        markName: 'nestedPageSuggest',
+        tooltipRenderOpts: {
+          ...tooltipRenderOpts,
+          tooltipDOMSpec
+        }
+      }),
       NodeView.createPlugin({
         name: linkedPageNodeName,
         containerDOM: ['div', { class: 'linkedPage-container' }]

--- a/components/common/CharmEditor/components/linkedPage/linkedPage.plugins.ts
+++ b/components/common/CharmEditor/components/linkedPage/linkedPage.plugins.ts
@@ -65,7 +65,7 @@ export function linkedPagePlugins({
       }),
       // add temporary stub to support old mark name
       suggestTooltip.plugins({
-        key: suggestTooltipKey,
+        key: new PluginKey('suggestTooltipKey-deprecated'),
         markName: 'nestedPageSuggest',
         tooltipRenderOpts: {
           ...tooltipRenderOpts,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ccf7b7d</samp>

Rename `nestedPageSuggest` mark to `linkedPageSuggest` and refactor tooltip plugin. Add stub for backward compatibility in `linkedPagePlugins` function in `components/common/CharmEditor/components/linkedPage/linkedPage.plugins.ts`.

### WHY
<!-- author to complete -->
