### PR TITLE
Fix computing default space page to display

### DIFF
--- a/lib/session/__tests__/getDefaultPageForSpace.spec.ts
+++ b/lib/session/__tests__/getDefaultPageForSpace.spec.ts
@@ -11,7 +11,7 @@ describe('getDefaultPageForSpace()', () => {
     const { space, user } = await generateUserAndSpace();
     await createPage({
       createdAt: new Date(),
-      index: 1,
+      index: 2,
       path: 'second-page',
       spaceId: space.id,
       createdBy: user.id,
@@ -21,12 +21,24 @@ describe('getDefaultPageForSpace()', () => {
     // create a page that is first based on index
     const page = await createPage({
       createdAt: new Date(Date.now() + 100000),
-      index: 0,
+      index: 1,
       spaceId: space.id,
       path: 'first-page',
       createdBy: user.id,
       // add basic permission
       pagePermissions: [{ permissionLevel: 'view', spaceId: space.id }]
+    });
+
+    // child page with lower index
+    await createPage({
+      createdAt: new Date(),
+      index: 0,
+      spaceId: space.id,
+      path: 'child-page',
+      createdBy: user.id,
+      // add basic permission
+      pagePermissions: [{ permissionLevel: 'view', spaceId: space.id }],
+      parentId: page.id
     });
 
     const url = await getDefaultPageForSpace({ space, userId: user.id });

--- a/lib/session/getDefaultPageForSpace.ts
+++ b/lib/session/getDefaultPageForSpace.ts
@@ -87,7 +87,8 @@ async function getDefaultPageForSpaceRaw({
     where: {
       id: {
         in: accessiblePageIds
-      }
+      },
+      parentId: null
     },
     select: {
       createdAt: true,

--- a/lib/session/getDefaultPageForSpace.ts
+++ b/lib/session/getDefaultPageForSpace.ts
@@ -87,15 +87,15 @@ async function getDefaultPageForSpaceRaw({
     where: {
       id: {
         in: accessiblePageIds
-      },
-      parentId: null
+      }
     },
     select: {
       createdAt: true,
       id: true,
       index: true,
       path: true,
-      type: true
+      type: true,
+      parentId: true
     }
   });
 
@@ -105,10 +105,12 @@ async function getDefaultPageForSpaceRaw({
   }, {});
 
   // Find the first top-level page that is not card and hasn't been deleted yet.
-  const topLevelPages = filterVisiblePages(pageMap);
+  const visiblePages = filterVisiblePages(pageMap);
+  const topLevelPages = visiblePages.filter((page) => !page.parentId);
+  const pagesToLookup = topLevelPages.length ? topLevelPages : visiblePages;
 
   // TODO: simplify types of sortNodes input to only be index and createdAt
-  const sortedPages = pageTree.sortNodes(topLevelPages as PageMeta[]);
+  const sortedPages = pageTree.sortNodes(pagesToLookup as PageMeta[]);
 
   const firstPage = sortedPages[0];
   if (firstPage) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 897550b</samp>

Added a condition to `getDefaultPageForSpaceRaw` to ensure the default page for a space is a top-level page. This supports the new subpage feature in `app.charmverse.io`.

### WHY
Quick workaround to computing default page to redirect to in new space - the issue here was that it sorted all pages, including child pages and their indexes. Actually page navigation (sidebar) uses a bit more complex logic so I believe the easiest way will be to just do not fetch child pages
