### PR TITLE
Replaced `useSWRImmutable` with `useSWR` in `useNotifications`

### DIFF
--- a/components/nexus/hooks/useNotifications.ts
+++ b/components/nexus/hooks/useNotifications.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import useSWRImmutable from 'swr/immutable';
+import useSWR from 'swr';
 
 import charmClient from 'charmClient';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
@@ -13,14 +13,10 @@ export function useNotifications() {
     error: serverError,
     isLoading,
     mutate
-  } = useSWRImmutable(
-    user ? `/notifications/list/${user.id}` : null,
-    () => charmClient.notifications.getNotifications(),
-    {
-      // 10 minutes
-      refreshInterval: 1000 * 10 * 60
-    }
-  );
+  } = useSWR(user ? `/notifications/list/${user.id}` : null, () => charmClient.notifications.getNotifications(), {
+    // 10 minutes
+    refreshInterval: 1000 * 10 * 60
+  });
 
   const error = serverError?.message || serverError;
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3251ea8</samp>

Updated the `useNotifications` hook to use the latest version of `useSWR`. This improves the code quality and performance of the `components/nexus/hooks/useNotifications.ts` file.

### WHY
<!-- author to complete -->
