### PR TITLE
changing serverless github action to use cache from main

### DIFF
--- a/.github/workflows/deploy_serverless_prod.yml
+++ b/.github/workflows/deploy_serverless_prod.yml
@@ -14,18 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        function_name: ["webhook-queueWorker", "webhookChecker"]
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - name: serverless deploy
+      - name: Install dependencies
+        uses: ./.github/actions/install
+      - name: serverless deploy ${{ matrix.function_name }}
         uses: serverless/github-action@v3.1
         with:
-          args: deploy --stage prod --function webhook-queueWorker
+          args: deploy --stage prod --function ${{ matrix.function_name }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy_serverless_staging.yml
+++ b/.github/workflows/deploy_serverless_staging.yml
@@ -17,18 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        function_name: ["webhook-queueWorker", "webhookChecker"]
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - name: serverless deploy
+      - name: Install dependencies
+        uses: ./.github/actions/install
+      - name: serverless deploy ${{ matrix.function_name }}
         uses: serverless/github-action@v3.1
         with:
-          args: deploy --function webhook-queueWorker
+          args: deploy --function ${{ matrix.function_name }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/serverless/webhook/worker.ts
+++ b/serverless/webhook/worker.ts
@@ -12,6 +12,7 @@ import { whiteListedWebhookEvents } from 'lib/webhookPublisher/interfaces';
 
 /**
  * SQS worker, message are executed one by one
+ * Changing comments to trigger deploy
  */
 export const webhookWorker = async (event: SQSEvent): Promise<SQSBatchResponse> => {
   // Store failed messageIDs


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 700a919</samp>

This pull request updates the `deploy_serverless_prod` and `deploy_serverless_staging` workflows to use a matrix strategy and a custom action for deploying two functions: `webhook-queueWorker` and `webhookChecker`. It also adds a comment to `serverless/webhook/worker.ts` to test the deployment.

### WHY
<!-- author to complete -->
