### PR TITLE
Space specific notifications UI

### DIFF
--- a/components/common/Avatar.tsx
+++ b/components/common/Avatar.tsx
@@ -61,6 +61,11 @@ const sizeVariantStyleMap: Partial<Record<AvatarSize, Record<AvatarVariant, Reac
     rounded: { borderRadius: '4px' },
     circular: null,
     square: null
+  },
+  xSmall: {
+    rounded: { borderRadius: '4px' },
+    circular: null,
+    square: null
   }
 };
 

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -45,6 +45,7 @@ function HeaderComponent({ open, openSidebar }: HeaderProps) {
     spaceId: currentSpace?.id
   });
   const { notifications = [] } = useNotifications();
+  const unreadNotifications = notifications.filter((notification) => !notification.read);
 
   // Post permissions hook will not make an API call if post ID is null. Since we can't conditionally render hooks, we pass null as the post ID. This is the reason for the 'null as any' statement
   const forumPostInfo = usePostByPath();
@@ -63,7 +64,7 @@ function HeaderComponent({ open, openSidebar }: HeaderProps) {
           ...(open && { display: 'none' })
         }}
       >
-        <Badge badgeContent={notifications.length} color='error'>
+        <Badge badgeContent={unreadNotifications.length} color='error'>
           <MenuIcon />
         </Badge>
       </IconButton>

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import MenuIcon from '@mui/icons-material/Menu';
+import { Badge } from '@mui/material';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Toolbar from '@mui/material/Toolbar';
@@ -8,6 +9,7 @@ import { memo } from 'react';
 
 import { FullPageActionsMenuButton } from 'components/common/PageActions/FullPageActionsMenuButton';
 import { usePostByPath } from 'components/forum/hooks/usePostByPath';
+import { useNotifications } from 'components/nexus/hooks/useNotifications';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePage } from 'hooks/usePage';
 import { usePageIdFromPath } from 'hooks/usePageFromPath';
@@ -42,6 +44,7 @@ function HeaderComponent({ open, openSidebar }: HeaderProps) {
     pageIdOrPath: currentSpace ? basePageId : undefined,
     spaceId: currentSpace?.id
   });
+  const { notifications = [] } = useNotifications();
 
   // Post permissions hook will not make an API call if post ID is null. Since we can't conditionally render hooks, we pass null as the post ID. This is the reason for the 'null as any' statement
   const forumPostInfo = usePostByPath();
@@ -60,7 +63,9 @@ function HeaderComponent({ open, openSidebar }: HeaderProps) {
           ...(open && { display: 'none' })
         }}
       >
-        <MenuIcon />
+        <Badge badgeContent={notifications.length} color='error'>
+          <MenuIcon />
+        </Badge>
       </IconButton>
 
       <Box

--- a/components/common/PageLayout/components/Header/Header.tsx
+++ b/components/common/PageLayout/components/Header/Header.tsx
@@ -44,8 +44,7 @@ function HeaderComponent({ open, openSidebar }: HeaderProps) {
     pageIdOrPath: currentSpace ? basePageId : undefined,
     spaceId: currentSpace?.id
   });
-  const { notifications = [] } = useNotifications();
-  const unreadNotifications = notifications.filter((notification) => !notification.read);
+  const { unreadNotifications } = useNotifications();
 
   // Post permissions hook will not make an API call if post ID is null. Since we can't conditionally render hooks, we pass null as the post ID. This is the reason for the 'null as any' statement
   const forumPostInfo = usePostByPath();

--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -40,7 +40,7 @@ import PageNavigation from '../PageNavigation';
 import { SearchInWorkspaceModal } from '../SearchInWorkspaceModal';
 import TrashModal from '../TrashModal';
 
-import { NotificationsPopover, NotificationUpdates } from './components/NotificationsPopover';
+import { NotificationUpdates } from './components/NotificationsPopover';
 import { SectionName } from './components/SectionName';
 import { sidebarItemStyles, SidebarLink } from './components/SidebarButton';
 import SidebarSubmenu from './components/SidebarSubmenu';

--- a/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
@@ -47,15 +47,17 @@ const StyledSidebarBox = styled(Box)`
 
 export const NotificationCountBox = styled(Box)`
   background-color: ${({ theme }) => theme.palette.error.main};
-  color: white;
-  width: 20px;
-  display: flex;
-  justify-content: center;
+  display: inline-flex;
   align-items: center;
-  border-radius: 20%;
-  font-weight: semi-bold;
-  font-size: 12px;
-  padding: 2px;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  font-size: 10px;
+  text-align: center;
+  font-weight: 600;
+  border-radius: 3px;
+  color: white;
 `;
 
 export function NotificationUpdates() {

--- a/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
@@ -60,10 +60,12 @@ export const NotificationCountBox = styled(Box)`
 
 export function NotificationUpdates() {
   const notificationPopupState = usePopupState({ variant: 'popover', popupId: 'notifications-menu' });
-  const { notifications = [], isLoading, mutate: mutateNotifications } = useNotifications();
-  const { space } = useCurrentSpace();
-  const spaceNotifications = notifications.filter((notification) => space && notification.spaceId === space.id);
-  const unreadNotifications = spaceNotifications.filter((notification) => !notification.read);
+  const {
+    currentSpaceNotifications,
+    currentSpaceUnreadNotifications,
+    isLoading,
+    mutate: mutateNotifications
+  } = useNotifications();
 
   return (
     <Box>
@@ -72,7 +74,9 @@ export function NotificationUpdates() {
           <QueryBuilderOutlinedIcon color='secondary' fontSize='small' />
           Updates
         </Stack>
-        {unreadNotifications.length !== 0 && <NotificationCountBox>{unreadNotifications.length}</NotificationCountBox>}
+        {currentSpaceUnreadNotifications.length !== 0 && (
+          <NotificationCountBox>{currentSpaceUnreadNotifications.length}</NotificationCountBox>
+        )}
       </StyledSidebarBox>
       <Popover
         {...bindPopover(notificationPopupState)}
@@ -91,7 +95,7 @@ export function NotificationUpdates() {
         }}
       >
         <NotificationsPopover
-          notifications={spaceNotifications}
+          notifications={currentSpaceNotifications}
           mutateNotifications={mutateNotifications}
           isLoading={isLoading}
           close={notificationPopupState.close}

--- a/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
@@ -90,6 +90,7 @@ export default function SidebarSubmenu({
   openProfileModal: (event: MouseEvent<Element, globalThis.MouseEvent>, path?: string) => void;
 }) {
   const { notifications = [] } = useNotifications();
+  const unreadNotifications = notifications.filter((n) => !n.read);
   const theme = useTheme();
   const showMobileFullWidthModal = !useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -191,7 +192,9 @@ export default function SidebarSubmenu({
         <Tooltip title='Close sidebar' placement='bottom'>
           <IconButton onClick={closeSidebar} size='small' sx={{ position: 'absolute', right: 0, top: 12 }}>
             <MenuOpenIcon />
-            {notifications.length ? <NotificationCountBox mx={1}>{notifications.length}</NotificationCountBox> : null}
+            {unreadNotifications.length ? (
+              <NotificationCountBox mx={1}>{unreadNotifications.length}</NotificationCountBox>
+            ) : null}
           </IconButton>
         </Tooltip>
       )}

--- a/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
@@ -89,8 +89,7 @@ export default function SidebarSubmenu({
   logoutCurrentUser: () => void;
   openProfileModal: (event: MouseEvent<Element, globalThis.MouseEvent>, path?: string) => void;
 }) {
-  const { notifications = [] } = useNotifications();
-  const unreadNotifications = notifications.filter((n) => !n.read);
+  const { notifications = [], otherSpacesUnreadNotifications } = useNotifications();
   const theme = useTheme();
   const showMobileFullWidthModal = !useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -192,8 +191,8 @@ export default function SidebarSubmenu({
         <Tooltip title='Close sidebar' placement='bottom'>
           <IconButton onClick={closeSidebar} size='small' sx={{ position: 'absolute', right: 0, top: 12 }}>
             <MenuOpenIcon />
-            {unreadNotifications.length ? (
-              <NotificationCountBox mx={1}>{unreadNotifications.length}</NotificationCountBox>
+            {otherSpacesUnreadNotifications.length ? (
+              <NotificationCountBox mx={1}>{otherSpacesUnreadNotifications.length}</NotificationCountBox>
             ) : null}
           </IconButton>
         </Tooltip>

--- a/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
@@ -187,16 +187,19 @@ export default function SidebarSubmenu({
           Sign out
         </MenuItem>
       </Menu>
-      {currentSpace && (
-        <Tooltip title='Close sidebar' placement='bottom'>
-          <IconButton onClick={closeSidebar} size='small' sx={{ position: 'absolute', right: 0, top: 12 }}>
-            <MenuOpenIcon />
-            {otherSpacesUnreadNotifications.length ? (
-              <NotificationCountBox mx={1}>{otherSpacesUnreadNotifications.length}</NotificationCountBox>
-            ) : null}
-          </IconButton>
-        </Tooltip>
-      )}
+      <Box sx={{ position: 'absolute', right: 0, top: 12 }} px={2}>
+        {currentSpace && (
+          <Tooltip title='Close sidebar' placement='bottom'>
+            <IconButton onClick={closeSidebar} size='small'>
+              <MenuOpenIcon />
+            </IconButton>
+          </Tooltip>
+        )}
+
+        {otherSpacesUnreadNotifications.length ? (
+          <NotificationCountBox ml={0.5}>{otherSpacesUnreadNotifications.length}</NotificationCountBox>
+        ) : null}
+      </Box>
 
       <Modal
         size='medium'

--- a/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import AddIcon from '@mui/icons-material/Add';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import MenuOpenIcon from '@mui/icons-material/MenuOpen';
+import { Stack } from '@mui/material';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
@@ -21,6 +22,7 @@ import Avatar from 'components/common/Avatar';
 import { CreateSpaceForm } from 'components/common/CreateSpaceForm';
 import { Modal } from 'components/common/Modal';
 import UserDisplay from 'components/common/UserDisplay';
+import { useNotifications } from 'components/nexus/hooks/useNotifications';
 import { useUserDetails } from 'components/settings/profile/hooks/useUserDetails';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useSpaces } from 'hooks/useSpaces';
@@ -29,6 +31,7 @@ import { hasNftAvatar } from 'lib/users/hasNftAvatar';
 
 import { headerHeight } from '../../Header/Header';
 
+import { NotificationCountBox } from './NotificationsPopover';
 import SpaceListItem from './SpaceListItem';
 import WorkspaceAvatar from './WorkspaceAvatar';
 
@@ -86,6 +89,7 @@ export default function SidebarSubmenu({
   logoutCurrentUser: () => void;
   openProfileModal: (event: MouseEvent<Element, globalThis.MouseEvent>, path?: string) => void;
 }) {
+  const { notifications = [] } = useNotifications();
   const theme = useTheme();
   const showMobileFullWidthModal = !useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -159,18 +163,21 @@ export default function SidebarSubmenu({
           </Typography>
         </MenuItem>
         <Divider />
-        <Typography component='p' variant='caption' mx={2} mb={0.5}>
+        <Typography component='p' variant='caption' mx={2} mb={1}>
           My Spaces
         </Typography>
-        {spaces.map((_space) => (
-          <SpaceListItem
-            key={_space.id}
-            disabled={isSaving || !isLoaded || isCreatingSpace}
-            selected={currentSpace?.domain === _space.domain}
-            space={_space}
-            changeOrderHandler={changeOrderHandler}
-          />
-        ))}
+        <Stack gap={1}>
+          {spaces.map((_space) => (
+            <SpaceListItem
+              notifications={notifications}
+              key={_space.id}
+              disabled={isSaving || !isLoaded || isCreatingSpace}
+              selected={currentSpace?.domain === _space.domain}
+              space={_space}
+              changeOrderHandler={changeOrderHandler}
+            />
+          ))}
+        </Stack>
         <MenuItem onClick={showSpaceForm} data-test='spaces-menu-add-new-space'>
           <AddIcon sx={{ m: '5px 15px 5px 8px' }} />
           Create or join a space
@@ -184,9 +191,11 @@ export default function SidebarSubmenu({
         <Tooltip title='Close sidebar' placement='bottom'>
           <IconButton onClick={closeSidebar} size='small' sx={{ position: 'absolute', right: 0, top: 12 }}>
             <MenuOpenIcon />
+            {notifications.length ? <NotificationCountBox mx={1}>{notifications.length}</NotificationCountBox> : null}
           </IconButton>
         </Tooltip>
       )}
+
       <Modal
         size='medium'
         open={spaceFormOpen}

--- a/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
@@ -135,7 +135,7 @@ export default function SidebarSubmenu({
       >
         {currentSpace ? (
           <>
-            <WorkspaceAvatar name={currentSpace.name} image={currentSpace.spaceImage ?? null} />
+            <WorkspaceAvatar size='xSmall' name={currentSpace.name} image={currentSpace.spaceImage ?? null} />
             <Typography variant='body1' data-test='sidebar-space-name' noWrap ml={1}>
               {currentSpace.name ?? 'Spaces'}
             </Typography>
@@ -187,7 +187,7 @@ export default function SidebarSubmenu({
           Sign out
         </MenuItem>
       </Menu>
-      <Box sx={{ position: 'absolute', right: 0, top: 12 }} px={2}>
+      <Box sx={{ position: 'absolute', right: 0, top: 12 }} px={1}>
         {currentSpace && (
           <Tooltip title='Close sidebar' placement='bottom'>
             <IconButton onClick={closeSidebar} size='small'>
@@ -197,7 +197,9 @@ export default function SidebarSubmenu({
         )}
 
         {otherSpacesUnreadNotifications.length ? (
-          <NotificationCountBox ml={0.5}>{otherSpacesUnreadNotifications.length}</NotificationCountBox>
+          <NotificationCountBox ml={0.5} mr={1}>
+            {otherSpacesUnreadNotifications.length}
+          </NotificationCountBox>
         ) : null}
       </Box>
 

--- a/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
@@ -61,12 +61,20 @@ const SidebarHeader = styled(Box)(
   .MuiIconButton-root, .MuiButton-root {
     transition: ${theme.transitions.create('all', {
       easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.enteringScreen
+      duration: theme.transitions.duration.shorter
     })}
   }
+  
   & .MuiIconButton-root {
+    background-color: ${theme.palette.background.light};
     border-radius: 4px;
-  }`
+    padding: 2px;
+  }
+
+  & .MuiIconButton-root:hover {
+    background-color: ${theme.palette.background.default};
+  }
+  `
 );
 
 const StyledCreateSpaceForm = styled(CreateSpaceForm)`
@@ -187,11 +195,11 @@ export default function SidebarSubmenu({
           Sign out
         </MenuItem>
       </Menu>
-      <Box sx={{ position: 'absolute', right: 0, top: 12 }} px={1}>
+      <Box sx={{ position: 'absolute', right: 0 }} px={1}>
         {currentSpace && (
           <Tooltip title='Close sidebar' placement='bottom'>
             <IconButton onClick={closeSidebar} size='small'>
-              <MenuOpenIcon />
+              <MenuOpenIcon fontSize='small' />
             </IconButton>
           </Tooltip>
         )}

--- a/components/common/PageLayout/components/Sidebar/components/SpaceListItem.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/SpaceListItem.tsx
@@ -5,6 +5,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import NextLink from 'next/link';
 
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import type { Notification } from 'lib/notifications/interfaces';
 import { getSpaceUrl } from 'lib/utilities/browser';
 
@@ -25,9 +26,12 @@ export default function SpaceListItem({
   selected,
   disabled
 }: SpaceListItemProps) {
-  const spaceNotifications = notifications.filter(
-    (notification) => notification.spaceId === space.id && !notification.read
-  );
+  const { space: currentSpace } = useCurrentSpace();
+  // Don't show notifications badge for the current space (notion ux)
+  const spaceNotifications =
+    currentSpace?.id === space.id
+      ? []
+      : notifications.filter((notification) => notification.spaceId === space.id && !notification.read);
   return (
     <DraggableListItem name='spaceItem' itemId={space.id} changeOrderHandler={changeOrderHandler} key={space.domain}>
       <MenuItem

--- a/components/common/PageLayout/components/Sidebar/components/SpaceListItem.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/SpaceListItem.tsx
@@ -1,9 +1,11 @@
 import type { Space } from '@charmverse/core/prisma';
+import { Badge } from '@mui/material';
 import type { MenuItemProps } from '@mui/material/MenuItem';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import NextLink from 'next/link';
 
+import type { Notification } from 'lib/notifications/interfaces';
 import { getSpaceUrl } from 'lib/utilities/browser';
 
 import DraggableListItem from '../../DraggableListItem';
@@ -12,10 +14,20 @@ import WorkspaceAvatar from './WorkspaceAvatar';
 
 interface SpaceListItemProps extends MenuItemProps {
   space: Space;
+  notifications: Notification[];
   changeOrderHandler: (draggedProperty: string, droppedOnProperty: string) => Promise<void>;
 }
 
-export default function SpaceListItem({ space, changeOrderHandler, selected, disabled }: SpaceListItemProps) {
+export default function SpaceListItem({
+  notifications,
+  space,
+  changeOrderHandler,
+  selected,
+  disabled
+}: SpaceListItemProps) {
+  const spaceNotifications = notifications.filter(
+    (notification) => notification.spaceId === space.id && !notification.read
+  );
   return (
     <DraggableListItem name='spaceItem' itemId={space.id} changeOrderHandler={changeOrderHandler} key={space.domain}>
       <MenuItem
@@ -24,7 +36,9 @@ export default function SpaceListItem({ space, changeOrderHandler, selected, dis
         selected={selected}
         disabled={disabled}
       >
-        <WorkspaceAvatar name={space.name} image={space.spaceImage} />
+        <Badge badgeContent={spaceNotifications.length} color='error'>
+          <WorkspaceAvatar name={space.name} image={space.spaceImage} />
+        </Badge>
         <Typography noWrap ml={1}>
           {space.name}
         </Typography>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b4d5f61</samp>

This pull request adds and improves the notifications feature for the app.charmverse.io website. It displays the number of notifications on the header menu icon, the sidebar submenu, and the space avatars. It also filters the notifications by the current space and uses hooks to fetch and update the notifications data. It affects the files `Header.tsx`, `NotificationsPopover.tsx`, `SidebarSubmenu.tsx`, `SpaceListItem.tsx`, and `Sidebar.tsx`.

### WHY
<!-- author to complete -->
