### PR TITLE
Ux proposal connect

### DIFF
--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/OpenWalletSelectorButton.tsx
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/OpenWalletSelectorButton.tsx
@@ -1,0 +1,12 @@
+import { Button } from 'components/common/Button';
+
+import { useWeb3ConnectionManager } from '../../Web3ConnectionManager';
+
+export function OpenWalletSelectorButton({ color }: { color?: string }) {
+  const { connectWallet } = useWeb3ConnectionManager();
+  return (
+    <Button variant='outlined' onClick={connectWallet} color={color}>
+      Connect Wallet
+    </Button>
+  );
+}

--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -146,12 +146,3 @@ export function WalletSelectorModal() {
     </Modal>
   );
 }
-
-export function OpenWalletSelectorModal({ color }: { color?: string }) {
-  const { connectWallet } = useWeb3ConnectionManager();
-  return (
-    <Button variant='outlined' onClick={connectWallet} color={color}>
-      Connect Wallet
-    </Button>
-  );
-}

--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -9,6 +9,7 @@ import type { Connector } from 'wagmi';
 import { useAccount, useConnect } from 'wagmi';
 
 import { useMetamaskConnect } from 'components/_app/Web3ConnectionManager/hooks/useMetamaskConnect';
+import { Button } from 'components/common/Button';
 import ErrorComponent from 'components/common/errors/WalletError';
 import Link from 'components/common/Link';
 import { Modal } from 'components/common/Modal';
@@ -143,5 +144,14 @@ export function WalletSelectorModal() {
     <Modal open={isWalletSelectorModalOpen} onClose={closeWalletSelectorModal}>
       <WalletSelector />
     </Modal>
+  );
+}
+
+export function OpenWalletSelectorModal({ color }: { color?: string }) {
+  const { connectWallet } = useWeb3ConnectionManager();
+  return (
+    <Button variant='outlined' onClick={connectWallet} color={color}>
+      Connect Wallet
+    </Button>
   );
 }

--- a/components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails.tsx
+++ b/components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails.tsx
@@ -1,15 +1,9 @@
 import PublishIcon from '@mui/icons-material/ElectricBolt';
 import { Box, Chip, Divider, Stack, Typography } from '@mui/material';
 import Alert from '@mui/material/Alert';
-import MuiButton from '@mui/material/Button';
 
-import { WalletSelector } from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal';
-import {
-  OpenWalletSelectorModal,
-  WalletSelectorModal
-} from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal';
+import { OpenWalletSelectorModal } from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal';
 import { Button } from 'components/common/Button';
-import ButtonChip from 'components/common/ButtonChip';
 import Loader from 'components/common/LoadingComponent';
 import { useSnapshotVoting } from 'components/proposals/components/SnapshotVoting/hooks/useSnapshotVoting';
 import { SnapshotVotingForm } from 'components/proposals/components/SnapshotVoting/SnapshotVotingForm';

--- a/components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails.tsx
+++ b/components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails.tsx
@@ -1,8 +1,15 @@
 import PublishIcon from '@mui/icons-material/ElectricBolt';
 import { Box, Chip, Divider, Stack, Typography } from '@mui/material';
 import Alert from '@mui/material/Alert';
+import MuiButton from '@mui/material/Button';
 
+import { WalletSelector } from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal';
+import {
+  OpenWalletSelectorModal,
+  WalletSelectorModal
+} from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal';
 import { Button } from 'components/common/Button';
+import ButtonChip from 'components/common/ButtonChip';
 import Loader from 'components/common/LoadingComponent';
 import { useSnapshotVoting } from 'components/proposals/components/SnapshotVoting/hooks/useSnapshotVoting';
 import { SnapshotVotingForm } from 'components/proposals/components/SnapshotVoting/SnapshotVotingForm';
@@ -99,7 +106,19 @@ export function SnapshotVoteDetails({ snapshotProposalId }: Props) {
         <Box display='flex' flexDirection='column' gap={1}>
           {isVotingActive ? (
             <Box>
-              <Stack mb={1}>{votingDisabledStatus && <Alert severity='warning'>{votingDisabledStatus}</Alert>}</Stack>
+              <Stack mb={1}>
+                {votingDisabledStatus && (
+                  <Alert
+                    sx={{ alignItems: 'center' }}
+                    severity='warning'
+                    action={
+                      votingDisabledStatus.reason === 'account' ? <OpenWalletSelectorModal color='inherit' /> : null
+                    }
+                  >
+                    {votingDisabledStatus.message}
+                  </Alert>
+                )}
+              </Stack>
               <SnapshotVotingForm
                 snapshotProposal={snapshotProposal}
                 votingPower={votingPower}

--- a/components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails.tsx
+++ b/components/common/CharmEditor/components/inlineVote/components/SnapshotVoteDetails.tsx
@@ -2,7 +2,7 @@ import PublishIcon from '@mui/icons-material/ElectricBolt';
 import { Box, Chip, Divider, Stack, Typography } from '@mui/material';
 import Alert from '@mui/material/Alert';
 
-import { OpenWalletSelectorModal } from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal';
+import { OpenWalletSelectorButton } from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal/OpenWalletSelectorButton';
 import { Button } from 'components/common/Button';
 import Loader from 'components/common/LoadingComponent';
 import { useSnapshotVoting } from 'components/proposals/components/SnapshotVoting/hooks/useSnapshotVoting';
@@ -106,7 +106,7 @@ export function SnapshotVoteDetails({ snapshotProposalId }: Props) {
                     sx={{ alignItems: 'center' }}
                     severity='warning'
                     action={
-                      votingDisabledStatus.reason === 'account' ? <OpenWalletSelectorModal color='inherit' /> : null
+                      votingDisabledStatus.reason === 'account' ? <OpenWalletSelectorButton color='inherit' /> : null
                     }
                   >
                     {votingDisabledStatus.message}

--- a/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
+++ b/components/common/PageActions/components/SnapshotAction/PublishingForm.tsx
@@ -14,7 +14,7 @@ import { useEffect, useState } from 'react';
 import { getAddress } from 'viem';
 
 import charmClient from 'charmClient';
-import { OpenWalletSelectorModal } from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal';
+import { OpenWalletSelectorButton } from 'components/_app/Web3ConnectionManager/components/WalletSelectorModal/OpenWalletSelectorButton';
 import FieldLabel from 'components/common/form/FieldLabel';
 import InputEnumToOption from 'components/common/form/InputEnumToOptions';
 import InputGeneratorText from 'components/common/form/InputGeneratorText';
@@ -440,7 +440,7 @@ export function PublishingForm({ onSubmit, pageId }: Props) {
                 {formError instanceof MissingWeb3AccountError ? (
                   <Alert
                     sx={{ alignItems: 'center' }}
-                    action={!web3Provider ? <OpenWalletSelectorModal color='inherit' /> : null}
+                    action={!web3Provider ? <OpenWalletSelectorButton color='inherit' /> : null}
                     severity={formError.severity as AlertColor}
                   >
                     We couldn't detect your wallet. Please unlock your wallet and try publishing again.

--- a/components/proposals/components/SnapshotVoting/hooks/useSnapshotVoting.ts
+++ b/components/proposals/components/SnapshotVoting/hooks/useSnapshotVoting.ts
@@ -85,6 +85,8 @@ export function useSnapshotVoting({ snapshotProposalId }: { snapshotProposalId: 
   };
 }
 
+type VotingDisabledReason = 'account' | 'no_vote_power' | 'vote_inactive';
+
 function getVotingDisabledStatus({
   account,
   votingPower,
@@ -93,17 +95,26 @@ function getVotingDisabledStatus({
   account?: string | null;
   votingPower: number;
   isVotingActive: boolean;
-}) {
+}): null | { reason: VotingDisabledReason; message: string } {
   if (!account) {
-    return 'You need to connect your wallet to vote on snapshot proposals.';
+    return {
+      reason: 'account',
+      message: 'You need to connect your wallet to vote on snapshot proposals.'
+    };
   }
 
   if (!votingPower) {
-    return 'You do not have voting power to vote on this proposal.';
+    return {
+      reason: 'no_vote_power',
+      message: 'You do not have voting power to vote on this proposal.'
+    };
   }
 
   if (!isVotingActive) {
-    return 'Voting is not active for this proposal.';
+    return {
+      reason: 'vote_inactive',
+      message: 'Voting is not active for this proposal.'
+    };
   }
 
   return null;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8427e3e</samp>

This pull request adds and integrates a new component for selecting a wallet to connect to the web3 provider in various scenarios where the user needs to interact with snapshot proposals. It also enhances the logic and UI for displaying the voting disabled status for snapshot proposals. It affects the files `WalletSelectorModal.tsx`, `SnapshotVoteDetails.tsx`, `PublishingForm.tsx`, and `useSnapshotVoting.ts`.

### WHY
Add a button to connect your wallet inside proposals and publish to snapshot
