### PR TITLE
Feat/sticky save proposal button

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/dialog.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import CloseIcon from '@mui/icons-material/Close';
-import { Box, DialogActions } from '@mui/material';
+import { Box, DialogActions, Divider, Stack } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import Modal from '@mui/material/Modal';
 import clsx from 'clsx';
@@ -31,6 +31,22 @@ const Content = styled.div`
   -webkit-overflow-scrolling: touch;
 `;
 
+const FooterActionsContainer = styled(Box)`
+  width: 100%;
+  max-width: 100%;
+  margin: 0 auto;
+  position: relative;
+  padding: 0 40px 0 30px;
+
+  ${({ theme }) => theme.breakpoints.up('lg')} {
+    width: 860px;
+  }
+
+  ${({ theme }) => theme.breakpoints.up('md')} {
+    padding: 0 80px;
+  }
+`;
+
 function FBDialog(props: Props) {
   const { toolbar, toolsMenu, fullWidth = false, footerActions } = props;
 
@@ -59,7 +75,14 @@ function FBDialog(props: Props) {
             </Toolbar>
             <Content>{props.children}</Content>
 
-            {!!footerActions && <DialogActions>{footerActions}</DialogActions>}
+            {!!footerActions && (
+              <Stack>
+                <Divider light />
+                <FooterActionsContainer>
+                  <DialogActions sx={{ px: 0 }}>{footerActions}</DialogActions>
+                </FooterActionsContainer>
+              </Stack>
+            )}
           </div>
         </div>
       </div>

--- a/components/common/BoardEditor/focalboard/src/components/dialog.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/dialog.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import CloseIcon from '@mui/icons-material/Close';
-import { Box } from '@mui/material';
+import { Box, DialogActions } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import Modal from '@mui/material/Modal';
 import clsx from 'clsx';
@@ -15,6 +15,7 @@ type Props = {
   className?: string;
   onClose: () => void;
   fullWidth?: boolean;
+  footerActions?: React.ReactNode;
 };
 
 const Toolbar = styled(Box)`
@@ -31,7 +32,7 @@ const Content = styled.div`
 `;
 
 function FBDialog(props: Props) {
-  const { toolbar, toolsMenu, fullWidth = false } = props;
+  const { toolbar, toolsMenu, fullWidth = false, footerActions } = props;
 
   useHotkeys('esc', () => props.onClose());
 
@@ -57,6 +58,8 @@ function FBDialog(props: Props) {
               )}
             </Toolbar>
             <Content>{props.children}</Content>
+
+            {!!footerActions && <DialogActions>{footerActions}</DialogActions>}
           </div>
         </div>
       </div>

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -1,40 +1,29 @@
-import { log } from '@charmverse/core/log';
 import styled from '@emotion/styled';
 import type { Theme } from '@mui/material';
-import { Box, Stack, useMediaQuery } from '@mui/material';
+import { Box, useMediaQuery } from '@mui/material';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { mutate } from 'swr';
 import { useElementSize } from 'usehooks-ts';
 
-import { useCreateProposal } from 'charmClient/hooks/proposals';
 import PageBanner from 'components/[pageId]/DocumentPage/components/PageBanner';
 import PageHeader, { getPageTop } from 'components/[pageId]/DocumentPage/components/PageHeader';
 import { Container } from 'components/[pageId]/DocumentPage/DocumentPage';
-import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
-import { ScrollableWindow } from 'components/common/PageLayout';
 import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemplates';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import { usePages } from 'hooks/usePages';
 import { usePreventReload } from 'hooks/usePreventReload';
-import { useSnackbar } from 'hooks/useSnackbar';
-import type { RubricDataInput } from 'lib/proposal/rubric/upsertRubricCriteria';
 import type { PageContent } from 'lib/prosemirror/interfaces';
-import { setUrlWithoutRerender } from 'lib/utilities/browser';
 import { fontClassName } from 'theme/fonts';
 
 import { ProposalProperties } from '../ProposalProperties/ProposalProperties';
 
 import type { ProposalPageAndPropertiesInput } from './hooks/useProposalDialog';
-import { useProposalDialog } from './hooks/useProposalDialog';
 
 type Props = {
   setFormInputs: (params: Partial<ProposalPageAndPropertiesInput>) => void;
   formInputs: ProposalPageAndPropertiesInput;
   contentUpdated: boolean;
-  setContentUpdated: (changed: boolean) => void;
 };
 
 const StyledContainer = styled(Container)`
@@ -42,16 +31,11 @@ const StyledContainer = styled(Container)`
 `;
 
 // Note: this component is only used before a page is saved to the DB
-export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, setContentUpdated }: Props) {
+export function NewProposalPage({ setFormInputs, formInputs, contentUpdated }: Props) {
   const { space: currentSpace } = useCurrentSpace();
-  const { showMessage } = useSnackbar();
-  const { showProposal } = useProposalDialog();
   const [, { width: containerWidth }] = useElementSize();
   const isSmallScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('lg'));
-  const { mutatePage } = usePages();
   const [readOnlyEditor, setReadOnlyEditor] = useState(false);
-
-  const { trigger: createProposalTrigger, isMutating: isCreatingProposal } = useCreateProposal();
 
   usePreventReload(contentUpdated);
 
@@ -70,84 +54,11 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
     (t) => t.id === formInputs?.proposalTemplateId && t.reviewers.length > 0
   );
 
-  async function createProposal() {
-    log.info('[user-journey] Create a proposal');
-    if (formInputs.categoryId && currentSpace) {
-      // TODO: put validation inside the properties form component
-      try {
-        formInputs.rubricCriteria.forEach((criteria) => {
-          if (criteria.type === 'range') {
-            if (
-              (!criteria.parameters.min && criteria.parameters.min !== 0) ||
-              (!criteria.parameters.max && criteria.parameters.max !== 0)
-            ) {
-              throw new Error('Range values are invalid');
-            }
-            if (criteria.parameters.min >= criteria.parameters.max) {
-              throw new Error('Minimum must be less than Maximum');
-            }
-          }
-        });
-      } catch (error) {
-        showMessage((error as Error).message, 'error');
-        return;
-      }
-      const createdProposal = await createProposalTrigger({
-        authors: formInputs.authors,
-        categoryId: formInputs.categoryId,
-        pageProps: {
-          content: formInputs.content,
-          contentText: formInputs.contentText ?? '',
-          title: formInputs.title,
-          sourceTemplateId: formInputs.proposalTemplateId,
-          headerImage: formInputs.headerImage,
-          icon: formInputs.icon
-        },
-        evaluationType: formInputs.evaluationType,
-        rubricCriteria: formInputs.rubricCriteria as RubricDataInput[],
-        reviewers: formInputs.reviewers,
-        spaceId: currentSpace.id,
-        publishToLens: formInputs.publishToLens,
-        fields: formInputs.fields
-      }).catch((err: any) => {
-        showMessage(err.message ?? 'Something went wrong', 'error');
-        throw err;
-      });
-
-      if (createdProposal) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { proposal, ...page } = createdProposal;
-        mutatePage(page);
-        mutate(`/api/spaces/${currentSpace.id}/proposals`);
-        showProposal({
-          pageId: page.id,
-          onClose() {
-            setUrlWithoutRerender(router.pathname, { id: null });
-          }
-        });
-        setUrlWithoutRerender(router.pathname, { id: page.id });
-        setContentUpdated(false);
-      }
-    }
-  }
-
   function updateProposalContent({ doc, rawText }: ICharmEditorOutput) {
-    setContentUpdated(true);
     setFormInputs({
       content: doc,
       contentText: rawText
     });
-  }
-
-  let disabledTooltip = '';
-  if (!formInputs.title) {
-    disabledTooltip = 'Title is required';
-  } else if (!formInputs.categoryId) {
-    disabledTooltip = 'Category is required';
-  } else if (currentSpace?.requireProposalTemplate && !formInputs.proposalTemplateId) {
-    disabledTooltip = 'Template is required';
-  } else if (formInputs.reviewers.length === 0) {
-    disabledTooltip = 'Reviewers are required';
   }
 
   return (
@@ -213,17 +124,6 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated, set
               </div>
             </CharmEditor>
           </Box>
-          <Stack flexDirection='row' gap={1} justifyContent='flex-end' my={2}>
-            <Button
-              disabled={Boolean(disabledTooltip) || !contentUpdated || isCreatingProposal}
-              disabledTooltip={disabledTooltip}
-              onClick={createProposal}
-              loading={isCreatingProposal}
-              data-test='create-proposal-button'
-            >
-              Create
-            </Button>
-          </Stack>
         </StyledContainer>
       </Box>
     </div>

--- a/components/proposals/components/ProposalDialog/ProposalDialog.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalDialog.tsx
@@ -52,7 +52,6 @@ export function ProposalDialog({ pageId, newProposal, onClose }: Props) {
   });
 
   const { space } = useCurrentSpace();
-  const { user } = useUser();
   const { page, isLoading: isPageLoading, refreshPage } = usePage({ pageIdOrPath: pageId });
 
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);

--- a/components/proposals/components/ProposalDialog/ProposalDialog.tsx
+++ b/components/proposals/components/ProposalDialog/ProposalDialog.tsx
@@ -13,6 +13,7 @@ import LoadingComponent from 'components/common/LoadingComponent';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import { FullPageActionsMenuButton } from 'components/common/PageActions/FullPageActionsMenuButton';
 import { DocumentHeaderElements } from 'components/common/PageLayout/components/Header/components/DocumentHeaderElements';
+import { useNewProposal } from 'components/proposals/components/ProposalDialog/hooks/useNewProposal';
 import { useCharmEditor } from 'hooks/useCharmEditor';
 import { useCurrentPage } from 'hooks/useCurrentPage';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
@@ -38,14 +39,22 @@ export function ProposalDialog({ pageId, newProposal, onClose }: Props) {
   const { setCurrentPageId } = useCurrentPage();
   const { editMode, resetPageProps, setPageProps } = useCharmEditor();
 
+  const {
+    formInputs,
+    setFormInputs,
+    clearFormInputs,
+    contentUpdated,
+    createProposal,
+    isCreatingProposal,
+    disabledTooltip
+  } = useNewProposal({
+    newProposal
+  });
+
   const { space } = useCurrentSpace();
   const { user } = useUser();
   const { page, isLoading: isPageLoading, refreshPage } = usePage({ pageIdOrPath: pageId });
-  const [formInputs, setFormInputs] = useState<ProposalPageAndPropertiesInput>(
-    emptyState({ ...newProposal, userId: user?.id })
-  );
 
-  const [contentUpdated, setContentUpdated] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
 
   const isLoading = !!pageId && isPageLoading;
@@ -100,13 +109,6 @@ export function ProposalDialog({ pageId, newProposal, onClose }: Props) {
   }, []);
 
   useEffect(() => {
-    setFormInputs((prevState) => ({
-      ...prevState,
-      publishToLens: !!user?.publishToLensDefault
-    }));
-  }, [user?.id]);
-
-  useEffect(() => {
     if (page?.id) {
       trackPageView({ spaceId: page.spaceId, pageId: page.id, type: page.type, spaceDomain: space?.domain });
     }
@@ -114,8 +116,7 @@ export function ProposalDialog({ pageId, newProposal, onClose }: Props) {
 
   function close() {
     onClose();
-    setFormInputs(emptyState());
-    setContentUpdated(false);
+    clearFormInputs();
     setShowConfirmDialog(false);
   }
 
@@ -161,6 +162,19 @@ export function ProposalDialog({ pageId, newProposal, onClose }: Props) {
           </Stack>
         ) : null
       }
+      footerActions={
+        isLoading || page || !newProposal ? null : (
+          <Button
+            disabled={Boolean(disabledTooltip) || !contentUpdated || isCreatingProposal}
+            disabledTooltip={disabledTooltip}
+            onClick={createProposal}
+            loading={isCreatingProposal}
+            data-test='create-proposal-button'
+          >
+            Save
+          </Button>
+        )
+      }
     >
       {isLoading ? (
         <LoadingComponent isLoading />
@@ -168,15 +182,7 @@ export function ProposalDialog({ pageId, newProposal, onClose }: Props) {
         // Document page is used in a few places, so it is responsible for retrieving its own permissions
         <DocumentPage page={page} refreshPage={refreshPage} readOnly={readOnly} savePage={savePage} />
       ) : (
-        <NewProposalPage
-          formInputs={formInputs}
-          setFormInputs={(_formInputs) => {
-            setContentUpdated(true);
-            setFormInputs((existingFormInputs) => ({ ...existingFormInputs, ..._formInputs }));
-          }}
-          contentUpdated={contentUpdated}
-          setContentUpdated={setContentUpdated}
-        />
+        <NewProposalPage formInputs={formInputs} setFormInputs={setFormInputs} contentUpdated={contentUpdated} />
       )}
       <ConfirmDeleteModal
         onClose={() => {
@@ -191,26 +197,4 @@ export function ProposalDialog({ pageId, newProposal, onClose }: Props) {
       />
     </Dialog>
   );
-}
-
-function emptyState({
-  userId,
-  ...inputs
-}: Partial<ProposalPageAndPropertiesInput> & { userId?: string } = {}): ProposalPageAndPropertiesInput {
-  return {
-    categoryId: null,
-    content: null,
-    contentText: '',
-    headerImage: null,
-    icon: null,
-    evaluationType: 'vote',
-    proposalTemplateId: null,
-    reviewers: [],
-    rubricCriteria: [],
-    title: '',
-    publishToLens: false,
-    fields: { properties: {} },
-    ...inputs,
-    authors: userId ? [userId] : []
-  };
 }

--- a/components/proposals/components/ProposalDialog/hooks/useNewProposal.tsx
+++ b/components/proposals/components/ProposalDialog/hooks/useNewProposal.tsx
@@ -1,0 +1,170 @@
+import { log } from '@charmverse/core/log';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { mutate } from 'swr';
+
+import { useCreateProposal } from 'charmClient/hooks/proposals';
+import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
+import {
+  useProposalDialog,
+  type ProposalPageAndPropertiesInput
+} from 'components/proposals/components/ProposalDialog/hooks/useProposalDialog';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import { usePages } from 'hooks/usePages';
+import { useSnackbar } from 'hooks/useSnackbar';
+import { useUser } from 'hooks/useUser';
+import type { RubricDataInput } from 'lib/proposal/rubric/upsertRubricCriteria';
+import { setUrlWithoutRerender } from 'lib/utilities/browser';
+
+type Props = {
+  newProposal?: Partial<ProposalPageAndPropertiesInput>;
+};
+
+export function useNewProposal({ newProposal }: Props) {
+  const { user } = useUser();
+  const { showMessage } = useSnackbar();
+  const { space: currentSpace } = useCurrentSpace();
+  const { showProposal } = useProposalDialog();
+  const { mutatePage } = usePages();
+  const router = useRouter();
+  const { trigger: createProposalTrigger, isMutating: isCreatingProposal } = useCreateProposal();
+
+  const [contentUpdated, setContentUpdated] = useState(false);
+  const [formInputs, setFormInputsRaw] = useState<ProposalPageAndPropertiesInput>(
+    emptyState({ ...newProposal, userId: user?.id })
+  );
+
+  const setFormInputs = useCallback((partialFormInputs: Partial<ProposalPageAndPropertiesInput>) => {
+    setContentUpdated(true);
+    setFormInputsRaw((existingFormInputs) => ({ ...existingFormInputs, ...partialFormInputs }));
+  }, []);
+
+  const clearFormInputs = useCallback(() => {
+    setFormInputs(emptyState());
+    setContentUpdated(false);
+  }, [setFormInputs]);
+
+  useEffect(() => {
+    setFormInputsRaw((v) => ({
+      ...v,
+      publishToLens: !!user?.publishToLensDefault
+    }));
+  }, [setFormInputs, user?.publishToLensDefault]);
+
+  async function createProposal() {
+    log.info('[user-journey] Create a proposal');
+    if (formInputs.categoryId && currentSpace) {
+      // TODO: put validation inside the properties form component
+      try {
+        formInputs.rubricCriteria.forEach((criteria) => {
+          if (criteria.type === 'range') {
+            if (
+              (!criteria.parameters.min && criteria.parameters.min !== 0) ||
+              (!criteria.parameters.max && criteria.parameters.max !== 0)
+            ) {
+              throw new Error('Range values are invalid');
+            }
+            if (criteria.parameters.min >= criteria.parameters.max) {
+              throw new Error('Minimum must be less than Maximum');
+            }
+          }
+        });
+      } catch (error) {
+        showMessage((error as Error).message, 'error');
+        return;
+      }
+      const createdProposal = await createProposalTrigger({
+        authors: formInputs.authors,
+        categoryId: formInputs.categoryId,
+        pageProps: {
+          content: formInputs.content,
+          contentText: formInputs.contentText ?? '',
+          title: formInputs.title,
+          sourceTemplateId: formInputs.proposalTemplateId,
+          headerImage: formInputs.headerImage,
+          icon: formInputs.icon
+        },
+        evaluationType: formInputs.evaluationType,
+        rubricCriteria: formInputs.rubricCriteria as RubricDataInput[],
+        reviewers: formInputs.reviewers,
+        spaceId: currentSpace.id,
+        publishToLens: formInputs.publishToLens,
+        fields: formInputs.fields
+      }).catch((err: any) => {
+        showMessage(err.message ?? 'Something went wrong', 'error');
+        throw err;
+      });
+
+      if (createdProposal) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { proposal, ...page } = createdProposal;
+        mutatePage(page);
+        mutate(`/api/spaces/${currentSpace.id}/proposals`);
+        showProposal({
+          pageId: page.id,
+          onClose() {
+            setUrlWithoutRerender(router.pathname, { id: null });
+          }
+        });
+        setUrlWithoutRerender(router.pathname, { id: page.id });
+        setContentUpdated(false);
+      }
+    }
+  }
+
+  const disabledTooltip = useMemo(() => {
+    if (!formInputs.title) {
+      return 'Title is required';
+    }
+
+    if (!formInputs.categoryId) {
+      return 'Category is required';
+    }
+
+    if (currentSpace?.requireProposalTemplate && !formInputs.proposalTemplateId) {
+      return 'Template is required';
+    }
+
+    if (formInputs.reviewers.length === 0) {
+      return 'Reviewers are required';
+    }
+  }, [
+    currentSpace?.requireProposalTemplate,
+    formInputs.categoryId,
+    formInputs.proposalTemplateId,
+    formInputs.reviewers.length,
+    formInputs.title
+  ]);
+
+  return {
+    formInputs,
+    setFormInputs,
+    clearFormInputs,
+    createProposal,
+    disabledTooltip,
+    isCreatingProposal,
+    contentUpdated
+  };
+}
+
+export function emptyState({
+  userId,
+  ...inputs
+}: Partial<ProposalPageAndPropertiesInput> & { userId?: string } = {}): ProposalPageAndPropertiesInput {
+  return {
+    categoryId: null,
+    content: null,
+    contentText: '',
+    headerImage: null,
+    icon: null,
+    evaluationType: 'vote',
+    proposalTemplateId: null,
+    reviewers: [],
+    rubricCriteria: [],
+    title: '',
+    publishToLens: false,
+    fields: { properties: {} },
+    ...inputs,
+    authors: userId ? [userId] : []
+  };
+}

--- a/stories/ProposalsPage/Proposals.stories.tsx
+++ b/stories/ProposalsPage/Proposals.stories.tsx
@@ -118,7 +118,6 @@ export function NewProposal() {
             setFormInputs((__formInputs) => ({ ...__formInputs, ..._formInputs }));
           }}
           contentUpdated={contentUpdated}
-          setContentUpdated={setContentUpdated}
         />
       </Paper>
     </Context>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a45a442</samp>

Refactored the proposal creation feature to use a custom hook and a dialog component. The `useNewProposal` hook handles the form logic and API calls, while the `ProposalDialog` component displays the form and the create button. The `FBDialog` component was also updated to support custom footer actions.

### WHY
Add opitonal footer to page dialog, refactor proposal page to have sticky save button (this is parial update for "save" behavior in rewards)

<img width="1219" alt="Screenshot 2023-10-17 at 14 21 51" src="https://github.com/charmverse/app.charmverse.io/assets/5198394/11d58529-890a-4332-ad3e-30959f158327">

