### PR TITLE
remove use of notifyNewProposals

### DIFF
--- a/lib/notifications/proposals/createProposalNotifications.ts
+++ b/lib/notifications/proposals/createProposalNotifications.ts
@@ -77,7 +77,6 @@ export async function createProposalNotifications(
           domain: true,
           name: true,
           paidTier: true,
-          notifyNewProposals: true,
           notificationToggles: true
         }
       });

--- a/lib/spaces/updateSpace.ts
+++ b/lib/spaces/updateSpace.ts
@@ -9,14 +9,7 @@ import { DuplicateDataError, InvalidInputError } from 'lib/utilities/errors';
 export type UpdateableSpaceFields = Partial<
   Pick<
     Space,
-    | 'notifyNewProposals'
-    | 'hiddenFeatures'
-    | 'domain'
-    | 'name'
-    | 'spaceImage'
-    | 'features'
-    | 'memberProfiles'
-    | 'notificationToggles'
+    'hiddenFeatures' | 'domain' | 'name' | 'spaceImage' | 'features' | 'memberProfiles' | 'notificationToggles'
   >
 >;
 

--- a/scripts/migrations/2023_10_10_remove_notifyNewProposals.ts
+++ b/scripts/migrations/2023_10_10_remove_notifyNewProposals.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { prisma } from '@charmverse/core/prisma-client';
 
 // Script 2 - Migrate spaces


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5367f07</samp>

This pull request removes the deprecated `notifyNewProposals` field from the codebase and the database. It simplifies the notification logic for new proposals and relies on the `notificationToggles` field instead.

### WHY
<!-- author to complete -->
