### PR TITLE
Height of the scrollable container should be 100%

### DIFF
--- a/components/[pageId]/EditorPage/EditorPage.tsx
+++ b/components/[pageId]/EditorPage/EditorPage.tsx
@@ -121,7 +121,7 @@ export function EditorPage({ pageId: pageIdOrPath }: { pageId: string }) {
     } else {
       // Document page is used in a few places, so it is responsible for retrieving its own permissions
       return (
-        <Box sx={{ overflowY: 'auto' }}>
+        <Box height='100%' sx={{ overflowY: 'auto' }}>
           <DocumentPage page={page} refreshPage={refreshPage} readOnly={readOnly} savePage={savePage} />
         </Box>
       );


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eda6e4b</samp>

Fixed document content height bug in `EditorPage` component. Added `height` prop to `Box` component in `components/[pageId]/EditorPage/EditorPage.tsx`.

### WHY
One issue is that embedded dropdowns get cut off:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/9eef8ffc-75ba-47da-8ed3-f4eb228075c2)

