### PR TITLE
improve page search for charmeditor component

### DIFF
--- a/components/common/CharmEditor/components/PageList.tsx
+++ b/components/common/CharmEditor/components/PageList.tsx
@@ -1,26 +1,21 @@
-import type { PageMeta } from '@charmverse/core/pages';
-import type { PostCategoryWithPermissions } from '@charmverse/core/permissions';
 import type { Page } from '@charmverse/core/prisma';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
-import { useMemo } from 'react';
 
 import { PageIcon } from 'components/common/PageLayout/components/PageIcon';
 import PageTitle from 'components/common/PageLayout/components/PageTitle';
-import type { StaticPage, StaticPagesType } from 'components/common/PageLayout/components/Sidebar/utils/staticPages';
+import type { StaticPagesType } from 'components/common/PageLayout/components/Sidebar/utils/staticPages';
 
-export type AllPagesProp = Pick<Page, 'id' | 'title' | 'path' | 'hasContent' | 'icon'> & {
+export type PageListItem = Pick<Page, 'id' | 'title' | 'path' | 'hasContent' | 'icon'> & {
   type: Page['type'] | StaticPagesType | 'forum_category';
 };
 
 interface Props {
   activeItemIndex?: number;
   activePageId?: string;
-  pages: PageMeta[];
-  staticPages?: StaticPage[];
-  forumCategories?: PostCategoryWithPermissions[];
-  onSelectPage: (pageId: string, type: AllPagesProp['type'], path: string) => void;
+  pages: PageListItem[];
+  onSelectPage: (pageId: string, type: PageListItem['type'], path: string) => void;
   emptyText?: string;
   style?: React.CSSProperties;
 }
@@ -30,47 +25,13 @@ export default function PagesList({
   activeItemIndex = -1,
   activePageId,
   pages,
-  staticPages,
-  forumCategories,
   onSelectPage,
   style
 }: Props) {
   function isActive(pageId: string, index: number) {
     return pageId === activePageId || index === activeItemIndex;
   }
-
-  const allPages = useMemo(() => {
-    const memoPage: AllPagesProp[] = pages.map((page) => ({
-      id: page.id,
-      path: page.path,
-      hasContent: page.hasContent,
-      title: page.title,
-      type: page.type,
-      icon: page.icon
-    }));
-
-    const memoForumCategories: AllPagesProp[] = (forumCategories || []).map((page) => ({
-      id: page.id,
-      path: page.path || '',
-      hasContent: true,
-      title: `Forum > ${page.name}`,
-      type: 'forum_category',
-      icon: null
-    }));
-
-    const memoStaticPage: AllPagesProp[] = (staticPages || []).map((page) => ({
-      id: page.path,
-      path: page.path,
-      hasContent: true,
-      title: page.title,
-      type: page.path,
-      icon: null
-    }));
-
-    return memoStaticPage.concat(memoPage).concat(memoForumCategories);
-  }, [pages, staticPages, forumCategories]);
-
-  if (allPages.length === 0) {
+  if (pages.length === 0) {
     return (
       <Typography
         style={{
@@ -87,7 +48,7 @@ export default function PagesList({
 
   return (
     <div style={style}>
-      {allPages.map((page, pageIndex) => (
+      {pages.map((page, pageIndex) => (
         <MenuItem
           data-test={`page-option-${page.id}`}
           data-value={page.id}

--- a/components/common/PageLayout/components/PageIcon.tsx
+++ b/components/common/PageLayout/components/PageIcon.tsx
@@ -11,7 +11,7 @@ import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { Box } from '@mui/material';
 import type { ComponentProps, ReactNode } from 'react';
 
-import type { AllPagesProp } from 'components/common/CharmEditor/components/PageList';
+import type { PageListItem } from 'components/common/CharmEditor/components/PageList';
 import EmojiIcon from 'components/common/Emoji';
 import { greyColor2 } from 'theme/colors';
 
@@ -60,7 +60,7 @@ export function LinkedIcon({ children }: { children: ReactNode }) {
 
 type PageIconProps = Omit<ComponentProps<typeof StyledPageIcon>, 'icon'> & {
   icon?: ReactNode | null | 'application';
-  pageType?: AllPagesProp['type'];
+  pageType?: PageListItem['type'];
   isEditorEmpty?: boolean;
   isLinkedPage?: boolean;
 };

--- a/lib/utilities/__tests__/strings.spec.ts
+++ b/lib/utilities/__tests__/strings.spec.ts
@@ -1,4 +1,4 @@
-import { conditionalPlural, sanitizeForRegex, isUrl, isValidEmail } from '../strings';
+import { conditionalPlural, sanitizeForRegex, isUrl, isValidEmail, stringSimilarity } from '../strings';
 
 describe('strings', () => {
   it('should sanitize parenthesis in a regex', () => {
@@ -61,5 +61,18 @@ describe('isValidEmail', () => {
   it('should return false for an invalid email', () => {
     expect(isValidEmail('hello')).toBe(false);
     expect(isValidEmail('charmverse.io')).toBe(false);
+  });
+});
+
+describe('stringSimilarity()', () => {
+  it('should return 1 for identical strings', () => {
+    expect(stringSimilarity('hello', 'hello')).toBe(1);
+  });
+  it('should return 0 for completely different strings', () => {
+    expect(stringSimilarity('hello', 'world')).toBe(0);
+  });
+  it('should return a value between 0 and 1 for similar strings', () => {
+    expect(stringSimilarity('hello', 'hell')).toBeGreaterThan(0);
+    expect(stringSimilarity('hello', 'hell')).toBeLessThan(1);
   });
 });

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -194,3 +194,36 @@ const emailRegexp =
 export function isValidEmail(email: string) {
   return !!email && !!email.match(emailRegexp);
 }
+
+// from https://stackoverflow.com/questions/23305000/javascript-fuzzy-search-that-makes-sense
+// https://gist.github.com/mavaddat/a522c2ed59162d6330569999cab03d76
+export function stringSimilarity(str1?: string, str2?: string, gramSize: number = 2) {
+  function getNGrams(s: string, len: number) {
+    s = ' '.repeat(len - 1) + s.toLowerCase() + ' '.repeat(len - 1);
+    const v = new Array(s.length - len + 1);
+    for (let i = 0; i < v.length; i++) {
+      v[i] = s.slice(i, i + len);
+    }
+    return v;
+  }
+
+  if (!str1?.length || !str2?.length) {
+    return 0.0;
+  }
+
+  const s1 = str1.length < str2.length ? str1 : str2;
+  const s2 = str1.length < str2.length ? str2 : str1;
+
+  const pairs1 = getNGrams(s1, gramSize);
+  const pairs2 = getNGrams(s2, gramSize);
+  const set = new Set<string>(pairs1);
+
+  const total = pairs2.length;
+  let hits = 0;
+  for (const item of pairs2) {
+    if (set.delete(item)) {
+      hits += 1;
+    }
+  }
+  return hits / total;
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c37b74d</samp>

This pull request adds a `stringSimilarity` function to the `lib/utilities/strings` module and uses it to improve the linked pages list component in the `CharmEditor`. The function compares two strings based on their n-gram content and returns a score between 0 and 1. The linked pages list component filters and sorts the pages based on the user input and the similarity score.

### WHY
Current search is very naive - the word you enter has to be the start of the page title. I found an interesting thread on SO with some ideas, my main criterion is just being able to type a word and have it search any word in the title.
https://stackoverflow.com/questions/23305000/javascript-fuzzy-search-that-makes-sense

Now that search is better, I removed the way we always kept static pages above categories, which are above user pages. The algorithm is loose enough that static pages were always getting in the way :P but i think when they show up it will be more relevant