### PR TITLE
adding concurrency grouping to organize the order of deployment. 

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -7,6 +7,9 @@ on:
 env:
   SELECTED_PERMISSION_API_TAG: latest
 
+concurrency:
+  group: staging-${{ github.ref }}
+
 jobs:
   deploy:
     if: |

--- a/.github/workflows/destroy_staging.yml
+++ b/.github/workflows/destroy_staging.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [unlabeled, closed]
 
+concurrency:
+  group: staging-${{ github.ref }}
+
 jobs:
   clean-up:
     if: |

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -14,6 +14,9 @@ on:
         description: 'Core pkg version to update to'
         required: true
 
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+
 env:
   SELECTED_PERMISSION_API_TAG: latest
 

--- a/.github/workflows/update_core_pkg.yml
+++ b/.github/workflows/update_core_pkg.yml
@@ -10,6 +10,10 @@ on:
         description: 'Core pkg version'
         required: true
 
+# This grouping will let us include the main ci workflow as part of this group
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+
 jobs:
   build-test-env:
     name: Build test env


### PR DESCRIPTION
This will not cancel any in-progress workflow run, will just put the workflow run in queue, and will cancel any previously already enqueued and pending workflow run

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f3ebb5</samp>

Add concurrency groups to various GitHub workflows to prevent redundant or conflicting runs. This improves the efficiency and reliability of the CI/CD pipeline for the app.

### WHY
<!-- author to complete -->
