### PR TITLE
send user to the full page view of the last card they were on

### DIFF
--- a/lib/session/__tests__/getDefaultPageForSpace.spec.ts
+++ b/lib/session/__tests__/getDefaultPageForSpace.spec.ts
@@ -119,6 +119,20 @@ describe('getDefaultPageForSpace()', () => {
     const url = await getDefaultPageForSpace({ space, userId: user.id, host: customDomain });
     expect(url).toEqual(`/proposals%20?id=123`);
   });
+
+  it('should take user to the canonical page if it was displayed in a card originally', async () => {
+    const { space, user } = await generateUserAndSpace();
+    const page = await createPage({ spaceId: space.id, createdBy: user.id });
+    await savePageView({
+      createdBy: user.id,
+      spaceId: space.id,
+      pageId: page.id,
+      pageType: 'page',
+      meta: { pathname: `/parent-database-path?cardId=${page.id}` }
+    });
+    const url = await getDefaultPageForSpace({ space, userId: user.id });
+    expect(url).toEqual(`/${space.domain}/${page.path}`);
+  });
 });
 
 type EventData = Pick<UserSpaceAction, 'pageType' | 'createdBy' | 'spaceId'> & {

--- a/lib/session/__tests__/getDefaultPageForSpace.spec.ts
+++ b/lib/session/__tests__/getDefaultPageForSpace.spec.ts
@@ -75,7 +75,7 @@ describe('getDefaultPageForSpace()', () => {
     await savePageView({ createdBy: user.id, spaceId: space.id, postId: post.id, pageType: 'post' });
 
     const url = await getDefaultPageForSpace({ space, userId: user.id });
-    expect(url).toEqual(`/${space.domain}/forum?postId=${post.id}`);
+    expect(url).toEqual(`/${space.domain}/forum/post/${post.path}`);
   });
 
   it('should encode Japanese characters', async () => {
@@ -87,19 +87,19 @@ describe('getDefaultPageForSpace()', () => {
     expect(url).toEqual(encodeURI(`/${space.domain}/${page.path}`));
   });
 
-  it('should properly encode pathnames with encoded characters', async () => {
+  it('should not re-encode encoded characters in the original path', async () => {
     const { space, user } = await generateUserAndSpace();
-    const page = await createPage({ spaceId: space.id, createdBy: user.id, path: '日本語' });
+    const page = await createPage({ spaceId: space.id, createdBy: user.id });
     await savePageView({
       createdBy: user.id,
       spaceId: space.id,
       pageId: page.id,
       pageType: 'page',
-      meta: { pathname: `/proposals%20?id=123` }
+      meta: { pathname: `/${page.path}%20?id=123` }
     });
 
     const url = await getDefaultPageForSpace({ space, userId: user.id });
-    expect(url).toEqual(`/${space.domain}/proposals%20?id=123`);
+    expect(url).toEqual(`/${space.domain}/${page.path}%20?id=123`);
   });
 
   it('should not include subdomain when going to custom domain', async () => {
@@ -107,12 +107,10 @@ describe('getDefaultPageForSpace()', () => {
     const { space, user } = await generateUserAndSpace({
       spaceCustomDomain: customDomain
     });
-    const page = await createPage({ spaceId: space.id, createdBy: user.id, path: '日本語' });
     await savePageView({
       createdBy: user.id,
       spaceId: space.id,
-      pageId: page.id,
-      pageType: 'page',
+      pageType: 'proposals_list',
       meta: { pathname: `/proposals%20?id=123` }
     });
 

--- a/lib/session/getDefaultPageForSpace.ts
+++ b/lib/session/getDefaultPageForSpace.ts
@@ -47,7 +47,6 @@ async function getDefaultPageForSpaceRaw({
 }) {
   const { id: spaceId } = space;
   const lastPageView = await getLastPageView({ userId, spaceId });
-
   const defaultSpaceUrl = getSpaceUrl(space, host);
   if (lastPageView) {
     // grab the original path a user was on to include query params like filters, etc.
@@ -68,9 +67,11 @@ async function getDefaultPageForSpaceRaw({
         return fullPathname;
       }
       return `${defaultSpaceUrl}/${lastPageView.page.path}`;
-    }
-    // handle static pages
-    else {
+    } else {
+      if (fullPathname) {
+        return fullPathname;
+      }
+      // handle static pages - this is probably not necessary since pathname is always defined now
       const staticPath = staticPagesToDirect[lastPageView.pageType as StaticPageType];
       if (staticPath) {
         return `${defaultSpaceUrl}${staticPath}`;

--- a/lib/session/getDefaultPageForSpace.ts
+++ b/lib/session/getDefaultPageForSpace.ts
@@ -50,17 +50,23 @@ async function getDefaultPageForSpaceRaw({
 
   const defaultSpaceUrl = getSpaceUrl(space, host);
   if (lastPageView) {
+    // grab the original path a user was on to include query params like filters, etc.
     const pathname = (lastPageView.meta as ViewMeta)?.pathname;
-    if (pathname) {
-      return getSubdomainPath(pathname, space, host);
-    }
-    // reconstruct the URL if no pathname is saved (should not be an issue a few weeks after the release of this code on Sep 12 2023)
+    const fullPathname = pathname && getSubdomainPath(pathname, space, host);
     // handle forum posts
     if (lastPageView.post) {
-      return `${defaultSpaceUrl}/forum?postId=${lastPageView.post.id}`;
+      // use the original path if it was the actual post page
+      if (fullPathname?.includes(lastPageView.post.path)) {
+        return fullPathname;
+      }
+      return `${defaultSpaceUrl}/forum/post/${lastPageView.post.path}`;
     }
     // handle pages
     else if (lastPageView.page) {
+      // use the original path if it was the actual post page
+      if (fullPathname?.includes(lastPageView.page.path)) {
+        return fullPathname;
+      }
       return `${defaultSpaceUrl}/${lastPageView.page.path}`;
     }
     // handle static pages


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae3d22f</samp>

This pull request fixes a bug where the user would be redirected to the wrong URL when revisiting a space that contains forum posts or pages displayed in cards. It updates the `getDefaultPageForSpace` function and its tests to handle these cases correctly.

### WHY
Following Notion UX: if you are looking at a database card last, they send you to the full view as the default page
