### PR TITLE
cache database state (fix for calendar views in inline databases)

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/calendar/fullCalendar.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/calendar/fullCalendar.tsx
@@ -81,17 +81,15 @@ function CalendarFullView(props: Props): JSX.Element | null {
 
   const { pages } = usePages();
 
-  const isEditable = useCallback((): boolean => {
-    if (
-      readOnly ||
-      !dateDisplayProperty ||
-      dateDisplayProperty.type === 'createdTime' ||
-      dateDisplayProperty.type === 'updatedTime'
-    ) {
-      return false;
-    }
-    return true;
-  }, [readOnly, dateDisplayProperty]);
+  let isEditable = true;
+  if (
+    readOnly ||
+    !dateDisplayProperty ||
+    dateDisplayProperty.type === 'createdTime' ||
+    dateDisplayProperty.type === 'updatedTime'
+  ) {
+    isEditable = false;
+  }
 
   const myEventsList = useMemo(
     () =>
@@ -267,8 +265,8 @@ function CalendarFullView(props: Props): JSX.Element | null {
         plugins={[dayGridPlugin, interactionPlugin]}
         initialView='dayGridMonth'
         events={myEventsList}
-        editable={isEditable()}
-        eventResizableFromStart={isEditable()}
+        editable={isEditable}
+        eventResizableFromStart={isEditable}
         headerToolbar={toolbar}
         buttonText={buttonText}
         eventClick={eventClick}

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -560,22 +560,20 @@ function CenterPanel(props: Props) {
                   </Typography>
                 )}
                 {/* Show page title for linked boards */}
-                {activePage &&
-                  activeView?.fields?.sourceType === 'board_page' &&
-                  boardPageType === 'inline_linked_board' && (
-                    <Button
-                      color='secondary'
-                      startIcon={<CallMadeIcon />}
-                      variant='text'
-                      size='large'
-                      href={`${router.pathname.startsWith('/share') ? '/share' : ''}/${space?.domain}/${
-                        activePage?.path
-                      }`}
-                      sx={{ fontSize: 22, fontWeight: 700, py: 0 }}
-                    >
-                      {activePage?.title || 'Untitled'}
-                    </Button>
-                  )}
+                {activePage && activeView?.fields?.linkedSourceId && boardPageType === 'inline_linked_board' && (
+                  <Button
+                    color='secondary'
+                    startIcon={<CallMadeIcon />}
+                    variant='text'
+                    size='large'
+                    href={`${router.pathname.startsWith('/share') ? '/share' : ''}/${space?.domain}/${
+                      activePage?.path
+                    }`}
+                    sx={{ fontSize: 22, fontWeight: 700, py: 0 }}
+                  >
+                    {activePage?.title || 'Untitled'}
+                  </Button>
+                )}
                 {activeBoard && activeView?.fields.viewType === 'board' && (
                   <Kanban
                     board={activeBoard}

--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions/useSourceOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSourceOptions/useSourceOptions.tsx
@@ -83,6 +83,7 @@ export function useSourceOptions({ rootBoard, showView, activeView }: Props) {
     constructedView.title = sourcePage.title ?? '';
     constructedView.fields.viewType = relatedSourceView?.fields.viewType ?? 'table';
     constructedView.fields.linkedSourceId = sourceDatabaseId;
+    constructedView.fields.sourceType = 'board_page';
     constructedView.fields.groupById = relatedSourceView?.fields.groupById;
     constructedView.fields.visibleOptionIds = relatedSourceView?.fields.visibleOptionIds ?? [];
     constructedView.fields.visiblePropertyIds = relatedSourceView?.fields.visiblePropertyIds ?? [];

--- a/components/common/BoardEditor/focalboard/src/store/boards.ts
+++ b/components/common/BoardEditor/focalboard/src/store/boards.ts
@@ -79,11 +79,15 @@ export const getSortedTemplates = createSelector(getTemplates, (templates) => {
   return Object.values(templates).sort((a, b) => a.title.localeCompare(b.title));
 });
 
-export function getBoard(boardId: string): (state: RootState) => Board | undefined {
-  return (state: RootState): Board | undefined => {
-    return state.boards.boards[boardId] || state.boards.templates[boardId] || undefined;
-  };
-}
+export const makeSelectBoard = () =>
+  createSelector(
+    getBoards,
+    getTemplates,
+    (state: RootState, boardId: string) => boardId,
+    (boards, templates, boardId: string) => {
+      return boards[boardId] || templates[boardId];
+    }
+  );
 
 export const getCurrentBoard = createSelector(
   (state: RootState) => state.boards.current,

--- a/components/common/BoardEditor/focalboard/src/store/cards.ts
+++ b/components/common/BoardEditor/focalboard/src/store/cards.ts
@@ -12,9 +12,7 @@ import type { PagesMap } from 'lib/pages';
 import { Constants } from '../constants';
 import { Utils } from '../utils';
 
-import { getBoard } from './boards';
 import { blockLoad, initialDatabaseLoad } from './databaseBlocksLoad';
-import { getView } from './views';
 
 import type { RootState } from './index';
 
@@ -121,11 +119,6 @@ export const getCurrentBoardCards = createSelector(
     return Object.values(cards).filter((c) => c.parentId === boardId) as Card[];
   }
 );
-
-export const getBoardCards = (boardId: string) =>
-  createSelector(getCards, (cards: { [key: string]: Card }) => {
-    return Object.values(cards).filter((c) => c.parentId === boardId) as Card[];
-  });
 
 export const getCurrentBoardTemplates = createSelector(
   (state: RootState) => state.boards.current,
@@ -327,13 +320,16 @@ function searchFilterCards(cards: Card[], board: Board, searchTextRaw: string): 
   });
 }
 
-export const getViewCardsSortedFilteredAndGrouped = (props: { viewId: string; boardId: string; pages: PagesMap }) =>
+type getViewCardsProps = { viewId: string; boardId: string; pages: PagesMap };
+
+export const makeSelectViewCardsSortedFilteredAndGrouped = () =>
   createSelector(
-    getBoardCards(props.boardId),
-    getBoard(props.boardId),
-    getView(props.viewId),
-    () => null,
-    (cards, board, view) => {
+    (state: RootState, props: getViewCardsProps) =>
+      Object.values(state.cards.cards).filter((c) => c.parentId === props.boardId) as Card[],
+    (state: RootState, props: getViewCardsProps) => state.boards.boards[props.boardId],
+    (state: RootState, props: getViewCardsProps) => state.views.views[props.viewId],
+    (state: RootState, props: getViewCardsProps) => props.pages,
+    (cards, board, view, pages) => {
       if (!view || !board || !cards) {
         return [];
       }
@@ -353,7 +349,7 @@ export const getViewCardsSortedFilteredAndGrouped = (props: { viewId: string; bo
               ...card.fields,
               properties: {
                 ...card.fields.properties,
-                [Constants.titleColumnId]: props.pages[card.id]?.title ?? ''
+                [Constants.titleColumnId]: pages[card.id]?.title ?? ''
               }
             }
           }))

--- a/components/common/BoardEditor/focalboard/src/store/views.ts
+++ b/components/common/BoardEditor/focalboard/src/store/views.ts
@@ -82,14 +82,16 @@ export const { updateViews, setCurrent, updateView, addView, deleteViews } = vie
 export const { reducer } = viewsSlice;
 
 export const getViews = (state: RootState): { [key: string]: BoardView } => state.views.views;
-export const getSortedViews = (boardId: string) =>
+
+// export a factory to be memoized, so multiple instances can be used at once
+export const makeSelectSortedViews = () =>
   createSelector(
-    (state: RootState) => state.boards.boards[boardId],
+    (state: RootState, boardId: string) => state.boards.boards[boardId],
     getViews,
     (board, views) => {
       const viewIds = board?.fields.viewIds ? board?.fields.viewIds : Object.keys(views);
       return Object.values(views)
-        .filter((v) => v.parentId === boardId)
+        .filter((v) => v.parentId === board?.id)
         .sort((a, b) => (viewIds.indexOf(a.id) > viewIds.indexOf(b.id) ? 1 : -1))
         .map((v) => createBoardView(v));
     }
@@ -100,6 +102,15 @@ export function getView(viewId: string | undefined): (state: RootState) => Board
     return viewId ? state.views.views[viewId] ?? null : null;
   };
 }
+
+export const makeSelectView = () =>
+  createSelector(
+    getViews,
+    (state: RootState, viewId: string) => viewId,
+    (views, viewId) => {
+      return views[viewId];
+    }
+  );
 
 export function getLoadedBoardViews(): (state: RootState) => Record<string, boolean> {
   return (state: RootState): Record<string, boolean> => {

--- a/components/common/BoardEditor/focalboard/src/widgets/icons/calendar.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/icons/calendar.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export default function CalendarIcon({ fontSize }: { fontSize?: 'small' }): JSX.Element {
   const size = fontSize === 'small' ? 20 : 24;
   return (

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -9,7 +9,7 @@ import CardDialog from 'components/common/BoardEditor/focalboard/src/components/
 import { getBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import { initialDatabaseLoad } from 'components/common/BoardEditor/focalboard/src/store/databaseBlocksLoad';
 import { useAppDispatch, useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
-import { getSortedViews, getView } from 'components/common/BoardEditor/focalboard/src/store/views';
+import { makeSelectSortedViews, makeSelectView } from 'components/common/BoardEditor/focalboard/src/store/views';
 import FocalBoardPortal from 'components/common/BoardEditor/FocalBoardPortal';
 import { usePage } from 'hooks/usePage';
 import { usePagePermissions } from 'hooks/usePagePermissions';
@@ -87,7 +87,8 @@ interface DatabaseViewProps extends CharmNodeViewProps {
 
 export function InlineDatabase({ containerWidth, readOnly: readOnlyOverride, node }: DatabaseViewProps) {
   const pageId = node.attrs.pageId as string;
-  const views = useAppSelector(getSortedViews(pageId));
+  const selectSortedViews = useMemo(makeSelectSortedViews, []);
+  const views = useAppSelector((state) => selectSortedViews(state, pageId));
   const router = useRouter();
   const dispatch = useAppDispatch();
 
@@ -99,9 +100,9 @@ export function InlineDatabase({ containerWidth, readOnly: readOnlyOverride, nod
     }
   }, [views?.length]);
 
-  const currentView = useAppSelector(getView(currentViewId || '')) ?? undefined;
+  const selectView = useMemo(makeSelectView, []);
+  const currentView = useAppSelector((state) => selectView(state, currentViewId || '')) ?? undefined;
   const { page: boardPage, updatePage } = usePage({ pageIdOrPath: pageId });
-
   const [shownCardId, setShownCardId] = useState<string | null>(null);
 
   const boards = useAppSelector(getBoards);

--- a/components/common/PageActions/components/DatabasePageActionList.tsx
+++ b/components/common/PageActions/components/DatabasePageActionList.tsx
@@ -11,6 +11,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
 import { useRouter } from 'next/router';
 import Papa from 'papaparse';
+import { useMemo } from 'react';
 import type { ChangeEvent } from 'react';
 
 import charmClient from 'charmClient';
@@ -18,7 +19,7 @@ import { CsvExporter } from 'components/common/BoardEditor/focalboard/csvExporte
 import mutator from 'components/common/BoardEditor/focalboard/src/mutator';
 import { getSortedBoards } from 'components/common/BoardEditor/focalboard/src/store/boards';
 import {
-  getViewCardsSortedFilteredAndGrouped,
+  makeSelectViewCardsSortedFilteredAndGrouped,
   sortCards
 } from 'components/common/BoardEditor/focalboard/src/store/cards';
 import { useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
@@ -82,8 +83,9 @@ export function DatabasePageActionList({ pagePermissions, onComplete, page }: Pr
     }
   }
 
-  const cards = useAppSelector(
-    getViewCardsSortedFilteredAndGrouped({
+  const selectViewCardsSortedFilteredAndGrouped = useMemo(makeSelectViewCardsSortedFilteredAndGrouped, []);
+  const cards = useAppSelector((state) =>
+    selectViewCardsSortedFilteredAndGrouped(state, {
       boardId: board?.id ?? '',
       viewId: view?.id ?? '',
       pages

--- a/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
+++ b/components/common/PageLayout/components/PageNavigation/components/TreeNode.tsx
@@ -1,12 +1,12 @@
 import type { Page } from '@charmverse/core/prisma';
 import { useTreeItem } from '@mui/lab/TreeItem';
 import Typography from '@mui/material/Typography';
-import { memo, useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
 import { databaseViewsLoad } from 'components/common/BoardEditor/focalboard/src/store/databaseBlocksLoad';
 import { useAppDispatch, useAppSelector } from 'components/common/BoardEditor/focalboard/src/store/hooks';
-import { getSortedViews, getLoadedBoardViews } from 'components/common/BoardEditor/focalboard/src/store/views';
+import { makeSelectSortedViews, getLoadedBoardViews } from 'components/common/BoardEditor/focalboard/src/store/views';
 import { useFocalboardViews } from 'hooks/useFocalboardViews';
 import useRefState from 'hooks/useRefState';
 import { formatViewTitle } from 'lib/focalboard/boardView';
@@ -156,7 +156,8 @@ function DraggableTreeNode({
 
   const { focalboardViewsRecord, setFocalboardViewsRecord } = useFocalboardViews();
 
-  const views = useAppSelector(getSortedViews(item.id));
+  const selectSortedViews = useMemo(makeSelectSortedViews, []);
+  const views = useAppSelector((state) => selectSortedViews(state, item.id));
   const hasSelectedChildView = views.some((view) => view.id === selectedNodeId);
   const { expanded } = useTreeItem(item.id);
 

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -10,10 +10,6 @@
   }
 }
 
-.bangle-editor a:not(.MuiTypography-root) {
-  text-decoration: underline;
-}
-
 .bangle-editor li[data-bangle-is-todo] > span:first-child > input {
   margin-top: 0.45rem;
 }
@@ -134,13 +130,12 @@ img.ProseMirror-separator {
  * Component-Styling
  */
 
-// Making sure inline database header link doesn't have underlines
-.bangle-editor a:not(.MuiTypography-root) {
+.bangle-editor .charm-link {
   color: #4299e1;
   text-decoration: underline;
 }
 
-.bangle-editor a:hover:not(.MuiTypography-root) {
+.bangle-editor .charm-link:hover {
   color: #24659b;
   text-decoration: underline;
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at df21471</samp>

This pull request improves the performance and readability of the `BoardEditor` component and its subcomponents by using memoized selectors, functions, and props. It also fixes some style issues with the `FullCalendar` component and removes unused code from various files.

### TO TEST
Create an inline database with a calendar view. Add a second inline database, with any view type, to reproduce the issue fixed by memoizing the selectors.

### WHY
Normally, we don't have many issues with the database component re-rendering a lot. This issue exposed itself inside of an inline database using the fullcalendar plugin. As you hover over the page, it re-renders the CharmEditor, which re-renders the Centerpanel component. Because of the way the redux selectors were written, it was actually creating new cards, views, etc. each time regardless if the original state changed.

Technical explanation:
I think this is due to how i was passing in viewId, etc. into a method which called createSelector() inside. So we were actually creating a new selector on every render. The second issue is that if you had two inline databases in one page, they use the same selector and overwrite the cache each time! So the solution to this is useMemo(). I copied the new patterns from here: https://redux.js.org/usage/deriving-data-selectors

https://discord.com/channels/894960387743698944/1164581599527055461/1164581599527055461