### PR TITLE
Remove condition on updating subscriptions

### DIFF
--- a/lib/subscription/__tests__/updateProSubscription.spec.ts
+++ b/lib/subscription/__tests__/updateProSubscription.spec.ts
@@ -179,43 +179,4 @@ describe('updateProSubscription', () => {
       })
     ).rejects.toBeInstanceOf(InvalidStateError);
   });
-
-  it(`Should fail if the stripe subscription is not active`, async () => {
-    const customerId = `cus_${v4()}`;
-    const subscriptionId = `sub_${v4()}`;
-    const spaceId = space.id;
-
-    const stripeSubscriptionDetails = {
-      id: subscriptionId,
-      status: 'incomplete',
-      metadata: {
-        spaceId
-      },
-      customer: {
-        id: customerId,
-        metadata: {
-          spaceId
-        }
-      },
-      items: {
-        data: [
-          {
-            price: stripeMockIds.priceId,
-            quantity: 10
-          }
-        ]
-      }
-    };
-
-    (stripeClient.subscriptions.retrieve as jest.Mock) = jest.fn().mockResolvedValue(stripeSubscriptionDetails);
-    (stripeClient.subscriptions.update as jest.Mock) = stripeMock.stripeClient.subscriptions.update;
-    (stripeClient.customers.update as jest.Mock) = stripeMock.stripeClient.customers.update;
-
-    await expect(
-      updateProSubscription({
-        spaceId,
-        payload: {}
-      })
-    ).rejects.toBeInstanceOf(InvalidStateError);
-  });
 });

--- a/lib/subscription/updateProSubscription.ts
+++ b/lib/subscription/updateProSubscription.ts
@@ -42,10 +42,6 @@ export async function updateProSubscription({
     throw new InvalidStateError(`Can't update the subscription of a deleted customer ${stripeCustomer.id}`);
   }
 
-  if (stripeSubscription?.status !== 'active') {
-    throw new InvalidStateError(`Subscription ${stripeSubscription.id} is not active`);
-  }
-
   if (billingEmail) {
     await stripeClient.customers.update(stripeCustomer.id, {
       email: billingEmail


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0ce08a</samp>

Removed unnecessary error handling for past_due subscriptions in `updateProSubscription` function. Simplified the logic and improved the user experience for updating or cancelling pro subscriptions.

### WHY
We had block on updating subscription info. Could find a reason to keep it, so I deleted it
