### PR TITLE
Fix missing viewids in imported blocks from exported space

### DIFF
--- a/lib/templates/__tests__/importWorkspacePages.spec.ts
+++ b/lib/templates/__tests__/importWorkspacePages.spec.ts
@@ -7,6 +7,8 @@ import type { Page, Space, User } from '@charmverse/core/prisma';
 import { prisma } from '@charmverse/core/prisma-client';
 import { v4 } from 'uuid';
 
+import { Block, prismaToBlock } from 'lib/focalboard/block';
+import type { Board } from 'lib/focalboard/board';
 import { createPage, generateBoard, generateUserAndSpace } from 'testing/setupDatabase';
 
 import { exportWorkspacePages, exportWorkspacePagesToDisk } from '../exportWorkspacePages';
@@ -96,6 +98,10 @@ describe('importWorkspacePages', () => {
       }
     });
 
+    const boardBlock = prismaToBlock(blocks.find((b) => b.type === 'board')!) as Board;
+    const viewBlocks = blocks.filter((b) => b.type === 'view');
+
+    expect(boardBlock.fields.viewIds.sort()).toStrictEqual(viewBlocks.map((b) => b.id).sort());
     expect(pages.length).toBe(totalSourcePages);
     expect(blocks.length).toBe(totalSourceBlocks);
   });

--- a/lib/templates/importWorkspacePages.ts
+++ b/lib/templates/importWorkspacePages.ts
@@ -329,15 +329,16 @@ export async function generateImportWorkspacePages({
       }
     } else if (isBoardPageType(node.type)) {
       const boardBlock = node.blocks?.board;
-      const viewBlocks = node.blocks?.views ?? [];
+      const viewBlocks = (node.blocks?.views ?? []).map((view) => ({ ...view, id: v4() }));
+      if (boardBlock && boardBlock.fields) {
+        (boardBlock.fields as any).viewIds = viewBlocks.map((viewBlock) => viewBlock.id);
+      }
 
       // We don't want to create empty databases, but we do want to allow inline databases to be empty so they can be initialised
       if (boardBlock && ((!node.type.match('inline') && viewBlocks.length > 0) || node.type.match('inline'))) {
         [boardBlock, ...viewBlocks].forEach((block) => {
           if (block.type === 'board') {
             block.id = newId;
-          } else {
-            block.id = v4();
           }
 
           block.rootId = newId;

--- a/lib/templates/importWorkspacePages.ts
+++ b/lib/templates/importWorkspacePages.ts
@@ -6,7 +6,7 @@ import type { PageMeta } from '@charmverse/core/pages';
 import type { Page } from '@charmverse/core/prisma';
 import { Prisma } from '@charmverse/core/prisma';
 import { prisma } from '@charmverse/core/prisma-client';
-import { v4, validate } from 'uuid';
+import { v4 as uuid, validate } from 'uuid';
 
 import type { BountyWithDetails } from 'lib/bounties';
 import { isBoardPageType } from 'lib/pages/isBoardPageType';
@@ -56,7 +56,7 @@ function updateReferences({ oldNewPageIdHashMap, pages }: UpdateRefs) {
       if (node.type === 'poll') {
         const attrs = node.attrs as { pollId: string };
         if (attrs.pollId) {
-          const newPollId = v4();
+          const newPollId = uuid();
           extractedPolls.set(attrs.pollId, { newPollId, pageId: page.id, originalId: attrs.pollId });
           attrs.pollId = newPollId;
         }
@@ -66,7 +66,7 @@ function updateReferences({ oldNewPageIdHashMap, pages }: UpdateRefs) {
         let newPageId = oldPageId ? oldNewPageIdHashMap[oldPageId] : undefined;
 
         if (oldPageId && !newPageId) {
-          newPageId = v4();
+          newPageId = uuid();
           oldNewPageIdHashMap[oldPageId] = newPageId;
           oldNewPageIdHashMap[newPageId] = oldPageId;
         }
@@ -80,7 +80,7 @@ function updateReferences({ oldNewPageIdHashMap, pages }: UpdateRefs) {
         let newPageId = oldPageId ? oldNewPageIdHashMap[oldPageId] : undefined;
 
         if (oldPageId && !newPageId) {
-          newPageId = v4();
+          newPageId = uuid();
           oldNewPageIdHashMap[oldPageId] = newPageId;
           oldNewPageIdHashMap[newPageId] = oldPageId;
         }
@@ -179,7 +179,7 @@ export async function generateImportWorkspacePages({
     const existingNewPageId =
       node.type === 'page' || isBoardPageType(node.type) ? oldNewPageIdHashMap[node.id] : undefined;
 
-    const newId = rootPageId ?? existingNewPageId ?? v4();
+    const newId = rootPageId ?? existingNewPageId ?? uuid();
 
     oldNewPageIdHashMap[newId] = node.id;
     oldNewPageIdHashMap[node.id] = newId;
@@ -208,14 +208,14 @@ export async function generateImportWorkspacePages({
 
     const currentParentId = newParentId ?? rootParentId ?? undefined;
 
-    const newPermissionId = v4();
+    const newPermissionId = uuid();
 
     // Reassigned when creating the root permission
     rootSpacePermissionId = rootSpacePermissionId ?? newPermissionId;
 
     const pagePermissions = includePermissions
       ? node.permissions.map(({ sourcePermission, pageId, inheritedFromPermission, ...permission }) => {
-          const newPagePermissionId = v4();
+          const newPagePermissionId = uuid();
 
           oldNewPermissionMap[permission.id] = newPagePermissionId;
 
@@ -329,7 +329,7 @@ export async function generateImportWorkspacePages({
       }
     } else if (isBoardPageType(node.type)) {
       const boardBlock = node.blocks?.board;
-      const viewBlocks = (node.blocks?.views ?? []).map((view) => ({ ...view, id: v4() }));
+      const viewBlocks = (node.blocks?.views ?? []).map((view) => ({ ...view, id: uuid() }));
       if (boardBlock && boardBlock.fields) {
         (boardBlock.fields as any).viewIds = viewBlocks.map((viewBlock) => viewBlock.id);
       }
@@ -388,7 +388,7 @@ export async function generateImportWorkspacePages({
           space.proposalCategories.find((cat) => cat.title === category.title)?.id ||
           proposalCategoryArgs.find((proposalCategoryArg) => proposalCategoryArg.title === category.title)?.id;
         if (!categoryId) {
-          categoryId = v4();
+          categoryId = uuid();
           proposalCategoryArgs.push({
             id: categoryId,
             title: category.title,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23c2bb1</samp>

This pull request enhances the workspace import feature by supporting the Focalboard block format and fixing id conflicts for board and view blocks. It also updates the corresponding test case in `importWorkspacePages.spec.ts`.

### WHY
<!-- author to complete -->
