### PR TITLE
allow using Return to outdent lists

### DIFF
--- a/components/common/CharmEditor/components/listItemNew/commands.ts
+++ b/components/common/CharmEditor/components/listItemNew/commands.ts
@@ -100,6 +100,24 @@ export const backspaceKeyCommand =
     )(state, dispatch, view);
   };
 
+export const enterKeyCommand = (): Command => (state, dispatch, view) => {
+  const selectedNode = state.selection.$from.parent;
+  const isEmptyParagraph = selectedNode.childCount === 0 && selectedNode.type.name === 'paragraph';
+  const selectionStart = state.selection.$from;
+  const depth = selectionStart.depth;
+
+  // If row is empty, outdent the list item
+  if (isEmptyParagraph && depth > 2) {
+    const parentNode = selectionStart.node(depth - 1);
+    const listNode = selectionStart.node(depth - 2);
+    const isListItem = parentNode.type.name === 'list_item';
+    if (isListItem && isEmptyParagraph && listNode.attrs.indent > 0) {
+      return indentCommand(-1)(state, dispatch, view);
+    }
+  }
+  return splitListCommand()(state, dispatch, view);
+};
+
 export function removeList(): Command {
   return (state: EditorState, dispatch) => {
     const { schema, selection } = state;

--- a/components/common/CharmEditor/components/listItemNew/listItemPlugins.ts
+++ b/components/common/CharmEditor/components/listItemNew/listItemPlugins.ts
@@ -1,5 +1,5 @@
 import type { RawPlugins } from '@bangle.dev/core';
-import { wrappingInputRule } from '@bangle.dev/pm';
+import { wrappingInputRule, chainCommands } from '@bangle.dev/pm';
 import { parentHasDirectParentOfType } from '@bangle.dev/pm-commands';
 import { createObject, filter } from '@bangle.dev/utils';
 import { keymap } from 'prosemirror-keymap';
@@ -8,13 +8,7 @@ import { Plugin } from 'prosemirror-state';
 
 import { isMac } from 'lib/utilities/browser';
 
-import {
-  updateNodeAttrs,
-  indentCommand,
-  listItemMergeCommand,
-  backspaceKeyCommand,
-  splitListCommand
-} from './commands';
+import { updateNodeAttrs, indentCommand, listItemMergeCommand, backspaceKeyCommand, enterKeyCommand } from './commands';
 import { ListItemNodeView } from './listItemNodeView';
 import { BULLET_LIST, ORDERED_LIST, LIST_ITEM } from './nodeNames';
 import { isNodeTodo, wrappingInputRuleForTodo } from './todo';
@@ -60,7 +54,7 @@ export function plugins({ readOnly }: { readOnly: boolean }): RawPlugins {
             todoChecked: attrs.todoChecked == null ? false : !attrs.todoChecked
           }))
         ),
-        Enter: splitListCommand(),
+        Enter: enterKeyCommand(),
         Tab: indentCommand(1),
         'Shift-Tab': indentCommand(-1),
         Backspace: backspaceKeyCommand(schema.nodes[BULLET_LIST]),

--- a/components/common/CharmEditor/components/placeholder/placeholder.ts
+++ b/components/common/CharmEditor/components/placeholder/placeholder.ts
@@ -36,15 +36,17 @@ export function placeholderPlugin(text: string = defaultPlaceholderText) {
         // add to empty paragraph nodes, we can skip checkIsContentEmpty() since it's a little slower
         const selectedNode = state.selection.$from.parent;
         const isEmptyParagraph = selectedNode.childCount === 0 && selectedNode.type.name === 'paragraph';
-        const shouldShow = shouldShowPlaceholder(state);
-        if (isEmptyParagraph && shouldShow) {
-          const resolved = state.doc.resolve(state.selection.from);
-          return DecorationSet.create(state.doc, [
-            Decoration.node(resolved.before(), resolved.after(), {
-              class: 'charm-placeholder',
-              'data-placeholder': text
-            })
-          ]);
+        if (isEmptyParagraph) {
+          const shouldShow = shouldShowPlaceholder(state);
+          if (shouldShow) {
+            const resolved = state.doc.resolve(state.selection.from);
+            return DecorationSet.create(state.doc, [
+              Decoration.node(resolved.before(), resolved.after(), {
+                class: 'charm-placeholder',
+                'data-placeholder': text
+              })
+            ]);
+          }
         }
         return null;
       }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cac0b87</samp>

This pull request improves the list editing and placeholder features of the `CharmEditor` component. It introduces a new `enterKeyCommand` that outdents or splits list items, and optimizes the placeholder plugin to check for empty paragraphs.

### WHY
<!-- author to complete -->
