### PR TITLE
replace unicode characters that appear incorrectly sometimes

### DIFF
--- a/components/common/CharmEditor/components/listItemNew/czi-list.scss
+++ b/components/common/CharmEditor/components/listItemNew/czi-list.scss
@@ -97,33 +97,25 @@ html {
   width: 24pt;
 }
 
-/* [FS] IRAD-947 2020-05-26
-Bullet list type changing fix */
 
-/* prettier-ignore */
 .ProseMirror ul[data-indent='7'] li > span > p::before,
-/* prettier-ignore */
 .ProseMirror ul[data-indent='4'] li > span > p::before,
-/* prettier-ignore */
 .ProseMirror ul[data-indent='1'] li > span > p::before {
-  content: '\25e6'; /* circle */
+  content: '◦'; /* circle */
 }
 
-/* prettier-ignore */
 .ProseMirror ul[data-indent='5'] li > span > p::before,
-/* prettier-ignore */
 .ProseMirror ul[data-indent='2'] li > span > p::before {
-  content: '\25aa'; /* square */
+  content: '▪'; /* square */
 }
 
 .ProseMirror ul[data-indent='6'] li > span > p::before,
 .ProseMirror ul[data-indent='3'] li > span > p::before,
 .ProseMirror ul[data-indent='0'] li > span > p::before {
-  content: '\2022'; /* circle */
+  content: '•'; /* circle */
 }
 
 /* To do lists */
-
 
 .ProseMirror {
   li[data-bangle-is-todo] {

--- a/components/common/CharmEditor/components/listItemNew/listItemNodeView.ts
+++ b/components/common/CharmEditor/components/listItemNew/listItemNodeView.ts
@@ -4,6 +4,7 @@ import type { EditorState, Transaction } from 'prosemirror-state';
 import type { NodeView, Decoration, EditorView } from 'prosemirror-view';
 
 import { MARK_TEXT_COLOR, MARK_FONT_SIZE } from './markNames';
+import { LIST_ITEM } from './nodeNames';
 
 // This implements the `NodeView` interface
 // https://prosemirror.net/docs/ref/#view.NodeView
@@ -38,15 +39,15 @@ export class ListItemNodeView implements NodeView {
       }
     }
 
-    // Connect the two contentDOM and containerDOM for pm to write to
-    // this.containerDOM?.appendChild(this.contentDOM!);
-
     this._updateDOM(node);
   }
 
   // This implements the `NodeView` interface.
   // update(node: Node, decorations: Decoration[]): boolean {
   update(node: Node): boolean {
+    if (LIST_ITEM !== node.type.name) {
+      return false;
+    }
     return this._updateDOM(node);
   }
 
@@ -112,21 +113,21 @@ export class ListItemNodeView implements NodeView {
 
     // handle TO DO
     const { todoChecked } = node.attrs;
-    if (todoChecked == null) {
-      removeCheckbox(this.dom!);
-      return false;
+    if (todoChecked === null) {
+      removeCheckbox(this.dom);
+      return true;
     }
 
     // if parent is not bulletList i.e. it is orderedList
     if (!checkParentBulletList(this.view.state, this.getPos())) {
-      return false;
+      return true;
     }
     // assume nothing about the dom elements state.
     // for example it is possible that the checkbox is not created
     // when a regular list is converted to todo list only update handler
     // will be called. The create handler was called in the past
     // but without the checkbox element, hence the checkbox wont be there
-    setupCheckbox(this.dom!, node.attrs, this.readOnly, (attrs: Node['attrs']) => {
+    setupCheckbox(this.dom, node.attrs, this.readOnly, (attrs: Node['attrs']) => {
       this.view.dispatch(updateAttrs(this.getPos(), node, attrs, this.view.state.tr));
     });
     // const checkbox = this!.containerDOM!.firstChild!.firstChild! as HTMLInputElement;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6f16a2</samp>

Simplify bullet symbols in `czi-list.scss`. Use circle and square characters instead of unicode escapes for better readability.

### WHY

Found a similar issue on stack overflow: https://stackoverflow.com/questions/10393462/placing-unicode-character-in-css-content-value/10393517#10393517

[<!-- author to complete -->
](https://www.loom.com/share/3d9d7de5ebeb4aa08f907b75d40b4aae?sid=4c8fbfef-c02b-4e3f-9820-983638524254)