### PR TITLE
fix styling of lists inside of inline databases

### DIFF
--- a/components/common/CharmEditor/components/listItemNew/czi-list.scss
+++ b/components/common/CharmEditor/components/listItemNew/czi-list.scss
@@ -12,8 +12,8 @@ html {
   --tab-width: 24px;
 }
 
-.ProseMirror ol:not(.old-list),
-.ProseMirror ul:not(.old-list) {
+.ProseMirror ol,
+.ProseMirror ul {
   /*
    * Use `column-span: all` and `display: flow-root` to force formatting context
    * https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
@@ -29,16 +29,6 @@ html {
 }
 
 /* bullet indentation */
-.ProseMirror li:not(.old-list > li) {
-  /* This assumes the space needed for 3 digits numbers */
-  display: block;
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-  position: relative;
-  zoom: 1;
-}
-
 .ProseMirror li > span > p {
   // margin: 0;
   // margin-block-end: 0;
@@ -62,7 +52,7 @@ html {
   width: var(--tab-width);
 }
 
-.ProseMirror ol:not(.old-list) {
+.ProseMirror ol {
   /* counter-reset: czi-counter;
   list-style-type: none; */
   --czi-counter-name: czi-counter-0;
@@ -72,11 +62,11 @@ html {
   counter-reset: none;
 }
 
-.ProseMirror ol:not(.old-list) > li {
+.ProseMirror ol > li {
   counter-increment: var(--czi-counter-name);
 }
 
-.ProseMirror ol:not([data-counter-reset='none']):not(.old-list) {
+.ProseMirror ol:not([data-counter-reset='none']) {
   counter-reset: var(--czi-counter-name) var(--czi-counter-reset);
 }
 

--- a/components/common/stories/CharmEditorStories/Components/Lists.stories.tsx
+++ b/components/common/stories/CharmEditorStories/Components/Lists.stories.tsx
@@ -37,53 +37,17 @@ export function Lists() {
     _.bullet_list({ indent: 1 }, _.list_item(_.p('Cucumber')), _.list_item(_.p('Pumpkin'))),
     _.bullet_list({ indent: 2 }, _.list_item(_.p('Squash'))),
     _.bullet_list({ indent: 3 }, _.list_item(_.p('Zucchini'))),
-    _.heading({ level: 2 }, 'Old Bullet list'),
-    _.bulletList(
-      _.listItem(_.p('Bread')),
-      _.listItem(_.p('Milk')),
-      _.listItem(
-        _.p('Vegetables'),
-        _.bulletList(
-          _.listItem(_.p('Cucumber')),
-          _.listItem(_.p('Pumpkin'), _.bulletList(_.listItem(_.p('Squash'), _.bulletList(_.listItem(_.p('Zucchini'))))))
-        )
-      )
-    ),
     _.heading({ level: 2 }, 'Ordered list'),
     _.ordered_list(_.list_item(_.p('Bread')), _.list_item(_.p('Milk')), _.list_item(_.p('Vegetables'))),
     _.ordered_list({ indent: 1 }, _.list_item(_.p('Cucumber')), _.list_item(_.p('Pumpkin'))),
     _.ordered_list({ indent: 2 }, _.list_item(_.p('Squash'))),
     _.ordered_list({ indent: 3 }, _.list_item(_.p('Zucchini'))),
-    _.heading({ level: 2 }, 'Old Ordered list'),
-    _.orderedList(
-      _.listItem(_.p('Bread')),
-      _.listItem(_.p('Milk')),
-      _.listItem(
-        _.p('Vegetables'),
-        _.orderedList(
-          _.listItem(_.p('Cucumber')),
-          _.listItem(
-            _.p('Pumpkin'),
-            _.orderedList(_.listItem(_.p('Squash'), _.orderedList(_.listItem(_.p('Zucchini')))))
-          )
-        )
-      )
-    ),
     _.heading({ level: 2 }, 'Todo list'),
     _.bullet_list(
       _.list_item({ todoChecked: true }, _.p('Task 1')),
       _.list_item({ todoChecked: false }, _.p('Task 2'))
     ),
-    _.bullet_list({ indent: 1 }, _.list_item({ todoChecked: false }, _.p('Nested task'))),
-    _.heading({ level: 2 }, 'Old Todo list'),
-    _.bulletList(
-      _.listItem({ todoChecked: true }, _.p('Task 1')),
-      _.listItem(
-        { todoChecked: false },
-        _.p('Task 2'),
-        _.bulletList(_.listItem({ todoChecked: false }, _.p('Nested task')))
-      )
-    )
+    _.bullet_list({ indent: 1 }, _.list_item({ todoChecked: false }, _.p('Nested task')))
   );
   return renderEditorWithContent({ content, title: 'Lists' });
 }

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -287,45 +287,9 @@ ol li {
   transition: background-color 150ms ease-in-out;
 }
 
-.bangle-editor .old-list li[data-bangle-is-todo] {
-  display: flex;
-  flex-direction: row;
-  position: relative;
-}
-
-.bangle-editor .old-list li[data-bangle-is-todo] > span:first-child {
-  margin-left: -1.5rem;
-}
-
-.bangle-editor .old-list li[data-bangle-is-todo] > span:first-child > input {
-  margin-top: 0.5rem;
-  margin-right: 6px;
-  outline: none;
-  position: relative;
-}
-
 .bangle-editor > ol {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
-}
-
-.bangle-editor .old-list {
-  list-style-position: outside;
-  padding-left: 1.5rem;
-  // hide new list style
-  p::before {
-    display: none !important;
-  }
-  li {
-    display: list-item;
-  }
-  p {
-    padding-left: 0 !important;
-  }
-}
-
-.bangle-editor ol.old-list {
-  list-style-type: decimal;
 }
 
 .bangle-editor > p {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d05c1e3</samp>

Refactored the list styles in `CharmEditor` to use the new `czi-list` component and removed the old ones. Simplified the CSS rules and updated the `Lists` story to reflect the changes.

### WHY
The prosemirror CSS is overriding styles for inline database . Using Storybook, found a bunch of styles we could just remove.


<img width="756" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/8aa622c1-5f6c-4b46-a0d5-42636defc1af">
