### PR TITLE
Japaenese events

### DIFF
--- a/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
@@ -94,7 +94,6 @@ export function PageTitleInput({
         data-test='editor-page-title'
         inputRef={titleInput}
         value={title}
-        multiline
         placeholder={placeholder || 'Untitled'}
         autoFocus={!value && !readOnly && !isTouchScreen()}
         variant='standard'

--- a/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
@@ -1,8 +1,8 @@
 import { EditorViewContext } from '@bangle.dev/react';
 import styled from '@emotion/styled';
-import type { TextFieldProps } from '@mui/material';
 import { TextField, Typography } from '@mui/material';
 import { useContext, useEffect, useRef, useState } from 'react';
+import type { ChangeEvent } from 'react';
 
 import { insertAndFocusFirstLine } from 'lib/prosemirror/insertAndFocusFirstLine';
 import { isTouchScreen } from 'lib/utilities/browser';
@@ -69,31 +69,15 @@ export function PageTitleInput({
     if (updatedAtExternal && updatedAt && updatedAt < updatedAtExternal) {
       setTitle(value);
     }
-  }, [value, updatedAtExternal]);
+  }, [value, updatedAtExternal, updatedAt, setTitle]);
 
-  function updateTitle(newTitle: string) {
+  function _onChange(event: ChangeEvent<HTMLInputElement>) {
+    const newTitle = event.target.value;
     const _updatedAt = new Date().toISOString();
     setTitle(newTitle);
     setUpdatedAt(_updatedAt);
     onChange({ title: newTitle, updatedAt: _updatedAt });
   }
-
-  const handleKeyDown: TextFieldProps['onKeyDown'] = (event) => {
-    const pressedEnter = event.key === 'Enter';
-    const pressedCtrl = event.ctrlKey;
-    if (pressedEnter) {
-      if (!pressedCtrl) {
-        event.preventDefault();
-        // add a delay for Japanese keybaords, which for some reason copy the current text to the document
-        setTimeout(() => {
-          insertAndFocusFirstLine(view);
-        });
-      } else {
-        const inputElement = event.target as HTMLInputElement;
-        updateTitle(`${inputElement.value}\n`);
-      }
-    }
-  };
 
   if (readOnly) {
     return <StyledReadOnlyTitle data-test='editor-page-title'>{value || 'Untitled'}</StyledReadOnlyTitle>;
@@ -114,10 +98,7 @@ export function PageTitleInput({
         placeholder={placeholder || 'Untitled'}
         autoFocus={!value && !readOnly && !isTouchScreen()}
         variant='standard'
-        onKeyDown={handleKeyDown}
-        onChange={(e) => {
-          updateTitle(e.target.value);
-        }}
+        onChange={_onChange}
       />
     </form>
   );

--- a/hooks/useIMEComposition.tsx
+++ b/hooks/useIMEComposition.tsx
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import type { RefObject } from 'react';
+
+export type InputType = HTMLInputElement | HTMLTextAreaElement;
+
+// A hook to determine if someone is using foreign language input to type via IME events
+// reference: https://www.stum.de/2016/06/24/handling-ime-events-in-javascript/
+export function useIMEComposition(ref: RefObject<InputType>) {
+  const [isComposing, setIsComposing] = useState(false); // IME Composing going on
+  const [hasCompositionJustEnded, sethasCompositionJustEnded] = useState(false); // Used to swallow keyup event related to compositionend
+
+  useEffect(() => {
+    const elm = ref.current;
+
+    function onKeyUp(e: Event) {
+      if (isComposing || hasCompositionJustEnded) {
+        // IME composing fires keydown/keyup events
+        sethasCompositionJustEnded(false);
+        e.stopPropagation();
+        e.preventDefault();
+      }
+    }
+    function onCompositionStart() {
+      setIsComposing(true);
+    }
+    function onCompositionEnd() {
+      setIsComposing(false);
+      // some browsers (IE, Firefox, Safari) send a keyup event after
+      //  compositionend, some (Chrome, Edge) don't. This is to swallow
+      // the next keyup event, unless a keydown event happens first
+      sethasCompositionJustEnded(true);
+    }
+    function onKeyDown(e: Event) {
+      // Safari on OS X may send a keydown of 229 after compositionend
+      if ((e as KeyboardEvent).which !== 229) {
+        sethasCompositionJustEnded(false);
+      }
+    }
+    if (elm) {
+      elm.addEventListener('keyup', onKeyUp);
+      elm.addEventListener('compositionstart', onCompositionStart);
+      elm.addEventListener('compositionend', onCompositionEnd);
+      elm.addEventListener('keydown', onKeyDown);
+    }
+    return () => {
+      // remove event listeners
+      if (elm) {
+        elm.removeEventListener('keyup', onKeyUp);
+        elm.removeEventListener('compositionstart', onCompositionStart);
+        elm.removeEventListener('compositionend', onCompositionEnd);
+        elm.removeEventListener('keydown', onKeyDown);
+      }
+    };
+  }, [isComposing, hasCompositionJustEnded, ref]);
+
+  return { isOrWasComposing: isComposing || hasCompositionJustEnded };
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e4278c</samp>

The pull request enhances the title input component for foreign language input by using a custom hook to detect IME composition. The hook `useIMEComposition` is defined in a new file `hooks/useIMEComposition.tsx` and returns a boolean flag that indicates the IME status. The component uses the hook and refactors the keyboard event handlers to simplify the logic and improve the user experience.

### WHY
The title input is actually pretty complicated. Notion uses an h1 tag with contenteditable, FWIW. But it must:
- support wrapping lines for long titles (which regular text input does not, even with break-word CSS rule)
- allow us to jump to the document body on "Enter" being pressed, unless user is using Enter to submit a Japenese character. More info: https://cotoacademy.com/type-japanese-windows-10/ 

The text input is most ideal because then we could listen to a form submit event when user hits Return, but it does not support text wrapping. There's also no simple API to tell if a user is using a foreign language keyboard input. I finally found someone who managed to make it work by listening to several DOM events: https://www.stum.de/2016/06/24/handling-ime-events-in-javascript/. Not rocket science, indeed!