### PR TITLE
disable drag an ddrop cards on mobile

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanbanCard.tsx
@@ -16,6 +16,7 @@ import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
 import type { Board, IPropertyTemplate } from 'lib/focalboard/board';
 import type { Card } from 'lib/focalboard/card';
+import { isTouchScreen } from 'lib/utilities/browser';
 
 import { useSortable } from '../../hooks/sortable';
 import mutator from '../../mutator';
@@ -51,7 +52,7 @@ const StyledBox = styled(Box)`
 const KanbanCard = React.memo((props: Props) => {
   const { card, board } = props;
   const intl = useIntl();
-  const [isDragging, isOver, cardRef] = useSortable('card', card, !props.readOnly, props.onDrop);
+  const [isDragging, isOver, cardRef] = useSortable('card', card, !props.readOnly && !isTouchScreen(), props.onDrop);
   const visiblePropertyTemplates = props.visiblePropertyTemplates || [];
   let className = props.isSelected ? 'KanbanCard selected' : 'KanbanCard';
   if (props.isManualSort && isOver) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e11b714</samp>

Fixed kanban card dragging on touch screens in `focalboard` component. Used `isTouchScreen` function to disable `useSortable` hook on touch devices.

### WHY
Drag and drop is confusing on mobile when you also want to scroll. This is the PR where we added mobile support, for reference: https://github.com/charmverse/app.charmverse.io/commit/60c60b83c5d305147254c0c93d9227e289e63063
