### PR TITLE
fix error in breadcrumbs when rewards does not exist

### DIFF
--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -22,6 +22,7 @@ import { useFavoritePages } from 'hooks/useFavoritePages';
 import { useFeaturesAndMembers } from 'hooks/useFeaturesAndMemberProfiles';
 import { useForumCategories } from 'hooks/useForumCategories';
 import { useHasMemberLevel } from 'hooks/useHasMemberLevel';
+import { useIsCharmverseSpace } from 'hooks/useIsCharmverseSpace';
 import useKeydownPress from 'hooks/useKeydownPress';
 import { useSmallScreen } from 'hooks/useMediaScreens';
 import type { SettingsPath } from 'hooks/useSettingsDialog';
@@ -227,6 +228,7 @@ export function Sidebar({ closeSidebar, navAction }: SidebarProps) {
   }, [favoritePageIds, userSpacePermissions, navAction, addPage, showMemberFeatures]);
 
   const { features } = useFeaturesAndMembers();
+  const isCharmverse = useIsCharmverseSpace();
 
   return (
     <SidebarContainer>
@@ -275,7 +277,7 @@ export function Sidebar({ closeSidebar, navAction }: SidebarProps) {
                   )}
                   <Divider sx={{ mx: 2, my: 1 }} />
                   {features
-                    .filter((feat) => !feat.isHidden)
+                    .filter((feat) => !feat.isHidden || (!isCharmverse && feat.path === 'rewards'))
                     .map((feat) => {
                       if (
                         showMemberFeatures ||

--- a/hooks/useFeaturesAndMemberProfiles.tsx
+++ b/hooks/useFeaturesAndMemberProfiles.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react';
 import type { FeatureJson, StaticPagesType } from 'components/common/PageLayout/components/Sidebar/utils/staticPages';
 import { STATIC_PAGES } from 'components/common/PageLayout/components/Sidebar/utils/staticPages';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import { useIsCharmverseSpace } from 'hooks/useIsCharmverseSpace';
 import type { MemberProfileJson } from 'lib/profile/memberProfiles';
 import { memberProfileLabels, memberProfileNames } from 'lib/profile/memberProfiles';
 import { sortArrayByObjectProperty } from 'lib/utilities/array';
@@ -21,7 +20,6 @@ type MappedFeatures = Record<
 
 export const useFeaturesAndMembers = () => {
   const { space, isLoading } = useCurrentSpace();
-  const isCharmverse = useIsCharmverseSpace();
 
   const features = useMemo(() => {
     const dbFeatures = Object.fromEntries(((space?.features || []) as FeatureJson[]).map((_feat) => [_feat.id, _feat]));
@@ -30,8 +28,7 @@ export const useFeaturesAndMembers = () => {
       STATIC_PAGES,
       'feature',
       ((space?.features || []) as FeatureJson[]).map((feat) => feat.id)
-      // hide rewards entry for spaces
-    ).filter((feat) => !(!isCharmverse && feat.feature === 'rewards'));
+    );
 
     const extendedFeatures = sortedFeatures.map(({ feature, ...restFeat }) => ({
       ...restFeat,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 24c7ae9</samp>

This pull request enhances the sidebar component to hide the `rewards` feature for non-Charmverse spaces and refactors the `useFeaturesAndMemberProfiles` hook to simplify its logic and remove unused code.

### WHY
We have some code that assumes 'rewards' exists, but right now it's only for CV spaces. I think its safer to just hide the rewards tab on the sidebar. I think this may expose it in the Admin Settings, but if we can deploy the new UI this week, i think it's not a big deal