### PR TITLE
Add cleanup script

### DIFF
--- a/lib/utilities/file.ts
+++ b/lib/utilities/file.ts
@@ -23,7 +23,8 @@ function getCallerDirectory() {
 
 /**
  * Utility for when we need to write to the same folder as caller when executing scripts
+ * @append Use this param to append content instead of overwriting the old file
  */
-export async function writeToSameFolder({ data, fileName }: { data: any; fileName: string }) {
-  await fs.writeFile(`${getCallerDirectory()}/${fileName}`, data);
+export async function writeToSameFolder({ data, fileName, append }: { data: any; fileName: string; append?: boolean }) {
+  await (append ? fs.appendFile : fs.writeFile)(`${getCallerDirectory()}/${fileName}`, data);
 }

--- a/scripts/migrations/2023_10_02_cleanupStripe.ts
+++ b/scripts/migrations/2023_10_02_cleanupStripe.ts
@@ -1,7 +1,6 @@
 import { prisma } from "@charmverse/core/prisma-client";
-import { arrayUtils } from "@charmverse/core/utilities";
 import { stripeClient } from "lib/subscription/stripe";
-import Stripe from "stripe";
+import { writeToSameFolder } from "lib/utilities/file";
 
 
 
@@ -19,41 +18,39 @@ if (!ignoredCustomerIds.some(c => c.startsWith('cus'))) {
 // Script 1 - Delete irrelevant subscriptions
 export async function cleanupStripe(cursor?: string): Promise<void> {
 
-  let subs = await stripeClient.subscriptions.list({
-    starting_after: cursor,
-    expand: ['data.items', 'data.items.data.plan', 'data.customer'],
-    limit: 100,
+  let customers = await stripeClient.customers.list({
     created: {
-      // Feb 2nd 2023
-      gt: 1683049611
-    } 
-  });
+      // March 4th
+      gt: 1677935503
+    },
+    limit: 100,
+    starting_after: cursor
+  })
 
-
-
-  for (const sub of subs.data) {
-    if (!ignoredCustomerIds.includes((sub.customer as Stripe.Customer).id) && sub.items.data.some(i => i.plan.product === 'community')) {
-      processed+=1;
-      console.log((sub.customer as Stripe.Customer).metadata.domain)
-      await stripeClient.subscriptions.del(sub.id, {invoice_now: false})
-      await prisma.stripeSubscription.delete({
-        where: {
-          subscriptionId: sub.id
-        }
-      })
+  for (const cus of customers.data) {
+    if (typeof cus.id === 'string' && cus.id.startsWith('cus')  && !ignoredCustomerIds.includes(cus.id)) {
+      processed += 1;
+      await stripeClient.customers.del(cus.id)
       .catch(err => {
-        const issue = `${(sub.customer as Stripe.Customer).metadata.domain} // ${(sub.customer as Stripe.Customer).metadata.spaceId}`;
-        console.log('Error deleting for', issue, err)
+        const issue = `Error deleting in STRIPE for ${cus.metadata.domain} // ${cus.metadata.spaceId} ${err}`;
+        writeToSameFolder({ fileName: 'stripelog.txt', data: issue, append: true})
+        console.log(issue)
+      })
+      await prisma.stripeSubscription.deleteMany({
+        where: {
+          customerId: cus.id          
+        }
       })
     }
   }
-  const newCursor = subs.data[subs.data.length - 1].id;
 
-  total += subs.data.length;
+  const newCursor = customers.data[customers.data.length - 1].id;
+
+  total += customers.data.length;
 
   console.log('Total Processed', processed, 'Cursor:', newCursor, 'Position', total);
 
-  if (subs.has_more) {
+  if (customers.has_more) {
     return cleanupStripe(newCursor)
   }
 }
@@ -62,41 +59,53 @@ export async function cleanupStripe(cursor?: string): Promise<void> {
 // Script 2 - Migrate spaces
 async function migrateSpaces() {
 
-  const customers = await Promise.all(ignoredCustomerIds.map(cust => {
-    return stripeClient.customers.retrieve(cust, {expand: ['subscriptions']}) as Promise<Stripe.Customer>
-  }))
-
-  const ignoredSpaceIds = customers.map(c => c.metadata.spaceId);
-
-
-  // await prisma.space.updateMany({
-  //   where: {
-  //     paidTier: 'cancelled',
-  //     id: {
-  //       notIn: ignoredSpaceIds
-  //     }
-  //   },
-  //   data: {
-  //     paidTier: 'community'
-  //   }
-  // })
-
-  // Catch any stripe subscriptions we didnt catch in first
-  await prisma.stripeSubscription.deleteMany({
+  await prisma.space.updateMany({
     where: {
-      space: {
-        domain: {
-          startsWith: 'cvt'
-        }
-      },
-      spaceId: {
-        notIn: ignoredSpaceIds
-      }
+      paidTier: 'cancelled'
+    },
+    data: {
+      paidTier: 'community'
     }
   })
-
-  console.log(ignoredSpaceIds.sort(), arrayUtils.uniqueValues(ignoredSpaceIds).length)
 }
 
-// migrateSpaces().then(() => console.log('done'))
-cleanupStripe().then(() => console.log('done'))
+// Script 3 - Migrate spaces
+async function dropCancelled() {
+  const subscription = await prisma.stripeSubscription.findMany({});
+
+  for (const sub of subscription) {
+    try {
+      const stripeSub = await stripeClient.subscriptions.retrieve(sub.subscriptionId);
+      if (stripeSub.status === 'canceled') {
+        await prisma.stripeSubscription.delete({
+          where: {
+            id: sub.id
+          }
+        })
+      }
+    } catch (err) {
+      console.log((err as any).code)
+    }
+  }
+}
+
+//migrateSpaces().then(() => console.log('done'))
+// cleanupStripe().then(() => console.log('done'))
+// dropCancelled().then(() => console.log('done'))
+
+// prisma.space.findMany({
+//   where: {
+//     stripeSubscription: {
+//       some: {}
+//     }
+//   },
+//   select: {
+//     domain: true,
+//     stripeSubscription: {
+//       select: {
+//         customerId: true,
+//         subscriptionId: true
+//       }
+//     }
+//   }
+// }).then(count => console.log(JSON.stringify(count, null, 2)))

--- a/scripts/migrations/2023_10_02_cleanupStripe.ts
+++ b/scripts/migrations/2023_10_02_cleanupStripe.ts
@@ -1,0 +1,89 @@
+import { prisma } from "@charmverse/core/prisma-client";
+import { arrayUtils } from "@charmverse/core/utilities";
+import { stripeClient } from "lib/subscription/stripe";
+import Stripe from "stripe";
+
+
+
+let processed = 0;
+
+// Request customer IDs from team
+const ignoredCustomerIds: string[] = [
+]
+
+if (!ignoredCustomerIds.some(c => c.startsWith('cus'))) {
+  throw new Error('No customer IDs provided for ignore list')
+}
+
+
+// Script 1 - Delete irrelevant subscriptions
+export async function cleanupStripe(cursor?: string): Promise<void> {
+
+  let subs = await stripeClient.subscriptions.list({
+    starting_after: cursor,
+    expand: ['data.items', 'data.items.data.plan'],
+    limit: 4,
+    created: {
+      // Feb 2nd 2023
+      gt: 1683049611
+    } 
+  });
+
+  for (const sub of subs.data) {
+    if (!ignoredCustomerIds.some(c => c === sub.customer) && sub.items.data.some(i => i.plan.product === 'community')) {
+      // await stripeClient.subscriptions.del(sub.customer as string, {invoice_now: false})
+      await prisma.stripeSubscription.delete({
+        where: {
+          id: sub.id
+        }
+      })
+    }
+  }
+  const newCursor = subs.data[subs.data.length - 1].id;
+
+  processed += subs.data.length;
+
+  console.log('Total Processed', processed, 'Cursor:', newCursor, 'CUST', ignoredCustomerIds.length, 'Subs:', subs.data.map(s => s.id), 'Will Process')
+
+  if (subs.has_more) {
+    return cleanupStripe(newCursor)
+  }
+}
+
+
+// Script 2 - Migrate spaces
+async function migrateSpaces() {
+
+  const customers = await Promise.all(ignoredCustomerIds.map(cust => {
+    return stripeClient.customers.retrieve(cust, {expand: ['subscriptions']}) as Promise<Stripe.Customer>
+  }))
+
+  const ignoredSpaceIds = customers.map(c => c.metadata.spaceId);
+
+
+  await prisma.space.updateMany({
+    where: {
+      paidTier: 'cancelled',
+      id: {
+        notIn: ignoredSpaceIds
+      }
+    },
+    data: {
+      paidTier: 'community'
+    }
+  })
+
+  // Catch any stripe subscriptions we didnt catch in first
+  await prisma.stripeSubscription.deleteMany({
+    where: {
+      spaceId: {
+        notIn: ignoredSpaceIds
+      }
+    }
+  })
+
+  console.log(ignoredSpaceIds.sort(), arrayUtils.uniqueValues(ignoredSpaceIds).length)
+}
+
+migrateSpaces().then(() => console.log('done'))
+// cleanupStripe().then(() => console.log('done'))


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8ba140</samp>

This change adds a migration script `scripts/migrations/2023_10_02_cleanupStripe.ts` that imports the necessary modules and variables, defines a global counter and an array of ignored customers, and validates the input. The script is part of a migration to clean up the Stripe data and subscriptions for the Charmverse app.

### WHY
Cleanup script for Stripe