### PR TITLE
Fix db table row handles

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/table/__snapshots__/table.spec.tsx.snap
+++ b/components/common/BoardEditor/focalboard/src/components/table/__snapshots__/table.spec.tsx.snap
@@ -285,12 +285,10 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
             style="opacity: 1;"
           >
             <div
-              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+              class="icons row-actions MuiBox-root css-0"
             >
-              <button
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
+              <div
+                class="charm-drag-handle MuiBox-root css-0"
               >
                 <svg
                   aria-hidden="true"
@@ -303,7 +301,11 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
                     d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                   />
                 </svg>
-              </button>
+              </div>
+            </div>
+            <div
+              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+            >
               <div
                 style="display: flex; width: 100%;"
               >
@@ -421,12 +423,10 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
             style="opacity: 1;"
           >
             <div
-              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+              class="icons row-actions MuiBox-root css-0"
             >
-              <button
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
+              <div
+                class="charm-drag-handle MuiBox-root css-0"
               >
                 <svg
                   aria-hidden="true"
@@ -439,7 +439,11 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
                     d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                   />
                 </svg>
-              </button>
+              </div>
+            </div>
+            <div
+              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+            >
               <div
                 style="display: flex; width: 100%;"
               >
@@ -959,12 +963,10 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 2`
             style="opacity: 1;"
           >
             <div
-              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+              class="icons row-actions MuiBox-root css-0"
             >
-              <button
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
+              <div
+                class="charm-drag-handle MuiBox-root css-0"
               >
                 <svg
                   aria-hidden="true"
@@ -977,7 +979,11 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 2`
                     d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                   />
                 </svg>
-              </button>
+              </div>
+            </div>
+            <div
+              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+            >
               <div
                 style="display: flex; width: 100%;"
               >
@@ -1089,12 +1095,10 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 2`
             style="opacity: 1;"
           >
             <div
-              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+              class="icons row-actions MuiBox-root css-0"
             >
-              <button
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
+              <div
+                class="charm-drag-handle MuiBox-root css-0"
               >
                 <svg
                   aria-hidden="true"
@@ -1107,7 +1111,11 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 2`
                     d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                   />
                 </svg>
-              </button>
+              </div>
+            </div>
+            <div
+              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+            >
               <div
                 style="display: flex; width: 100%;"
               >
@@ -1624,12 +1632,10 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
             style="opacity: 1;"
           >
             <div
-              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+              class="icons row-actions MuiBox-root css-0"
             >
-              <button
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
+              <div
+                class="charm-drag-handle MuiBox-root css-0"
               >
                 <svg
                   aria-hidden="true"
@@ -1642,7 +1648,11 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
                     d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                   />
                 </svg>
-              </button>
+              </div>
+            </div>
+            <div
+              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+            >
               <div
                 style="display: flex; width: 100%;"
               >
@@ -1760,12 +1770,10 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
             style="opacity: 1;"
           >
             <div
-              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+              class="icons row-actions MuiBox-root css-0"
             >
-              <button
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
+              <div
+                class="charm-drag-handle MuiBox-root css-0"
               >
                 <svg
                   aria-hidden="true"
@@ -1778,7 +1786,11 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
                     d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                   />
                 </svg>
-              </button>
+              </div>
+            </div>
+            <div
+              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+            >
               <div
                 style="display: flex; width: 100%;"
               >
@@ -2298,12 +2310,10 @@ exports[`components/table/Table extended should match snapshot with UpdatedBy 1`
             style="opacity: 1;"
           >
             <div
-              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+              class="icons row-actions MuiBox-root css-0"
             >
-              <button
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
+              <div
+                class="charm-drag-handle MuiBox-root css-0"
               >
                 <svg
                   aria-hidden="true"
@@ -2316,7 +2326,11 @@ exports[`components/table/Table extended should match snapshot with UpdatedBy 1`
                     d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                   />
                 </svg>
-              </button>
+              </div>
+            </div>
+            <div
+              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+            >
               <div
                 style="display: flex; width: 100%;"
               >
@@ -2428,12 +2442,10 @@ exports[`components/table/Table extended should match snapshot with UpdatedBy 1`
             style="opacity: 1;"
           >
             <div
-              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+              class="icons row-actions MuiBox-root css-0"
             >
-              <button
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
+              <div
+                class="charm-drag-handle MuiBox-root css-0"
               >
                 <svg
                   aria-hidden="true"
@@ -2446,7 +2458,11 @@ exports[`components/table/Table extended should match snapshot with UpdatedBy 1`
                     d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                   />
                 </svg>
-              </button>
+              </div>
+            </div>
+            <div
+              class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+            >
               <div
                 style="display: flex; width: 100%;"
               >

--- a/components/common/BoardEditor/focalboard/src/components/table/__snapshots__/tableRow.spec.tsx.snap
+++ b/components/common/BoardEditor/focalboard/src/components/table/__snapshots__/tableRow.spec.tsx.snap
@@ -12,12 +12,10 @@ exports[`components/table/TableRow should match snapshot 1`] = `
       style="opacity: 1;"
     >
       <div
-        class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+        class="icons row-actions MuiBox-root css-0"
       >
-        <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="charm-drag-handle MuiBox-root css-0"
         >
           <svg
             aria-hidden="true"
@@ -30,7 +28,11 @@ exports[`components/table/TableRow should match snapshot 1`] = `
               d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
             />
           </svg>
-        </button>
+        </div>
+      </div>
+      <div
+        class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+      >
         <div
           style="display: flex; width: 100%;"
         >
@@ -107,12 +109,10 @@ exports[`components/table/TableRow should match snapshot, collapsed tree 1`] = `
       style="opacity: 1;"
     >
       <div
-        class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+        class="icons row-actions MuiBox-root css-0"
       >
-        <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="charm-drag-handle MuiBox-root css-0"
         >
           <svg
             aria-hidden="true"
@@ -125,7 +125,11 @@ exports[`components/table/TableRow should match snapshot, collapsed tree 1`] = `
               d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
             />
           </svg>
-        </button>
+        </div>
+      </div>
+      <div
+        class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+      >
         <div
           style="display: flex; width: 100%;"
         >
@@ -202,12 +206,10 @@ exports[`components/table/TableRow should match snapshot, display properties 1`]
       style="opacity: 1;"
     >
       <div
-        class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+        class="icons row-actions MuiBox-root css-0"
       >
-        <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="charm-drag-handle MuiBox-root css-0"
         >
           <svg
             aria-hidden="true"
@@ -220,7 +222,11 @@ exports[`components/table/TableRow should match snapshot, display properties 1`]
               d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
             />
           </svg>
-        </button>
+        </div>
+      </div>
+      <div
+        class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+      >
         <div
           style="display: flex; width: 100%;"
         >
@@ -345,12 +351,10 @@ exports[`components/table/TableRow should match snapshot, isSelected 1`] = `
       style="opacity: 1;"
     >
       <div
-        class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+        class="icons row-actions MuiBox-root css-0"
       >
-        <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="charm-drag-handle MuiBox-root css-0"
         >
           <svg
             aria-hidden="true"
@@ -363,7 +367,11 @@ exports[`components/table/TableRow should match snapshot, isSelected 1`] = `
               d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
             />
           </svg>
-        </button>
+        </div>
+      </div>
+      <div
+        class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+      >
         <div
           style="display: flex; width: 100%;"
         >
@@ -519,12 +527,10 @@ exports[`components/table/TableRow should match snapshot, resizing column 1`] = 
       style="opacity: 1;"
     >
       <div
-        class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+        class="icons row-actions MuiBox-root css-0"
       >
-        <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall icons css-1t9kyav-MuiButtonBase-root-MuiIconButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="charm-drag-handle MuiBox-root css-0"
         >
           <svg
             aria-hidden="true"
@@ -537,7 +543,11 @@ exports[`components/table/TableRow should match snapshot, resizing column 1`] = 
               d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
             />
           </svg>
-        </button>
+        </div>
+      </div>
+      <div
+        class="octo-table-cell title-cell MuiBox-root css-v7v99c"
+      >
         <div
           style="display: flex; width: 100%;"
         >

--- a/components/common/BoardEditor/focalboard/src/components/table/table.scss
+++ b/components/common/BoardEditor/focalboard/src/components/table/table.scss
@@ -72,6 +72,24 @@
     }
   }
 
+  .octo-table-row, .octo-table-cell {
+    .icons {
+      opacity: 0;
+      position: absolute;
+      left: -35px;
+
+      &.row-actions {
+        padding: 10px;
+      }
+    }
+
+    &:hover {
+      .icons {
+        opacity: 1;
+      }
+    }
+  }
+
   .octo-table-cell {
     flex: 0 0 auto;
     display: flex;
@@ -86,18 +104,9 @@
     font-size: 14px;
     position: relative;
     text-overflow: ellipsis;
-    .icons {
-      opacity: 0;
-      position: absolute;
-      left: -40px;
-    }
 
     &:hover {
       background-color: rgba(var(--center-channel-color-rgb), 0.05);
-
-      .icons {
-        opacity: 1;
-      }
     }
 
     &.title-cell {

--- a/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableRow.tsx
@@ -99,7 +99,7 @@ function TableRow(props: Props) {
   };
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleClick = (event: MouseEvent<HTMLElement>) => {
     event.stopPropagation();
     event.preventDefault();
     setAnchorEl(event.currentTarget);
@@ -150,6 +150,14 @@ function TableRow(props: Props) {
       ref={cardRef}
       style={{ opacity: isDragging ? 0.5 : 1 }}
     >
+      {!props.readOnly && (
+        <Box className='icons row-actions' onClick={handleClick}>
+          <Box className='charm-drag-handle'>
+            <DragIndicatorIcon color='secondary' />
+          </Box>
+        </Box>
+      )}
+
       {/* Columns, one per property */}
       {visiblePropertyTemplates.map((template, templateIndex) => {
         if (template.id === Constants.titleColumnId) {
@@ -168,11 +176,6 @@ function TableRow(props: Props) {
               key={template.id}
               onPaste={(e) => e.stopPropagation()}
             >
-              {!props.readOnly && templateIndex === 0 && (
-                <IconButton className='icons' onClick={handleClick} size='small'>
-                  <DragIndicatorIcon color='secondary' />
-                </IconButton>
-              )}
               <div style={{ display: 'flex', width: '100%' }}>
                 <div className='octo-icontitle' style={{ alignSelf: 'flex-start', alignItems: 'flex-start' }}>
                   <PageIcon isEditorEmpty={!hasContent} pageType='page' icon={pageIcon} />
@@ -203,11 +206,6 @@ function TableRow(props: Props) {
             ref={columnRef}
             onPaste={(e) => e.stopPropagation()}
           >
-            {!props.readOnly && templateIndex === 0 && (
-              <IconButton className='icons' onClick={handleClick} size='small'>
-                <DragIndicatorIcon color='secondary' />
-              </IconButton>
-            )}
             <PropertyValueElement
               readOnly={props.readOnly}
               syncWithPageId={cardPage?.syncWithPageId}

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -458,16 +458,16 @@ ol li {
   margin-top: 5px;
   // opacity: 0;
   transition: opacity 0.2s ease-in-out;
+}
 
-  .charm-drag-handle {
-    display: flex;
-    cursor: grab;
-    opacity: 0.5;
-    transition: opacity 0.2s ease-in-out;
+.charm-drag-handle {
+  display: flex;
+  cursor: grab;
+  opacity: 0.5;
+  transition: opacity 0.2s ease-in-out;
 
-    &:hover {
-      opacity: 1;
-    }
+  &:hover {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d0dac3b</samp>

This pull request enhances the table component in the BoardEditor by adding row reordering and editing features, and improving the icon visibility and placement. It also refactors the style rules for the drag handle by moving them from the `theme/@bangle.dev/styles.scss` file to the `components/common/BoardEditor/focalboard/src/components/table/table.scss` file.

### WHY
Fix showind db table handes - they shjould work w/e column you hover instead of 1st one
