### PR TITLE
pass in updated information when publishing a draft

### DIFF
--- a/components/forum/components/PostPage/PostPage.tsx
+++ b/components/forum/components/PostPage/PostPage.tsx
@@ -176,7 +176,12 @@ export function PostPage({
   async function publishDraftPost(draftPost: Post) {
     if (!isPublishingDraftPost) {
       setIsPublishingDraftPost(true);
+      // pass in latest content as well
       await charmClient.forum.updateForumPost(draftPost.id, {
+        categoryId,
+        content: formInputs.content,
+        contentText: formInputs.contentText,
+        title: formInputs.title,
         isDraft: false
       });
       setIsPublishingDraftPost(false);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e8b21b</samp>

Fixed a bug where published posts would not show the latest content. Updated `publishDraftPost` function in `PostPage.tsx` to pass in the latest draft post data.

### WHY
If a user doesn't click "update draft" before publishing, their changes don't get pulled in.
