### PR TITLE
add required fields to proposal form

### DIFF
--- a/.storybook/mockApi.ts
+++ b/.storybook/mockApi.ts
@@ -11,7 +11,7 @@ import {
   proposalCategories,
   proposalTemplates,
   userProfile,
-  userMemberProfile,
+  userMemberProfile
 } from '../stories/lib/mockData';
 
 // mock requests globally via msw. see : https://storybook.js.org/addons/msw-storybook-addon
@@ -80,6 +80,9 @@ const proposalHandlers = {
       evaluation_closed: true
     };
     return res(ctx.json(permissions));
+  }),
+  reviewerIds: rest.get(`/api/proposals/:pageId/get-user-reviewerids`, (req, res, ctx) => {
+    return res(ctx.json([]));
   }),
   proposalPermissions: rest.post(`/api/permissions/proposals/compute-proposal-permissions`, (req, res, ctx) => {
     const permissions: ProposalPermissionFlags = {

--- a/components/common/BoardEditor/components/properties/PropertyLabel.tsx
+++ b/components/common/BoardEditor/components/properties/PropertyLabel.tsx
@@ -7,18 +7,25 @@ import Button from '../../focalboard/src/widgets/buttons/button';
 type PropertyLabelProps = {
   children: ReactNode;
   readOnly?: boolean;
+  required?: boolean;
   highlighted?: boolean;
 };
 
-const Wrapper = styled(Box)<{ highlighted?: boolean }>`
+const Wrapper = styled(({ highlighted, ...props }: any) => <Box {...props} />)<{ highlighted?: boolean }>`
   color: ${({ highlighted }) => (highlighted ? 'var(--primary-text) !important' : '')};
 `;
 
-export function PropertyLabel({ children, readOnly = true, highlighted }: PropertyLabelProps) {
+const Asterisk = styled.span`
+  color: var(--danger-text);
+`;
+
+export function PropertyLabel({ children, required, readOnly = true, highlighted }: PropertyLabelProps) {
   if (readOnly) {
     return (
       <Wrapper className='octo-propertyname octo-propertyname--readonly' highlighted={highlighted}>
-        <Button>{children}</Button>
+        <Button rightIcon icon={required && <Asterisk>&nbsp;*</Asterisk>}>
+          {children}
+        </Button>
       </Wrapper>
     );
   }

--- a/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
+++ b/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
@@ -161,7 +161,6 @@ export function UserAndRoleSelect({
   const { isFreeSpace } = useIsFreeSpace();
   // TODO: Make this component agnostic to 'reviewers' by defining the options outside of it
   const { data: reviewerPool } = useGetReviewerPool(proposalCategoryId);
-
   const filteredMembers = members.filter((member) => !member.isBot);
   // For public spaces, we don't want to show reviewer roles
   const applicableValues = isFreeSpace

--- a/components/proposals/components/ProposalProperties/ProposalProperties.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalProperties.tsx
@@ -366,7 +366,7 @@ export function ProposalProperties({
           {/* Select a category */}
           <Box justifyContent='space-between' gap={2} alignItems='center' mb='6px'>
             <Box display='flex' height='fit-content' flex={1} className='octo-propertyrow'>
-              <PropertyLabel readOnly highlighted>
+              <PropertyLabel readOnly required={isNewProposal} highlighted>
                 Category
               </PropertyLabel>
               <Box display='flex' flex={1}>
@@ -419,7 +419,7 @@ export function ProposalProperties({
                 flexGrow: 1
               }}
             >
-              <PropertyLabel readOnly highlighted>
+              <PropertyLabel readOnly required={isNewProposal} highlighted>
                 Author
               </PropertyLabel>
               <Box display='flex' flex={1}>
@@ -440,7 +440,7 @@ export function ProposalProperties({
           {/* Select reviewers */}
           <Box justifyContent='space-between' gap={2} alignItems='center' mb='6px'>
             <Box display='flex' height='fit-content' flex={1} className='octo-propertyrow'>
-              <PropertyLabel readOnly highlighted>
+              <PropertyLabel readOnly required={isNewProposal} highlighted>
                 Reviewer
               </PropertyLabel>
               <UserAndRoleSelect

--- a/stories/ProposalsPage/Proposals.stories.tsx
+++ b/stories/ProposalsPage/Proposals.stories.tsx
@@ -147,6 +147,9 @@ export function ProposalInEvaluation() {
 ProposalInEvaluation.parameters = {
   msw: {
     handlers: {
+      proposalReviewerPool: rest.get('/api/proposals/reviewer-pool', (req, res, ctx) => {
+        return res(ctx.json(null));
+      }),
       proposal: rest.get('/api/proposals/:proposalId', (req, res, ctx) => {
         const rubricCriteria: ProposalWithUsersAndRubric['rubricCriteria'] = [
           {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 07811e9</samp>

This pull request improves the user interface and testing of the proposal editor and the proposals page. It adds `required` indicators to the proposal properties, removes an unused component, and adds mock API handlers for reviewer selection and filtering. It also fixes a linting issue in `.storybook/mockApi.ts`.

### WHY
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/971e6f7e-74a3-4935-b2b7-399dcbaa8eed)
