### PR TITLE
Add icon for proposal reviewer and author property in proposal table

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderPropertiesMenu.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeaderPropertiesMenu.tsx
@@ -46,6 +46,8 @@ export const iconForPropertyType = (propertyType: PropertyType, props?: SvgIconP
     case 'text':
       return <SubjectIcon fontSize='small' {...props} />;
     case 'updatedBy':
+    case 'proposalReviewer':
+    case 'proposalAuthor':
       return <PersonIcon fontSize='small' {...props} />;
     case 'updatedTime':
       return <AccessTimeIcon fontSize='small' {...props} />;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f53311</samp>

Added icons for custom property types in board view header. The `iconForPropertyType` function in `viewHeaderPropertiesMenu.tsx` now handles 'proposalReviewer' and 'proposalAuthor' types.

### WHY
Before
![image](https://github.com/charmverse/app.charmverse.io/assets/34683631/9418a3c4-1d3f-406f-b917-d0a83f7f60f3)
![image](https://github.com/charmverse/app.charmverse.io/assets/34683631/e87b2e06-4621-4f69-b71f-c9403e4094e8)

After
![image](https://github.com/charmverse/app.charmverse.io/assets/34683631/abac70c8-c10e-43c4-8926-d99034ea0ea1)
![image](https://github.com/charmverse/app.charmverse.io/assets/34683631/1ef19fb7-ed9c-4e2d-874f-023a222066d3)
