### PR TITLE
Show cursor for callout without text

### DIFF
--- a/components/common/CharmEditor/components/callout/components/Callout.tsx
+++ b/components/common/CharmEditor/components/callout/components/Callout.tsx
@@ -125,7 +125,7 @@ export default function Callout({
             />
           </Menu>
         </CalloutEmoji>
-        <Box my={0.5}>{children}</Box>
+        {children}
       </StyledCallout>
     </Box>
   );


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0243ea</samp>

Removed margin from callout component children in `CharmEditor`. This improves the layout and readability of the editor content.

### WHY
<!-- author to complete -->
