### PR TITLE
retain the original query params when redirecting from an old page path

### DIFF
--- a/lib/utilities/browser.ts
+++ b/lib/utilities/browser.ts
@@ -1,9 +1,11 @@
 import { baseUrl, isDevEnv } from 'config/constants';
-import { getAppApexDomain } from 'lib/utilities/domains/getAppApexDomain';
-import { getCustomDomainFromHost } from 'lib/utilities/domains/getCustomDomainFromHost';
-import { getSpaceDomainFromHost } from 'lib/utilities/domains/getSpaceDomainFromHost';
-import { isLocalhostAlias } from 'lib/utilities/domains/isLocalhostAlias';
-import { getAppOriginURL } from 'lib/utilities/getAppOriginURL';
+
+import { getAppApexDomain } from './domains/getAppApexDomain';
+import { getCustomDomainFromHost } from './domains/getCustomDomainFromHost';
+import { getSpaceDomainFromHost } from './domains/getSpaceDomainFromHost';
+import { isLocalhostAlias } from './domains/isLocalhostAlias';
+import { getAppOriginURL } from './getAppOriginURL';
+import { addQueryToUrl } from './url';
 
 // using deprectead feature, navigator.userAgent doesnt exist yet in FF - https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform
 export function isMac() {
@@ -112,20 +114,12 @@ function scrollIntoViewIfNeededPolyfill(element: HTMLElement, centerIfNeeded?: b
 
 // @source: https://stackoverflow.com/questions/5999118/how-can-i-add-or-update-a-query-string-parameter
 export function getNewUrl(params: Record<string, string | null>, currentUrl = window.location.href) {
-  const url = new URL(currentUrl, currentUrl.match('http') ? undefined : window.location.origin);
-  const urlParams: URLSearchParams = new URLSearchParams(url.search);
-  for (const key in params) {
-    if (params.hasOwnProperty(key)) {
-      const value = params[key];
-      if (typeof value === 'string') {
-        urlParams.set(key, value);
-      } else {
-        urlParams.delete(key);
-      }
-    }
-  }
-  url.search = urlParams.toString();
-  return url;
+  return addQueryToUrl({
+    url: currentUrl || window.location.href,
+    urlBase: window.location.origin,
+    query: params,
+    replace: true
+  });
 }
 
 /**

--- a/lib/utilities/domains/__tests__/getPagePath.spec.ts
+++ b/lib/utilities/domains/__tests__/getPagePath.spec.ts
@@ -38,4 +38,16 @@ describe('getPagePath', () => {
     });
     expect(result).toEqual('/members');
   });
+
+  it('should append the original query params', () => {
+    const result = getPagePath({
+      spaceDomain: 'apples',
+      path: 'members',
+      hostName: 'work.foobar.com',
+      query: {
+        cardId: 'foobar'
+      }
+    });
+    expect(result).toEqual('/members?cardId=foobar');
+  });
 });

--- a/lib/utilities/domains/getPagePath.ts
+++ b/lib/utilities/domains/getPagePath.ts
@@ -1,8 +1,28 @@
+import type { ParsedUrlQuery } from 'querystring';
+
+import { addQueryToUrl } from 'lib/utilities/url';
+
 import { getCustomDomainFromHost } from './getCustomDomainFromHost';
 import { getSpaceDomainFromHost } from './getSpaceDomainFromHost';
 
 // Given a hostname, space domain, and path, return a path that can be used to open a page.
-export function getPagePath({ hostName, spaceDomain, path }: { hostName?: string; spaceDomain: string; path: string }) {
+export function getPagePath({
+  hostName,
+  spaceDomain,
+  path,
+  query
+}: {
+  hostName?: string;
+  spaceDomain: string;
+  path: string;
+  query?: ParsedUrlQuery;
+}) {
   const isDomainInPath = !getCustomDomainFromHost(hostName) && !getSpaceDomainFromHost(hostName);
-  return encodeURI(`/${isDomainInPath ? `${spaceDomain}/` : ''}${path}`);
+  const pathWithDomain = `/${isDomainInPath ? `${spaceDomain}/` : ''}${path}`;
+  const { pathname, search } = addQueryToUrl({
+    url: pathWithDomain,
+    query
+  });
+  const pathWithQuery = `${pathname}${search}`;
+  return encodeURI(pathWithQuery);
 }

--- a/lib/utilities/url.ts
+++ b/lib/utilities/url.ts
@@ -1,0 +1,29 @@
+import type { ParsedUrlQuery } from 'querystring';
+
+// add query params to a url
+export function addQueryToUrl({
+  url,
+  query,
+  replace,
+  urlBase = 'http://localhost:3000'
+}: {
+  url: string;
+  urlBase?: string;
+  replace?: boolean;
+  query?: ParsedUrlQuery | Record<string, string | null>;
+}) {
+  const result = new URL(url, url.match('http') ? undefined : urlBase);
+  const queryParams = new URLSearchParams(result.search);
+  for (const key in query) {
+    if (query.hasOwnProperty(key)) {
+      const value = query[key];
+      if (typeof value === 'string') {
+        queryParams.set(key, value);
+      } else if (replace) {
+        queryParams.delete(key);
+      }
+    }
+  }
+  result.search = queryParams.toString();
+  return result;
+}

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -74,6 +74,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
             destination: getPagePath({
               hostName: ctx.req.headers.host,
               path: page.path,
+              query: ctx.query,
               spaceDomain: domain
             }),
             permanent: false

--- a/pages/invite/page.tsx
+++ b/pages/invite/page.tsx
@@ -59,6 +59,7 @@ export const getServerSideProps: GetServerSideProps = withSessionSsr<Props>(asyn
           destination: getPagePath({
             hostName: context.req.headers.host,
             path: page.path,
+            query: context.query,
             spaceDomain: page.space.domain
           }),
           permanent: false


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd5d32e</samp>

Added support for query parameters in page paths and URLs. Refactored some utility functions to handle query parameters consistently and use relative imports. Added a new test case for the `getPagePath` function. Updated the `[domain]/[pageId]` and `invite/page` pages to receive and use the query parameters from the request context.

### WHY
You can see what happens when you go to this link: https://app.charmverse.io/charmverse/page-49366552253645923?viewId=50d940bb-fdbd-40ba-9816-616d6138a663&cardId=9218e859-2198-4df3-a0f2-1a71a01835d3. It is to our task board, but using an old path. When we redirect, we lose the cardId and it never appears.
