### PR TITLE
update example for permissions to use ip address

### DIFF
--- a/.env.test.local.example
+++ b/.env.test.local.example
@@ -9,4 +9,4 @@ SERVERLESS_PORT=3020
 # necessary so that the serverless app can be tested locally
 MAILGUN_DOMAIN=mg.charmverse.com
 MAILGUN_KEY=test-key
-PERMISSIONS_API_URL=http://localhost:3001
+PERMISSIONS_API_URL=http://127.0.0.1:3001


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c8802c</samp>

Updated the `.env.test.local.example` file to use `127.0.0.1` for the `PERMISSIONS_API_URL` variable. This improves the test reliability and performance of the app.charmverse.io repository.

### WHY
<!-- author to complete -->
