### PR TITLE
Add upgrade to community flows

### DIFF
--- a/__integration-tests__/server/pages/api/spaces/[id]/switch-to-community-tier.spec.ts
+++ b/__integration-tests__/server/pages/api/spaces/[id]/switch-to-community-tier.spec.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { Space, User } from '@charmverse/core/prisma';
+import { prisma } from '@charmverse/core/prisma-client';
+import { testUtilsUser } from '@charmverse/core/test';
+import request from 'supertest';
+
+import type { SpacePublicProposalToggle } from 'lib/spaces/toggleSpacePublicProposals';
+import { baseUrl, loginUser } from 'testing/mockApiCall';
+import { generateSpaceUser } from 'testing/setupDatabase';
+
+let nonAdminUser: User;
+let nonAdminUserCookie: string;
+let adminUser: User;
+let adminUserCookie: string;
+let space: Space;
+
+beforeAll(async () => {
+  const { space: generatedSpace, user } = await testUtilsUser.generateUserAndSpace({
+    isAdmin: false,
+    spacePaidTier: 'free'
+  });
+
+  space = generatedSpace;
+  nonAdminUser = user;
+  adminUser = await generateSpaceUser({
+    isAdmin: true,
+    spaceId: space.id
+  });
+
+  nonAdminUserCookie = await loginUser(nonAdminUser.id);
+  adminUserCookie = await loginUser(adminUser.id);
+});
+
+describe('POST /api/spaces/[id]/switch-to-community-tier - Use community plan', () => {
+  it('should update a space`s paid tier, if user is the admin and return the space, responding with 200', async () => {
+    const update: Pick<SpacePublicProposalToggle, 'publicProposals'> = {
+      publicProposals: true
+    };
+    await request(baseUrl)
+      .post(`/api/spaces/${space.id}/switch-to-community-tier`)
+      .set('Cookie', adminUserCookie)
+      .send(update)
+      .expect(200);
+    const updatedSpace = await prisma.space.findUniqueOrThrow({ where: { id: space.id } });
+
+    expect(updatedSpace.paidTier).toBe('community');
+  });
+
+  it('should fail if the user is not an admin of the space, and respond 401', async () => {
+    await request(baseUrl)
+      .post(`/api/spaces/${space.id}/switch-to-community-tier`)
+      .set('Cookie', nonAdminUserCookie)
+      .send({
+        publicProposals: true
+      })
+      .expect(401);
+  });
+});

--- a/__integration-tests__/server/pages/api/spaces/[id]/switch-to-free-tier.spec.ts
+++ b/__integration-tests__/server/pages/api/spaces/[id]/switch-to-free-tier.spec.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { Space, User } from '@charmverse/core/prisma';
+import { prisma } from '@charmverse/core/prisma-client';
+import { testUtilsUser } from '@charmverse/core/test';
+import request from 'supertest';
+
+import type { SpacePublicProposalToggle } from 'lib/spaces/toggleSpacePublicProposals';
+import { baseUrl, loginUser } from 'testing/mockApiCall';
+import { generateSpaceUser } from 'testing/setupDatabase';
+
+let nonAdminUser: User;
+let nonAdminUserCookie: string;
+let adminUser: User;
+let adminUserCookie: string;
+let space: Space;
+
+beforeAll(async () => {
+  const { space: generatedSpace, user } = await testUtilsUser.generateUserAndSpace({
+    isAdmin: false,
+    spacePaidTier: 'free'
+  });
+
+  space = generatedSpace;
+  nonAdminUser = user;
+  adminUser = await generateSpaceUser({
+    isAdmin: true,
+    spaceId: space.id
+  });
+
+  nonAdminUserCookie = await loginUser(nonAdminUser.id);
+  adminUserCookie = await loginUser(adminUser.id);
+});
+
+describe('POST /api/spaces/[id]/switch-to-free-tier - Use free Public Goods plan', () => {
+  it('should update a space`s paid tier, if user is the admin and return the space, responding with 200', async () => {
+    const update: Pick<SpacePublicProposalToggle, 'publicProposals'> = {
+      publicProposals: true
+    };
+    await request(baseUrl)
+      .post(`/api/spaces/${space.id}/switch-to-free-tier`)
+      .set('Cookie', adminUserCookie)
+      .send(update)
+      .expect(200);
+    const updatedSpace = await prisma.space.findUniqueOrThrow({ where: { id: space.id } });
+
+    expect(updatedSpace.paidTier).toBe('free');
+  });
+
+  it('should fail if the user is not an admin of the space, and respond 401', async () => {
+    await request(baseUrl)
+      .post(`/api/spaces/${space.id}/switch-to-free-tier`)
+      .set('Cookie', nonAdminUserCookie)
+      .send({
+        publicProposals: true
+      })
+      .expect(401);
+  });
+});

--- a/charmClient/apis/subscriptionApi.ts
+++ b/charmClient/apis/subscriptionApi.ts
@@ -38,6 +38,10 @@ export class SubscriptionApi {
     return http.POST<Space>(`/api/spaces/${spaceId}/switch-to-free-tier`);
   }
 
+  switchToCommunityTier(spaceId: string) {
+    return http.POST<Space>(`/api/spaces/${spaceId}/switch-to-community-tier`);
+  }
+
   validateDiscount(spaceId: string, payload: { coupon: string }) {
     return http.POST<CouponDetails | null>(`/api/spaces/${spaceId}/validate-discount`, payload);
   }

--- a/lib/subscription/__tests__/updateToCommunityTier.spec.ts
+++ b/lib/subscription/__tests__/updateToCommunityTier.spec.ts
@@ -1,0 +1,22 @@
+import { InvalidInputError } from '@charmverse/core/errors';
+import { testUtilsUser } from '@charmverse/core/test';
+
+import { updateToCommunityTier } from '../updateToCommunityTier';
+
+describe('updateProSubscription', () => {
+  it(`Should update the space to community`, async () => {
+    const { space, user } = await testUtilsUser.generateUserAndSpace({ spacePaidTier: 'free' });
+
+    await expect(updateToCommunityTier(space.id, user.id)).resolves.toMatchObject({
+      ...space,
+      paidTier: 'community',
+      updatedAt: expect.any(Date)
+    });
+  });
+
+  it(`Should fail to update the space if it is on the Enterprise plan`, async () => {
+    const { space, user } = await testUtilsUser.generateUserAndSpace({ spacePaidTier: 'enterprise' });
+
+    await expect(updateToCommunityTier(space.id, user.id)).rejects.toBeInstanceOf(InvalidInputError);
+  });
+});

--- a/lib/subscription/__tests__/updateToFreeTier.spec.ts
+++ b/lib/subscription/__tests__/updateToFreeTier.spec.ts
@@ -1,4 +1,4 @@
-import { DataNotFoundError } from '@charmverse/core/errors';
+import { DataNotFoundError, InvalidInputError } from '@charmverse/core/errors';
 import { testUtilsUser } from '@charmverse/core/test';
 import { v4 } from 'uuid';
 
@@ -62,6 +62,12 @@ describe('updateProSubscription', () => {
     const userId = user.id;
 
     await expect(updateToFreeTier(spaceId, userId)).resolves.not.toThrow();
+  });
+
+  it(`Should fail to update the space if it is on the Enterprise plan`, async () => {
+    const { space, user } = await testUtilsUser.generateUserAndSpace({ spacePaidTier: 'enterprise' });
+
+    await expect(updateToFreeTier(space.id, user.id)).rejects.toBeInstanceOf(InvalidInputError);
   });
 
   it(`Should fail if the space does not exist`, async () => {

--- a/lib/subscription/updateToCommunityTier.ts
+++ b/lib/subscription/updateToCommunityTier.ts
@@ -1,0 +1,29 @@
+import { InvalidInputError } from '@charmverse/core/errors';
+import { prisma } from '@charmverse/core/prisma-client';
+
+export async function updateToCommunityTier(spaceId: string, userId: string) {
+  const existingSpace = await prisma.space.findUniqueOrThrow({
+    where: {
+      id: spaceId
+    },
+    select: {
+      paidTier: true
+    }
+  });
+
+  if (existingSpace.paidTier === 'enterprise') {
+    throw new InvalidInputError(`This space is already on an Enterprise plan`);
+  }
+
+  const updatedSpace = await prisma.space.update({
+    where: {
+      id: spaceId
+    },
+    data: {
+      updatedAt: new Date(),
+      updatedBy: userId,
+      paidTier: 'community'
+    }
+  });
+  return updatedSpace;
+}

--- a/lib/subscription/updateToFreeTier.ts
+++ b/lib/subscription/updateToFreeTier.ts
@@ -1,4 +1,4 @@
-import { DataNotFoundError } from '@charmverse/core/errors';
+import { DataNotFoundError, InvalidInputError } from '@charmverse/core/errors';
 import { prisma } from '@charmverse/core/prisma-client';
 
 import { getActiveSpaceSubscription } from './getActiveSpaceSubscription';
@@ -11,6 +11,8 @@ export async function updateToFreeTier(spaceId: string, userId: string) {
     const space = await prisma.space.findFirst({ where: { id: spaceId } });
     if (!space) {
       throw new DataNotFoundError('Space not found');
+    } else if (space.paidTier === 'enterprise') {
+      throw new InvalidInputError(`This space is already on the enterprise plan`);
     }
   }
 

--- a/pages/api/spaces/[id]/switch-to-community-tier.ts
+++ b/pages/api/spaces/[id]/switch-to-community-tier.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
+
+import { onError, onNoMatch, requireSpaceMembership, requireUser } from 'lib/middleware';
+import { withSessionRoute } from 'lib/session/withSession';
+import { updateToCommunityTier } from 'lib/subscription/updateToCommunityTier';
+
+const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+
+handler
+  .use(requireUser)
+  .use(
+    requireSpaceMembership({
+      adminOnly: true,
+      spaceIdKey: 'id'
+    })
+  )
+  .post(switchToFreeTier);
+
+async function switchToFreeTier(req: NextApiRequest, res: NextApiResponse<void>) {
+  const spaceId = req.query.id as string;
+  const userId = req.session.user.id;
+
+  await updateToCommunityTier(spaceId, userId);
+
+  res.status(200).end();
+}
+
+export default withSessionRoute(handler);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd92bc2</samp>

This pull request adds the functionality to switch to the community plan from the space subscription settings UI. It implements the UI component, the API endpoints, the database functions, and the tests for this feature. It also prevents spaces on the enterprise plan from switching to the free plan by throwing an error. It modifies the files `components/settings/subscription/CreateSubscriptionInformation.tsx`, `lib/subscription/updateToFreeTier.ts`, and `lib/subscription/__tests__/updateToFreeTier.spec.ts`, and adds the files `charmClient/apis/subscriptionApi.ts`, `lib/subscription/updateToCommunityTier.ts`, `lib/subscription/__tests__/updateToCommunityTier.spec.ts`, `pages/api/spaces/[id]/switch-to-community-tier.ts`, `__integration-tests__/server/pages/api/spaces/[id]/switch-to-community-tier.spec.ts`, and `__integration-tests__/server/pages/api/spaces/[id]/switch-to-free-tier.spec.ts`.

### WHY
Add option for switching to community tier