### PR TITLE
Fix additionalPaths for duplicated page

### DIFF
--- a/lib/pages/duplicatePage.ts
+++ b/lib/pages/duplicatePage.ts
@@ -32,7 +32,7 @@ export async function duplicatePage({
     parentId,
     updateTitle: true,
     includePermissions: true,
-    resetAdditionalPaths: true
+    resetPaths: true
   });
 
   if (rootPageIds.length > 1) {

--- a/lib/pages/duplicatePage.ts
+++ b/lib/pages/duplicatePage.ts
@@ -31,7 +31,8 @@ export async function duplicatePage({
     exportData: data,
     parentId,
     updateTitle: true,
-    includePermissions: true
+    includePermissions: true,
+    resetAdditionalPaths: true
   });
 
   if (rootPageIds.length > 1) {

--- a/lib/templates/importWorkspacePages.ts
+++ b/lib/templates/importWorkspacePages.ts
@@ -26,7 +26,7 @@ type WorkspaceImportOptions = {
   parentId?: string | null;
   updateTitle?: boolean;
   includePermissions?: boolean;
-  resetAdditionalPaths?: boolean;
+  resetPaths?: boolean;
 };
 
 type UpdateRefs = {
@@ -119,7 +119,7 @@ export async function generateImportWorkspacePages({
   parentId: rootParentId,
   updateTitle,
   includePermissions,
-  resetAdditionalPaths
+  resetPaths
 }: WorkspaceImportOptions): Promise<{
   pageArgs: Prisma.PageCreateArgs[];
   blockArgs: Prisma.BlockCreateManyArgs;
@@ -295,13 +295,13 @@ export async function generateImportWorkspacePages({
       }
     };
 
-    if (resetAdditionalPaths && newPageContent.data.additionalPaths) {
+    if (newPageContent.data.additionalPaths) {
       const additionalPath = generatePagePathFromPathAndTitle({
         existingPagePath: newPageContent.data.path,
         title: newPageContent.data.title as string
       });
 
-      newPageContent.data.additionalPaths = [additionalPath];
+      newPageContent.data.additionalPaths = resetPaths ? [additionalPath] : [];
     }
 
     if (node.type.match('card')) {
@@ -481,7 +481,7 @@ export async function importWorkspacePages({
   parentId,
   updateTitle,
   includePermissions,
-  resetAdditionalPaths
+  resetPaths
 }: WorkspaceImportOptions): Promise<Omit<WorkspaceImportResult, 'bounties'>> {
   const {
     pageArgs,
@@ -500,7 +500,7 @@ export async function importWorkspacePages({
     parentId,
     updateTitle,
     includePermissions,
-    resetAdditionalPaths
+    resetPaths
   });
 
   const pagesToCreate = pageArgs.length;

--- a/lib/templates/importWorkspacePages.ts
+++ b/lib/templates/importWorkspacePages.ts
@@ -295,7 +295,7 @@ export async function generateImportWorkspacePages({
       }
     };
 
-    if (resetAdditionalPaths) {
+    if (resetAdditionalPaths && newPageContent.data.additionalPaths) {
       const additionalPath = generatePagePathFromPathAndTitle({
         existingPagePath: newPageContent.data.path,
         title: newPageContent.data.title as string

--- a/lib/templates/importWorkspacePages.ts
+++ b/lib/templates/importWorkspacePages.ts
@@ -295,14 +295,17 @@ export async function generateImportWorkspacePages({
       }
     };
 
-    if (newPageContent.data.additionalPaths) {
-      const additionalPath = generatePagePathFromPathAndTitle({
+    if (resetPaths) {
+      const newPath = generatePagePathFromPathAndTitle({
         existingPagePath: newPageContent.data.path,
         title: newPageContent.data.title as string
       });
 
-      newPageContent.data.additionalPaths = resetPaths ? [additionalPath] : [];
+      newPageContent.data.path = newPath;
     }
+
+    // Always reset additional paths
+    newPageContent.data.additionalPaths = [];
 
     if (node.type.match('card')) {
       const cardBlock = node.blocks?.card;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f6beb2</samp>

Renamed and updated a module for duplicating pages within a workspace. Added an option to reset the additional paths of the duplicated pages based on their titles.

### WHY
Fix additionalPaths when page is being duplicated
