### PR TITLE
Fixed issue with mobile page icon selection

### DIFF
--- a/components/[pageId]/DocumentPage/components/PageHeader.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeader.tsx
@@ -5,7 +5,7 @@ import CasinoOutlinedIcon from '@mui/icons-material/CasinoOutlined';
 import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import EmojiEmotionsOutlinedIcon from '@mui/icons-material/EmojiEmotionsOutlined';
 import ImageIcon from '@mui/icons-material/Image';
-import { ListItemButton, Menu, Stack } from '@mui/material';
+import { ClickAwayListener, ListItemButton, Menu, Stack } from '@mui/material';
 import Box from '@mui/material/Box';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -161,22 +161,23 @@ function PageHeader({ headerImage, icon, readOnly, setPage, title, updatedAt, re
           </div>
         )}
         {subMenuAnchorEl && (
-          <div>
-            <Menu
-              anchorEl={subMenuAnchorEl}
-              open={Boolean(subMenuAnchorEl)}
-              anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-              transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-            >
-              <CustomEmojiPicker
-                onUpdate={(emoji) => {
-                  setSubMenuAnchorEl(null);
-                  closeMenu();
-                  updatePageIcon(emoji);
-                }}
-              />
-            </Menu>
-          </div>
+          <Menu
+            anchorEl={subMenuAnchorEl}
+            open={Boolean(subMenuAnchorEl)}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+            onClick={() => {
+              setSubMenuAnchorEl(null);
+            }}
+          >
+            <CustomEmojiPicker
+              onUpdate={(emoji) => {
+                setSubMenuAnchorEl(null);
+                closeMenu();
+                updatePageIcon(emoji);
+              }}
+            />
+          </Menu>
         )}
         <Controls className='page-controls'>
           {!readOnly && !icon && (

--- a/components/[pageId]/DocumentPage/components/PageHeader.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeader.tsx
@@ -1,16 +1,18 @@
 import type { Page } from '@charmverse/core/prisma';
 import styled from '@emotion/styled';
+import ArrowDropDownOutlinedIcon from '@mui/icons-material/ArrowDropDownOutlined';
+import CasinoOutlinedIcon from '@mui/icons-material/CasinoOutlined';
 import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import EmojiEmotionsOutlinedIcon from '@mui/icons-material/EmojiEmotionsOutlined';
 import ImageIcon from '@mui/icons-material/Image';
-import { ListItemButton } from '@mui/material';
+import { ListItemButton, Menu, Stack } from '@mui/material';
 import Box from '@mui/material/Box';
-import { memo } from 'react';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import { memo, useCallback, useState } from 'react';
 
 import { BlockIcons } from 'components/common/BoardEditor/focalboard/src/blockIcons';
 import { randomEmojiList } from 'components/common/BoardEditor/focalboard/src/emojiList';
-import Menu from 'components/common/BoardEditor/focalboard/src/widgets/menu';
-import MenuWrapper from 'components/common/BoardEditor/focalboard/src/widgets/menuWrapper';
 import { CustomEmojiPicker } from 'components/common/CustomEmojiPicker';
 import EmojiIcon from 'components/common/Emoji';
 import { randomIntFromInterval } from 'lib/utilities/random';
@@ -71,6 +73,18 @@ function PageHeader({ headerImage, icon, readOnly, setPage, title, updatedAt, re
     const _icon = randomEmojiList[randomIntFromInterval(0, randomEmojiList.length - 1)];
     setPage({ icon: _icon });
   }
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [subMenuAnchorEl, setSubMenuAnchorEl] = useState<null | HTMLElement>(null);
+
+  const showMenu = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  function closeMenu() {
+    setAnchorEl(null);
+  }
 
   function updatePageIcon(_icon: string | null) {
     setPage({ icon: _icon });
@@ -88,41 +102,81 @@ function PageHeader({ headerImage, icon, readOnly, setPage, title, updatedAt, re
     <>
       <EditorHeader className='font-family-default'>
         {icon && (
-          <MenuWrapper>
-            <EmojiIcon size='large' icon={icon} />
-            {
-              // Menu wrapper requires 2 children to show, so we provide an empty div in readonly case
-              readOnly ? (
-                <div></div>
-              ) : (
-                <Menu>
-                  <Menu.Text
-                    id='random'
-                    icon={<EmojiEmotionsOutlinedIcon />}
-                    name='Random'
-                    onClick={() => {
-                      updatePageIcon(BlockIcons.shared.randomIcon());
-                    }}
-                  />
-                  <Menu.SubMenu id='pick' icon={<EmojiEmotionsOutlinedIcon />} name='Pick icon'>
-                    <CustomEmojiPicker
-                      onUpdate={(emoji) => {
-                        updatePageIcon(emoji);
-                      }}
-                    />
-                  </Menu.SubMenu>
-                  <Menu.Text
-                    id='remove'
-                    icon={<DeleteOutlineOutlinedIcon />}
-                    name='Remove icon'
-                    onClick={() => {
-                      updatePageIcon(null);
-                    }}
-                  />
-                </Menu>
-              )
-            }
-          </MenuWrapper>
+          <div>
+            <EmojiIcon size='large' icon={icon} onClick={showMenu} />
+
+            {readOnly ? (
+              <div />
+            ) : (
+              <Menu
+                anchorEl={anchorEl}
+                open={Boolean(anchorEl)}
+                onClose={closeMenu}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+              >
+                <ListItemButton
+                  dense
+                  disabled={readOnly}
+                  onClick={() => {
+                    updatePageIcon(BlockIcons.shared.randomIcon());
+                    closeMenu();
+                  }}
+                >
+                  <ListItemIcon>
+                    <CasinoOutlinedIcon />
+                  </ListItemIcon>
+                  <ListItemText>Random</ListItemText>
+                </ListItemButton>
+
+                <ListItemButton
+                  dense
+                  disabled={readOnly}
+                  onClick={(e) => {
+                    setSubMenuAnchorEl(e.currentTarget);
+                  }}
+                >
+                  <ListItemIcon>
+                    <EmojiEmotionsOutlinedIcon />
+                  </ListItemIcon>
+                  <ListItemText>Pick icon</ListItemText>
+                  <ArrowDropDownOutlinedIcon sx={{ ml: 3 }} />
+                </ListItemButton>
+
+                <ListItemButton
+                  dense
+                  disabled={readOnly}
+                  onClick={() => {
+                    updatePageIcon(null);
+                    closeMenu();
+                  }}
+                >
+                  <ListItemIcon>
+                    <DeleteOutlineOutlinedIcon />
+                  </ListItemIcon>
+                  <ListItemText>Remove icon</ListItemText>
+                </ListItemButton>
+              </Menu>
+            )}
+          </div>
+        )}
+        {subMenuAnchorEl && (
+          <div>
+            <Menu
+              anchorEl={subMenuAnchorEl}
+              open={Boolean(subMenuAnchorEl)}
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+            >
+              <CustomEmojiPicker
+                onUpdate={(emoji) => {
+                  setSubMenuAnchorEl(null);
+                  closeMenu();
+                  updatePageIcon(emoji);
+                }}
+              />
+            </Menu>
+          </div>
         )}
         <Controls className='page-controls'>
           {!readOnly && !icon && (

--- a/components/common/BoardEditor/focalboard/src/widgets/emojiPicker.scss
+++ b/components/common/BoardEditor/focalboard/src/widgets/emojiPicker.scss
@@ -1,4 +1,5 @@
 .EmojiPicker {
+  overflow-x: auto;
   .emoji-mart {
     color: rgb(var(--center-channel-color-rgb));
     background: rgb(var(--center-channel-bg-rgb));


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e72b068</samp>

Redesigned and refactored the page icon menu in `PageHeader.tsx` to use MUI components and icons, and to enable icon editing. Added state and logic for menu interactions.

### WHY
[Card](https://app.charmverse.io/charmverse/tech-task-list-49366552253645923?viewId=b72dd329-8b1b-4980-9c81-0ec60bd02c45&cardId=b669a10d-8a0e-4d7e-8001-bafca22b7801)
