### PR TITLE
fix the check for build id

### DIFF
--- a/components/_app/hooks/useDatadogLogger.tsx
+++ b/components/_app/hooks/useDatadogLogger.tsx
@@ -26,7 +26,7 @@ export default function useDatadogLogger() {
         forwardErrorsToLogs: true,
         sessionSampleRate: 100,
         env: appEnv,
-        version: env('REACT_APP_BUILD_ID')
+        version: env('BUILD_ID')
       });
     }
   }, []);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -151,9 +151,12 @@ export default function App({ Component, pageProps, router }: AppPropsWithLayout
   // Check if a new version of the application is available every 5 minutes.
   useInterval(async () => {
     const data = await charmClient.getBuildId();
-    if (!isOldBuild && data.buildId !== env('REACT_APP_BUILD_ID')) {
+    if (!isOldBuild && data.buildId !== env('BUILD_ID')) {
       setIsOldBuild(true);
-      log.info('Requested user to refresh their browser to get new version');
+      log.info('Requested user to refresh their browser to get new version', {
+        oldVersion: env('BUILD_ID'),
+        newVersion: data.buildId
+      });
     }
   }, 180000);
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2feea21</samp>

Use `BUILD_ID` instead of `REACT_APP_BUILD_ID` for versioning and log version changes in `pages/_app.tsx`. This improves consistency and visibility of app updates.

### WHY
<!-- author to complete -->
