### PR TITLE
fix input being copied from title to doc body when using japanese cha…

### DIFF
--- a/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
@@ -77,7 +77,10 @@ export function PageTitleInput({ value, updatedAt: updatedAtExternal, onChange, 
     if (pressedEnter) {
       if (!pressedCtrl) {
         event.preventDefault();
-        insertAndFocusFirstLine(view);
+        // add a delay for Japanese keybaords, which for some reason copy the current text to the document
+        setTimeout(() => {
+          insertAndFocusFirstLine(view);
+        });
       } else {
         const inputElement = event.target as HTMLInputElement;
         updateTitle(`${inputElement.value}\n`);


### PR DESCRIPTION
…racters

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcea1fb</samp>

Fix a bug with Japanese keyboards on page title input. Add a delay for inserting and focusing the first line of the document in `PageTitleInput.tsx`.

### WHY
For some reason, when this input appears, if you hit "Enter" to move to the page body, it copies the last few characters to the doc as well. My guess is that the OS is doing something which does not finish before we move the cursor to the document:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/581f1c3d-5519-4ad3-9f85-3e99266dafed)

