### PR TITLE
remove logic about readonly source data that is no longer used

### DIFF
--- a/components/[pageId]/DatabasePage/DatabasePage.tsx
+++ b/components/[pageId]/DatabasePage/DatabasePage.tsx
@@ -50,8 +50,7 @@ export function DatabasePage({ page, setPage, readOnly = false, pagePermissions 
 
   const { setFocalboardViewsRecord } = useFocalboardViews();
   const readOnlyBoard = readOnly || !pagePermissions?.edit_content;
-  // TODO: remove this feature entirely after some time has passed and we are sure we dont need it. Disabled on April 4, 2023.
-  const readOnlySourceData = false; // activeView?.fields?.sourceType === 'google_form'; // blocks that are synced cannot be edited
+
   useEffect(() => {
     if (typeof router.query.cardId === 'string') {
       setShownCardId(router.query.cardId);
@@ -155,7 +154,6 @@ export function DatabasePage({ page, setPage, readOnly = false, pagePermissions 
           <CenterPanel
             currentRootPageId={page.id}
             readOnly={Boolean(readOnlyBoard)}
-            readOnlySourceData={readOnlySourceData}
             board={board}
             setPage={setPage}
             pageIcon={page.icon}

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.spec.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.spec.tsx
@@ -93,7 +93,6 @@ describe('components/centerPanel', () => {
         <ReduxProvider store={store}>
           <CenterPanel
             currentRootPageId={board.id}
-            readOnlySourceData={false}
             showView={jest.fn()}
             setPage={() => {}}
             views={[activeView]}
@@ -114,7 +113,6 @@ describe('components/centerPanel', () => {
         <ReduxProvider store={store}>
           <CenterPanel
             currentRootPageId={board.id}
-            readOnlySourceData={false}
             showView={jest.fn()}
             setPage={() => {}}
             views={[activeView]}
@@ -135,7 +133,6 @@ describe('components/centerPanel', () => {
         <ReduxProvider store={store}>
           <CenterPanel
             currentRootPageId={board.id}
-            readOnlySourceData={false}
             showView={jest.fn()}
             setPage={() => {}}
             views={[activeView]}
@@ -160,7 +157,6 @@ describe('components/centerPanel', () => {
             <ReduxProvider store={store}>
               <CenterPanel
                 currentRootPageId={board.id}
-                readOnlySourceData={false}
                 showView={jest.fn()}
                 setPage={() => {}}
                 views={[activeView]}

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -67,7 +67,6 @@ type Props = WrappedComponentProps &
     views: BoardView[];
     hideBanner?: boolean;
     readOnly: boolean;
-    readOnlySourceData: boolean;
     addCard: (card: Card) => void;
     pageIcon?: string | null;
     setPage: (p: Partial<Page>) => void;
@@ -173,7 +172,7 @@ function CenterPanel(props: Props) {
 
   const backgroundRef = React.createRef<HTMLDivElement>();
   const keydownHandler = (keyName: string, e: KeyboardEvent) => {
-    if (e.target !== document.body || props.readOnly || props.readOnlySourceData) {
+    if (e.target !== document.body || props.readOnly) {
       return;
     }
 
@@ -504,7 +503,6 @@ function CenterPanel(props: Props) {
               addCardTemplate={() => addCard('', true, {}, false, true)}
               editCardTemplate={editCardTemplate}
               readOnly={props.readOnly}
-              readOnlySourceData={props.readOnlySourceData}
               embeddedBoardPath={props.embeddedBoardPath}
             />
           )}
@@ -574,7 +572,7 @@ function CenterPanel(props: Props) {
                   visibleGroups={visibleGroups}
                   hiddenGroups={hiddenGroups}
                   selectedCardIds={state.selectedCardIds}
-                  readOnly={props.readOnly || props.readOnlySourceData}
+                  readOnly={props.readOnly}
                   onCardClicked={cardClicked}
                   addCard={addCard}
                   showCard={showCard}
@@ -592,7 +590,6 @@ function CenterPanel(props: Props) {
                   visibleGroups={visibleGroups}
                   selectedCardIds={state.selectedCardIds}
                   readOnly={props.readOnly}
-                  readOnlySourceData={props.readOnlySourceData}
                   cardIdToFocusOnRender={state.cardIdToFocusOnRender}
                   showCard={showCard}
                   addCard={addCard}
@@ -606,7 +603,7 @@ function CenterPanel(props: Props) {
                   board={activeBoard}
                   cards={cards}
                   activeView={activeView}
-                  readOnly={props.readOnly || props.readOnlySourceData}
+                  readOnly={props.readOnly}
                   dateDisplayProperty={dateDisplayProperty}
                   showCard={showCard}
                   addCard={(properties: Record<string, string>) => {
@@ -620,7 +617,7 @@ function CenterPanel(props: Props) {
                   board={activeBoard}
                   cards={cards}
                   activeView={activeView}
-                  readOnly={props.readOnly || props.readOnlySourceData}
+                  readOnly={props.readOnly}
                   onCardClicked={cardClicked}
                   selectedCardIds={state.selectedCardIds}
                   addCard={(show) => addCard('', show)}

--- a/components/common/BoardEditor/focalboard/src/components/table/table.spec.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/table.spec.tsx
@@ -79,7 +79,6 @@ describe('components/table/Table', () => {
       <ReduxProvider store={store}>
         <Table
           cardPages={[]}
-          readOnlySourceData={false}
           board={board}
           activeView={view}
           visibleGroups={[]}
@@ -108,7 +107,6 @@ describe('components/table/Table', () => {
       <ReduxProvider store={store}>
         <Table
           cardPages={[]}
-          readOnlySourceData={false}
           board={board}
           activeView={view}
           visibleGroups={[]}
@@ -138,7 +136,6 @@ describe('components/table/Table', () => {
       <ReduxProvider store={store}>
         <Table
           cardPages={[]}
-          readOnlySourceData={false}
           board={board}
           activeView={{ ...view, fields: { ...view.fields, groupById: 'property1' } } as BoardView}
           visibleGroups={[{ option: { id: '', value: 'test', color: '' }, cardPages: [], cards: [] }]}
@@ -245,7 +242,6 @@ describe('components/table/Table extended', () => {
               }) as PageMeta
             }
           ]}
-          readOnlySourceData={false}
           board={board}
           activeView={view}
           visibleGroups={[]}
@@ -346,7 +342,6 @@ describe('components/table/Table extended', () => {
               }) as PageMeta
             }
           ]}
-          readOnlySourceData={false}
           board={board}
           activeView={view}
           visibleGroups={[]}
@@ -425,7 +420,6 @@ describe('components/table/Table extended', () => {
               }) as PageMeta
             }
           ]}
-          readOnlySourceData={false}
           board={board}
           activeView={view}
           visibleGroups={[]}
@@ -531,7 +525,6 @@ describe('components/table/Table extended', () => {
               }) as PageMeta
             }
           ]}
-          readOnlySourceData={false}
           board={board}
           activeView={view}
           visibleGroups={[]}

--- a/components/common/BoardEditor/focalboard/src/components/table/table.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/table.tsx
@@ -29,7 +29,6 @@ type Props = {
   visibleGroups: BoardGroup[];
   groupByProperty?: IPropertyTemplate;
   readOnly: boolean;
-  readOnlySourceData: boolean;
   cardIdToFocusOnRender: string;
   showCard: (cardId: string | null, parentId?: string) => void;
   addCard: (groupByOptionId?: string) => Promise<void>;
@@ -229,7 +228,6 @@ function Table(props: Props): JSX.Element {
           resizingColumn={resizingColumn}
           columnRefs={columnRefs}
           readOnly={props.readOnly}
-          readOnlySourceData={props.readOnlySourceData}
         />
 
         {/* Table rows */}
@@ -243,7 +241,7 @@ function Table(props: Props): JSX.Element {
                   activeView={activeView}
                   groupByProperty={groupByProperty}
                   group={group}
-                  readOnly={props.readOnly || props.readOnlySourceData}
+                  readOnly={props.readOnly}
                   columnRefs={columnRefs}
                   selectedCardIds={props.selectedCardIds}
                   cardIdToFocusOnRender={props.cardIdToFocusOnRender}
@@ -269,7 +267,7 @@ function Table(props: Props): JSX.Element {
               columnRefs={columnRefs}
               cardPages={cardPages}
               selectedCardIds={props.selectedCardIds}
-              readOnly={props.readOnly || props.readOnlySourceData}
+              readOnly={props.readOnly}
               cardIdToFocusOnRender={props.cardIdToFocusOnRender}
               offset={offset}
               resizingColumn={resizingColumn}
@@ -286,25 +284,22 @@ function Table(props: Props): JSX.Element {
 
         {/* Add New row */}
         <div className='octo-table-footer'>
-          {!props.readOnly &&
-            !props.readOnlySourceData &&
-            !activeView.fields.groupById &&
-            !props.disableAddingCards && (
-              <div
-                data-test='table-add-card'
-                className='octo-table-cell'
-                onClick={() => {
-                  props.addCard('');
-                }}
-              >
-                <Box display='flex' gap={1} alignItems='center'>
-                  <Add fontSize='small' />
-                  <Typography fontSize='small' id='TableComponent.plus-new'>
-                    New
-                  </Typography>
-                </Box>
-              </div>
-            )}
+          {!props.readOnly && !activeView.fields.groupById && !props.disableAddingCards && (
+            <div
+              data-test='table-add-card'
+              className='octo-table-cell'
+              onClick={() => {
+                props.addCard('');
+              }}
+            >
+              <Box display='flex' gap={1} alignItems='center'>
+                <Add fontSize='small' />
+                <Typography fontSize='small' id='TableComponent.plus-new'>
+                  New
+                </Typography>
+              </Box>
+            </div>
+          )}
         </div>
 
         <CalculationRow
@@ -313,7 +308,7 @@ function Table(props: Props): JSX.Element {
           activeView={activeView}
           resizingColumn={resizingColumn}
           offset={offset}
-          readOnly={props.readOnly || props.readOnlySourceData}
+          readOnly={props.readOnly}
         />
       </div>
     </div>

--- a/components/common/BoardEditor/focalboard/src/components/table/tableHeader.spec.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableHeader.spec.tsx
@@ -18,7 +18,6 @@ describe('components/table/TableHeaderMenu', () => {
     const onAutoSizeColumn = jest.fn();
     const component = wrapDNDIntl(
       <TableHeader
-        readOnlySourceData={false}
         readOnly={false}
         sorted='none'
         name='my Name'

--- a/components/common/BoardEditor/focalboard/src/components/table/tableHeader.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableHeader.tsx
@@ -50,7 +50,6 @@ import HorizontalGrip from './horizontalGrip';
 
 type Props = {
   readOnly: boolean;
-  readOnlySourceData: boolean;
   sorted: 'up' | 'down' | 'none';
   name: string;
   board: Board;
@@ -75,7 +74,7 @@ const DEFAULT_BLOCK_IDS = [
 ];
 
 function TableHeader(props: Props): JSX.Element {
-  const { activeView, board, views, cards, sorted, name, type, template, readOnly, readOnlySourceData } = props;
+  const { activeView, board, views, cards, sorted, name, type, template, readOnly } = props;
   const { id: templateId } = template;
   const [isDragging, isOver, columnRef] = useSortable('column', props.template, !readOnly, props.onDrop);
   const columnWidth = (_templateId: string): number => {
@@ -332,7 +331,7 @@ function TableHeader(props: Props): JSX.Element {
       ref={columnRef}
     >
       <Stack width='100%' justifyContent='center'>
-        {readOnly || readOnlySourceData ? (
+        {readOnly ? (
           label
         ) : (
           <div ref={toggleRef}>

--- a/components/common/BoardEditor/focalboard/src/components/table/tableHeaders.spec.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableHeaders.spec.tsx
@@ -15,7 +15,6 @@ describe('components/table/TableHeaders', () => {
   test('should match snapshot', async () => {
     const component = wrapDNDIntl(
       <TableHeaders
-        readOnlySourceData={false}
         board={board}
         cards={[card]}
         activeView={view}

--- a/components/common/BoardEditor/focalboard/src/components/table/tableHeaders.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/table/tableHeaders.tsx
@@ -30,7 +30,6 @@ type Props = {
   activeView: BoardView;
   views: BoardView[];
   readOnly: boolean;
-  readOnlySourceData: boolean;
   resizingColumn: string;
   offset: number;
   columnRefs: Map<string, React.RefObject<HTMLDivElement>>;
@@ -194,7 +193,6 @@ function TableHeaders(props: Props): JSX.Element {
             name={template.name}
             sorted={sorted}
             readOnly={props.readOnly}
-            readOnlySourceData={props.readOnlySourceData}
             board={board}
             activeView={activeView}
             cards={cards}
@@ -209,7 +207,7 @@ function TableHeaders(props: Props): JSX.Element {
       })}
       {/* empty column for actions */}
       <div className='octo-table-cell header-cell' style={{ flexGrow: 1, borderRight: '0 none' }}>
-        {!props.readOnly && !props.readOnlySourceData && (
+        {!props.readOnly && (
           <>
             <Button {...bindTrigger(addPropertyPopupState)}>
               <AddIcon data-test='add-table-prop' fontSize='small' />

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.spec.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.spec.tsx
@@ -48,7 +48,6 @@ describe('components/viewHeader/viewHeader', () => {
         <ReduxProvider store={store}>
           <ViewHeader
             currentRootPageId={card.id}
-            readOnlySourceData={false}
             showCard={jest.fn()}
             showView={jest.fn()}
             toggleViewOptions={jest.fn()}
@@ -73,7 +72,6 @@ describe('components/viewHeader/viewHeader', () => {
           <ViewHeader
             viewsBoard={board}
             currentRootPageId={card.id}
-            readOnlySourceData={false}
             showCard={jest.fn()}
             showView={jest.fn()}
             toggleViewOptions={jest.fn()}

--- a/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewHeader/viewHeader.tsx
@@ -44,7 +44,6 @@ type Props = {
   addCardTemplate: () => void;
   editCardTemplate: (cardTemplateId: string) => void;
   readOnly: boolean;
-  readOnlySourceData: boolean;
   dateDisplayProperty?: IPropertyTemplate;
   disableUpdatingUrl?: boolean;
   maxTabsShown?: number;
@@ -222,7 +221,7 @@ function ViewHeader(props: Props) {
 
             {/* New card button */}
 
-            {!props.readOnlySourceData && activeBoard?.fields.sourceType !== 'proposals' && (
+            {activeBoard?.fields.sourceType !== 'proposals' && (
               <NewCardButton
                 addCard={props.addCard}
                 addCardFromTemplate={addPageFromTemplate}

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -128,7 +128,6 @@ export function InlineDatabase({ containerWidth, readOnly: readOnlyOverride, nod
   const readOnly =
     typeof readOnlyOverride === 'undefined' ? currentPagePermissions?.edit_content !== true : readOnlyOverride;
 
-  const readOnlySourceData = currentView?.fields?.sourceType === 'google_form'; // blocks that are synced cannot be edited
   const deleteView = useCallback(
     (viewId: string) => {
       setCurrentViewId(views.filter((view) => view.id !== viewId)?.[0]?.id ?? null);
@@ -156,7 +155,6 @@ export function InlineDatabase({ containerWidth, readOnly: readOnlyOverride, nod
           onDeleteView={deleteView}
           hideBanner
           readOnly={readOnly}
-          readOnlySourceData={readOnlySourceData}
           board={board}
           embeddedBoardPath={boardPage.path}
           setPage={debouncedPageUpdate}

--- a/components/proposals/ProposalsPage.tsx
+++ b/components/proposals/ProposalsPage.tsx
@@ -187,7 +187,6 @@ export function ProposalsPage({ title }: { title: string }) {
                       visibleGroups={[]}
                       selectedCardIds={[]}
                       readOnly={!isAdmin}
-                      readOnlySourceData={false}
                       disableAddingCards={true}
                       showCard={openPage}
                       readOnlyTitle={true}

--- a/components/rewards/RewardsPage.tsx
+++ b/components/rewards/RewardsPage.tsx
@@ -207,7 +207,6 @@ export function RewardsPage({ title }: { title: string }) {
                       visibleGroups={[]}
                       selectedCardIds={[]}
                       readOnly
-                      readOnlySourceData={false}
                       disableAddingCards={true}
                       showCard={showRewardOrApplication}
                       readOnlyTitle={true}

--- a/stories/Databases/TableProperties.stories.tsx
+++ b/stories/Databases/TableProperties.stories.tsx
@@ -170,7 +170,6 @@ export function DatabaseTableView() {
             board={board}
             showCard={voidFunction}
             readOnly={false}
-            readOnlySourceData={false}
             views={[view]}
             activeView={view}
             addCard={voidFunction}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de19589</samp>

This pull request removes the `readOnlySourceData` prop and its related logic from various components in the `components` and `stories` directories. The purpose of this change is to eliminate the unused functionality of syncing data from Google Forms and simplify the code. This prop was related to the deprecated `sourceType` feature of the views, which was no longer needed.

### WHY
left a note to myself in April to delete this. I note we were still setting it in the inline database but that seems like a bug
