### PR TITLE
add migration script to remove notifyNewProposals

### DIFF
--- a/components/settings/space/SpaceSettings.tsx
+++ b/components/settings/space/SpaceSettings.tsx
@@ -146,7 +146,6 @@ export function SpaceSettings({
     await updateSpace({
       id: space.id,
       notificationToggles: notificationToggles as Prisma.InputJsonValue,
-      notifyNewProposals: null,
       features,
       memberProfiles,
       name: values.name,
@@ -540,11 +539,6 @@ function getProfileWidgetLogo(name: MemberProfileName) {
 
 function _getFormValues(space: Space): FormValues {
   const notificationToggles = { ...(space.notificationToggles as any) } as NotificationToggles;
-  // convert deprecated proposals notification preference
-  if (typeof notificationToggles.proposals__start_discussion === 'undefined' && !space.notifyNewProposals) {
-    notificationToggles.proposals__start_discussion = false;
-    notificationToggles.proposals__vote = false;
-  }
   // set all notifications to true by default. TODO: find a programmatic way to do this?
   notificationToggles.proposals ??= true;
   notificationToggles.polls ??= true;

--- a/lib/notifications/proposals/createProposalNotifications.ts
+++ b/lib/notifications/proposals/createProposalNotifications.ts
@@ -83,9 +83,8 @@ export async function createProposalNotifications(
       });
 
       const notificationToggles = space.notificationToggles as NotificationToggles;
-      const notifyNewProposals =
-        Boolean(space.notifyNewProposals) || notificationToggles.proposals__start_discussion !== false;
-      const notifyNewVotes = Boolean(space.notifyNewProposals) || notificationToggles.proposals__vote !== false;
+      const notifyNewProposals = notificationToggles.proposals__start_discussion !== false;
+      const notifyNewVotes = notificationToggles.proposals__vote !== false;
 
       const spaceRoles = await prisma.spaceRole.findMany({
         where: {

--- a/lib/notifications/proposals/createProposalNotifications.ts
+++ b/lib/notifications/proposals/createProposalNotifications.ts
@@ -82,10 +82,6 @@ export async function createProposalNotifications(
         }
       });
 
-      const notificationToggles = space.notificationToggles as NotificationToggles;
-      const notifyNewProposals = notificationToggles.proposals__start_discussion !== false;
-      const notifyNewVotes = notificationToggles.proposals__vote !== false;
-
       const spaceRoles = await prisma.spaceRole.findMany({
         where: {
           spaceId
@@ -137,12 +133,16 @@ export async function createProposalNotifications(
         const action = getProposalAction({
           currentStatus: proposal.status,
           isAuthor,
-          isReviewer: isReviewer || isReviewerRole,
-          notifyNewProposals,
-          notifyNewVotes
+          isReviewer: isReviewer || isReviewerRole
         });
 
         if (!action) {
+          continue;
+        }
+
+        // check notification preferences
+        const notificationToggles = space.notificationToggles as NotificationToggles;
+        if (notificationToggles[`proposals__${action}`] === false) {
           continue;
         }
 

--- a/lib/proposal/getProposalAction.ts
+++ b/lib/proposal/getProposalAction.ts
@@ -12,28 +12,22 @@ export type ProposalTaskAction =
 export function getProposalAction({
   isAuthor,
   currentStatus,
-  isReviewer,
-  notifyNewProposals,
-  notifyNewVotes
+  isReviewer
 }: {
   currentStatus: ProposalStatus;
   isAuthor: boolean;
   isReviewer: boolean;
-  notifyNewProposals: boolean;
-  notifyNewVotes: boolean;
 }): ProposalTaskAction | null {
   if (currentStatus === 'discussion') {
     if (isAuthor) {
       return 'start_review';
     }
-    if (notifyNewProposals) {
-      return 'start_discussion';
-    }
+    return 'start_discussion';
   } else if (currentStatus === 'reviewed') {
     if (isAuthor) {
       return 'reviewed';
     }
-  } else if (currentStatus === 'vote_active' && notifyNewVotes) {
+  } else if (currentStatus === 'vote_active') {
     return 'vote';
   } else if (currentStatus === 'review') {
     if (isReviewer) {

--- a/scripts/migrations/2023_10_10_remove_notifyNewProposals.ts
+++ b/scripts/migrations/2023_10_10_remove_notifyNewProposals.ts
@@ -1,0 +1,20 @@
+import { prisma } from '@charmverse/core/prisma-client';
+
+// Script 2 - Migrate spaces
+async function migrateSpaces() {
+  const r = await prisma.space.updateMany({
+    where: {
+      notifyNewProposals: {
+        not: null
+      }
+    },
+    data: {
+      notificationToggles: {
+        proposals__start_discussion: false,
+        proposals__vote: false
+      }
+    }
+  });
+}
+
+migrateSpaces().then(() => console.log('done'));

--- a/scripts/migrations/2023_10_10_remove_notifyNewProposals.ts
+++ b/scripts/migrations/2023_10_10_remove_notifyNewProposals.ts
@@ -4,9 +4,7 @@ import { prisma } from '@charmverse/core/prisma-client';
 async function migrateSpaces() {
   const r = await prisma.space.updateMany({
     where: {
-      notifyNewProposals: {
-        not: null
-      }
+      notifyNewProposals: null
     },
     data: {
       notificationToggles: {

--- a/testing/mocks/space.ts
+++ b/testing/mocks/space.ts
@@ -24,7 +24,6 @@ export const createMockSpace = (space?: Partial<Space>): Space => {
     snapshotDomain: null,
     spaceImage: null,
     defaultPostCategoryId: null,
-    notifyNewProposals: null,
     requireProposalTemplate: null,
     defaultPagePermissionGroup: null,
     defaultPublicPages: null,

--- a/testing/setupDatabase.ts
+++ b/testing/setupDatabase.ts
@@ -200,7 +200,6 @@ export async function generateUserAndSpace({
               domain: `domain-${v4()}`,
               customDomain: spaceCustomDomain,
               publicBountyBoard,
-              notifyNewProposals: null,
               notificationToggles: spaceNotificationToggles,
               ...(superApiTokenId ? { superApiToken: { connect: { id: superApiTokenId } } } : undefined)
             }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a056384</samp>

This pull request removes the deprecated `notifyNewProposals` field from the space model and related components, scripts, and tests. It also adds a migration script to update existing spaces with the new notification toggles for proposal events.

### WHY
<!-- author to complete -->
