### PR TITLE
only run chromatic on push flows

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,39 @@
+# Workflow name
+name: 'Chromatic'
+
+# Event for the workflow
+on: push
+
+# List of jobs
+jobs:
+  chromatic:
+    # Operating System
+    runs-on: ubuntu-latest
+    # Job steps
+    steps:
+      # Build and install app
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        uses: ./.github/actions/install
+
+      - name: Build app
+        uses: ./.github/actions/build
+
+      # Check if the branch is not main and run Chromatic
+      - name: Publish to Chromatic
+        if: github.ref != 'refs/heads/main'
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true
+          skip: 'dependabot/**' # skip dependabot PRs
+
+      # Check if the branch is main and accept all changes in Chromatic
+      - name: Publish to Chromatic and auto accept changes
+        if: github.ref == 'refs/heads/main'
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          autoAcceptChanges: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
+          traceChanged: true
           skip: 'dependabot/**' # skip dependabot PRs
 
       # Check if the branch is main and accept all changes in Chromatic

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -43,28 +43,6 @@ jobs:
         with:
           save_cache: true
 
-  chromatic:
-    name: Publish to Chromatic
-    runs-on: ubuntu-latest
-    needs: build-test-env
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Restore dependencies from cache
-        uses: ./.github/actions/install
-        with:
-          core_pkg_version: ${{ inputs.core_pkg_version }}
-
-      - name: Restore app from cache
-        uses: ./.github/actions/build
-
-      - uses: chromaui/action@v1
-        with:
-          onlyChanged: true
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-
   test:
     name: Validate code
     runs-on: ubuntu-latest


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8917a81</samp>

This pull request introduces a new workflow for Chromatic visual testing and review of UI components, and removes the Chromatic step from the test and deploy workflow. This improves the quality and consistency of the UI and reduces the complexity of the deployment process.

### WHY
<!-- author to complete -->
