### PR TITLE
Allow making payments using any EVM-compatible chain

### DIFF
--- a/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
+++ b/components/[pageId]/DocumentPage/components/BountyProperties/components/BountyApplicantsTable/BountyPaymentButton.tsx
@@ -1,3 +1,4 @@
+import { log } from '@charmverse/core/log';
 import type { UserGnosisSafe } from '@charmverse/core/prisma';
 import { BigNumber } from '@ethersproject/bignumber';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
@@ -175,6 +176,7 @@ export function BountyPaymentButton({
       }
     } catch (error: any) {
       const { message, level } = getPaymentErrorMessage(error);
+      log.warn(`Error sending payment on blockchain: ${message}`, { amount, chainId, error });
       onError(message, level);
     }
   };


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7727d54</samp>

Improved and fixed bounty payment logic and error handling in `BountyPaymentButton.tsx`. Added logging for `components/[pageId]/DocumentPage` component.

### WHY
I was testing with zsynk on accident and realized i couldn't make a payment. It turned out that we wouldn't even try to ask you to switch your wallet if we couldn't look up the chain config.

Then, I went further and just removed the need to lookup our config at all for payments. There is one case we used it to look up whether or not the bounty token is native. Instead, I just made it assume we want native if the token value is not a valid contract address. If the value is invalid, they'll get an error from the wallet anyway.

This also adds logging when an error occurs so we can help users in #support