### PR TITLE
Remove space domain from pathname in page_view event

### DIFF
--- a/charmClient/hooks/track.ts
+++ b/charmClient/hooks/track.ts
@@ -9,10 +9,13 @@ import { TrackApi } from '../apis/trackApi';
 const track = new TrackApi();
 
 export function trackPageView(page: Omit<PageEventMap['page_view'], 'userId'>) {
+  const fullPath = getBrowserPath();
+  const pathname = page.spaceDomain ? fullPath.replace(new RegExp(`^\\/${page.spaceDomain}`), '') : fullPath;
+
   track.trackAction('page_view', {
     ...page,
     meta: {
-      pathname: getBrowserPath()
+      pathname
     }
   });
 }
@@ -23,6 +26,7 @@ export function useTrackPageView(page: Omit<PageEventMap['page_view'], 'spaceId'
     if (currentSpace) {
       trackPageView({
         spaceId: currentSpace.id,
+        spaceDomain: currentSpace.domain,
         ...page
       });
     }

--- a/components/[pageId]/EditorPage/EditorPage.tsx
+++ b/components/[pageId]/EditorPage/EditorPage.tsx
@@ -35,7 +35,8 @@ export function EditorPage({ pageId: pageIdOrPath }: { pageId: string }) {
       trackPageView({
         type: page.type,
         pageId: page.id,
-        spaceId: page.spaceId
+        spaceId: page.spaceId,
+        spaceDomain: currentSpace?.domain
       });
       setCurrentPageId(page.id);
     }

--- a/components/[pageId]/SharedPage/SharedPage.tsx
+++ b/components/[pageId]/SharedPage/SharedPage.tsx
@@ -11,6 +11,7 @@ import ErrorPage from 'components/common/errors/ErrorPage';
 import LoadingComponent from 'components/common/LoadingComponent';
 import { useBounties } from 'hooks/useBounties';
 import { useCurrentPage } from 'hooks/useCurrentPage';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
 import { usePageTitle } from 'hooks/usePageTitle';
 import type { PublicPageResponse } from 'lib/pages/interfaces';
@@ -24,6 +25,7 @@ export function SharedPage({ publicPage }: Props) {
   const { setCurrentPageId } = useCurrentPage();
   const { pages } = usePages();
   const [, setTitleState] = usePageTitle();
+  const { space } = useCurrentSpace();
 
   const basePageId = publicPage?.page?.id || '';
 
@@ -42,7 +44,8 @@ export function SharedPage({ publicPage }: Props) {
     trackPageView({
       type: rootPage.type,
       pageId: rootPage.id,
-      spaceId: rootPage.spaceId
+      spaceId: rootPage.spaceId,
+      spaceDomain: space?.domain
     });
 
     setTitleState(rootPage.title);

--- a/components/common/PageDialog/PageDialog.tsx
+++ b/components/common/PageDialog/PageDialog.tsx
@@ -59,7 +59,7 @@ export function PageDialog(props: Props) {
 
   useEffect(() => {
     if (page?.id) {
-      trackPageView({ spaceId: page.spaceId, pageId: page.id, type: page.type });
+      trackPageView({ spaceId: page.spaceId, pageId: page.id, type: page.type, spaceDomain: domain });
     }
   }, [page?.id]);
 

--- a/components/forum/components/PostDialog/PostDialog.tsx
+++ b/components/forum/components/PostDialog/PostDialog.tsx
@@ -14,6 +14,7 @@ import { Button } from 'components/common/Button';
 import { DialogTitle } from 'components/common/Modal';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import { FullPageActionsMenuButton } from 'components/common/PageActions/FullPageActionsMenuButton';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useSmallScreen } from 'hooks/useMediaScreens';
 import { useUser } from 'hooks/useUser';
 import type { PostWithVotes } from 'lib/forums/posts/interfaces';
@@ -39,6 +40,7 @@ export function PostDialog({ post, isLoading, spaceId, onClose, newPostCategory 
   const [formInputs, setFormInputs] = useState<FormInputs>(post ?? { title: '', content: null, contentText: '' });
   const [contentUpdated, setContentUpdated] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const { space } = useCurrentSpace();
   const { user } = useUser();
   // only load drafts if user is logged in
   const {
@@ -63,7 +65,7 @@ export function PostDialog({ post, isLoading, spaceId, onClose, newPostCategory 
 
   useEffect(() => {
     if (spaceId && post?.id) {
-      trackPageView({ spaceId, postId: post.id, type: 'post' });
+      trackPageView({ spaceId, postId: post.id, type: 'post', spaceDomain: space?.domain });
     }
   }, [post?.id]);
 

--- a/components/proposals/components/ProposalDialog/ProposalDialog.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalDialog.tsx
@@ -13,6 +13,7 @@ import LoadingComponent from 'components/common/LoadingComponent';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import { FullPageActionsMenuButton } from 'components/common/PageActions/FullPageActionsMenuButton';
 import { useCurrentPage } from 'hooks/useCurrentPage';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePage } from 'hooks/usePage';
 import { usePages } from 'hooks/usePages';
 import { useUser } from 'hooks/useUser';
@@ -38,6 +39,7 @@ export function ProposalDialog({ pageId, newProposal, onClose }: Props) {
       setCurrentPageId(pageId);
     }
   }, [pageId]);
+  const { space } = useCurrentSpace();
   const { user } = useUser();
   const { page, isLoading: isPageLoading, refreshPage } = usePage({ pageIdOrPath: pageId });
   const [formInputs, setFormInputs] = useState<ProposalPageAndPropertiesInput>(
@@ -79,7 +81,7 @@ export function ProposalDialog({ pageId, newProposal, onClose }: Props) {
 
   useEffect(() => {
     if (page?.id) {
-      trackPageView({ spaceId: page.spaceId, pageId: page.id, type: page.type });
+      trackPageView({ spaceId: page.spaceId, pageId: page.id, type: page.type, spaceDomain: space?.domain });
     }
   }, [page?.id]);
 

--- a/lib/metrics/mixpanel/interfaces/PageEvent.ts
+++ b/lib/metrics/mixpanel/interfaces/PageEvent.ts
@@ -26,6 +26,7 @@ type ViewPageEvent = PageEvent & {
   postId?: string;
   meta?: { pathname: string };
   type: PageType | 'post' | StaticPageType;
+  spaceDomain?: string;
 };
 
 export interface PageEventMap {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 863c18f</samp>

Added space domain tracking to various page and dialog components. This involved updating the `trackPageView` function and the `ViewPageEvent` type to accept the `spaceDomain` as an optional parameter. The `useCurrentSpace` hook was used to get the current space domain from the browser path.

### WHY
Do not send space domain in pathname to avoid issues with redirecting after user changes domain name
