### PR TITLE
Save node_modules cache on core upgrades

### DIFF
--- a/.github/workflows/update_core_pkg.yml
+++ b/.github/workflows/update_core_pkg.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           core_pkg_version: ${{ inputs.core_pkg_version }}
           commit_core_pkg_upgrade: true
+          save_cache: true
 
       - name: Calculate Build ID
         id: get_build_id


### PR DESCRIPTION
Now that the install step only does restores with no explicit saves, we want to modify the install action so that it will save back the core upgrades

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4469069</samp>

Enable conda caching in the workflow that updates the core package. This improves the performance and reliability of the `.github/workflows/update_core_pkg.yml` file.

### WHY
<!-- author to complete -->
