### PR TITLE
Fix page permissions

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -355,7 +355,7 @@ function DocumentPage({ page, refreshPage, savePage, insideModal, readOnly = fal
                   </CardPropertiesWrapper>
                 </CharmEditor>
 
-                {page.type === 'proposal' && (
+                {page.type === 'proposal' && pagePermissions.comment && (
                   <Box mt='-100px'>
                     {/* add negative margin to offset height of .charm-empty-footer */}
                     <PageComments page={page} permissions={pagePermissions} />

--- a/components/common/PageActions/components/DocumentPageActionList.tsx
+++ b/components/common/PageActions/components/DocumentPageActionList.tsx
@@ -247,6 +247,7 @@ export function DocumentPageActionList({
         <>
           <Divider />
           <ListItemButton
+            disabled={!pagePermissions?.comment}
             onClick={() => {
               setCurrentPageActionDisplay('comments');
               onComplete();

--- a/pages/api/pages/[id]/comments/index.ts
+++ b/pages/api/pages/[id]/comments/index.ts
@@ -37,8 +37,8 @@ async function listPageCommentsHandler(req: NextApiRequest, res: NextApiResponse
     userId
   });
 
-  if (permissions.read !== true) {
-    throw new ActionNotPermittedError('You do not have permission to view this page');
+  if (permissions.comment !== true) {
+    throw new ActionNotPermittedError('You do not have permission to view comments this page');
   }
 
   const pageCommentsWithVotes = await listPageComments({ pageId, userId });

--- a/pages/api/pages/[id]/threads.ts
+++ b/pages/api/pages/[id]/threads.ts
@@ -26,7 +26,7 @@ async function getThreads(req: NextApiRequest, res: NextApiResponse) {
     userId: req.session?.user?.id
   });
 
-  if (computed.read !== true) {
+  if (computed.comment !== true) {
     throw new NotFoundError('Page not found');
   }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cab5b10</samp>

Refactored permission system for pages and threads. Updated `getThreads` API to use `comment` permission instead of `read` permission.

### WHY
Align page permissions consumption  threads & page comments