### PR TITLE
fix appearance of share modal on mobile

### DIFF
--- a/components/common/PageLayout/components/Header/components/ShareButton/ShareButton.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/ShareButton.tsx
@@ -28,19 +28,11 @@ export function ShareButton({ headerHeight, pageId }: Props) {
             variant='text'
             size='small'
             {...bindTrigger(popupState)}
-            // onClick={() => {
-            //   popupState.open();
-            // }}
           >
             Share
           </Button>
         ) : (
-          <IconButton
-            data-test='toggle-page-permissions-dialog'
-            onClick={() => {
-              popupState.open();
-            }}
-          >
+          <IconButton data-test='toggle-page-permissions-dialog' {...bindTrigger(popupState)}>
             <IosShare color='secondary' fontSize='small' />
           </IconButton>
         )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a789f6</samp>

Refactored the `ShareButton` component to use `material-ui-popup-state` for opening the share menu. This reduces code complexity and improves user experience.

### WHY
share modal was appearing off the bottom of the screen. Fixed now:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/72a0c7e9-cd28-4abf-9b69-ef22edfff97b)