### PR TITLE
Make proposal tempalte properties readonly

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -161,9 +161,7 @@ export function ProposalProperties({
 
   const onChangeRubricCriteriaDebounced = useCallback(debounce(onChangeRubricCriteria, 300), [proposal?.status]);
   const readOnlyCategory = !isAdmin && (!proposalPermissions?.edit || !!proposal?.page?.sourceTemplateId);
-  const readOnlyReviewers =
-    readOnlyProperties ||
-    (!isAdmin && !!proposalTemplates?.some((t) => t.id === proposal?.page?.sourceTemplateId && t.reviewers.length > 0));
+  const readOnlyReviewers = readOnlyProperties || (!isAdmin && sourceTemplate && sourceTemplate.reviewers.length > 0);
 
   return (
     <ProposalPropertiesBase

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -74,6 +74,22 @@ export function ProposalProperties({
   const canAnswerRubric = proposalPermissions?.evaluate;
   const canViewRubricAnswers = isAdmin || !!(user?.id && reviewerUserIds?.includes(user.id));
   const isFromTemplateSource = Boolean(proposal?.page?.sourceTemplateId);
+  const sourceTemplate = isFromTemplateSource
+    ? proposalTemplates?.find((template) => template.id === proposal?.page?.sourceTemplateId)
+    : undefined;
+
+  // properties with values from templates should be read only
+  const readOnlyCustomProperties =
+    !isAdmin && sourceTemplate?.fields
+      ? Object.entries((sourceTemplate?.fields as ProposalFields).properties)?.reduce((acc, [key, value]) => {
+          if (!value) {
+            return acc;
+          }
+
+          acc.push(key);
+          return acc;
+        }, [] as string[])
+      : [];
 
   const proposalFormInputs: ProposalPropertiesInput = {
     categoryId: proposal?.categoryId,
@@ -184,6 +200,7 @@ export function ProposalProperties({
       canViewRubricAnswers={canViewRubricAnswers}
       title={title || ''}
       isPublishingToLens={isPublishingToLens}
+      readOnlyCustomProperties={readOnlyCustomProperties}
     />
   );
 }

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
@@ -33,6 +33,7 @@ type Props = {
   pageUpdatedBy: string;
   pageUpdatedAt: string;
   mutator?: Mutator;
+  readOnlyProperties?: string[];
 };
 
 function CardDetailProperties(props: Props) {
@@ -249,6 +250,8 @@ function CardDetailProperties(props: Props) {
   return (
     <div className='octo-propertylist' data-test='card-detail-properties'>
       {board.fields?.cardProperties.map((propertyTemplate) => {
+        const readOnly = props.readOnly || props.readOnlyProperties?.includes(propertyTemplate.id) || false;
+
         return (
           <CardDetailProperty
             syncWithPageId={syncWithPageId}
@@ -264,7 +267,7 @@ function CardDetailProperties(props: Props) {
             pageUpdatedAt={pageUpdatedAt}
             pageUpdatedBy={pageUpdatedBy}
             property={propertyTemplate}
-            readOnly={props.readOnly}
+            readOnly={readOnly}
             mutator={mutator}
           />
         );

--- a/components/proposals/components/ProposalProperties/CustomPropertiesAdapter.tsx
+++ b/components/proposals/components/ProposalProperties/CustomPropertiesAdapter.tsx
@@ -10,9 +10,10 @@ type Props = {
   proposal: { spaceId?: string; id?: string } & ProposalFieldsProp;
   onChange?: (properties: ProposalPropertiesField) => void;
   readOnly?: boolean;
+  readOnlyProperties?: string[];
 };
 
-export function CustomPropertiesAdapter({ proposal, onChange, readOnly }: Props) {
+export function CustomPropertiesAdapter({ proposal, onChange, readOnly, readOnlyProperties }: Props) {
   const { user } = useUser();
   // TODO - use value from context instead of raw hook
   const { boardCustomProperties, card, cards, activeView, views, proposalPage, setBoardProposal } =
@@ -34,6 +35,7 @@ export function CustomPropertiesAdapter({ proposal, onChange, readOnly }: Props)
       pageUpdatedAt={proposalPage?.updatedAt.toString() || new Date().toString()}
       pageUpdatedBy={proposalPage?.updatedBy || user?.id || ''}
       mutator={mutator ?? undefined}
+      readOnlyProperties={readOnlyProperties}
     />
   );
 }

--- a/components/proposals/components/ProposalProperties/ProposalProperties.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalProperties.tsx
@@ -90,6 +90,7 @@ type ProposalPropertiesProps = {
   userId?: string;
   updateProposalStatus?: (newStatus: ProposalStatus) => Promise<void>;
   title: string;
+  readOnlyCustomProperties?: string[];
 };
 
 export function ProposalProperties({
@@ -120,7 +121,8 @@ export function ProposalProperties({
   userId,
   updateProposalStatus,
   title,
-  isPublishingToLens
+  isPublishingToLens,
+  readOnlyCustomProperties
 }: ProposalPropertiesProps) {
   const { proposalCategoriesWithCreatePermission, categories } = useProposalCategories();
   const [rubricView, setRubricView] = useState<number>(0);
@@ -231,7 +233,8 @@ export function ProposalProperties({
           })),
           proposalTemplateId: templatePage.id,
           evaluationType: proposalTemplate.evaluationType,
-          rubricCriteria: proposalTemplate.rubricCriteria
+          rubricCriteria: proposalTemplate.rubricCriteria,
+          fields: (proposalTemplate.fields as ProposalFields) || {}
         });
       }
     }
@@ -571,6 +574,7 @@ export function ProposalProperties({
 
           <CustomPropertiesAdapter
             readOnly={readOnlyAuthors}
+            readOnlyProperties={readOnlyCustomProperties}
             proposal={proposalFormInputs}
             onChange={(properties: ProposalPropertiesField) => {
               setProposalFormInputs({


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b403d47</samp>

This pull request adds a feature to make some custom properties of a proposal read-only in the UI. It affects the components that render and edit the proposal properties, such as `ProposalProperties`, `DocumentPage`, and `CardDetailProperties`. It uses a `readOnlyCustomProperties` prop to determine which properties should be read-only based on a template or user role.

### WHY
- fix creating proposal with custom props from template
- make filled props from template readonly
