### PR TITLE
Fix the layout of users and roles

### DIFF
--- a/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
+++ b/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
@@ -56,14 +56,14 @@ export const StyledUserPropertyContainer = styled(Box, {
   overflow: ${(props) => (props.displayType === 'table' ? 'hidden' : 'initial')};
 `;
 
-function SelectedReviewers({
+function SelectedOptions({
   value,
   readOnly,
   readOnlyMessage,
   onRemove,
   wrapColumn
 }: {
-  wrapColumn: boolean;
+  wrapColumn?: boolean;
   readOnly: boolean;
   readOnlyMessage?: string;
   value: GroupedOptionPopulated[];
@@ -78,20 +78,20 @@ function SelectedReviewers({
         gap={1}
         flexWrap={wrapColumn ? 'wrap' : 'nowrap'}
       >
-        {value.map((reviewer) => {
+        {value.map((option) => {
           return (
             <Stack
               alignItems='center'
               flexDirection='row'
-              key={reviewer.id}
+              key={option.id}
               gap={0.5}
               sx={wrapColumn ? { justifyContent: 'space-between', overflowX: 'hidden' } : { overflowX: 'hidden' }}
             >
-              {reviewer.group === 'user' && (
+              {option.group === 'user' && (
                 <>
-                  <UserDisplay fontSize={14} avatarSize='xSmall' user={reviewer} wrapName={wrapColumn} />
+                  <UserDisplay fontSize={14} avatarSize='xSmall' user={option} wrapName={wrapColumn} />
                   {!readOnly && (
-                    <IconButton size='small' onClick={() => onRemove(reviewer.id)}>
+                    <IconButton size='small' onClick={() => onRemove(option.id)}>
                       <CloseIcon
                         sx={{
                           fontSize: 14
@@ -103,14 +103,14 @@ function SelectedReviewers({
                   )}
                 </>
               )}
-              {reviewer.group === 'role' && (
+              {option.group === 'role' && (
                 <Chip
                   sx={{ px: 0.5, cursor: readOnly ? 'text' : 'pointer' }}
-                  label={reviewer.name}
-                  // color={reviewer.color}
-                  key={reviewer.id}
+                  label={option.name}
+                  // color={option.color}
+                  key={option.id}
                   size='small'
-                  onDelete={readOnly ? undefined : () => onRemove(reviewer.id)}
+                  onDelete={readOnly ? undefined : () => onRemove(option.id)}
                   deleteIcon={
                     <CloseIcon
                       sx={{
@@ -128,6 +128,7 @@ function SelectedReviewers({
     </Tooltip>
   );
 }
+
 type Props = {
   displayType?: 'details';
   onChange: (value: GroupedOptionPopulated[]) => void;
@@ -152,7 +153,7 @@ export function UserAndRoleSelect({
   variant = 'standard',
   value: inputValue,
   'data-test': dataTest,
-  wrapColumn = true,
+  wrapColumn,
   type = 'roleAndUser'
 }: Props): JSX.Element | null {
   const [isOpen, setIsOpen] = useState(false);
@@ -259,7 +260,7 @@ export function UserAndRoleSelect({
           {applicableValues.length === 0 ? (
             showEmptyPlaceholder && <EmptyPlaceholder>Empty</EmptyPlaceholder>
           ) : (
-            <SelectedReviewers
+            <SelectedOptions
               readOnlyMessage={readOnlyMessage}
               wrapColumn={wrapColumn}
               readOnly
@@ -333,7 +334,7 @@ export function UserAndRoleSelect({
           );
         }}
         renderTags={() => (
-          <SelectedReviewers wrapColumn readOnly={!!readOnly} value={populatedValue} onRemove={removeReviewer} />
+          <SelectedOptions wrapColumn readOnly={!!readOnly} value={populatedValue} onRemove={removeReviewer} />
         )}
         value={populatedValue}
       />

--- a/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
+++ b/components/common/BoardEditor/components/properties/UserAndRoleSelect.tsx
@@ -334,7 +334,12 @@ export function UserAndRoleSelect({
           );
         }}
         renderTags={() => (
-          <SelectedOptions wrapColumn readOnly={!!readOnly} value={populatedValue} onRemove={removeReviewer} />
+          <SelectedOptions
+            wrapColumn={wrapColumn}
+            readOnly={!!readOnly}
+            value={populatedValue}
+            onRemove={removeReviewer}
+          />
         )}
         value={populatedValue}
       />

--- a/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/propertyValueElement.tsx
@@ -177,9 +177,7 @@ function PropertyValueElement(props: Props) {
       />
     );
   } else if (propertyTemplate.id === REWARD_REVIEWERS_BLOCK_ID) {
-    return (
-      <UserAndRoleSelect wrapColumn={false} readOnly={readOnly} onChange={() => null} value={propertyValue as any} />
-    );
+    return <UserAndRoleSelect readOnly={readOnly} onChange={() => null} value={propertyValue as any} />;
   } else if (
     propertyTemplate.type === 'select' ||
     propertyTemplate.type === 'multiSelect' ||


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99f58cf</samp>

Refactored a common component for selecting users and roles in the board editor. Extracted the logic for rendering the selected options into a separate component called `SelectedOptions`. Simplified the usage of the `UserAndRoleSelect` component by removing an unnecessary prop.

### WHY
<!-- author to complete -->
