### PR TITLE
standardize the sorting of board views / fix default board

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewTabs.tsx
@@ -199,7 +199,7 @@ function ViewTabs(props: ViewTabsProps) {
   const showViewsMenuState = bindMenu(hiddenViewsPopupState);
 
   const views = viewsProp.filter((view) => !view.fields.inline);
-  const viewIds = props.viewIds.length === views.length ? props.viewIds : views.map((view) => view.id);
+  const viewIds = views.map((view) => view.id);
   const viewsRecord = viewsProp.reduce((acc, view) => {
     acc[view.id] = view;
     return acc;
@@ -207,16 +207,16 @@ function ViewTabs(props: ViewTabsProps) {
 
   // Find the index of the current view
   const currentViewIndex = viewIds.findIndex((viewId) => viewId === activeView?.id);
-  const shownViewIds = viewIds.slice(0, maxTabsShown);
-  let restViewIds = viewIds.slice(maxTabsShown);
+  const shownViews = views.slice(0, maxTabsShown);
+  let restViews = views.slice(maxTabsShown);
 
   // If the current view index is more than what we can show in the screen
   if (currentViewIndex >= maxTabsShown) {
-    const replacedViewId = shownViewIds[maxTabsShown - 1];
+    const replacedView = shownViews[maxTabsShown - 1];
     // Replace the current view as the last view of the shown views
-    shownViewIds[maxTabsShown - 1] = viewIds[currentViewIndex];
-    restViewIds = restViewIds.filter((viewId) => viewId !== activeView?.id);
-    restViewIds.unshift(replacedViewId);
+    shownViews[maxTabsShown - 1] = views[currentViewIndex];
+    restViews = restViews.filter((view) => view.id !== activeView?.id);
+    restViews.unshift(replacedView);
   }
 
   const { register, handleSubmit, setValue } = useForm<{ title: string }>({
@@ -275,7 +275,7 @@ function ViewTabs(props: ViewTabsProps) {
     );
     closeViewMenu();
     handleClose();
-  }, [dropdownView, showView, viewIds]);
+  }, [dropdownView, showView, board.id, viewIds]);
 
   const handleDeleteView = useCallback(async () => {
     Utils.log('deleteView');
@@ -293,7 +293,7 @@ function ViewTabs(props: ViewTabsProps) {
     if (nextViewId) {
       showView(nextViewId);
     }
-  }, [viewIds, dropdownView, showView, board.id]);
+  }, [viewIds, dropdownView, showView, onDeleteView, board.id]);
 
   function resyncGoogleFormData() {
     if (dropdownView) {
@@ -352,32 +352,28 @@ function ViewTabs(props: ViewTabsProps) {
         value={false} // use false to disable the indicator
         sx={{ minHeight: 0, mb: '-5px' }}
       >
-        {shownViewIds
-          .map((viewId) => {
-            const view = viewsRecord[viewId];
-            if (view) {
-              return (
-                <ViewTab
-                  onClick={handleViewClick}
-                  onDrop={reorderViews}
-                  view={view}
-                  isActive={activeView?.id === view.id}
-                  key={view.id}
-                  href={activeView?.id === view.id ? undefined : getViewUrl(view.id)}
-                />
-              );
-            }
-            return null;
+        {shownViews
+          .map((view) => {
+            return (
+              <ViewTab
+                onClick={handleViewClick}
+                onDrop={reorderViews}
+                view={view}
+                isActive={activeView?.id === view.id}
+                key={view.id}
+                href={activeView?.id === view.id ? undefined : getViewUrl(view.id)}
+              />
+            );
           })
           .filter(isTruthy)}
-        {restViewIds.length !== 0 && (
+        {restViews.length !== 0 && (
           <TabButton
             disableRipple
             sx={{ p: 0 }}
             {...showViewsTriggerState}
             label={
               <StyledTabContent color='secondary' fontSize='small' fontWeight={500}>
-                <span>{restViewIds.length} more...</span>
+                <span>{restViews.length} more...</span>
               </StyledTabContent>
             }
           />

--- a/components/common/BoardEditor/focalboard/src/mutator.ts
+++ b/components/common/BoardEditor/focalboard/src/mutator.ts
@@ -783,7 +783,6 @@ export class Mutator {
     const droppedViewIndex = tempViewIds.indexOf(droppedView.id);
     const dropzoneViewIndex = tempViewIds.indexOf(dropzoneView.id);
     tempViewIds.splice(dropzoneViewIndex, 0, tempViewIds.splice(droppedViewIndex, 1)[0]);
-
     await undoManager.perform(
       async () => {
         await this.patchBlock(boardId, { updatedFields: { viewIds: tempViewIds } }, publishIncrementalUpdate);

--- a/components/common/BoardEditor/focalboard/src/store/views.ts
+++ b/components/common/BoardEditor/focalboard/src/store/views.ts
@@ -82,11 +82,17 @@ export const { updateViews, setCurrent, updateView, addView, deleteViews } = vie
 export const { reducer } = viewsSlice;
 
 export const getViews = (state: RootState): { [key: string]: BoardView } => state.views.views;
-export const getSortedViews = createSelector(getViews, (views) => {
-  return Object.values(views)
-    .sort((a, b) => a.title.localeCompare(b.title))
-    .map((v) => createBoardView(v));
-});
+export const getSortedViews = (boardId: string) =>
+  createSelector(
+    (state: RootState) => state.boards.boards[boardId],
+    getViews,
+    (board, views) => {
+      const viewIds = board?.fields.viewIds ? board?.fields.viewIds : Object.keys(views);
+      return Object.values(views)
+        .sort((a, b) => (viewIds.indexOf(a.id) > viewIds.indexOf(b.id) ? 1 : -1))
+        .map((v) => createBoardView(v));
+    }
+  );
 
 export function getView(viewId: string | undefined): (state: RootState) => BoardView | null {
   return (state: RootState): BoardView | null => {
@@ -101,17 +107,16 @@ export function getLoadedBoardViews(): (state: RootState) => Record<string, bool
 }
 
 export const getCurrentBoardViews = createSelector(
-  (state: RootState) => state.boards.current,
+  (state: RootState) => state.boards.boards[state.boards.current],
   getViews,
   (
-    boardId: string,
-    views: {
-      [key: string]: BoardView;
-    }
+    board, // types are wrong: board is undefined by default
+    views
   ) => {
+    const viewIds = board?.fields.viewIds ? board?.fields.viewIds : Object.keys(views);
     return Object.values(views)
-      .filter((v) => v.parentId === boardId)
-      .sort((a, b) => a.title.localeCompare(b.title))
+      .filter((v) => v.parentId === board?.id)
+      .sort((a, b) => (viewIds.indexOf(a.id) > viewIds.indexOf(b.id) ? 1 : -1))
       .map((v) => createBoardView(v));
   }
 );

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -87,7 +87,7 @@ interface DatabaseViewProps extends CharmNodeViewProps {
 
 export function InlineDatabase({ containerWidth, readOnly: readOnlyOverride, node }: DatabaseViewProps) {
   const pageId = node.attrs.pageId as string;
-  const allViews = useAppSelector(getSortedViews);
+  const allViews = useAppSelector(getSortedViews(pageId));
   const router = useRouter();
   const dispatch = useAppDispatch();
 

--- a/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
@@ -151,12 +151,12 @@ function DraggableTreeNode({
         addPage({ ...page, parentId: item.id });
       }
     },
-    [addPage]
+    [item.id, addPage]
   );
 
   const { focalboardViewsRecord, setFocalboardViewsRecord } = useFocalboardViews();
 
-  const allViews = useAppSelector(getSortedViews);
+  const allViews = useAppSelector(getSortedViews(item.id));
   const views = allViews.filter((view) => view.parentId === item.id);
 
   const hasSelectedChildView = views.some((view) => view.id === selectedNodeId);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af0c0b4</samp>

This pull request refactors and improves the view selectors and components in the BoardEditor and CharmEditor modules. It makes the selectors more specific and consistent with the board and page contexts, and adds missing dependencies to the useEffect hooks. It also fixes some minor formatting issues in `mutator.ts`.

### WHY
The order of views in the sidebar is just alphabetical, it ignores how a user has organized the tabs. Also, when we select a default view, we are not respecting the order of views.
