### PR TITLE
maintain mux permissions for custom domains

### DIFF
--- a/lib/mux/config.ts
+++ b/lib/mux/config.ts
@@ -1,0 +1,10 @@
+export const muxTokenId = process.env.MUX_TOKEN_ID as string | undefined;
+export const muxTokenSecret = process.env.MUX_TOKEN_SECRET as string | undefined;
+
+// Playback Restriction restricts video to just charmverse domains. To generate a new restriction, use:
+// curl 'https://api.mux.com/video/v1/playback-restrictions' \
+//   -X POST \
+//   -d '{ "referrer": { "allowed_domains": ["*.charmverse.io", "*.charmverse.co"] } }' \
+//   -H "Content-Type: application/json" \
+//   -u $MUX_TOKEN_ID:$MUX_TOKEN_SECRET
+export const playbackRestrictionId = process.env.MUX_PLAYBACK_RESTRICTION_ID as string | undefined;

--- a/lib/mux/getSignedToken.ts
+++ b/lib/mux/getSignedToken.ts
@@ -1,5 +1,6 @@
 import Mux from '@mux/mux-node';
 
+import { playbackRestrictionId } from './config';
 import { mux } from './muxClient';
 
 type MuxJWTSignOptions = NonNullable<Parameters<typeof Mux.JWT.signPlaybackId>[1]>;
@@ -13,13 +14,6 @@ const baseOptions: MuxJWTSignOptions = {
   expiration: '7d' // E.g 60, "2 days", "10h", "7d", numeric value interpreted as seconds
 };
 
-// Playback Restriction restricts video to just charmverse domains. To generate a new restriction, use:
-// curl 'https://api.mux.com/video/v1/playback-restrictions' \
-//   -X POST \
-//   -d '{ "referrer": { "allowed_domains": ["*.charmverse.io", "*.charmverse.co"] } }' \
-//   -H "Content-Type: application/json" \
-//   -u $MUX_TOKEN_ID:$MUX_TOKEN_SECRET
-const playbackRestrictionId = process.env.MUX_PLAYBACK_RESTRICTION_ID as string | undefined;
 if (playbackRestrictionId) {
   baseOptions.params = {
     playback_restriction_id: playbackRestrictionId

--- a/lib/mux/muxClient.ts
+++ b/lib/mux/muxClient.ts
@@ -1,7 +1,6 @@
 import Mux from '@mux/mux-node';
 
-const muxTokenId = process.env.MUX_TOKEN_ID as string | undefined;
-const muxTokenSecret = process.env.MUX_TOKEN_SECRET as string | undefined;
+import { muxTokenId, muxTokenSecret } from './config';
 
 let maybeMux: Mux | undefined;
 if (muxTokenId && muxTokenSecret) {

--- a/lib/mux/updateAllowedPlaybackDomains.ts
+++ b/lib/mux/updateAllowedPlaybackDomains.ts
@@ -1,0 +1,27 @@
+import { log } from '@charmverse/core/log';
+import { prisma } from '@charmverse/core/prisma-client';
+
+import { isTruthy } from 'lib/utilities/types';
+
+import { playbackRestrictionId } from './config';
+import { mux } from './muxClient';
+
+const charmVerseDomains = ['*.charmverse.io', '*.charmverse.co'];
+
+// update referrers to include all custom subdomains
+export async function updateAllowedPlaybackDomains() {
+  if (mux && playbackRestrictionId) {
+    const spaces = await prisma.space.findMany({
+      where: {
+        customDomain: {
+          not: null
+        }
+      }
+    });
+    const customDomains = spaces.map((space) => space.customDomain).filter(isTruthy);
+    mux.Video.PlaybackRestrictions.putReferrer(playbackRestrictionId, {
+      allowed_domains: charmVerseDomains.concat(customDomains)
+    });
+    log.info('Updated referrers for mux playback restriction', { customDomains });
+  }
+}

--- a/lib/spaces/updateSpaceCustomDomain.ts
+++ b/lib/spaces/updateSpaceCustomDomain.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@charmverse/core/prisma-client';
 
+import { updateAllowedPlaybackDomains } from 'lib/mux/updateAllowedPlaybackDomains';
 import { isValidDomainName } from 'lib/utilities/domains/isValidDomainName';
 import { InvalidInputError } from 'lib/utilities/errors';
 import { isUniqueConstraintError } from 'lib/utilities/errors/prisma';
@@ -31,6 +32,9 @@ export async function updateSpaceCustomDomain(
         customDomain: data.customDomain || null
       }
     });
+
+    // update referrers to include all custom subdomains
+    await updateAllowedPlaybackDomains();
   } catch (error) {
     if (isUniqueConstraintError(error)) {
       throw new InvalidInputError(`Custom domain ${data.customDomain} is already in use`);

--- a/scripts/mux.ts
+++ b/scripts/mux.ts
@@ -1,0 +1,6 @@
+import { updateAllowedPlaybackDomains } from 'lib/mux/updateAllowedPlaybackDomains';
+
+// run this to manually refresh the allowed domains for video playback via mux
+(async () => {
+  await updateAllowedPlaybackDomains();
+})();


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aef21b8</samp>

Refactored the code for generating and using the mux token and playback restriction id. Added a function to sync the playback restriction with the custom domains of the spaces. Created a script to run the function manually.

### WHY
We whitelist the domains you can play a video on, which is currently only *.charmverse.io and *.charmverse.co. This PR overwrites/updates the whitelist whenever a custom space domain is set (I think!)

I ran the script locally and it fixed videos on work.charmverse.fyi
