### PR TITLE
Create new install action input to permit customized cache key

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -5,11 +5,15 @@ inputs:
     description: "Optional. Defaults to what's in package.json. Valid options are latest and custom version"
     required: false
   commit_core_pkg_upgrade:
-    description: 'Whether commit the update to core package back to branch'
+    description: "Whether commit the update to core package back to branch"
     required: false
   save_cache:
     description: "Whether to save the cache"
     required: false
+  cache_key_prefix:
+    description: "Cache key prefix"
+    required: false
+    default: "nodemodules-cache"
   use_github_core_branch:
     description: |
       Optional, core branch name to install from github.
@@ -40,7 +44,7 @@ runs:
       uses: actions/cache/restore@v3
       with:
         path: ./node_modules
-        key: nodemodules-cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('patches/**.patch', 'prisma/schema.prisma') }}
+        key: ${{ inputs.cache_key_prefix }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('patches/**.patch', 'prisma/schema.prisma') }}
 
     - name: Install npm dependencies
       shell: bash
@@ -85,4 +89,4 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: ./node_modules
-        key: nodemodules-cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('patches/**.patch', 'prisma/schema.prisma') }}
+        key: ${{ inputs.cache_key_prefix }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('patches/**.patch', 'prisma/schema.prisma') }}

--- a/.github/workflows/test_new_core_pkg.yml
+++ b/.github/workflows/test_new_core_pkg.yml
@@ -24,6 +24,8 @@ jobs:
         uses: ./.github/actions/install
         with:
           core_pkg_version: ${{ inputs.core_pkg_version }}
+          cache_key_prefix: "testCore-node-modules"
+          save_cache: true
 
       - name: Build app
         uses: ./.github/actions/build
@@ -71,6 +73,7 @@ jobs:
         uses: ./.github/actions/install
         with:
           core_pkg_version: ${{ inputs.core_pkg_version }}
+          cache_key_prefix: "testCore-node-modules"
 
       - name: Setup test database
         run: npx dotenv -e .env.test.local -- npm run prisma:reset

--- a/.github/workflows/update_core_pkg.yml
+++ b/.github/workflows/update_core_pkg.yml
@@ -29,12 +29,13 @@ jobs:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4.x
 
-      - name: Install dependencies
+      - name: Install dependencies and save cache for future main build
         id: install_dependencies
         uses: ./.github/actions/install
         with:
           core_pkg_version: ${{ inputs.core_pkg_version }}
           commit_core_pkg_upgrade: true
+          save_cache: true
 
       - name: Calculate Build ID
         id: get_build_id


### PR DESCRIPTION
Also modified core test and deploy workflows to save cache when appropriate, and testing workflow will be using different cache key entirely

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc8f1a5</samp>

This pull request enhances the caching functionality of the GitHub actions for installing and testing the core package of the app. It adds a new input parameter to the `install` action and updates the `test_new_core_pkg` and `update_core_pkg` workflows to use it.

### WHY
<!-- author to complete -->
