### PR TITLE
fix offset alert when horizontally scrolling page

### DIFF
--- a/components/[pageId]/DocumentPage/components/AlertContainer.tsx
+++ b/components/[pageId]/DocumentPage/components/AlertContainer.tsx
@@ -6,6 +6,7 @@ export const AlertContainer = styled.div<{ showPageActionSidebar: boolean }>(
   ${theme.breakpoints.up('lg')} {
     width: ${showPageActionSidebar ? 'calc(100% - 430px)' : '100%'};
     position: sticky;
+    left: 0;
     top: 0;
     z-index: var(--z-index-pageBar);
   }


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
When the page scrolls to the side, the banner falls off
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/cd4eff34-a848-411c-9acf-4c2d9e2280df)
