### PR TITLE
exit websocket process with success, not fail

### DIFF
--- a/background/initWebsockets.ts
+++ b/background/initWebsockets.ts
@@ -20,7 +20,7 @@ function cleanup() {
     log.info('[server] Closing HTTP server...');
     httpServer.close(() => {
       log.info('[server] Exiting process...');
-      process.exit(1);
+      process.exit(0);
     });
   });
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f432f3b</samp>

Changed the exit code of the `cleanup` function in `background/initWebsockets.ts` to indicate a normal shutdown. This improves the server's reliability and consistency.

### WHY
I don't think this will change much, but if anything it will have a positive effect on deploys
