### PR TITLE
fix lookup for public pages on custom domains

### DIFF
--- a/pages/[domain]/index.tsx
+++ b/pages/[domain]/index.tsx
@@ -22,11 +22,7 @@ export const getServerSideProps: GetServerSideProps = withSessionSsr(async (cont
     where: {
       OR: [
         {
-          // TODO: ask Marek why we need to support case-insensitivity for custom domains
-          customDomain: {
-            equals: domainOrCustomDomain,
-            mode: 'insensitive'
-          }
+          customDomain: domainOrCustomDomain
         },
         { domain: domainOrCustomDomain }
       ]

--- a/pages/api/public/pages/[...pageId]/index.ts
+++ b/pages/api/public/pages/[...pageId]/index.ts
@@ -160,11 +160,7 @@ async function getPublicPage(req: NextApiRequest, res: NextApiResponse<PublicPag
       : {
           OR: [
             {
-              // TODO: ask Marek why we need to support case-insensitivity for custom domains
-              customDomain: {
-                equals: spaceDomain,
-                mode: 'insensitive'
-              }
+              customDomain: spaceDomain
             },
             { domain: spaceDomain }
           ]


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8b5182</samp>

Enhanced the public pages API to handle custom domains better and query pages faster. Refactored the `getPublicPage` function in `pages/api/public/pages/[...pageId]/index.ts`.

### WHY
If you are logged in and visit a public page on custom domain, RouteGuard redirects you to /join. I thought the bug wsa in route guard, but then I realized that public/pages/[...pageId] was returning 404 (space not found), so there was no public page loaded