### PR TITLE
Revert "hide discord import until we are approved (#2841)"

### DIFF
--- a/components/settings/roles/RoleSettings.tsx
+++ b/components/settings/roles/RoleSettings.tsx
@@ -20,7 +20,7 @@ import { AdminRoleRow } from './components/AdminRoleRow';
 import type { CreateRoleInput } from './components/CreateRoleForm';
 import { CreateRoleForm } from './components/CreateRoleForm';
 import { GuestRoleRow } from './components/GuestRoleRow';
-import { ImportDiscordRolesMenuItem } from './components/ImportDiscordRolesMenuItem';
+import ImportDiscordRolesMenuItem from './components/ImportDiscordRolesMenuItem';
 import { MemberRoleRow } from './components/MemberRoleRow';
 import { DefaultPagePermissions } from './components/RolePermissions/components/DefaultPagePermissions';
 import { RoleRow } from './components/RoleRow';
@@ -162,7 +162,7 @@ export function RoleSettings({ space }: { space: Space }) {
       )}
 
       <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
-        {/* hide this until we are approved <ImportDiscordRolesMenuItem /> */}
+        <ImportDiscordRolesMenuItem />
         <ImportGuildRolesMenuItem onClose={handleClose} />
       </Menu>
 

--- a/components/settings/roles/RoleSettings.tsx
+++ b/components/settings/roles/RoleSettings.tsx
@@ -20,7 +20,7 @@ import { AdminRoleRow } from './components/AdminRoleRow';
 import type { CreateRoleInput } from './components/CreateRoleForm';
 import { CreateRoleForm } from './components/CreateRoleForm';
 import { GuestRoleRow } from './components/GuestRoleRow';
-import ImportDiscordRolesMenuItem from './components/ImportDiscordRolesMenuItem';
+import { ImportDiscordRolesMenuItem } from './components/ImportDiscordRolesMenuItem';
 import { MemberRoleRow } from './components/MemberRoleRow';
 import { DefaultPagePermissions } from './components/RolePermissions/components/DefaultPagePermissions';
 import { RoleRow } from './components/RoleRow';

--- a/components/settings/roles/components/ImportDiscordRolesMenuItem.tsx
+++ b/components/settings/roles/components/ImportDiscordRolesMenuItem.tsx
@@ -6,7 +6,7 @@ import { useIsAdmin } from 'hooks/useIsAdmin';
 import { getDiscordLoginPath } from 'lib/discord/getDiscordLoginPath';
 import DiscordIcon from 'public/images/logos/discord_logo.svg';
 
-export function ImportDiscordRolesMenuItem() {
+export default function ImportDiscordRolesMenuItem() {
   const router = useRouter();
   const { space } = useCurrentSpace();
 

--- a/components/settings/roles/components/ImportDiscordRolesMenuItem.tsx
+++ b/components/settings/roles/components/ImportDiscordRolesMenuItem.tsx
@@ -6,7 +6,7 @@ import { useIsAdmin } from 'hooks/useIsAdmin';
 import { getDiscordLoginPath } from 'lib/discord/getDiscordLoginPath';
 import DiscordIcon from 'public/images/logos/discord_logo.svg';
 
-export default function ImportDiscordRolesMenuItem() {
+export function ImportDiscordRolesMenuItem() {
   const router = useRouter();
   const { space } = useCurrentSpace();
 


### PR DESCRIPTION
This reverts commit 6e7744c22085659d71fcd7cf1a2a5111c4bb639c.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dafaf6e</samp>

Added a feature to import roles from Discord in the role settings page. Fixed a mismatch between the export and import of `ImportDiscordRolesMenuItem`.

### WHY
<!-- author to complete -->
