### PR TITLE
add default date property when switching view layout

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSidebar.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewSidebar.tsx
@@ -62,7 +62,7 @@ function ViewSidebar(props: Props) {
               {sidebarView === 'layout' && (
                 <>
                   <DatabaseSidebarHeader goBack={goToSidebarHome} title='Layout' onClose={props.closeSidebar} />
-                  <ViewLayoutOptions properties={props.board?.fields.cardProperties ?? []} view={props.view} />
+                  <ViewLayoutOptions board={props.board} view={props.view} />
                 </>
               )}
               {sidebarView === 'card-properties' && (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b70f3a1</samp>

Refactored and improved the `LayoutOptions` component for board views. Changed the prop type from `properties` to `board` and added automatic date property selection for the calendar view. Updated the `ViewLayoutOptions` and `ViewSidebar` components accordingly.

### WHY
<!-- author to complete -->
