### PR TITLE
hide placeholder on readonly pages

### DIFF
--- a/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
@@ -240,8 +240,7 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
         className={`bangle-editor-core ${readOnly ? 'readonly' : ''}`}
         data-page-id={pageId}
         style={{
-          minHeight: showLoader && isLoadingRef.current ? '200px' : undefined,
-          cursor: readOnly ? 'default' : 'text'
+          minHeight: showLoader && isLoadingRef.current ? '200px' : undefined
         }}
       >
         <StyledLoadingComponent isLoading={showLoader && isLoadingRef.current} />

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -531,6 +531,11 @@ ol li {
   top: 3px;
 }
 
+.readonly {
+  .charm-placeholder::before {
+    display: none;
+  }
+}
 
 
 /** Begin Resizable columns **/


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d2fe5b</samp>

Removed `cursor` style from `BangleEditor` and added `.readonly` class to `theme/@bangle.dev/styles.scss`. These changes improve the cursor and placeholder behavior of the `CharmEditor` component in different modes.

### WHY
I also removed a rule about cursor style for read only ... following Notion, we should keep the default "text" cursor