### PR TITLE
fix redirect when path includes space domain

### DIFF
--- a/lib/session/getDefaultPageForSpace.ts
+++ b/lib/session/getDefaultPageForSpace.ts
@@ -110,7 +110,6 @@ async function getDefaultPageForSpaceRaw({
   const sortedPages = pageTree.sortNodes(topLevelPages as PageMeta[]);
 
   const firstPage = sortedPages[0];
-
   if (firstPage) {
     return `${defaultSpaceUrl}/${firstPage.path}`;
   } else {

--- a/lib/utilities/__tests__/browser.spec.ts
+++ b/lib/utilities/__tests__/browser.spec.ts
@@ -1,4 +1,4 @@
-import { getNewUrl } from '../browser';
+import { getNewUrl, getSubdomainPath } from '../browser';
 
 describe('getNewUrl()', () => {
   const baseUrl = 'https://google.com/search?q=3531422';
@@ -19,5 +19,27 @@ describe('getNewUrl()', () => {
     const result = getNewUrl({ cardId: null }, `${baseUrl}&cardId=foo`);
 
     expect(result.toString()).toEqual(baseUrl);
+  });
+});
+
+describe('getSubdomainPath()', () => {
+  it('should not return the path with subdomain when on subdomain host', () => {
+    const result = getSubdomainPath('/foo', { domain: 'charmverse' }, 'charmverse.charmverse.io');
+    expect(result).toEqual('/foo');
+  });
+
+  it('should not return the path with subdomain when on custom domain host', () => {
+    const result = getSubdomainPath('/foo', { domain: 'charmverse' }, 'charmverse.charmverse.io');
+    expect(result).toEqual('/foo');
+  });
+
+  it('should return the path with subdomain', () => {
+    const result = getSubdomainPath('/foo', { domain: 'charmverse' });
+    expect(result).toEqual('/charmverse/foo');
+  });
+
+  it('should return the path with subdomain even if the path includes or is the subdomain', () => {
+    const result = getSubdomainPath('/charmverse', { domain: 'charmverse' });
+    expect(result).toEqual('/charmverse/charmverse');
   });
 });

--- a/lib/utilities/browser.ts
+++ b/lib/utilities/browser.ts
@@ -252,7 +252,7 @@ export function fullyDecodeURI(uri: string) {
 // strip out custom or domain depending on the host
 export function getSubdomainPath(
   path: string,
-  config?: { domain: string; customDomain: string | null },
+  config?: { domain: string; customDomain?: string | null },
   host?: string
 ) {
   const subdomain = getSpaceDomainFromHost(host);
@@ -273,9 +273,8 @@ export function getSubdomainPath(
   if (subdomain) {
     return path.replace(new RegExp(`^\\/${subdomain}`), '');
   }
-
   // if we are not using a custom domain or subdomain, make sure that the space domain exists in the URL
-  if (config && !customDomain && !path.startsWith(`/${config?.domain}`)) {
+  if (config && !customDomain && !path.startsWith(`/${config?.domain}/`)) {
     return `/${config.domain}${path}`;
   }
   return path;

--- a/pages/[domain]/index.tsx
+++ b/pages/[domain]/index.tsx
@@ -43,6 +43,7 @@ export const getServerSideProps: GetServerSideProps = withSessionSsr(async (cont
   // 3. send user to default page for the space
 
   let destination = await getDefaultPageForSpace({ host: context.req.headers.host, space, userId: sessionUserId });
+
   // append existing query params, lie 'account' or 'subscription'
   Object.keys(context.query).forEach((key) => {
     if (key !== 'returnUrl' && key !== 'domain') {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f17878</samp>

This pull request adds and tests a new utility function `getSubdomainPath` to handle subdomain-based routing in the app. It also fixes a bug and improves the flexibility of the same function in `lib/session/getDefaultPageForSpace.ts`. The other changes are minor formatting adjustments.

### WHY
<!-- author to complete -->
