### PR TITLE
use ip address for permissions api for systems that default to ip6

### DIFF
--- a/.env.test.local.example
+++ b/.env.test.local.example
@@ -9,4 +9,4 @@ SERVERLESS_PORT=3020
 # necessary so that the serverless app can be tested locally
 MAILGUN_DOMAIN=mg.charmverse.com
 MAILGUN_KEY=test-key
-PERMISSIONS_API_URL=http://localhost:3001
+PERMISSIONS_API_URL=http://127.0.0.1:3001


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96c2b33</samp>

Updated the `.env.test.local.example` file to use `127.0.0.1` for the `PERMISSIONS_API_URL` variable. This improves the test reliability and performance of the app.charmverse.io repository.

### WHY
On OSX, i get ECONNREFUSED if i use localhost
