### PR TITLE
spin up different ports for test servers

### DIFF
--- a/__integration-tests__/server/pages/api/v1/proposals/[proposalId]/snapshot-vote.spec.ts
+++ b/__integration-tests__/server/pages/api/v1/proposals/[proposalId]/snapshot-vote.spec.ts
@@ -114,7 +114,7 @@ describe('POST /api/v1/proposals/{proposalId}/snapshot-vote', () => {
       };
     });
 
-    const server = await listen(8500);
+    const server = await listen(8501);
 
     const response = await request(baseUrl)
       .post(`/api/v1/proposals/${proposal.id}/snapshot-vote`)
@@ -139,7 +139,7 @@ describe('POST /api/v1/proposals/{proposalId}/snapshot-vote', () => {
       };
     });
 
-    const server = await listen(8500);
+    const server = await listen(8502);
 
     const response = await request(baseUrl)
       .post(`/api/v1/proposals/${proposal.id}/snapshot-vote`)
@@ -169,7 +169,7 @@ describe('POST /api/v1/proposals/{proposalId}/snapshot-vote', () => {
       };
     });
 
-    const server = await listen(8500);
+    const server = await listen(8503);
 
     const response = await request(baseUrl)
       .post(`/api/v1/proposals/${proposal.id}/snapshot-vote`)
@@ -206,7 +206,7 @@ describe('POST /api/v1/proposals/{proposalId}/snapshot-vote', () => {
       };
     });
 
-    const server = await listen(8500);
+    const server = await listen(8504);
 
     const response = await request(baseUrl)
       .post(`/api/v1/proposals/${proposal.id}/snapshot-vote`)


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e19ccab</samp>

Updated integration tests for `snapshot-vote` API to use different port numbers. This avoids port conflicts when running the tests in parallel.

### WHY
I believe these tests are currently flaky. Here's one example https://github.com/charmverse/app.charmverse.io/actions/runs/6660206646/job/18101421381
