### PR TITLE
Allow reviewer creating a vote

### DIFF
--- a/lib/permissions/proposals/__tests__/baseComputeProposalPermissions.spec.ts
+++ b/lib/permissions/proposals/__tests__/baseComputeProposalPermissions.spec.ts
@@ -151,7 +151,7 @@ describe('computeProposalPermissions - base', () => {
       edit: false,
       make_public: false,
       delete: false,
-      create_vote: false,
+      create_vote: true,
       archive: false,
       unarchive: false
     });

--- a/lib/permissions/proposals/computeProposalPermissions.ts
+++ b/lib/permissions/proposals/computeProposalPermissions.ts
@@ -73,7 +73,7 @@ export async function baseComputeProposalPermissions({
     });
 
     if (isReviewer) {
-      permissions.addPermissions(['view', 'comment', 'review', 'evaluate']);
+      permissions.addPermissions(['view', 'comment', 'review', 'evaluate', 'create_vote']);
     }
 
     // Add default space member permissions


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d88c090</samp>

Add voting feature to proposals in Charmverse app. Update `computeProposalPermissions.ts` to grant `create_vote` permission to reviewers.

### WHY
Add base permissions to allow reviewer creating a vote
