### PR TITLE
Bullet list improvements

### DIFF
--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -365,7 +365,7 @@ ol li {
   padding-left: 20px;
 
   & > :not(:first-child) {
-    display: none;
+    display: none !important; /** Add !important for lists or other elements that set display **/
   }
 
   &[open] {
@@ -374,7 +374,7 @@ ol li {
     }
 
     & > :not(:first-child) {
-      display: block;
+      display: block !important;
     }
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bbc9e41</samp>

This pull request improves the functionality and appearance of the `CharmEditor` component for changing the indent level of nodes. It enables selecting the entire row to change the indent level and ensures the display rules are consistent.

### WHY
- bullets not being hidden inside a toggle (CSS fix)
- when highlighting the whole row of a list item, we should indent it