### PR TITLE
attempt to fix flaky tests

### DIFF
--- a/lib/focalboard/__tests__/createCardsFromProposals.spec.ts
+++ b/lib/focalboard/__tests__/createCardsFromProposals.spec.ts
@@ -28,7 +28,18 @@ describe('createCardsFromProposals', () => {
   });
 
   beforeEach(async () => {
-    await prisma.$transaction([prisma.page.deleteMany(), prisma.proposal.deleteMany()]);
+    await prisma.$transaction([
+      prisma.page.deleteMany({
+        where: {
+          spaceId: space.id
+        }
+      }),
+      prisma.proposal.deleteMany({
+        where: {
+          spaceId: space.id
+        }
+      })
+    ]);
   });
 
   it('should create cards from proposals', async () => {

--- a/lib/focalboard/__tests__/updateCardsFromProposals.spec.ts
+++ b/lib/focalboard/__tests__/updateCardsFromProposals.spec.ts
@@ -29,7 +29,18 @@ describe('updateCardsFromProposals()', () => {
   });
 
   beforeEach(async () => {
-    await prisma.$transaction([prisma.page.deleteMany(), prisma.proposal.deleteMany()]);
+    await prisma.$transaction([
+      prisma.page.deleteMany({
+        where: {
+          spaceId: space.id
+        }
+      }),
+      prisma.proposal.deleteMany({
+        where: {
+          spaceId: space.id
+        }
+      })
+    ]);
   });
 
   it('should update cards from proposals', async () => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e165730</samp>

The pull request improves the test suites for `createCardsFromProposals` and `updateCardsFromProposals` by adding a `where` clause to the `deleteMany` calls in the `beforeEach` hooks. This ensures that only the relevant pages and proposals are deleted before each test, avoiding conflicts and improving performance.

### WHY
<!-- author to complete -->
