### PR TITLE
fix hiding rewards for non-cv spaces

### DIFF
--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -277,7 +277,7 @@ export function Sidebar({ closeSidebar, navAction }: SidebarProps) {
                   )}
                   <Divider sx={{ mx: 2, my: 1 }} />
                   {features
-                    .filter((feat) => !feat.isHidden || (!isCharmverse && feat.path === 'rewards'))
+                    .filter((feat) => !feat.isHidden && (feat.path !== 'rewards' || isCharmverse))
                     .map((feat) => {
                       if (
                         showMemberFeatures ||


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0e71b3</samp>

Refactored features filtering logic in `Sidebar.tsx` to hide rewards feature for non-charmverse users.

### WHY
<!-- author to complete -->
