### PR TITLE
extending a longer wait for beanstalk env to recover

### DIFF
--- a/.github/workflows/update_core_pkg.yml
+++ b/.github/workflows/update_core_pkg.yml
@@ -232,6 +232,7 @@ jobs:
           deployment_package: ${{matrix.deployment_package}}
           use_existing_version_if_available: true # allows triggering re-deploys with same version
           wait_for_deployment: true
+          wait_for_environment_recovery: 120
 
   discord_alert:
     name: Notify discord of failure


### PR DESCRIPTION
This is so we don't prematurely fail the deploy. This change only affects deployment triggered by core updates

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7831d3f</samp>

Add a `wait` parameter to the `deploy` step of the `update-core-pkg` workflow. This improves the reliability and accuracy of the deployment process by allowing the application to stabilize after each update.

### WHY
<!-- author to complete -->
