### PR TITLE
wait for space to load before sending app loaded event

### DIFF
--- a/hooks/useAppLoadedEvent.ts
+++ b/hooks/useAppLoadedEvent.ts
@@ -8,18 +8,18 @@ import { getBrowserPath } from 'lib/utilities/browser';
 
 export function useAppLoadedEvent() {
   const { isLoaded } = useUser();
-  const { space } = useCurrentSpace();
+  const { space, isLoading: isSpaceLoading } = useCurrentSpace();
 
   const debouncedTrackAction = useRef(debounce(charmClient.track.trackAction, 2000)).current;
 
   const trackAppLoaded = useCallback(() => {
-    if (isLoaded) {
+    if (isLoaded && !isSpaceLoading) {
       debouncedTrackAction('app_loaded', {
         spaceId: space?.id,
         meta: { pathname: getBrowserPath() }
       });
     }
-  }, [isLoaded, space?.id]);
+  }, [isLoaded, isSpaceLoading, space?.id]);
 
   useEffect(() => {
     trackAppLoaded();


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39b43d2</samp>

Improved `app_loaded` event tracking by using `isSpaceLoading` state from `useCurrentSpace` hook. Updated `useAppLoadedEvent` hook and its dependencies in `hooks/useAppLoadedEvent.ts`.

### WHY
<!-- author to complete -->
