### PR TITLE
make regular roles readonly for non-admins

### DIFF
--- a/components/settings/roles/RoleSettings.tsx
+++ b/components/settings/roles/RoleSettings.tsx
@@ -124,7 +124,7 @@ export function RoleSettings({ space }: { space: Space }) {
           <Typography variant='caption'>Custom role permissions override Default.</Typography>
           {roles?.map((role) => (
             <RoleRow
-              readOnly={!isAdmin}
+              readOnly={!!role.source || !isAdmin}
               assignRoles={assignRoles}
               deleteRole={deleteRole}
               refreshRoles={refreshRoles}
@@ -134,12 +134,14 @@ export function RoleSettings({ space }: { space: Space }) {
           ))}
           {roles?.length === 0 && !isCreateFormVisible && !isFreeSpace && (
             <Box p={3} mt={2} sx={{ border: '1px solid var(--input-border)', textAlign: 'center' }}>
-              <Typography sx={{ mb: 2 }} variant='body2' color='secondary'>
+              <Typography variant='body2' color='secondary'>
                 No roles have been created yet.
               </Typography>
-              <Button onClick={showCreateRoleForm} disabled={isValidating} variant='outlined'>
-                Add a role
-              </Button>
+              {isAdmin && (
+                <Button sx={{ mt: 2 }} onClick={showCreateRoleForm} disabled={isValidating} variant='outlined'>
+                  Add a role
+                </Button>
+              )}
             </Box>
           )}
         </>

--- a/components/settings/roles/components/RoleRow.tsx
+++ b/components/settings/roles/components/RoleRow.tsx
@@ -62,7 +62,7 @@ export function RoleRow({ readOnly, role, assignRoles, deleteRole, refreshRoles 
     <RoleRowBase
       members={assignedMembers}
       eligibleMembers={eligibleMembers}
-      readOnlyMembers={!!role.source}
+      readOnlyMembers={readOnly}
       memberRoleId={role.id}
       title={role.name}
       description={description}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 49d6bbe</samp>

This pull request improves the role management feature in `components/settings/roles` by enforcing admin permissions and preventing changes to predefined roles. It also simplifies the `RoleRow` component by passing a `readOnly` prop from the parent component.

### WHY
https://app.charmverse.io/charmverse/role-remove-icon-shown-in-non-admin-mode-7234944164142691
