### PR TITLE
Attempt to fix sockets in staging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,13 @@ services:
       - NEXT_PUBLIC_APP_ENV=staging
     profiles:
       - stg-sockets
+
+  stg-sockets-sidecar:
+    extends:
+      service: stg-sockets
+    ports:
+      - '3002:3000'
+    profiles:
       - stg-webapp
 
   devapp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       service: defaults
     command: ['sh', '-c', 'node ./.next/server/websockets.js']
     ports:
-      - '3002:3000'
+      - '80:3000'
     environment:
       - NEXT_PUBLIC_APP_ENV=staging
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,9 +88,12 @@ services:
 
   stg-sockets-sidecar:
     extends:
-      service: stg-sockets
+      service: defaults
+    command: ['sh', '-c', 'node ./.next/server/websockets.js']
     ports:
       - '3002:3000'
+    environment:
+      - NEXT_PUBLIC_APP_ENV=staging
     profiles:
       - stg-webapp
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b4583d</samp>

Split `stg-sockets` service into two services in `docker-compose.yml` to expose websockets server on port 80 for staging. This allows the webapp to connect to the websockets server using the same domain and protocol.

### WHY
<!-- author to complete -->
