### PR TITLE
Fix collabland connect space response

### DIFF
--- a/pages/api/v1/collabland/connect.ts
+++ b/pages/api/v1/collabland/connect.ts
@@ -20,10 +20,10 @@ handler
   )
   .post(connectSpaceHandler);
 
-async function connectSpaceHandler(req: NextApiRequest, res: NextApiResponse<Promise<SpaceApiResponse>>) {
+async function connectSpaceHandler(req: NextApiRequest, res: NextApiResponse<SpaceApiResponse>) {
   const { state, discordServerId } = req.body as { state: string; discordServerId: string };
 
-  const connectedSpace = connectSpace({ state, discordServerId });
+  const connectedSpace = await connectSpace({ state, discordServerId });
 
   return res.status(201).json(connectedSpace);
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3270b1e</samp>

Fixed a bug in the `/api/v1/collabland/connect` endpoint that caused an error when connecting a space. Added the `await` keyword to the `connectSpaceHandler` function in `pages/api/v1/collabland/connect.ts` to resolve the promise returned by `connectSpace`.

### WHY
<!-- author to complete -->
