### PR TITLE
allow guests to receive space events otherwise the UI is broken

### DIFF
--- a/hooks/useWebSocketClient.tsx
+++ b/hooks/useWebSocketClient.tsx
@@ -139,5 +139,5 @@ export const useWebSocketClient = () => useContext(WebSocketClientContext);
 
 export function emitSocketMessage<Data = any>(message: ClientMessage, cb?: (data: Data) => void) {
   // @ts-ignore cb can be passed
-  socket.emit('message', message, cb);
+  socket?.emit('message', message, cb);
 }

--- a/lib/websockets/broadcaster.ts
+++ b/lib/websockets/broadcaster.ts
@@ -98,9 +98,6 @@ export class WebsocketBroadcaster implements AbstractWebsocketBroadcaster {
     if (!spaceRole) {
       socket.send(new SpaceMembershipRequiredError(`User ${userId} does not have access to ${roomId}`));
       return;
-    } else if (spaceRole.isGuest && roomId === spaceRole.spaceId) {
-      socket.send(new SpaceMembershipRequiredError(`Guests cannot subscribe to room events ${roomId}`));
-      return;
     }
 
     Object.keys(socket.rooms).forEach((room) => {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "notifications:debug": "ts-node --transpileOnly ./scripts/readNotifications.ts",
     "server:dev": "npx react-env --path .env.local -- node node_modules/.bin/next start",
     "server:sockets": "cross-env REACT_APP_WEBSOCKETS_HOST=http://localhost:3002 npm start",
-    "start": "cross-env NODE_OPTIONS=\"--max_old_space_size=8192 --experimental-vm-modules\" next dev",
+    "start": "cross-env NODE_OPTIONS=\"--max_old_space_size=8192 --experimental-vm-modules\" npx react-env --path .env.local -- next dev",
     "start:debug": "cross-env NODE_OPTIONS='--inspect' next",
     "start:ssl": "(npx local-ssl-proxy --source 3000 --target 8080) & next dev --port 8080",
     "start:ssl:prod": "(npx local-ssl-proxy --source 3000 --target 8080) & next start --port 8080",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7bc9d99</samp>

This pull request improves the websocket client hook, fixes a bug with guest subscriptions, and enables dynamic environment configuration. It modifies the files `hooks/useWebSocketClient.tsx`, `lib/websockets/broadcaster.ts`, and `package.json`.

### WHY
A guest user is deleting pages and wondering why they don't disappear from the sidebar. It was because we disable all events from a space for them. But that is a bad idea since events are required for the app to work

This was removed in a PR last July: https://github.com/charmverse/app.charmverse.io/pull/2508. But I notice another change was to not subscribe them to new pages, and I left that logic in place