### PR TITLE
fix closing sidebar when navigating favorites

### DIFF
--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -177,7 +177,7 @@ export function Sidebar({ closeSidebar, navAction }: SidebarProps) {
         {favoritePageIds.length > 0 && (
           <Box mb={2}>
             <SectionName mb={1}>FAVORITES</SectionName>
-            <PageNavigation isFavorites rootPageIds={favoritePageIds} />
+            <PageNavigation isFavorites rootPageIds={favoritePageIds} onClick={navAction} />
           </Box>
         )}
         <WorkspaceLabel data-test='page-sidebar-header'>
@@ -229,7 +229,7 @@ export function Sidebar({ closeSidebar, navAction }: SidebarProps) {
         </Box>
       </>
     );
-  }, [favoritePageIds, userSpacePermissions, navAction, addPage, showMemberFeatures]);
+  }, [favoritePageIds, userSpacePermissions, isMobile, navAction, addPage, showMemberFeatures]);
 
   const { features } = useFeaturesAndMembers();
   const isCharmverse = useIsCharmverseSpace();

--- a/components/common/PageLayout/components/Sidebar/Sidebar.tsx
+++ b/components/common/PageLayout/components/Sidebar/Sidebar.tsx
@@ -279,7 +279,7 @@ export function Sidebar({ closeSidebar, navAction }: SidebarProps) {
                       label='Invites'
                     />
                   )}
-                  <NotificationUpdates />
+                  <NotificationUpdates closeSidebar={navAction} />
                   <Divider sx={{ mx: 2, my: 1 }} />
                   {features
                     .filter((feat) => feat.path !== 'rewards' || isCharmverse) // hide Rewards behind feature flag

--- a/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
@@ -60,7 +60,7 @@ export const NotificationCountBox = styled(Box)`
   color: white;
 `;
 
-export function NotificationUpdates() {
+export function NotificationUpdates({ closeSidebar }: { closeSidebar?: VoidFunction }) {
   const notificationPopupState = usePopupState({ variant: 'popover', popupId: 'notifications-menu' });
   const {
     currentSpaceNotifications,
@@ -68,6 +68,11 @@ export function NotificationUpdates() {
     isLoading,
     mutate: mutateNotifications
   } = useNotifications();
+
+  function close() {
+    notificationPopupState.close();
+    closeSidebar?.();
+  }
 
   return (
     <Box>
@@ -100,7 +105,7 @@ export function NotificationUpdates() {
           notifications={currentSpaceNotifications}
           mutateNotifications={mutateNotifications}
           isLoading={isLoading}
-          close={notificationPopupState.close}
+          close={close}
         />
       </Popover>
     </Box>
@@ -118,7 +123,6 @@ export function NotificationsPopover({
   mutateNotifications: KeyedMutator<Notification[]>;
   isLoading: boolean;
 }) {
-  const { getDisplayProperties } = useMemberProperties();
   const theme = useTheme();
   const [inboxState, setInboxState] = useState<'unread' | 'unarchived'>('unarchived');
   const [activeTab, setActiveState] = useState<'Inbox' | 'Archived'>('Inbox');


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 477b956</samp>

Improved the responsiveness and usability of the sidebar component on mobile devices. Added a feature to close the sidebar when a page is selected on `components/common/PageLayout/components/Sidebar/Sidebar.tsx`.

### WHY
<!-- author to complete -->
