### PR TITLE
Fixed notion import button url

### DIFF
--- a/lib/utilities/__tests__/browser.spec.ts
+++ b/lib/utilities/__tests__/browser.spec.ts
@@ -23,6 +23,11 @@ describe('getNewUrl()', () => {
 });
 
 describe('getSubdomainPath()', () => {
+  it('should not modify the path that starts with /api', () => {
+    const result = getSubdomainPath('/api', { domain: 'charmverse' });
+    expect(result).toEqual('/api');
+  });
+
   it('should not return the path with subdomain when on subdomain host', () => {
     const result = getSubdomainPath('/foo', { domain: 'charmverse' }, 'charmverse.charmverse.io');
     expect(result).toEqual('/foo');

--- a/lib/utilities/browser.ts
+++ b/lib/utilities/browser.ts
@@ -255,6 +255,10 @@ export function getSubdomainPath(
   config?: { domain: string; customDomain?: string | null },
   host?: string
 ) {
+  if (path.startsWith('/api')) {
+    return path;
+  }
+
   const subdomain = getSpaceDomainFromHost(host);
   const customDomain = getCustomDomainFromHost(host);
   // strip out domain when using full custom domain


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aabd90b</samp>

Added a condition to `getSubdomainPath` to handle API paths correctly. Added a unit test for this condition in `lib/utilities/__tests__/browser.spec.ts`.

### WHY
<!-- author to complete -->
