### PR TITLE
add sign-in button on public pages

### DIFF
--- a/components/common/PageLayout/SharedPageLayout.tsx
+++ b/components/common/PageLayout/SharedPageLayout.tsx
@@ -1,5 +1,6 @@
 import type { PageType } from '@charmverse/core/prisma';
 import styled from '@emotion/styled';
+import ArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import { Box } from '@mui/material';
 import Head from 'next/head';
 import Image from 'next/image';
@@ -20,6 +21,7 @@ import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useIsSpaceMember } from 'hooks/useIsSpaceMember';
 import { useSmallScreen } from 'hooks/useMediaScreens';
 import { useSharedPage } from 'hooks/useSharedPage';
+import { useUser } from 'hooks/useUser';
 import darkLogoImage from 'public/images/charmverse_logo_icon.png';
 
 const LayoutContainer = styled.div`
@@ -68,6 +70,8 @@ export function SharedPageLayout({ children, basePageId, basePageType }: Props) 
   const logo = darkLogoImage;
   const isMobile = useSmallScreen();
   const { publicPageType } = useSharedPage();
+  const { user } = useUser();
+  const router = useRouter();
 
   return (
     <DocumentPageProviders>
@@ -96,15 +100,52 @@ export function SharedPageLayout({ children, basePageId, basePageType }: Props) 
                 <PageTitleWithBreadcrumbs pageId={basePageId} pageType={basePageType} />
               )}
 
-              <Button
-                startIcon={<LogoImage width={32} height={32} src={logo} alt='' />}
-                variant='text'
-                color='inherit'
-                href='/'
-                external // avoid space domain being added
-              >
-                Try CharmVerse
-              </Button>
+              <Box>
+                {user && (
+                  <Button
+                    endIcon={<ArrowRightIcon />}
+                    variant='text'
+                    color='inherit'
+                    href='/'
+                    external // avoid space domain being added
+                  >
+                    Go to my space
+                  </Button>
+                )}
+                {!user && (
+                  <>
+                    <Button
+                      variant='outlined'
+                      color='inherit'
+                      href={`/?returnUrl=${router.asPath}`}
+                      sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
+                      external // avoid space domain being added
+                    >
+                      Sign in
+                    </Button>
+                    <Button
+                      startIcon={
+                        <Box position='relative' width={24} height={20} mt='-12px'>
+                          <LogoImage
+                            style={{ position: 'absolute', top: 0 }}
+                            width={32}
+                            height={32}
+                            src={logo}
+                            alt=''
+                          />
+                        </Box>
+                      }
+                      variant='text'
+                      color='inherit'
+                      href='/'
+                      sx={{ ml: 1 }}
+                      external // avoid space domain being added
+                    >
+                      Try CharmVerse
+                    </Button>
+                  </>
+                )}
+              </Box>
             </Box>
           </StyledToolbar>
           {isMobile && publicPageType === 'proposals' && (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eea64d1</samp>

Updated header button component in `SharedPageLayout.tsx` to handle user authentication state. The button now shows different options and styles for logged-in and logged-out users.

### WHY
Customer request to add a clear way to sign in

Logged out:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/488d9939-3701-45d4-bb2e-3aa0645b8f57)


Logged in:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/7b657b4f-a47f-4b7e-a21a-878e2c9021cd)
