### PR TITLE
fix encoding of URIs

### DIFF
--- a/charmClient/hooks/track.ts
+++ b/charmClient/hooks/track.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import type { PageEventMap } from 'lib/metrics/mixpanel/interfaces/PageEvent';
+import { getBrowserPath } from 'lib/utilities/browser';
 
 import { TrackApi } from '../apis/trackApi';
 
@@ -11,7 +12,7 @@ export function trackPageView(page: Omit<PageEventMap['page_view'], 'userId'>) {
   track.trackAction('page_view', {
     ...page,
     meta: {
-      pathname: window.location.pathname + window.location.search
+      pathname: getBrowserPath()
     }
   });
 }

--- a/components/_app/Web3ConnectionManager/hooks/useMetamaskConnect.ts
+++ b/components/_app/Web3ConnectionManager/hooks/useMetamaskConnect.ts
@@ -1,7 +1,7 @@
 import MetaMaskOnboarding from '@metamask/onboarding';
 import { useRef } from 'react';
 
-import { isTouchScreen } from 'lib/utilities/browser';
+import { getBrowserPath, isTouchScreen } from 'lib/utilities/browser';
 
 const MM_DEEPLINK_SCHEMA = 'https://metamask.app.link/dapp/';
 
@@ -36,7 +36,7 @@ export function useMetamaskConnect(handleConnect: () => void) {
 }
 
 function getMMDeeplink() {
-  const currentUrl = window.location.host + window.location.pathname + window.location.search;
+  const currentUrl = window.location.host + getBrowserPath();
   const deeplink = MM_DEEPLINK_SCHEMA + currentUrl;
 
   return deeplink;

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/__snapshots__/comment.spec.tsx.snap
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/__snapshots__/comment.spec.tsx.snap
@@ -104,7 +104,6 @@ exports[`components/cardDetail/comment return comment 1`] = `
       >
         <div
           class="bangle-editor-core readonly"
-          style="cursor: default;"
         >
           <span />
           <div
@@ -266,7 +265,6 @@ exports[`components/cardDetail/comment return comment and delete comment 1`] = `
       >
         <div
           class="bangle-editor-core readonly"
-          style="cursor: default;"
         >
           <span />
           <div
@@ -358,7 +356,6 @@ exports[`components/cardDetail/comment return comment readonly 1`] = `
       >
         <div
           class="bangle-editor-core readonly"
-          style="cursor: default;"
         >
           <span />
           <div

--- a/hooks/useAppLoadedEvent.ts
+++ b/hooks/useAppLoadedEvent.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import charmClient from 'charmClient';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useUser } from 'hooks/useUser';
+import { getBrowserPath } from 'lib/utilities/browser';
 
 export function useAppLoadedEvent() {
   const { isLoaded } = useUser();
@@ -15,7 +16,7 @@ export function useAppLoadedEvent() {
     if (isLoaded) {
       debouncedTrackAction('app_loaded', {
         spaceId: space?.id,
-        meta: { pathname: window.location.pathname + window.location.search }
+        meta: { pathname: getBrowserPath() }
       });
     }
   }, [isLoaded, space?.id]);

--- a/lib/session/__tests__/getDefaultPageForSpace.spec.ts
+++ b/lib/session/__tests__/getDefaultPageForSpace.spec.ts
@@ -65,9 +65,37 @@ describe('getDefaultPageForSpace()', () => {
     const url = await getDefaultPageForSpace({ space, userId: user.id });
     expect(url).toEqual(`/${space.domain}/forum?postId=${post.id}`);
   });
+
+  it('should encode Japanese characters', async () => {
+    const { space, user } = await generateUserAndSpace();
+    const page = await createPage({ spaceId: space.id, createdBy: user.id, path: '日本語' });
+    await savePageView({ createdBy: user.id, spaceId: space.id, pageId: page.id, pageType: 'page' });
+
+    const url = await getDefaultPageForSpace({ space, userId: user.id });
+    expect(url).toEqual(encodeURI(`/${space.domain}/${page.path}`));
+  });
+
+  it('should properly encode pathnames with encoded characters', async () => {
+    const { space, user } = await generateUserAndSpace();
+    const page = await createPage({ spaceId: space.id, createdBy: user.id, path: '日本語' });
+    await savePageView({
+      createdBy: user.id,
+      spaceId: space.id,
+      pageId: page.id,
+      pageType: 'page',
+      meta: { pathname: `/proposals%20?id=123` }
+    });
+
+    const url = await getDefaultPageForSpace({ space, userId: user.id });
+    expect(url).toEqual(`/${space.domain}/proposals%20?id=123`);
+  });
 });
 
-type EventData = Pick<UserSpaceAction, 'pageType' | 'createdBy' | 'spaceId'> & { pageId?: string; postId?: string };
+type EventData = Pick<UserSpaceAction, 'pageType' | 'createdBy' | 'spaceId'> & {
+  pageId?: string;
+  postId?: string;
+  meta?: any;
+};
 
 function savePageView(event: EventData) {
   return prisma.userSpaceAction.create({

--- a/lib/session/getDefaultPageForSpace.ts
+++ b/lib/session/getDefaultPageForSpace.ts
@@ -7,7 +7,7 @@ import { prisma } from '@charmverse/core/prisma-client';
 import type { StaticPageType, PageEventMap } from 'lib/metrics/mixpanel/interfaces/PageEvent';
 import { filterVisiblePages } from 'lib/pages/filterVisiblePages';
 import { getPermissionsClient } from 'lib/permissions/api/routers';
-import { getSubdomainPath, getSpaceUrl } from 'lib/utilities/browser';
+import { getSubdomainPath, getSpaceUrl, fullyDecodeURI } from 'lib/utilities/browser';
 
 type ViewMeta = PageEventMap['page_view']['meta'];
 
@@ -20,8 +20,23 @@ const staticPagesToDirect: { [key in StaticPageType]?: string } = {
 
 const pageTypes = Object.keys(PageType).concat('post', ...Object.keys(staticPagesToDirect));
 
-// get default page when we have a space domain
 export async function getDefaultPageForSpace({
+  space,
+  host,
+  userId
+}: {
+  space: Pick<Space, 'id' | 'domain' | 'customDomain'>;
+  host?: string;
+  userId: string;
+}) {
+  const defaultPage = await getDefaultPageForSpaceRaw({ space, host, userId });
+  // encode to handle Japanese characters
+  // call fullyDecodeURI to handle cases where we saved the pathname with encoded characters
+  return encodeURI(fullyDecodeURI(defaultPage));
+}
+
+// get default page when we have a space domain
+async function getDefaultPageForSpaceRaw({
   space,
   host,
   userId

--- a/lib/utilities/browser.ts
+++ b/lib/utilities/browser.ts
@@ -226,6 +226,29 @@ export function highlightDomElement(domElement: HTMLElement, postHighlight?: () 
   }, 1000);
 }
 
+// decode the path to handle special characters
+export function getBrowserPath() {
+  return decodeURIComponent(window.location.pathname + window.location.search);
+}
+
+// determine if a URL has encoded characters (ex: '/civil-lime-planarian/%E5%A0%B1%%85%AC%E3')
+function isEncoded(uri: string) {
+  uri = uri || '';
+  try {
+    const decoded = decodeURIComponent(uri);
+    return decoded !== uri;
+  } catch (error) {
+    return false;
+  }
+}
+
+export function fullyDecodeURI(uri: string) {
+  while (isEncoded(uri)) {
+    uri = decodeURIComponent(uri);
+  }
+
+  return uri;
+}
 // strip out custom or domain depending on the host
 export function getSubdomainPath(
   path: string,

--- a/pages/[domain]/index.tsx
+++ b/pages/[domain]/index.tsx
@@ -47,8 +47,6 @@ export const getServerSideProps: GetServerSideProps = withSessionSsr(async (cont
   // 3. send user to default page for the space
 
   let destination = await getDefaultPageForSpace({ host: context.req.headers.host, space, userId: sessionUserId });
-  // encode to handle Japanese characters
-  destination = encodeURI(destination);
   // append existing query params, lie 'account' or 'subscription'
   Object.keys(context.query).forEach((key) => {
     if (key !== 'returnUrl' && key !== 'domain') {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b19e1cd</samp>

No summary available (Limit exceeded: required to process 71383 tokens, but only 50000 are allowed per call)

### WHY
I did not realize that window.location.pathname returns the encoded form of the path, so we ended up double-encoding paths.
