### PR TITLE
fix links to forum posts for document events

### DIFF
--- a/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
@@ -12,7 +12,6 @@ import { Fragment, useMemo, useState } from 'react';
 import { FiInbox } from 'react-icons/fi';
 import { IoFilterCircleOutline } from 'react-icons/io5';
 import type { KeyedMutator } from 'swr';
-import useSWRImmutable from 'swr/immutable';
 
 import charmClient from 'charmClient';
 import Avatar from 'components/common/Avatar';
@@ -23,10 +22,8 @@ import Link from 'components/common/Link';
 import LoadingComponent from 'components/common/LoadingComponent';
 import MultiTabs from 'components/common/MultiTabs';
 import { useNotifications } from 'components/nexus/hooks/useNotifications';
-import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useDateFormatter } from 'hooks/useDateFormatter';
 import { useSmallScreen } from 'hooks/useMediaScreens';
-import { useUser } from 'hooks/useUser';
 import { getNotificationMetadata } from 'lib/notifications/getNotificationMetadata';
 import type { Notification } from 'lib/notifications/interfaces';
 import type { MarkNotifications } from 'lib/notifications/markNotifications';

--- a/lib/notifications/getNotificationMetadata.tsx
+++ b/lib/notifications/getNotificationMetadata.tsx
@@ -236,9 +236,10 @@ export function getNotificationMetadata(notification: Notification): {
     }
 
     case 'document': {
+      const basePath = notification.pageType === 'post' ? '/forum/post' : '';
       return {
         content: getDocumentContent(notification as DocumentNotification),
-        href: `/${notification.pagePath}${getUrlSearchParamsFromNotificationType(notification)}`,
+        href: `${basePath}/${notification.pagePath}${getUrlSearchParamsFromNotificationType(notification)}`,
         pageTitle: notification.pageTitle
       };
     }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b066bb</samp>

Fixed a bug in the notification link for document posts and cleaned up some unused code. Modified the `href` value in `getNotificationMetadata.tsx` and removed unused imports from `NotificationsPopover.tsx`.

### WHY
<!-- author to complete -->
