### PR TITLE
Fix flaky forum category e2e test

### DIFF
--- a/__e2e__/forum/editDescription.spec.ts
+++ b/__e2e__/forum/editDescription.spec.ts
@@ -78,6 +78,7 @@ test.describe.serial('Update category permissions', () => {
 
     // Open edit description dialog
     await forumHomePage.getCategoryContextMenuLocator(postCategory.id).click();
+    await forumHomePage.getCategoryEditDescriptionLocator(postCategory.id).waitFor({ state: 'visible' });
     await forumHomePage.getCategoryEditDescriptionLocator(postCategory.id).click();
 
     // Edit text in modal and save

--- a/__e2e__/po/forumHome.po.ts
+++ b/__e2e__/po/forumHome.po.ts
@@ -89,7 +89,7 @@ export class ForumHomePage {
   }
 
   getCategoryContextMenuLocator(categoryId: string) {
-    return this.page.locator(`data-test=open-category-context-menu-${categoryId}`);
+    return this.page.locator(`data-test=open-forum-category-context-menu-${categoryId}`);
   }
 
   getCategoryEditDescriptionLocator(categoryId: string) {

--- a/components/forum/components/CategoryContextMenu.tsx
+++ b/components/forum/components/CategoryContextMenu.tsx
@@ -15,7 +15,6 @@ import PopperPopup from 'components/common/PopperPopup';
 import { UpgradeChip } from 'components/settings/subscription/UpgradeWrapper';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useIsAdmin } from 'hooks/useIsAdmin';
-import { useIsFreeSpace } from 'hooks/useIsFreeSpace';
 import { useForumCategoryNotification } from 'hooks/useUserSpaceNotifications';
 
 import { EditCategoryDialog } from './EditCategoryDialog';
@@ -33,8 +32,6 @@ export function CategoryContextMenu({ category, onChange, onDelete, onSetNewDefa
   const [tempName, setTempName] = useState(category.name || '');
   const { space } = useCurrentSpace();
   const isAdmin = useIsAdmin();
-
-  const { isFreeSpace } = useIsFreeSpace();
 
   const notifications = useForumCategoryNotification(category.id);
 
@@ -163,7 +160,7 @@ export function CategoryContextMenu({ category, onChange, onDelete, onSetNewDefa
   return (
     <>
       <PopperPopup popupContent={popupContent} onClose={onSave}>
-        <IconButton data-test={`open-category-context-menu-${category.id}`} size='small'>
+        <IconButton data-test={`open-forum-category-context-menu-${category.id}`} size='small'>
           <MoreHorizIcon fontSize='small' />
         </IconButton>
       </PopperPopup>

--- a/components/forum/components/ForumFilterListLink.tsx
+++ b/components/forum/components/ForumFilterListLink.tsx
@@ -13,14 +13,22 @@ import { usePostCategoryPermissions } from '../hooks/usePostCategoryPermissions'
 import { CategoryContextMenu } from './CategoryContextMenu';
 
 const StyledMenuItem = styled(MenuItem)`
-  ${hoverIconsStyle({ marginForIcons: false })}
-
   min-height: 36px;
 
   &.Mui-focused,
   &.Mui-selected,
   &.Mui-selected.Mui-focused {
     background-color: ${({ theme }) => theme.palette.action.selected};
+  }
+
+  &:hover .icons {
+    transition: opacity 150ms ease-in-out;
+    opacity: 1;
+  }
+
+  & .icons {
+    transition: opacity 150ms ease-in-out;
+    opacity: 0;
   }
 `;
 type ForumSortFilterLinkProps = {

--- a/components/proposals/components/ProposalViewOptions/components/ProposalCategoryContextMenu.tsx
+++ b/components/proposals/components/ProposalViewOptions/components/ProposalCategoryContextMenu.tsx
@@ -1,5 +1,4 @@
 import type { ProposalCategoryWithPermissions } from '@charmverse/core/permissions';
-import { Edit } from '@mui/icons-material';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import LockIcon from '@mui/icons-material/Lock';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
@@ -113,7 +112,7 @@ export function ProposalCategoryContextMenu({ category }: Props) {
   return (
     <>
       <PopperPopup popupContent={popupContent} onClose={onSave}>
-        <IconButton data-test={`open-category-context-menu-${category.id}`} size='small'>
+        <IconButton data-test={`open-proposal-category-context-menu-${category.id}`} size='small'>
           <MoreHorizIcon fontSize='small' />
         </IconButton>
       </PopperPopup>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b3c1aa</samp>

This pull request fixes some data-test attribute values and removes some unused code in the `CategoryContextMenu` components for forum and proposal categories. It also updates the end-to-end test and the page object for the forum category context menu to reflect the changes.

### WHY
<!-- author to complete -->
