### PR TITLE
Add depcruiser rule to protect against test code imports inside production code

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -44,6 +44,18 @@ module.exports = {
         path: '^components'
       }
     },
+    {
+      name: 'no-test-imports',
+      comment:
+        'This module imports a test utility file. Test utilities cannot be used in production',
+      severity: 'error',
+      from: {
+        pathNot: "^.*(\\.spec\\.ts|\\.spec\\.tsx|__e2e__|__integration-tests__|testing|testUtils).*$"
+      },
+      to: {
+        path: 'testing/|__e2e__/'
+      }
+    },
     /* rules from the 'recommended' preset: */
     // {
     //   name: 'no-orphans',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "NODE_OPTIONS=\"--max_old_space_size=4096\" npx next build",
     "build:win": "npx next build",
     "build:analyze": "cross-env ANALYZE=true next build",
-    "verifydeps": "npx depcruise --ts-config ./tsconfig.json --config -- ./",
+    "verifydeps": "npx depcruise --ts-config ./tsconfig.json --config .dependency-cruiser.js -- ./",
     "deploy:staging": "npx cdk deploy \"stg-charmverse-${STAGE}\" --outputs-file cdk.out.json",
     "postdeploy:staging": "node --eval \"console.log('env_url=' + require('./cdk.out.json')['stg-charmverse-${STAGE}'].DeploymentUrl)\"  >> $GITHUB_OUTPUT",
     "destroy:staging": "npx cdk destroy \"stg-charmverse-${STAGE}\" --force",


### PR DESCRIPTION
…

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9999ef2</samp>

This pull request adds a new dependency-cruiser rule to prevent importing test utilities in production code and updates the `verifydeps` script to use the custom configuration file. This improves the separation and security of test and production code.

### WHY
CI Protection layer to avoid code imports causing production issues