### PR TITLE
Drag and drop nested pages within each other in editor

### DIFF
--- a/__e2e__/charmEditor/inlinePalette.spec.ts
+++ b/__e2e__/charmEditor/inlinePalette.spec.ts
@@ -52,7 +52,7 @@ test('Create linkedPage using inline palette in the charmEditor', async ({ docum
 
   await linkedPageInlinePaletteLocator.click();
 
-  const linkedPageCharmEditorLocator = documentPage.page.locator(`[data-id="page-${linkedPage.id}"]`);
+  const linkedPageCharmEditorLocator = documentPage.page.locator(`[data-id="${linkedPage.id}"]`);
 
   await linkedPageCharmEditorLocator.click();
 

--- a/components/_app/GlobalComponents.tsx
+++ b/components/_app/GlobalComponents.tsx
@@ -2,7 +2,6 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { mutate } from 'swr';
 
-import { useAppDispatch } from 'components/common/BoardEditor/focalboard/src/store/hooks';
 import HexagonalAvatarMask from 'components/common/HexagonalAvatarMask';
 import Snackbar from 'components/common/Snackbar';
 import { MemberProfileDialogGlobal } from 'components/members/components/MemberProfileDialogGlobal';
@@ -10,7 +9,6 @@ import { ApplicationDialog } from 'components/rewards/components/RewardApplicati
 import { useImportDiscordRoles } from 'components/settings/roles/hooks/useImportDiscordRoles';
 import { useAppLoadedEvent } from 'hooks/useAppLoadedEvent';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import useKeydownPress from 'hooks/useKeydownPress';
 import { useMarkNotificationFromUrl } from 'hooks/useMarkNotificationFromUrl';
 import { getPagesListCacheKey, usePages } from 'hooks/usePages';
 import { useSettingsDialog } from 'hooks/useSettingsDialog';

--- a/components/_app/GlobalComponents.tsx
+++ b/components/_app/GlobalComponents.tsx
@@ -10,6 +10,7 @@ import { ApplicationDialog } from 'components/rewards/components/RewardApplicati
 import { useImportDiscordRoles } from 'components/settings/roles/hooks/useImportDiscordRoles';
 import { useAppLoadedEvent } from 'hooks/useAppLoadedEvent';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import useKeydownPress from 'hooks/useKeydownPress';
 import { useMarkNotificationFromUrl } from 'hooks/useMarkNotificationFromUrl';
 import { getPagesListCacheKey, usePages } from 'hooks/usePages';
 import { useSettingsDialog } from 'hooks/useSettingsDialog';

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -1,6 +1,5 @@
 import type { EditorState, EditorView } from '@bangle.dev/pm';
 import { Node } from '@bangle.dev/pm';
-import { useEditorState } from '@bangle.dev/react';
 import { log } from '@charmverse/core/log';
 import type { PagePermissionFlags } from '@charmverse/core/permissions';
 import type { PageType } from '@charmverse/core/prisma';
@@ -28,6 +27,7 @@ import { extractDeletedThreadIds } from 'lib/prosemirror/plugins/inlineComments/
 import { setUrlWithoutRerender } from 'lib/utilities/browser';
 
 import { BangleEditor as ReactBangleEditor } from './components/@bangle.dev/react/ReactEditor';
+import { useEditorState } from './components/@bangle.dev/react/useEditorState';
 import { BookmarkNodeView } from './components/bookmark/BookmarkNodeView';
 import Callout from './components/callout/components/Callout';
 import { CryptoPrice } from './components/CryptoPrice';

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -326,7 +326,8 @@ function CharmEditor({
     plugins: getPlugins(),
     initialValue: isContentControlled && content ? Node.fromJSON(specRegistry.schema, content) : undefined,
     dropCursorOpts: {
-      color: 'var(--charmeditor-active)'
+      color: 'var(--charmeditor-active)',
+      class: 'charmeditor-drop-cursor'
     }
   });
 

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -326,8 +326,7 @@ function CharmEditor({
     plugins: getPlugins(),
     initialValue: isContentControlled && content ? Node.fromJSON(specRegistry.schema, content) : undefined,
     dropCursorOpts: {
-      color: 'var(--charmeditor-active)',
-      class: 'charmeditor-drop-cursor'
+      color: 'var(--charmeditor-active)'
     }
   });
 

--- a/components/common/CharmEditor/InlineCharmEditor.tsx
+++ b/components/common/CharmEditor/InlineCharmEditor.tsx
@@ -2,7 +2,6 @@ import { bold, code, italic, paragraph, strike, underline } from '@bangle.dev/ba
 import { Plugin, SpecRegistry } from '@bangle.dev/core';
 import type { EditorView } from '@bangle.dev/pm';
 import { Node, PluginKey } from '@bangle.dev/pm';
-import { useEditorState } from '@bangle.dev/react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 import type { CSSProperties, ReactNode } from 'react';
@@ -12,6 +11,7 @@ import { useUser } from 'hooks/useUser';
 import type { PageContent } from 'lib/prosemirror/interfaces';
 
 import { BangleEditor as ReactBangleEditor } from './components/@bangle.dev/react/ReactEditor';
+import { useEditorState } from './components/@bangle.dev/react/useEditorState';
 import { userDataPlugin } from './components/charm/charm.plugins';
 import EmojiSuggest from './components/emojiSuggest/EmojiSuggest.component';
 import { pluginKeyName as emojiSuggestKeyName } from './components/emojiSuggest/emojiSuggest.constants';

--- a/components/common/CharmEditor/components/@bangle.dev/core/bangle-editor-state.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/bangle-editor-state.ts
@@ -1,0 +1,109 @@
+// Reference: https://github.com/bangle-io/bangle-editor/blob/13127cf2e4187ebaa6d5e01d80f4e9018fae02a5/lib/core/src/bangle-editor-state.ts
+
+import type { RawPlugins, RawSpecs } from '@bangle.dev/core';
+import { SpecRegistry } from '@bangle.dev/core';
+import type { dropCursor as pmDropCursor, EditorProps, Mark, ParseOptions, Schema, Selection } from '@bangle.dev/pm';
+import { DOMParser, EditorState, Node } from '@bangle.dev/pm';
+import { log } from '@charmverse/core/log';
+
+import { pluginLoader } from './plugin-loader';
+
+type InitialContent = string | Node | object;
+
+export interface BangleEditorStateProps<PluginMetadata = any> {
+  specRegistry?: SpecRegistry;
+  specs?: RawSpecs;
+  plugins?: RawPlugins;
+  initialValue?: InitialContent;
+  editorProps?: EditorProps;
+  pmStateOpts?: {
+    selection?: Selection | undefined;
+    storedMarks?: Mark[] | null | undefined;
+  };
+  pluginMetadata?: PluginMetadata;
+  dropCursorOpts?: Parameters<typeof pmDropCursor>[0];
+}
+
+const createDocument = ({
+  schema,
+  content,
+  parseOptions
+}: {
+  schema: Schema;
+  content?: InitialContent;
+  parseOptions?: ParseOptions;
+}): Node | undefined => {
+  const emptyDocument = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph'
+      }
+    ]
+  };
+
+  if (content == null) {
+    return schema.nodeFromJSON(emptyDocument);
+  }
+
+  if (content instanceof Node) {
+    return content;
+  }
+  if (typeof content === 'object') {
+    return schema.nodeFromJSON(content);
+  }
+
+  if (typeof content === 'string') {
+    const element = document.createElement('div');
+    element.innerHTML = content.trim();
+    return DOMParser.fromSchema(schema).parse(element, parseOptions);
+  }
+
+  return undefined;
+};
+
+export class BangleEditorState<PluginMetadata> {
+  specRegistry: SpecRegistry;
+
+  pmState: EditorState;
+
+  constructor({
+    specRegistry,
+    specs,
+    plugins = () => [],
+    initialValue,
+    editorProps,
+    pmStateOpts,
+    pluginMetadata,
+    dropCursorOpts
+  }: BangleEditorStateProps<PluginMetadata> = {}) {
+    if (specs && specRegistry) {
+      throw new Error('Cannot have both specs and specRegistry defined');
+    }
+
+    if (!specRegistry) {
+      specRegistry = new SpecRegistry(specs);
+    }
+
+    if (Array.isArray(plugins)) {
+      log.warn(
+        'The use plugins as an array is deprecated, please pass a function which returns an array of plugins. Refer: https://bangle.dev/docs/api/core#bangleeditorstate'
+      );
+    }
+    this.specRegistry = specRegistry;
+    const schema = this.specRegistry.schema;
+
+    const pmPlugins = pluginLoader(specRegistry, plugins, {
+      editorProps,
+      metadata: pluginMetadata,
+      dropCursorOpts
+    });
+
+    this.pmState = EditorState.create({
+      schema,
+      doc: createDocument({ schema, content: initialValue }),
+      plugins: pmPlugins,
+      ...pmStateOpts
+    });
+  }
+}

--- a/components/common/CharmEditor/components/@bangle.dev/core/bangle-editor.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/bangle-editor.ts
@@ -1,0 +1,65 @@
+import type { DirectEditorProps } from '@bangle.dev/pm';
+import { EditorView } from '@bangle.dev/pm';
+import { isTestEnv, toHTMLString } from '@bangle.dev/utils';
+
+import { BangleEditorState } from './bangle-editor-state';
+
+type PMViewOpts = Omit<DirectEditorProps, 'state' | 'dispatchTransaction' | 'attributes'>;
+
+export interface BangleEditorProps<PluginMetadata> {
+  focusOnInit?: boolean;
+  state: BangleEditorState<PluginMetadata>;
+  pmViewOpts?: PMViewOpts;
+}
+
+export class BangleEditor<PluginMetadata = any> {
+  destroyed: boolean;
+
+  view: EditorView;
+
+  constructor(element: HTMLElement, { focusOnInit = true, state, pmViewOpts = {} }: BangleEditorProps<PluginMetadata>) {
+    this.destroyed = false;
+    if (!(state instanceof BangleEditorState)) {
+      throw new Error('state is required and must be an instance of BangleEditorState');
+    }
+
+    this.view = new EditorView(element, {
+      state: state.pmState,
+      dispatchTransaction: (transaction) => {
+        const newState = this.view.state.apply(transaction);
+        this.view.updateState(newState);
+      },
+      attributes: { class: 'bangle-editor' },
+      ...pmViewOpts
+    });
+
+    if (focusOnInit) {
+      this.focusView();
+    }
+  }
+
+  destroy() {
+    if (this.destroyed) {
+      return;
+    }
+
+    if (this.view.isDestroyed) {
+      this.destroyed = true;
+      return;
+    }
+
+    this.destroyed = true;
+    this.view.destroy();
+  }
+
+  focusView() {
+    if (isTestEnv || this.view.hasFocus()) {
+      return;
+    }
+    this.view.focus();
+  }
+
+  toHTMLString() {
+    return toHTMLString(this.view.state);
+  }
+}

--- a/components/common/CharmEditor/components/@bangle.dev/core/editor-state-counter.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/editor-state-counter.ts
@@ -1,0 +1,37 @@
+import { Plugin, PluginKey } from '@bangle.dev/pm';
+
+import { PluginGroup, type RawPlugins } from './plugin-loader';
+
+const name = 'editorStateCounter';
+export const plugins = pluginsFactory;
+export const docChangedKey = new PluginKey(name);
+export const selectionChangedKey = new PluginKey(name);
+
+function pluginsFactory(): RawPlugins {
+  return () => {
+    return new PluginGroup(name, [
+      new Plugin({
+        key: docChangedKey,
+        state: {
+          init(_, _state) {
+            return 0;
+          },
+          apply(tr, pluginState, _oldState, _newState) {
+            return tr.docChanged ? pluginState + 1 : pluginState;
+          }
+        }
+      }),
+      new Plugin({
+        key: selectionChangedKey,
+        state: {
+          init(_, _state) {
+            return 0;
+          },
+          apply(_tr, pluginState, oldState, newState) {
+            return newState.selection.eq(oldState && oldState.selection) ? pluginState : pluginState + 1;
+          }
+        }
+      })
+    ]);
+  };
+}

--- a/components/common/CharmEditor/components/@bangle.dev/core/editor-state-counter.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/editor-state-counter.ts
@@ -1,6 +1,7 @@
 import { Plugin, PluginKey } from '@bangle.dev/pm';
 
-import { PluginGroup, type RawPlugins } from './plugin-loader';
+import { PluginGroup } from './plugin-group';
+import type { RawPlugins } from './plugin-loader';
 
 const name = 'editorStateCounter';
 export const plugins = pluginsFactory;

--- a/components/common/CharmEditor/components/@bangle.dev/core/history.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/history.ts
@@ -2,7 +2,8 @@ import * as pmHistory from '@bangle.dev/pm';
 import { keymap } from '@bangle.dev/pm';
 import { createObject } from '@bangle.dev/utils';
 
-import { PluginGroup, type RawPlugins } from './plugin-loader';
+import { PluginGroup } from './plugin-group';
+import { type RawPlugins } from './plugin-loader';
 
 export const plugins = pluginsFactory;
 export const commands = {

--- a/components/common/CharmEditor/components/@bangle.dev/core/history.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/history.ts
@@ -1,0 +1,41 @@
+import * as pmHistory from '@bangle.dev/pm';
+import { keymap } from '@bangle.dev/pm';
+import { createObject } from '@bangle.dev/utils';
+
+import { PluginGroup, type RawPlugins } from './plugin-loader';
+
+export const plugins = pluginsFactory;
+export const commands = {
+  undo,
+  redo
+};
+export const defaultKeys = {
+  undo: 'Mod-z',
+  redo: 'Mod-y',
+  redoAlt: 'Shift-Mod-z'
+};
+
+const name = 'history';
+
+function pluginsFactory({ historyOpts = {}, keybindings = defaultKeys } = {}): RawPlugins {
+  return () => {
+    return new PluginGroup(name, [
+      pmHistory.history(historyOpts),
+      keybindings &&
+        keymap(
+          createObject([
+            [keybindings.undo, undo()],
+            [keybindings.redo, redo()],
+            [keybindings.redoAlt, redo()]
+          ])
+        )
+    ]);
+  };
+}
+
+export function undo() {
+  return pmHistory.undo;
+}
+export function redo() {
+  return pmHistory.redo;
+}

--- a/components/common/CharmEditor/components/@bangle.dev/core/plugin-group.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/plugin-group.ts
@@ -1,0 +1,8 @@
+import type { Plugin } from '@bangle.dev/pm';
+
+interface DeepPluginArray extends Array<Plugin | DeepPluginArray> {}
+
+export class PluginGroup {
+  // eslint-disable-next-line no-empty-function, no-useless-constructor
+  constructor(public name: string, public plugins: DeepPluginArray) {}
+}

--- a/components/common/CharmEditor/components/@bangle.dev/core/plugin-loader.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/plugin-loader.ts
@@ -1,0 +1,198 @@
+// References: https://github.com/bangle-io/bangle-editor/blob/13127cf2e4187ebaa6d5e01d80f4e9018fae02a5/lib/core/src/plugin-loader.ts
+
+import { type SpecRegistry } from '@bangle.dev/core';
+import type { EditorProps, Schema } from '@bangle.dev/pm';
+import {
+  baseKeymap as pmBaseKeymap,
+  gapCursor as pmGapCursor,
+  InputRule,
+  inputRules as pmInputRules,
+  keymap,
+  Plugin,
+  undoInputRule as pmUndoInputRule
+} from '@bangle.dev/pm';
+import { bangleWarn } from '@bangle.dev/utils';
+import { log } from '@charmverse/core/log';
+
+import { dropCursor } from '../../prosemirror/prosemirror-dropcursor/dropcursor';
+
+import * as editorStateCounter from './editor-state-counter';
+import * as history from './history';
+
+export interface PluginPayload<T = any> {
+  schema: Schema;
+  specRegistry: SpecRegistry;
+  metadata: T;
+}
+
+interface DeepPluginArray extends Array<Plugin | DeepPluginArray> {}
+
+export class PluginGroup {
+  // eslint-disable-next-line no-empty-function, no-useless-constructor
+  constructor(public name: string, public plugins: DeepPluginArray) {}
+}
+
+type BaseRawPlugins = false | null | Plugin | InputRule | PluginGroup | BaseRawPlugins[];
+
+export type RawPlugins<T = any> = BaseRawPlugins | ((payLoad: PluginPayload<T>) => BaseRawPlugins);
+
+export function pluginLoader<T = any>(
+  specRegistry: SpecRegistry,
+  plugins: RawPlugins<T>,
+  {
+    metadata,
+    editorProps,
+    defaultPlugins = true,
+    dropCursorOpts,
+    transformPlugins = (p) => p
+  }: {
+    metadata?: T;
+    editorProps?: EditorProps;
+    defaultPlugins?: boolean;
+    dropCursorOpts?: Parameters<typeof dropCursor>[0];
+    transformPlugins?: (plugins: Plugin[]) => Plugin[];
+  } = {}
+): Plugin[] {
+  const schema = specRegistry.schema;
+  const pluginPayload = {
+    schema,
+    specRegistry,
+    metadata
+  };
+
+  // eslint-disable-next-line prefer-const
+  let [flatPlugins, pluginGroupNames] = flatten(plugins, pluginPayload);
+
+  if (defaultPlugins) {
+    const defaultPluginGroups: RawPlugins[] = [];
+
+    if (!pluginGroupNames.has('history')) {
+      defaultPluginGroups.push(history.plugins());
+    }
+
+    if (!pluginGroupNames.has('editorStateCounter')) {
+      defaultPluginGroups.push(editorStateCounter.plugins());
+    }
+
+    flatPlugins = flatPlugins.concat(
+      // TODO: deprecate the ability pass a callback to the plugins param of pluginGroup
+      flatten(defaultPluginGroups, pluginPayload)[0]
+    );
+
+    flatPlugins = processInputRules(flatPlugins);
+
+    flatPlugins.push(keymap(pmBaseKeymap), dropCursor(dropCursorOpts), pmGapCursor());
+  }
+
+  if (editorProps) {
+    flatPlugins.push(
+      new Plugin({
+        props: editorProps
+      })
+    );
+  }
+
+  flatPlugins = flatPlugins.filter(Boolean);
+  flatPlugins = transformPlugins(flatPlugins);
+
+  if (flatPlugins.some((p: any) => !(p instanceof Plugin))) {
+    log.warn(
+      'You are either using multiple versions of the library or not returning a Plugin class in your plugins. Investigate :',
+      flatPlugins.find((p: any) => !(p instanceof Plugin))
+    );
+    throw new Error('Invalid plugin');
+  }
+
+  validateNodeViews(flatPlugins, specRegistry);
+
+  return flatPlugins;
+}
+
+function processInputRules(plugins: Plugin[], { inputRules = true, undoInputRule = true } = {}) {
+  const newPlugins: any[] = [];
+  const match: InputRule[] = [];
+  plugins.forEach((plugin) => {
+    if (plugin instanceof InputRule) {
+      match.push(plugin);
+      return;
+    }
+    newPlugins.push(plugin);
+  });
+
+  if (inputRules) {
+    plugins = [
+      ...newPlugins,
+      pmInputRules({
+        rules: match
+      })
+    ];
+  }
+
+  if (undoInputRule) {
+    plugins.push(
+      keymap({
+        Backspace: pmUndoInputRule
+      })
+    );
+  }
+
+  return plugins;
+}
+
+function validateNodeViews(plugins: Plugin[], specRegistry: any) {
+  const nodeViewPlugins = plugins.filter((p: any) => p.props && p.props.nodeViews);
+  const nodeViewNames = new Map();
+  for (const plugin of nodeViewPlugins) {
+    for (const name of Object.keys(plugin.props.nodeViews as any)) {
+      if (!specRegistry.schema.nodes[name]) {
+        bangleWarn(
+          `When loading your plugins, we found nodeView implementation for the node '${name}' did not have a corresponding spec. Check the plugin:`,
+          plugin,
+          'and your specRegistry',
+          specRegistry
+        );
+
+        throw new Error(`NodeView validation failed. Spec for '${name}' not found.`);
+      }
+
+      if (nodeViewNames.has(name)) {
+        bangleWarn(
+          `When loading your plugins, we found more than one nodeView implementation for the node '${name}'. Bangle can only have a single nodeView implementation, please check the following two plugins`,
+          plugin,
+          nodeViewNames.get(name)
+        );
+        throw new Error(`NodeView validation failed. Duplicate nodeViews for '${name}' found.`);
+      }
+      nodeViewNames.set(name, plugin);
+    }
+  }
+}
+
+function flatten<T>(rawPlugins: RawPlugins, callbackPayload: PluginPayload<T>): [Plugin[], Set<string>] {
+  const pluginGroupNames = new Set<string>();
+
+  const recurse = (plugins: RawPlugins): any => {
+    if (Array.isArray(plugins)) {
+      return plugins.flatMap((p: any) => recurse(p)).filter(Boolean);
+    }
+
+    if (plugins instanceof PluginGroup) {
+      if (pluginGroupNames.has(plugins.name)) {
+        throw new Error(`Duplicate names of pluginGroups ${plugins.name} not allowed.`);
+      }
+      pluginGroupNames.add(plugins.name);
+      return recurse(plugins.plugins);
+    }
+
+    if (typeof plugins === 'function') {
+      if (!callbackPayload) {
+        throw new Error('Found a function but no payload');
+      }
+      return recurse(plugins(callbackPayload));
+    }
+
+    return plugins;
+  };
+
+  return [recurse(rawPlugins), pluginGroupNames];
+}

--- a/components/common/CharmEditor/components/@bangle.dev/core/plugin-loader.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/plugin-loader.ts
@@ -18,18 +18,12 @@ import { dropCursor } from '../../prosemirror/prosemirror-dropcursor/dropcursor'
 
 import * as editorStateCounter from './editor-state-counter';
 import * as history from './history';
+import { PluginGroup } from './plugin-group';
 
 export interface PluginPayload<T = any> {
   schema: Schema;
   specRegistry: SpecRegistry;
   metadata: T;
-}
-
-interface DeepPluginArray extends Array<Plugin | DeepPluginArray> {}
-
-export class PluginGroup {
-  // eslint-disable-next-line no-empty-function, no-useless-constructor
-  constructor(public name: string, public plugins: DeepPluginArray) {}
 }
 
 type BaseRawPlugins = false | null | Plugin | InputRule | PluginGroup | BaseRawPlugins[];

--- a/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
@@ -1,6 +1,5 @@
 import { history } from '@bangle.dev/base-components';
 import type { BangleEditorProps as CoreBangleEditorProps } from '@bangle.dev/core';
-import { BangleEditor as CoreBangleEditor } from '@bangle.dev/core';
 import { EditorState } from '@bangle.dev/pm';
 import type { Plugin } from '@bangle.dev/pm';
 import { EditorViewContext } from '@bangle.dev/react';
@@ -25,6 +24,7 @@ import { isTouchScreen } from 'lib/utilities/browser';
 
 import { FidusEditor } from '../../fiduswriter/fiduseditor';
 import type { ConnectionEvent } from '../../fiduswriter/ws';
+import { BangleEditor as CoreBangleEditor } from '../core/bangle-editor';
 
 import { nodeViewUpdateStore, useNodeViews } from './node-view-helpers';
 import { NodeViewWrapper } from './NodeViewWrapper';

--- a/components/common/CharmEditor/components/@bangle.dev/react/useEditorState.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/react/useEditorState.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+import type { BangleEditorStateProps } from '../core/bangle-editor-state';
+import { BangleEditorState } from '../core/bangle-editor-state';
+
+export function useEditorState(props: BangleEditorStateProps) {
+  if (props.plugins && typeof props.plugins !== 'function') {
+    throw new Error('plugins error: plugins must be a function');
+  }
+  const [state] = useState(
+    () =>
+      // Instantiate the editorState once and keep using that instance
+      // on subsequent renders.
+      // Passing a callback in useState lazy calls the
+      // functions on the first render and never again.
+      new BangleEditorState(props)
+  );
+  return state;
+}

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -2,8 +2,7 @@ import type { NodeViewProps } from '@bangle.dev/core';
 import { useEditorViewContext } from '@bangle.dev/react';
 import type { PageMeta } from '@charmverse/core/pages';
 import styled from '@emotion/styled';
-import { Box, Typography } from '@mui/material';
-import { useState } from 'react';
+import { Typography } from '@mui/material';
 
 import Link from 'components/common/Link';
 import { NoAccessPageIcon, PageIcon } from 'components/common/PageLayout/components/PageIcon';
@@ -58,7 +57,6 @@ export default function NestedPage({
   const staticPage = STATIC_PAGES.find((c) => c.path === node.attrs.path && node.attrs.type === c.path);
   const forumCategoryPage = categories.find((c) => c.id === node.attrs.id && node.attrs.type === 'forum_category');
   const parentPage = documentPage?.parentId ? pages[documentPage.parentId] : null;
-  const [isHoveredOver, setIsHoveredOver] = useState(false);
   let pageTitle = '';
   if (documentPage || staticPage) {
     pageTitle = (documentPage || staticPage)?.title || 'Untitled';
@@ -79,45 +77,30 @@ export default function NestedPage({
   const _isLinkedPage = isLinkedPage ?? (currentPageId ? parentPage?.id !== currentPageId : false);
 
   return (
-    <>
-      <Box py={0.125} className='nested-page-separator' />
-      <NestedPageContainer
-        onDragEnter={() => {
-          if (!isHoveredOver) {
-            setIsHoveredOver(true);
-          }
-        }}
-        onDragLeave={() => {
-          if (isHoveredOver) {
-            setIsHoveredOver(false);
-          }
-        }}
-        data-test={`${isLinkedPage ? 'linked-page' : 'nested-page'}-${pageId}`}
-        data-page-type={node.attrs.type ?? documentPage?.type}
-        href={appPath ? `/${appPath}` : undefined}
-        color='inherit'
-        data-id={`page-${pageId}`}
-        data-title={pageTitle}
-        data-path={fullPath}
-        className={isHoveredOver ? 'ProseMirror-selectednode' : ''}
-        onDragStart={() => {
-          const nodePos = getPos();
-          enableDragAndDrop(view, nodePos);
-        }}
-        data-type={node.attrs.type}
-      >
-        <div>
-          <LinkIcon
-            isLinkedPage={_isLinkedPage}
-            documentPage={documentPage}
-            staticPage={staticPage}
-            isCategoryPage={!!forumCategoryPage}
-          />
-        </div>
-        <StyledTypography>{pageTitle}</StyledTypography>
-      </NestedPageContainer>
-      <Box py={0.125} className='nested-page-separator' />
-    </>
+    <NestedPageContainer
+      data-test={`${isLinkedPage ? 'linked-page' : 'nested-page'}-${pageId}`}
+      data-page-type={node.attrs.type ?? documentPage?.type}
+      href={appPath ? `/${appPath}` : undefined}
+      color='inherit'
+      data-id={`page-${pageId}`}
+      data-title={pageTitle}
+      data-path={fullPath}
+      onDragStart={() => {
+        const nodePos = getPos();
+        enableDragAndDrop(view, nodePos);
+      }}
+      data-type={node.attrs.type}
+    >
+      <div>
+        <LinkIcon
+          isLinkedPage={_isLinkedPage}
+          documentPage={documentPage}
+          staticPage={staticPage}
+          isCategoryPage={!!forumCategoryPage}
+        />
+      </div>
+      <StyledTypography>{pageTitle}</StyledTypography>
+    </NestedPageContainer>
   );
 }
 

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -13,7 +13,7 @@ import { useForumCategories } from 'hooks/useForumCategories';
 import { usePages } from 'hooks/usePages';
 
 import { enableDragAndDrop } from '../../../utils';
-import { dragPluginKey } from '../../prosemirror/prosemirror-dropcursor/dropcursor';
+import { HOVERED_PAGE_NODE_CLASS, dragPluginKey } from '../../prosemirror/prosemirror-dropcursor/dropcursor';
 
 const NestedPageContainer = styled(Link)`
   align-items: center;
@@ -96,7 +96,7 @@ export default function NestedPage({
         const pluginState = dragPluginKey.getState(view.state);
         if (pluginState.hoveredDomNode) {
           view.dispatch(view.state.tr.setMeta(dragPluginKey, { hoveredDomNode: null }));
-          pluginState.hoveredDomNode.classList.remove('Prosemirror-hovered-page-node');
+          pluginState.hoveredDomNode.classList.remove(HOVERED_PAGE_NODE_CLASS);
         }
       }}
     >

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -2,7 +2,8 @@ import type { NodeViewProps } from '@bangle.dev/core';
 import { useEditorViewContext } from '@bangle.dev/react';
 import type { PageMeta } from '@charmverse/core/pages';
 import styled from '@emotion/styled';
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
+import { useState } from 'react';
 
 import Link from 'components/common/Link';
 import { NoAccessPageIcon, PageIcon } from 'components/common/PageLayout/components/PageIcon';
@@ -57,7 +58,7 @@ export default function NestedPage({
   const staticPage = STATIC_PAGES.find((c) => c.path === node.attrs.path && node.attrs.type === c.path);
   const forumCategoryPage = categories.find((c) => c.id === node.attrs.id && node.attrs.type === 'forum_category');
   const parentPage = documentPage?.parentId ? pages[documentPage.parentId] : null;
-
+  const [isHoveredOver, setIsHoveredOver] = useState(false);
   let pageTitle = '';
   if (documentPage || staticPage) {
     pageTitle = (documentPage || staticPage)?.title || 'Untitled';
@@ -78,30 +79,45 @@ export default function NestedPage({
   const _isLinkedPage = isLinkedPage ?? (currentPageId ? parentPage?.id !== currentPageId : false);
 
   return (
-    <NestedPageContainer
-      data-test={`${isLinkedPage ? 'linked-page' : 'nested-page'}-${pageId}`}
-      data-page-type={node.attrs.type ?? documentPage?.type}
-      href={appPath ? `/${appPath}` : undefined}
-      color='inherit'
-      data-id={`page-${pageId}`}
-      data-title={pageTitle}
-      data-path={fullPath}
-      onDragStart={() => {
-        const nodePos = getPos();
-        enableDragAndDrop(view, nodePos);
-      }}
-      data-type={node.attrs.type}
-    >
-      <div>
-        <LinkIcon
-          isLinkedPage={_isLinkedPage}
-          documentPage={documentPage}
-          staticPage={staticPage}
-          isCategoryPage={!!forumCategoryPage}
-        />
-      </div>
-      <StyledTypography>{pageTitle}</StyledTypography>
-    </NestedPageContainer>
+    <>
+      <Box py={0.125} className='nested-page-separator' />
+      <NestedPageContainer
+        onDragEnter={() => {
+          if (!isHoveredOver) {
+            setIsHoveredOver(true);
+          }
+        }}
+        onDragLeave={() => {
+          if (isHoveredOver) {
+            setIsHoveredOver(false);
+          }
+        }}
+        data-test={`${isLinkedPage ? 'linked-page' : 'nested-page'}-${pageId}`}
+        data-page-type={node.attrs.type ?? documentPage?.type}
+        href={appPath ? `/${appPath}` : undefined}
+        color='inherit'
+        data-id={`page-${pageId}`}
+        data-title={pageTitle}
+        data-path={fullPath}
+        className={isHoveredOver ? 'ProseMirror-selectednode' : ''}
+        onDragStart={() => {
+          const nodePos = getPos();
+          enableDragAndDrop(view, nodePos);
+        }}
+        data-type={node.attrs.type}
+      >
+        <div>
+          <LinkIcon
+            isLinkedPage={_isLinkedPage}
+            documentPage={documentPage}
+            staticPage={staticPage}
+            isCategoryPage={!!forumCategoryPage}
+          />
+        </div>
+        <StyledTypography>{pageTitle}</StyledTypography>
+      </NestedPageContainer>
+      <Box py={0.125} className='nested-page-separator' />
+    </>
   );
 }
 

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -14,7 +14,7 @@ import { useForumCategories } from 'hooks/useForumCategories';
 import { usePages } from 'hooks/usePages';
 
 import { enableDragAndDrop } from '../../../utils';
-import { HOVERED_PAGE_NODE_CLASS, pageNodeDropPluginKey } from '../../prosemirror/prosemirror-dropcursor/dropcursor';
+import { pageNodeDropPluginKey } from '../../prosemirror/prosemirror-dropcursor/dropcursor';
 
 const NestedPageContainer = styled(Link)`
   align-items: center;
@@ -46,11 +46,13 @@ const StyledTypography = styled(Typography)`
   border-bottom: 0.05em solid var(--link-underline);
 `;
 
-function resetHoverPluginState(view: EditorView) {
-  const pluginState = pageNodeDropPluginKey.getState(view.state);
-  if (pluginState.hoveredDomNode) {
-    view.dispatch(view.state.tr.setMeta(pageNodeDropPluginKey, { hoveredDomNode: null }));
-    pluginState.hoveredDomNode.classList.remove(HOVERED_PAGE_NODE_CLASS);
+function resetPageNodeDropPluginState(view: EditorView) {
+  const pluginState = pageNodeDropPluginKey.getState(view.state) as {
+    hoveredPageDomNode: HTMLElement | null;
+  };
+  if (pluginState.hoveredPageDomNode) {
+    view.dispatch(view.state.tr.setMeta(pageNodeDropPluginKey, { hoveredPageDomNode: null }));
+    pluginState.hoveredPageDomNode.removeAttribute('id');
   }
 }
 
@@ -93,7 +95,7 @@ export default function NestedPage({
       data-page-type={node.attrs.type ?? documentPage?.type}
       href={appPath ? `/${appPath}` : undefined}
       color='inherit'
-      data-id={`page-${pageId}`}
+      data-id={pageId}
       data-title={pageTitle}
       data-path={fullPath}
       onDragStart={() => {
@@ -103,13 +105,13 @@ export default function NestedPage({
       data-type={node.attrs.type}
       // Only works for firefox
       onDragExitCapture={() => {
-        resetHoverPluginState(view);
+        resetPageNodeDropPluginState(view);
       }}
-      // Should only works for chrome, firefox also handles it but for ff we have onDragExitCapture
+      // Should only works for chrome, opera and IE, firefox also handles it but for ff we have onDragExitCapture
       onDragLeaveCapture={() => {
-        const isChrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;
-        if (isChrome) {
-          resetHoverPluginState(view);
+        const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+        if (!isFirefox) {
+          resetPageNodeDropPluginState(view);
         }
       }}
     >

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -21,6 +21,7 @@ const NestedPageContainer = styled(Link)`
   padding: 3px 3px 3px 2px;
   position: relative;
   transition: background 20ms ease-in 0s;
+  margin: ${({ theme }) => `${theme.spacing(0.5)} 0px`};
 
   // disable hover UX on ios which converts first click to a hover event
   @media (pointer: fine) {

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -13,6 +13,7 @@ import { useForumCategories } from 'hooks/useForumCategories';
 import { usePages } from 'hooks/usePages';
 
 import { enableDragAndDrop } from '../../../utils';
+import { dragPluginKey } from '../../prosemirror/prosemirror-dropcursor/dropcursor';
 
 const NestedPageContainer = styled(Link)`
   align-items: center;
@@ -91,6 +92,13 @@ export default function NestedPage({
         enableDragAndDrop(view, nodePos);
       }}
       data-type={node.attrs.type}
+      onDragLeaveCapture={() => {
+        const pluginState = dragPluginKey.getState(view.state);
+        if (pluginState.hoveredDomNode) {
+          view.dispatch(view.state.tr.setMeta(dragPluginKey, { hoveredDomNode: null }));
+          pluginState.hoveredDomNode.classList.remove('Prosemirror-hovered-page-node');
+        }
+      }}
     >
       <div>
         <LinkIcon

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -80,6 +80,7 @@ export default function NestedPage({
   return (
     <NestedPageContainer
       data-test={`${isLinkedPage ? 'linked-page' : 'nested-page'}-${pageId}`}
+      data-page-type={node.attrs.type ?? documentPage?.type}
       href={appPath ? `/${appPath}` : undefined}
       color='inherit'
       data-id={`page-${pageId}`}

--- a/components/common/CharmEditor/components/nestedPage/nestedPage.plugins.ts
+++ b/components/common/CharmEditor/components/nestedPage/nestedPage.plugins.ts
@@ -73,7 +73,6 @@ export function pageNodeDropPlugin({ pageId }: { pageId?: string | null }) {
                       payload: {
                         pageId: parsedData.pageId,
                         newParentId: hoveredPageId ?? pageId,
-                        newIndex: -1,
                         dropPos: hoveredPageId
                           ? null
                           : coordinates.pos + (view.state.doc.nodeAt(coordinates.pos) ? 0 : 1)
@@ -109,7 +108,6 @@ export function pageNodeDropPlugin({ pageId }: { pageId?: string | null }) {
                     payload: {
                       pageId: draggedPageId,
                       newParentId: hoveredPageId,
-                      newIndex: -1,
                       draggedNode: draggedNode.toJSON(),
                       dragNodePos: view.state.selection.$anchor.pos,
                       currentParentId: pageId

--- a/components/common/CharmEditor/components/nestedPage/nestedPage.plugins.ts
+++ b/components/common/CharmEditor/components/nestedPage/nestedPage.plugins.ts
@@ -39,19 +39,17 @@ export function pageNodeDropPlugin({ pageId }: { pageId?: string | null }) {
         props: {
           handleDOMEvents: {
             drop(view, ev) {
+              const hoveredDomNode = pageNodeDropPluginKey.getState(view.state).hoveredDomNode as Element;
+              view.dispatch(view.state.tr.setMeta(pageNodeDropPluginKey, { hoveredDomNode: null }));
+              hoveredDomNode?.classList.remove(HOVERED_PAGE_NODE_CLASS);
+
               if (!ev.dataTransfer || !pageId) {
                 return false;
               }
 
               const sidebarPageData = ev.dataTransfer.getData('sidebar-page');
 
-              const hoveredDomNode = pageNodeDropPluginKey.getState(view.state).hoveredDomNode as Element;
               const hoveredPageId = hoveredDomNode?.getAttribute('data-id')?.split('page-')[1];
-
-              view.dispatch(view.state.tr.setMeta(pageNodeDropPluginKey, { hoveredDomNode: null }));
-              hoveredDomNode?.classList.remove(HOVERED_PAGE_NODE_CLASS);
-              const currentGapCursorDomNode = document.querySelector('.ProseMirror-gapcursor');
-              currentGapCursorDomNode?.classList.remove('ProseMirror-gapcursor');
 
               if (sidebarPageData) {
                 const coordinates = view.posAtCoords({

--- a/components/common/CharmEditor/components/nestedPage/nestedPage.plugins.ts
+++ b/components/common/CharmEditor/components/nestedPage/nestedPage.plugins.ts
@@ -1,4 +1,10 @@
-import { NodeView } from '@bangle.dev/core';
+import { Plugin, NodeView } from '@bangle.dev/core';
+import { TextSelection } from '@bangle.dev/pm';
+import type { PageType } from '@charmverse/core/prisma-client';
+
+import { emitSocketMessage } from 'hooks/useWebSocketClient';
+
+import { HOVERED_PAGE_NODE_CLASS, pageNodeDropPluginKey } from '../prosemirror/prosemirror-dropcursor/dropcursor';
 
 export function nestedPagePlugins() {
   return () => {
@@ -6,6 +12,122 @@ export function nestedPagePlugins() {
       NodeView.createPlugin({
         name: 'page',
         containerDOM: ['div', { class: 'page-container' }]
+      })
+    ];
+  };
+}
+
+export function pageNodeDropPlugin({ pageId }: { pageId?: string | null }) {
+  return () => {
+    return [
+      new Plugin({
+        key: pageNodeDropPluginKey,
+        state: {
+          init: () => {
+            return {
+              hoveredDomNode: null
+            };
+          },
+          apply: (tr, pluginState: { hoveredDomNode: Element | null }) => {
+            const newPluginState = tr.getMeta(pageNodeDropPluginKey);
+            if (newPluginState) {
+              return { ...pluginState, ...newPluginState };
+            }
+            return pluginState;
+          }
+        },
+        props: {
+          handleDOMEvents: {
+            drop(view, ev) {
+              if (!ev.dataTransfer || !pageId) {
+                return false;
+              }
+
+              const sidebarPageData = ev.dataTransfer.getData('sidebar-page');
+
+              const hoveredDomNode = pageNodeDropPluginKey.getState(view.state).hoveredDomNode as Element;
+              const hoveredPageId = hoveredDomNode?.getAttribute('data-id')?.split('page-')[1];
+
+              view.dispatch(view.state.tr.setMeta(pageNodeDropPluginKey, { hoveredDomNode: null }));
+              hoveredDomNode?.classList.remove(HOVERED_PAGE_NODE_CLASS);
+              const currentGapCursorDomNode = document.querySelector('.ProseMirror-gapcursor');
+              currentGapCursorDomNode?.classList.remove('ProseMirror-gapcursor');
+
+              if (sidebarPageData) {
+                const coordinates = view.posAtCoords({
+                  left: ev.clientX,
+                  top: ev.clientY
+                });
+
+                if (!coordinates) {
+                  return false;
+                }
+
+                try {
+                  const parsedData = JSON.parse(sidebarPageData) as { pageId: string | null; pageType: PageType };
+                  if (!parsedData.pageId) {
+                    return false;
+                  }
+                  ev.preventDefault();
+                  emitSocketMessage(
+                    {
+                      type: 'page_reordered_sidebar_to_editor',
+                      payload: {
+                        pageId: parsedData.pageId,
+                        newParentId: hoveredPageId ?? pageId,
+                        newIndex: -1,
+                        dropPos: hoveredPageId
+                          ? null
+                          : coordinates.pos + (view.state.doc.nodeAt(coordinates.pos) ? 0 : 1)
+                      }
+                    },
+                    () => {
+                      view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 0)));
+                    }
+                  );
+                  // + 1 for dropping in non empty node
+                  // + 0 for dropping in empty node (blank line)
+                  return false;
+                } catch (_) {
+                  return false;
+                }
+              } else if (hoveredDomNode) {
+                const draggedNode = view.state.doc.nodeAt(view.state.selection.$anchor.pos);
+
+                if (!draggedNode || hoveredDomNode.getAttribute('data-page-type') !== 'page') {
+                  return false;
+                }
+
+                const draggedPageId = draggedNode.attrs.id;
+
+                if (!hoveredPageId || hoveredPageId === draggedPageId) {
+                  return false;
+                }
+
+                ev.preventDefault();
+                emitSocketMessage(
+                  {
+                    type: 'page_reordered_editor_to_editor',
+                    payload: {
+                      pageId: draggedPageId,
+                      newParentId: hoveredPageId,
+                      newIndex: -1,
+                      draggedNode: draggedNode.toJSON(),
+                      dragNodePos: view.state.selection.$anchor.pos,
+                      currentParentId: pageId
+                    }
+                  },
+                  () => {
+                    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 0)));
+                  }
+                );
+                return false;
+              }
+
+              return false;
+            }
+          }
+        }
       })
     ];
   };

--- a/components/common/CharmEditor/components/nestedPage/nestedPage.plugins.ts
+++ b/components/common/CharmEditor/components/nestedPage/nestedPage.plugins.ts
@@ -4,7 +4,7 @@ import type { PageType } from '@charmverse/core/prisma-client';
 
 import { emitSocketMessage } from 'hooks/useWebSocketClient';
 
-import { HOVERED_PAGE_NODE_CLASS, pageNodeDropPluginKey } from '../prosemirror/prosemirror-dropcursor/dropcursor';
+import { pageNodeDropPluginKey } from '../prosemirror/prosemirror-dropcursor/dropcursor';
 
 export function nestedPagePlugins() {
   return () => {
@@ -25,10 +25,10 @@ export function pageNodeDropPlugin({ pageId }: { pageId?: string | null }) {
         state: {
           init: () => {
             return {
-              hoveredDomNode: null
+              hoveredPageDomNode: null
             };
           },
-          apply: (tr, pluginState: { hoveredDomNode: Element | null }) => {
+          apply: (tr, pluginState: { hoveredPageDomNode: HTMLElement | null }) => {
             const newPluginState = tr.getMeta(pageNodeDropPluginKey);
             if (newPluginState) {
               return { ...pluginState, ...newPluginState };
@@ -39,9 +39,10 @@ export function pageNodeDropPlugin({ pageId }: { pageId?: string | null }) {
         props: {
           handleDOMEvents: {
             drop(view, ev) {
-              const hoveredDomNode = pageNodeDropPluginKey.getState(view.state).hoveredDomNode as Element;
-              view.dispatch(view.state.tr.setMeta(pageNodeDropPluginKey, { hoveredDomNode: null }));
-              hoveredDomNode?.classList.remove(HOVERED_PAGE_NODE_CLASS);
+              const hoveredPageDomNode = pageNodeDropPluginKey.getState(view.state)
+                .hoveredPageDomNode as HTMLElement | null;
+              view.dispatch(view.state.tr.setMeta(pageNodeDropPluginKey, { hoveredPageDomNode: null }));
+              hoveredPageDomNode?.removeAttribute('id');
 
               if (!ev.dataTransfer || !pageId) {
                 return false;
@@ -49,7 +50,7 @@ export function pageNodeDropPlugin({ pageId }: { pageId?: string | null }) {
 
               const sidebarPageData = ev.dataTransfer.getData('sidebar-page');
 
-              const hoveredPageId = hoveredDomNode?.getAttribute('data-id')?.split('page-')[1];
+              const hoveredPageId = hoveredPageDomNode?.dataset.id;
 
               if (sidebarPageData) {
                 const coordinates = view.posAtCoords({
@@ -88,10 +89,10 @@ export function pageNodeDropPlugin({ pageId }: { pageId?: string | null }) {
                 } catch (_) {
                   return false;
                 }
-              } else if (hoveredDomNode) {
+              } else if (hoveredPageDomNode) {
                 const draggedNode = view.state.doc.nodeAt(view.state.selection.$anchor.pos);
 
-                if (!draggedNode || hoveredDomNode.getAttribute('data-page-type') !== 'page') {
+                if (!draggedNode || hoveredPageDomNode.getAttribute('data-page-type') !== 'page') {
                   return false;
                 }
 

--- a/components/common/CharmEditor/components/nestedPage/nestedPage.utils.ts
+++ b/components/common/CharmEditor/components/nestedPage/nestedPage.utils.ts
@@ -41,7 +41,7 @@ export async function replaceNestedPages(convertedToMarkdown: string): Promise<s
       (await import('lib/pages/server/generatePageLink')).generatePageLink
     : // Client-side method
       (pageId: string) => {
-        const documentNode = document.querySelector(`[data-id="page-${pageId}"]`) as HTMLDivElement;
+        const documentNode = document.querySelector(`[data-id="${pageId}"]`) as HTMLDivElement;
         const pageLink: PageLink = {
           title: (documentNode?.getAttribute('data-title') as string) ?? '',
           url: (documentNode?.getAttribute('data-path') as string) ?? ''

--- a/components/common/CharmEditor/components/prosemirror/prosemirror-dropcursor/dropcursor.ts
+++ b/components/common/CharmEditor/components/prosemirror/prosemirror-dropcursor/dropcursor.ts
@@ -4,7 +4,7 @@ import { Plugin, PluginKey } from 'prosemirror-state';
 import { dropPoint } from 'prosemirror-transform';
 import type { EditorView } from 'prosemirror-view';
 
-export const dragPluginKey = new PluginKey('dragPlugin');
+export const pageNodeDropPluginKey = new PluginKey('dragPlugin');
 export const HOVERED_PAGE_NODE_CLASS = 'Prosemirror-hovered-page-node';
 
 interface DropCursorOptions {
@@ -156,7 +156,7 @@ class DropCursorView {
       if (draggedNode?.attrs.id !== hoveredPageDomNodeId) {
         hoveredPageDomNode.classList.add(HOVERED_PAGE_NODE_CLASS);
         view.dispatch(
-          view.state.tr.setMeta(dragPluginKey, {
+          view.state.tr.setMeta(pageNodeDropPluginKey, {
             hoveredDomNode: hoveredPageDomNode
           })
         );
@@ -166,11 +166,11 @@ class DropCursorView {
       }
       return;
     } else {
-      const hoveredDomNode = dragPluginKey.getState(view.state)?.hoveredDomNode;
+      const hoveredDomNode = pageNodeDropPluginKey.getState(view.state)?.hoveredDomNode;
       if (hoveredDomNode) {
         hoveredDomNode.classList.remove(HOVERED_PAGE_NODE_CLASS);
         view.dispatch(
-          view.state.tr.setMeta(dragPluginKey, {
+          view.state.tr.setMeta(pageNodeDropPluginKey, {
             hoveredDomNode: null
           })
         );

--- a/components/common/CharmEditor/components/prosemirror/prosemirror-dropcursor/dropcursor.ts
+++ b/components/common/CharmEditor/components/prosemirror/prosemirror-dropcursor/dropcursor.ts
@@ -146,6 +146,8 @@ class DropCursorView {
         : null;
     const hoveredPageDomNodeId = hoveredPageDomNode?.getAttribute('data-id')?.split('page-')[1];
     const currentHoveredPageDomNode = document.querySelector('.Prosemirror-hovered-page-node');
+    const currentGapCursorDomNode = document.querySelector('.ProseMirror-gapcursor');
+    // Remove the class from the previous hovered page node
     if (currentHoveredPageDomNode?.getAttribute('data-id')?.split('page-')[1] !== hoveredPageDomNodeId) {
       currentHoveredPageDomNode?.classList.remove('Prosemirror-hovered-page-node');
     }
@@ -157,6 +159,9 @@ class DropCursorView {
             hoveredDomNode: hoveredPageDomNode
           })
         );
+        if (currentGapCursorDomNode) {
+          currentGapCursorDomNode.classList.remove('ProseMirror-gapcursor');
+        }
       }
       return;
     } else {

--- a/components/common/CharmEditor/components/prosemirror/prosemirror-dropcursor/dropcursor.ts
+++ b/components/common/CharmEditor/components/prosemirror/prosemirror-dropcursor/dropcursor.ts
@@ -127,7 +127,7 @@ class DropCursorView {
     this.element.style.left = `${(rect.left - parentLeft) / scaleX}px`;
     this.element.style.top = `${(rect.top - parentTop) / scaleY}px`;
     this.element.style.width = `${(rect.right - rect.left) / scaleX}px`;
-    this.element.style.height = `${(rect.bottom - rect.top) / scaleY}px`;
+    this.element.style.height = `3px`;
   }
 
   scheduleRemoval(timeout: number) {
@@ -147,7 +147,6 @@ class DropCursorView {
         : null;
     const hoveredPageDomNodeId = hoveredPageDomNode?.getAttribute('data-id')?.split('page-')[1];
     const currentHoveredPageDomNode = document.querySelector(`.${HOVERED_PAGE_NODE_CLASS}`);
-    const currentGapCursorDomNode = document.querySelector('.ProseMirror-gapcursor');
     // Remove the class from the previous hovered page node
     if (currentHoveredPageDomNode?.getAttribute('data-id')?.split('page-')[1] !== hoveredPageDomNodeId) {
       currentHoveredPageDomNode?.classList.remove(HOVERED_PAGE_NODE_CLASS);
@@ -160,9 +159,6 @@ class DropCursorView {
             hoveredDomNode: hoveredPageDomNode
           })
         );
-        if (currentGapCursorDomNode) {
-          currentGapCursorDomNode.classList.remove('ProseMirror-gapcursor');
-        }
       }
       return;
     } else {

--- a/components/common/CharmEditor/components/prosemirror/prosemirror-dropcursor/dropcursor.ts
+++ b/components/common/CharmEditor/components/prosemirror/prosemirror-dropcursor/dropcursor.ts
@@ -5,6 +5,7 @@ import { dropPoint } from 'prosemirror-transform';
 import type { EditorView } from 'prosemirror-view';
 
 export const dragPluginKey = new PluginKey('dragPlugin');
+export const HOVERED_PAGE_NODE_CLASS = 'Prosemirror-hovered-page-node';
 
 interface DropCursorOptions {
   /// The color of the cursor. Defaults to `black`. Use `false` to apply no color and rely only on class.
@@ -145,15 +146,15 @@ class DropCursorView {
         ? domElementAtCoords.parentElement
         : null;
     const hoveredPageDomNodeId = hoveredPageDomNode?.getAttribute('data-id')?.split('page-')[1];
-    const currentHoveredPageDomNode = document.querySelector('.Prosemirror-hovered-page-node');
+    const currentHoveredPageDomNode = document.querySelector(`.${HOVERED_PAGE_NODE_CLASS}`);
     const currentGapCursorDomNode = document.querySelector('.ProseMirror-gapcursor');
     // Remove the class from the previous hovered page node
     if (currentHoveredPageDomNode?.getAttribute('data-id')?.split('page-')[1] !== hoveredPageDomNodeId) {
-      currentHoveredPageDomNode?.classList.remove('Prosemirror-hovered-page-node');
+      currentHoveredPageDomNode?.classList.remove(HOVERED_PAGE_NODE_CLASS);
     }
     if (hoveredPageDomNode) {
       if (draggedNode?.attrs.id !== hoveredPageDomNodeId) {
-        hoveredPageDomNode.classList.add('Prosemirror-hovered-page-node');
+        hoveredPageDomNode.classList.add(HOVERED_PAGE_NODE_CLASS);
         view.dispatch(
           view.state.tr.setMeta(dragPluginKey, {
             hoveredDomNode: hoveredPageDomNode
@@ -167,7 +168,7 @@ class DropCursorView {
     } else {
       const hoveredDomNode = dragPluginKey.getState(view.state)?.hoveredDomNode;
       if (hoveredDomNode) {
-        hoveredDomNode.classList.remove('Prosemirror-hovered-page-node');
+        hoveredDomNode.classList.remove(HOVERED_PAGE_NODE_CLASS);
         view.dispatch(
           view.state.tr.setMeta(dragPluginKey, {
             hoveredDomNode: null

--- a/components/common/CharmEditor/components/prosemirror/prosemirror-dropcursor/dropcursor.ts
+++ b/components/common/CharmEditor/components/prosemirror/prosemirror-dropcursor/dropcursor.ts
@@ -1,0 +1,181 @@
+import type { EditorState } from 'prosemirror-state';
+import { Plugin } from 'prosemirror-state';
+import { dropPoint } from 'prosemirror-transform';
+import type { EditorView } from 'prosemirror-view';
+
+interface DropCursorOptions {
+  /// The color of the cursor. Defaults to `black`. Use `false` to apply no color and rely only on class.
+  color?: string | false;
+
+  /// The precise width of the cursor in pixels. Defaults to 1.
+  width?: number;
+
+  /// A CSS class name to add to the cursor element.
+  class?: string;
+}
+
+class DropCursorView {
+  width: number;
+
+  color: string | undefined;
+
+  class: string | undefined;
+
+  cursorPos: number | null = null;
+
+  element: HTMLElement | null = null;
+
+  timeout: number = -1;
+
+  handlers: { name: string; handler: (event: Event) => void }[];
+
+  constructor(readonly editorView: EditorView, options: DropCursorOptions) {
+    this.width = options.width ?? 1;
+    this.color = options.color === false ? undefined : options.color || 'black';
+    this.class = options.class;
+
+    this.handlers = ['dragover', 'dragend', 'drop', 'dragleave'].map((name) => {
+      const handler = (e: Event) => {
+        (this as any)[name](e);
+      };
+      editorView.dom.addEventListener(name, handler);
+      return { name, handler };
+    });
+  }
+
+  destroy() {
+    this.handlers.forEach(({ name, handler }) => this.editorView.dom.removeEventListener(name, handler));
+  }
+
+  update(editorView: EditorView, prevState: EditorState) {
+    if (this.cursorPos != null && prevState.doc !== editorView.state.doc) {
+      if (this.cursorPos > editorView.state.doc.content.size) this.setCursor(null);
+      else this.updateOverlay();
+    }
+  }
+
+  setCursor(pos: number | null) {
+    if (pos === this.cursorPos) return;
+    this.cursorPos = pos;
+    if (pos == null) {
+      this.element!.parentNode!.removeChild(this.element!);
+      this.element = null;
+    } else {
+      this.updateOverlay();
+    }
+  }
+
+  updateOverlay() {
+    const $pos = this.editorView.state.doc.resolve(this.cursorPos!);
+    const isBlock = !$pos.parent.inlineContent;
+    let rect;
+    const editorDOM = this.editorView.dom;
+    const editorRect = editorDOM.getBoundingClientRect();
+    const scaleX = editorRect.width / editorDOM.offsetWidth;
+    const scaleY = editorRect.height / editorDOM.offsetHeight;
+    if (isBlock) {
+      const before = $pos.nodeBefore;
+      const after = $pos.nodeAfter;
+      if (before || after) {
+        const node = this.editorView.nodeDOM(this.cursorPos! - (before ? before.nodeSize : 0));
+        if (node) {
+          const nodeRect = (node as HTMLElement).getBoundingClientRect();
+          let top = before ? nodeRect.bottom : nodeRect.top;
+          if (before && after)
+            top = (top + (this.editorView.nodeDOM(this.cursorPos!) as HTMLElement).getBoundingClientRect().top) / 2;
+          const halfWidth = (this.width / 2) * scaleY;
+          rect = { left: nodeRect.left, right: nodeRect.right, top: top - halfWidth, bottom: top + halfWidth };
+        }
+      }
+    }
+    if (!rect) {
+      const coords = this.editorView.coordsAtPos(this.cursorPos!);
+      const halfWidth = (this.width / 2) * scaleX;
+      rect = { left: coords.left - halfWidth, right: coords.left + halfWidth, top: coords.top, bottom: coords.bottom };
+    }
+
+    const parent = this.editorView.dom.offsetParent as HTMLElement;
+    if (!this.element) {
+      this.element = parent.appendChild(document.createElement('div'));
+      if (this.class) this.element.className = this.class;
+      this.element.style.cssText = 'position: absolute; z-index: 50; pointer-events: none;';
+      if (this.color) {
+        this.element.style.backgroundColor = this.color;
+      }
+    }
+    this.element.classList.toggle('prosemirror-dropcursor-block', isBlock);
+    this.element.classList.toggle('prosemirror-dropcursor-inline', !isBlock);
+    let parentLeft;
+    let parentTop;
+    if (!parent || (parent === document.body && getComputedStyle(parent).position === 'static')) {
+      // eslint-disable-next-line no-restricted-globals
+      parentLeft = -window.pageXOffset;
+      // eslint-disable-next-line no-restricted-globals
+      parentTop = -window.pageYOffset;
+    } else {
+      const _rect = parent.getBoundingClientRect();
+      const parentScaleX = _rect.width / parent.offsetWidth;
+      const parentScaleY = _rect.height / parent.offsetHeight;
+      parentLeft = _rect.left - parent.scrollLeft * parentScaleX;
+      parentTop = _rect.top - parent.scrollTop * parentScaleY;
+    }
+    this.element.style.left = `${(rect.left - parentLeft) / scaleX}px`;
+    this.element.style.top = `${(rect.top - parentTop) / scaleY}px`;
+    this.element.style.width = `${(rect.right - rect.left) / scaleX}px`;
+    this.element.style.height = `${(rect.bottom - rect.top) / scaleY}px`;
+  }
+
+  scheduleRemoval(timeout: number) {
+    clearTimeout(this.timeout);
+    this.timeout = window.setTimeout(() => this.setCursor(null), timeout);
+  }
+
+  dragover(event: DragEvent) {
+    if (!this.editorView.editable) return;
+    const pos = this.editorView.posAtCoords({ left: event.clientX, top: event.clientY });
+
+    const node = pos && pos.inside >= 0 && this.editorView.state.doc.nodeAt(pos.inside);
+    const disableDropCursor = node && node.type.spec.disableDropCursor;
+    const disabled =
+      typeof disableDropCursor === 'function' ? disableDropCursor(this.editorView, pos, event) : disableDropCursor;
+
+    if (pos && !disabled) {
+      let target: number | null = pos.pos;
+      if (this.editorView.dragging && this.editorView.dragging.slice) {
+        const point = dropPoint(this.editorView.state.doc, target, this.editorView.dragging.slice);
+        if (point != null) target = point;
+      }
+      this.setCursor(target);
+      this.scheduleRemoval(5000);
+    }
+  }
+
+  dragend() {
+    this.scheduleRemoval(20);
+  }
+
+  drop() {
+    this.scheduleRemoval(20);
+  }
+
+  dragleave(event: DragEvent) {
+    if (event.target === this.editorView.dom || !this.editorView.dom.contains((event as any).relatedTarget))
+      this.setCursor(null);
+  }
+}
+
+/// Create a plugin that, when added to a ProseMirror instance,
+/// causes a decoration to show up at the drop position when something
+/// is dragged over the editor.
+///
+/// Nodes may add a `disableDropCursor` property to their spec to
+/// control the showing of a drop cursor inside them. This may be a
+/// boolean or a function, which will be called with a view and a
+/// position, and should return a boolean.
+export function dropCursor(options: DropCursorOptions = {}): Plugin {
+  return new Plugin({
+    view(editorView) {
+      return new DropCursorView(editorView, options);
+    }
+  });
+}

--- a/components/common/CharmEditor/plugins.ts
+++ b/components/common/CharmEditor/plugins.ts
@@ -118,8 +118,9 @@ export function charmEditorPlugins({
             const hoveredPageId = hoveredDomNode?.getAttribute('data-id')?.split('page-')[1];
 
             view.dispatch(view.state.tr.setMeta(dragPluginKey, { hoveredDomNode: null }));
-            hoveredDomNode.classList.remove('Prosemirror-hovered-page-node');
-            view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 0)));
+            hoveredDomNode?.classList.remove('Prosemirror-hovered-page-node');
+            const currentGapCursorDomNode = document.querySelector('.ProseMirror-gapcursor');
+            currentGapCursorDomNode?.classList.remove('ProseMirror-gapcursor');
 
             if (sidebarPageData) {
               const coordinates = view.posAtCoords({
@@ -137,15 +138,20 @@ export function charmEditorPlugins({
                   return false;
                 }
                 ev.preventDefault();
-                emitSocketMessage({
-                  type: 'page_reordered_sidebar_to_editor',
-                  payload: {
-                    pageId: parsedData.pageId,
-                    newParentId: hoveredPageId ?? pageId,
-                    newIndex: -1,
-                    dropPos: hoveredPageId ? null : coordinates.pos + (view.state.doc.nodeAt(coordinates.pos) ? 0 : 1)
+                emitSocketMessage(
+                  {
+                    type: 'page_reordered_sidebar_to_editor',
+                    payload: {
+                      pageId: parsedData.pageId,
+                      newParentId: hoveredPageId ?? pageId,
+                      newIndex: -1,
+                      dropPos: hoveredPageId ? null : coordinates.pos + (view.state.doc.nodeAt(coordinates.pos) ? 0 : 1)
+                    }
+                  },
+                  () => {
+                    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 0)));
                   }
-                });
+                );
                 // + 1 for dropping in non empty node
                 // + 0 for dropping in empty node (blank line)
                 return false;
@@ -166,17 +172,22 @@ export function charmEditorPlugins({
               }
 
               ev.preventDefault();
-              emitSocketMessage({
-                type: 'page_reordered_editor_to_editor',
-                payload: {
-                  pageId: draggedPageId,
-                  newParentId: hoveredPageId,
-                  newIndex: -1,
-                  draggedNode: draggedNode.toJSON(),
-                  dragNodePos: view.state.selection.$anchor.pos,
-                  currentParentId: pageId
+              emitSocketMessage(
+                {
+                  type: 'page_reordered_editor_to_editor',
+                  payload: {
+                    pageId: draggedPageId,
+                    newParentId: hoveredPageId,
+                    newIndex: -1,
+                    draggedNode: draggedNode.toJSON(),
+                    dragNodePos: view.state.selection.$anchor.pos,
+                    currentParentId: pageId
+                  }
+                },
+                () => {
+                  view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 0)));
                 }
-              });
+              );
               return false;
             }
 

--- a/components/common/CharmEditor/plugins.ts
+++ b/components/common/CharmEditor/plugins.ts
@@ -115,9 +115,8 @@ export function charmEditorPlugins({
                 draggedNode &&
                 dom &&
                 (droppedNode.type.name === 'page' ||
-                  (droppedNode.type.name === 'linkedPage' && droppedNode.attrs.type === 'page') ||
-                  draggedNode.type.name === 'page' ||
-                  draggedNode.type.name === 'linkedPage');
+                  (droppedNode.type.name === 'linkedPage' && droppedNode.attrs.type === 'page')) &&
+                (draggedNode.type.name === 'page' || draggedNode.type.name === 'linkedPage');
 
               if (!validOperation) {
                 return false;
@@ -132,7 +131,7 @@ export function charmEditorPlugins({
 
               if (dom instanceof HTMLElement) {
                 const droppedDOMNode = dom.querySelector(`[data-id="page-${droppedPageId}"]`);
-                if (!droppedDOMNode) {
+                if (!droppedDOMNode || droppedDOMNode.getAttribute('data-page-type') !== 'page') {
                   return false;
                 }
 
@@ -145,7 +144,8 @@ export function charmEditorPlugins({
                     newIndex: -1,
                     trigger: 'editor-to-editor',
                     isLinkedPage: draggedNode.type.name === 'linkedPage',
-                    dragPos: view.state.tr.selection.$anchor.pos
+                    dragPos: view.state.tr.selection.$anchor.pos,
+                    currentParentId: pageId
                   }
                 });
               }

--- a/components/common/CharmEditor/plugins.ts
+++ b/components/common/CharmEditor/plugins.ts
@@ -36,7 +36,7 @@ import * as nft from './components/nft/nft.plugins';
 import paragraph from './components/paragraph';
 import * as pasteChecker from './components/pasteChecker/pasteChecker';
 import { placeholderPlugin } from './components/placeholder/placeholder';
-import { dragPluginKey } from './components/prosemirror/prosemirror-dropcursor/dropcursor';
+import { HOVERED_PAGE_NODE_CLASS, dragPluginKey } from './components/prosemirror/prosemirror-dropcursor/dropcursor';
 import * as rowActions from './components/rowActions/rowActions';
 import { plugins as trackPlugins } from './components/suggestions/suggestions.plugins';
 import * as tabIndent from './components/tabIndent';
@@ -118,7 +118,7 @@ export function charmEditorPlugins({
             const hoveredPageId = hoveredDomNode?.getAttribute('data-id')?.split('page-')[1];
 
             view.dispatch(view.state.tr.setMeta(dragPluginKey, { hoveredDomNode: null }));
-            hoveredDomNode?.classList.remove('Prosemirror-hovered-page-node');
+            hoveredDomNode?.classList.remove(HOVERED_PAGE_NODE_CLASS);
             const currentGapCursorDomNode = document.querySelector('.ProseMirror-gapcursor');
             currentGapCursorDomNode?.classList.remove('ProseMirror-gapcursor');
 

--- a/components/common/CharmEditor/plugins.ts
+++ b/components/common/CharmEditor/plugins.ts
@@ -108,6 +108,45 @@ export function charmEditorPlugins({
 
             const data = ev.dataTransfer.getData('sidebar-page');
             if (!data) {
+              const dom = view.nodeDOM(coordinates.pos);
+              const droppedNode = view.state.doc.nodeAt(coordinates.pos);
+              const draggedNode = view.state.doc.nodeAt(view.state.tr.selection.$anchor.pos);
+
+              if (
+                !droppedNode ||
+                !draggedNode ||
+                droppedNode.type.name !== 'page' ||
+                draggedNode.type.name !== 'page' ||
+                !dom
+              ) {
+                return false;
+              }
+
+              const draggedNodeId = draggedNode.attrs.id;
+              const droppedNodeId = droppedNode.attrs.id;
+
+              if (droppedNodeId === draggedNodeId) {
+                return false;
+              }
+
+              if (dom instanceof HTMLElement) {
+                const droppedPageId = droppedNode.attrs.id;
+                const droppedDOMNode = dom.querySelector(`[data-id="page-${droppedPageId}"]`);
+                if (!droppedDOMNode) {
+                  return false;
+                }
+
+                ev.preventDefault();
+                emitSocketMessage({
+                  type: 'page_reordered',
+                  payload: {
+                    pageId: draggedNodeId,
+                    newParentId: droppedNodeId,
+                    newIndex: -1,
+                    trigger: 'editor-to-editor'
+                  }
+                });
+              }
               return false;
             }
 

--- a/components/common/CharmEditor/plugins.ts
+++ b/components/common/CharmEditor/plugins.ts
@@ -135,12 +135,11 @@ export function charmEditorPlugins({
               hoveredDomNode.classList.remove('Prosemirror-hovered-page-node');
               ev.preventDefault();
               emitSocketMessage({
-                type: 'page_reordered',
+                type: 'page_reordered_editor_to_editor',
                 payload: {
                   pageId: draggedPageId,
                   newParentId: droppedPageId,
                   newIndex: -1,
-                  trigger: 'editor-to-editor',
                   draggedNode: draggedNode.toJSON(),
                   dragNodePos: view.state.selection.$anchor.pos,
                   currentParentId: pageId
@@ -166,12 +165,11 @@ export function charmEditorPlugins({
                 }
                 ev.preventDefault();
                 emitSocketMessage({
-                  type: 'page_reordered',
+                  type: 'page_reordered_sidebar_to_editor',
                   payload: {
                     pageId: parsedData.pageId,
                     newParentId: pageId,
                     newIndex: -1,
-                    trigger: 'sidebar-to-editor',
                     dropPos: coordinates.pos + (view.state.doc.nodeAt(coordinates.pos) ? 0 : 1)
                   }
                 });

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -145,8 +145,7 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
             type: 'page_reordered_sidebar_to_sidebar',
             payload: {
               pageId: droppedItem.id,
-              newParentId: containerItem.parentId,
-              newIndex: droppedItem.index
+              newParentId: containerItem.parentId
             }
           });
         }
@@ -192,8 +191,7 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
           type: 'page_reordered_sidebar_to_sidebar',
           payload: {
             pageId: droppedItem.id,
-            newParentId: containerItem.id,
-            newIndex: droppedItem.index
+            newParentId: containerItem.id
           }
         });
       }

--- a/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/PageNavigation/PageNavigation.tsx
@@ -142,12 +142,11 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
         // dropped on root level, so remove child page reference in parent's content
         if (droppedItem.parentId !== containerItem.parentId) {
           emitSocketMessage({
-            type: 'page_reordered',
+            type: 'page_reordered_sidebar_to_sidebar',
             payload: {
               pageId: droppedItem.id,
               newParentId: containerItem.parentId,
-              newIndex: droppedItem.index,
-              trigger: 'sidebar-to-sidebar'
+              newIndex: droppedItem.index
             }
           });
         }
@@ -190,12 +189,11 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
 
       if (parentId) {
         emitSocketMessage({
-          type: 'page_reordered',
+          type: 'page_reordered_sidebar_to_sidebar',
           payload: {
             pageId: droppedItem.id,
             newParentId: containerItem.id,
-            newIndex: droppedItem.index,
-            trigger: 'sidebar-to-sidebar'
+            newIndex: droppedItem.index
           }
         });
       }

--- a/lib/websockets/__tests__/spaceEvents.spec.ts
+++ b/lib/websockets/__tests__/spaceEvents.spec.ts
@@ -20,27 +20,35 @@ async function createPageAndSetupDocRooms({
   content,
   docRooms,
   spaceId,
-  user
+  user,
+  childCount = 1
 }: {
+  childCount?: number;
   spaceId: string;
   user: User;
   participants?: boolean;
-  content: (childPage: Page) => PageContent;
+  content: (...childPages: Page[]) => PageContent;
   docRooms: Map<string | undefined, DocumentRoom>;
 }) {
   const userId = user.id;
-  const childPageId = v4();
-  const childPage: Page = await testUtilsPages.generatePage({
-    id: childPageId,
-    spaceId,
-    createdBy: userId
-  });
-  const parentContent = content(childPage);
+  const childPages: Page[] = await Promise.all(
+    new Array(childCount).fill(0).map(() =>
+      testUtilsPages.generatePage({
+        id: v4(),
+        spaceId,
+        createdBy: userId
+      })
+    )
+  );
+
+  const parentContent = content(...childPages);
 
   const parentPage = await testUtilsPages.generatePage({ spaceId, createdBy: userId, content: parentContent });
-  await prisma.page.update({
+  await prisma.page.updateMany({
     where: {
-      id: childPage.id
+      id: {
+        in: childPages.map((page) => page.id)
+      }
     },
     data: {
       parentId: parentPage.id
@@ -93,9 +101,8 @@ async function createPageAndSetupDocRooms({
   return {
     docRooms,
     socketEmitMockFn,
-    childPageId,
     parentPage,
-    childPage,
+    childPages,
     websocketBroadcaster,
     relayBroadcastMockFn
   };
@@ -103,23 +110,26 @@ async function createPageAndSetupDocRooms({
 
 async function socketSetup({
   participants = false,
-  content
+  content,
+  childCount = 1
 }: {
+  childCount?: number;
   participants?: boolean;
-  content: (childPage: Page) => PageContent;
+  content: (...childPages: Page[]) => PageContent;
 }) {
   const { space, user } = await testUtilsUser.generateUserAndSpace({ isAdmin: true });
 
   const spaceId = space.id;
   const userId = user.id;
 
-  const { docRooms, childPage, childPageId, parentPage, socketEmitMockFn, websocketBroadcaster, relayBroadcastMockFn } =
+  const { docRooms, childPages, parentPage, socketEmitMockFn, websocketBroadcaster, relayBroadcastMockFn } =
     await createPageAndSetupDocRooms({
       participants,
       content,
       docRooms: new Map(),
       spaceId,
-      user
+      user,
+      childCount
     });
 
   const spaceEventHandler = new SpaceEventHandler(
@@ -141,20 +151,30 @@ async function socketSetup({
     user,
     parentPage,
     spaceEventHandler,
-    childPage,
+    childPages,
     relayBroadcastMockFn
   };
 }
 
-function contentWithChildPageNode(childPage: Page) {
+function contentWithChildPageNode(...childPages: (Page & { isLinkedPage?: boolean })[]) {
   return _.doc(
-    _.p('1'),
-    _.page({
-      id: childPage.id,
-      path: childPage.path,
-      type: childPage.type
-    }),
-    _.p('2')
+    ...childPages
+      .map((childPage, index) => [
+        _.p(`${index + 1}`),
+        childPage.isLinkedPage
+          ? _.linkedPage({
+              id: childPage.id,
+              path: childPage.path,
+              type: childPage.type
+            })
+          : _.page({
+              id: childPage.id,
+              path: childPage.path,
+              type: childPage.type
+            })
+      ])
+      .flat(),
+    _.p(`${childPages.length + 1}`)
   ).toJSON();
 }
 
@@ -162,15 +182,15 @@ const regularContent = _.doc(_.p('1'), _.p('2')).toJSON();
 
 describe('page delete event handler', () => {
   it(`Archive nested pages and remove it from parent document content when it have the nested page in its content and it is being viewed`, async () => {
-    const { relayBroadcastMockFn, socketEmitMockFn, childPage, spaceEventHandler, parentPage } = await socketSetup({
+    const { relayBroadcastMockFn, socketEmitMockFn, childPages, spaceEventHandler, parentPage } = await socketSetup({
       participants: true,
-      content: (childPage) => contentWithChildPageNode(childPage)
+      content: contentWithChildPageNode
     });
 
     const message: ClientMessage = {
       type: 'page_deleted',
       payload: {
-        id: childPage.id
+        id: childPages[0].id
       }
     };
 
@@ -187,7 +207,7 @@ describe('page delete event handler', () => {
 
     const childPageDb = await prisma.page.findUniqueOrThrow({
       where: {
-        id: childPage.id
+        id: childPages[0].id
       },
       select: {
         deletedAt: true
@@ -202,7 +222,12 @@ describe('page delete event handler', () => {
       {
         type: 'pages_meta_updated',
         payload: [
-          { id: childPage.id, deletedAt: expect.any(Date), spaceId: parentPage.spaceId, deletedBy: expect.any(String) }
+          {
+            id: childPages[0].id,
+            deletedAt: expect.any(Date),
+            spaceId: parentPage.spaceId,
+            deletedBy: expect.any(String)
+          }
         ]
       },
       parentPage.spaceId
@@ -211,21 +236,21 @@ describe('page delete event handler', () => {
       2,
       {
         type: 'pages_deleted',
-        payload: [{ id: childPage.id }]
+        payload: [{ id: childPages[0].id }]
       },
       parentPage.spaceId
     );
   });
 
   it(`Archive nested pages and remove it from parent documents content when it have the nested page in its content and it is not being viewed`, async () => {
-    const { socketEmitMockFn, relayBroadcastMockFn, childPage, spaceEventHandler, parentPage } = await socketSetup({
-      content: (childPage) => contentWithChildPageNode(childPage)
+    const { socketEmitMockFn, relayBroadcastMockFn, childPages, spaceEventHandler, parentPage } = await socketSetup({
+      content: contentWithChildPageNode
     });
 
     const message: ClientMessage = {
       type: 'page_deleted',
       payload: {
-        id: childPage.id
+        id: childPages[0].id
       }
     };
 
@@ -242,7 +267,7 @@ describe('page delete event handler', () => {
 
     const childPageDb = await prisma.page.findUniqueOrThrow({
       where: {
-        id: childPage.id
+        id: childPages[0].id
       },
       select: {
         deletedAt: true
@@ -257,7 +282,12 @@ describe('page delete event handler', () => {
       {
         type: 'pages_meta_updated',
         payload: [
-          { id: childPage.id, deletedAt: expect.any(Date), spaceId: parentPage.spaceId, deletedBy: expect.any(String) }
+          {
+            id: childPages[0].id,
+            deletedAt: expect.any(Date),
+            spaceId: parentPage.spaceId,
+            deletedBy: expect.any(String)
+          }
         ]
       },
       parentPage.spaceId
@@ -266,7 +296,7 @@ describe('page delete event handler', () => {
       2,
       {
         type: 'pages_deleted',
-        payload: [{ id: childPage.id }]
+        payload: [{ id: childPages[0].id }]
       },
       parentPage.spaceId
     );
@@ -275,13 +305,13 @@ describe('page delete event handler', () => {
 
 describe('page_restored event handler', () => {
   it('Restore nested pages and add it to parent page content when parent document has the nested page in its content and it is not being viewed', async () => {
-    const { socketEmitMockFn, relayBroadcastMockFn, childPage, spaceEventHandler, parentPage } = await socketSetup({
+    const { socketEmitMockFn, relayBroadcastMockFn, childPages, spaceEventHandler, parentPage } = await socketSetup({
       content: () => regularContent
     });
     const message: ClientMessage = {
       type: 'page_restored',
       payload: {
-        id: childPage.id
+        id: childPages[0].id
       }
     };
 
@@ -296,7 +326,7 @@ describe('page_restored event handler', () => {
     });
     const childPageDb = await prisma.page.findUniqueOrThrow({
       where: {
-        id: childPage.id
+        id: childPages[0].id
       },
       select: {
         deletedAt: true
@@ -307,7 +337,7 @@ describe('page_restored event handler', () => {
         _.p('1'),
         _.p('2'),
         _.page({
-          id: childPage.id
+          id: childPages[0].id
         })
       ).toJSON()
     );
@@ -317,7 +347,7 @@ describe('page_restored event handler', () => {
       1,
       {
         type: 'pages_meta_updated',
-        payload: [{ id: childPage.id, deletedAt: null, spaceId: parentPage.spaceId, deletedBy: null }]
+        payload: [{ id: childPages[0].id, deletedAt: null, spaceId: parentPage.spaceId, deletedBy: null }]
       },
       parentPage.spaceId
     );
@@ -325,21 +355,21 @@ describe('page_restored event handler', () => {
       2,
       {
         type: 'pages_restored',
-        payload: [{ id: childPage.id }]
+        payload: [{ id: childPages[0].id }]
       },
       parentPage.spaceId
     );
   });
 
   it(`Restore nested pages and add it to parent page content when parent document has the nested page in its content and it is being viewed`, async () => {
-    const { relayBroadcastMockFn, socketEmitMockFn, childPage, spaceEventHandler, parentPage } = await socketSetup({
+    const { relayBroadcastMockFn, socketEmitMockFn, childPages, spaceEventHandler, parentPage } = await socketSetup({
       content: () => regularContent
     });
 
     const message: ClientMessage = {
       type: 'page_restored',
       payload: {
-        id: childPage.id
+        id: childPages[0].id
       }
     };
 
@@ -356,7 +386,7 @@ describe('page_restored event handler', () => {
 
     const childPageDb = await prisma.page.findUniqueOrThrow({
       where: {
-        id: childPage.id
+        id: childPages[0].id
       },
       select: {
         deletedAt: true
@@ -368,7 +398,7 @@ describe('page_restored event handler', () => {
         _.p('1'),
         _.p('2'),
         _.page({
-          id: childPage.id
+          id: childPages[0].id
         })
       ).toJSON()
     );
@@ -379,7 +409,7 @@ describe('page_restored event handler', () => {
       1,
       {
         type: 'pages_meta_updated',
-        payload: [{ id: childPage.id, deletedAt: null, spaceId: parentPage.spaceId, deletedBy: null }]
+        payload: [{ id: childPages[0].id, deletedAt: null, spaceId: parentPage.spaceId, deletedBy: null }]
       },
       parentPage.spaceId
     );
@@ -387,7 +417,7 @@ describe('page_restored event handler', () => {
       2,
       {
         type: 'pages_restored',
-        payload: [{ id: childPage.id }]
+        payload: [{ id: childPages[0].id }]
       },
       parentPage.spaceId
     );
@@ -513,9 +543,9 @@ describe('page_created event handler', () => {
 
 describe('page_reordered_sidebar_to_sidebar event handler', () => {
   it(`Move page from one parent page to another parent page when both documents are being viewed`, async () => {
-    const { spaceEventHandler, socketEmitMockFn, parentPage, childPage, docRooms, space, user } = await socketSetup({
+    const { spaceEventHandler, socketEmitMockFn, parentPage, childPages, docRooms, space, user } = await socketSetup({
       participants: true,
-      content: (childPage) => contentWithChildPageNode(childPage)
+      content: contentWithChildPageNode
     });
 
     const { parentPage: parentPage2, socketEmitMockFn: socketEmitMockFn2 } = await createPageAndSetupDocRooms({
@@ -530,7 +560,7 @@ describe('page_reordered_sidebar_to_sidebar event handler', () => {
       type: 'page_reordered_sidebar_to_sidebar',
       payload: {
         newParentId: parentPage2.id,
-        pageId: childPage!.id
+        pageId: childPages[0].id
       }
     });
 
@@ -559,7 +589,9 @@ describe('page_reordered_sidebar_to_sidebar event handler', () => {
         _.p('1'),
         _.p('2'),
         _.page({
-          id: childPage!.id
+          id: childPages[0].id,
+          path: childPages[0].path,
+          type: childPages[0].type
         })
       ).toJSON()
     );
@@ -568,26 +600,26 @@ describe('page_reordered_sidebar_to_sidebar event handler', () => {
   });
 
   it(`Move page from one parent page to another parent page (with children) when none of the documents are being viewed`, async () => {
-    const { spaceEventHandler, childPage, parentPage, docRooms, space, user, socketEmitMockFn } = await socketSetup({
-      content: (childPage) => contentWithChildPageNode(childPage)
+    const { spaceEventHandler, childPages, parentPage, docRooms, space, user, socketEmitMockFn } = await socketSetup({
+      content: contentWithChildPageNode
     });
 
     const {
       parentPage: parentPage2,
-      childPage: childPage2,
+      childPages: childPages2,
       socketEmitMockFn: socketEmitMockFn2
     } = await createPageAndSetupDocRooms({
       docRooms,
       spaceId: space.id,
       user,
-      content: (childPage) => contentWithChildPageNode(childPage)
+      content: contentWithChildPageNode
     });
 
     await spaceEventHandler.onMessage({
       type: 'page_reordered_sidebar_to_sidebar',
       payload: {
         newParentId: parentPage2.id,
-        pageId: childPage!.id
+        pageId: childPages[0].id
       }
     });
 
@@ -615,13 +647,15 @@ describe('page_reordered_sidebar_to_sidebar event handler', () => {
       _.doc(
         _.p('1'),
         _.page({
-          id: childPage2!.id
+          id: childPages2[0].id,
+          path: childPages2[0].path,
+          type: childPages2[0].type
         }),
         _.p('2'),
         _.page({
-          id: childPage!.id,
-          path: childPage!.path,
-          type: childPage!.type
+          id: childPages[0].id,
+          path: childPages[0].path,
+          type: childPages[0].type
         })
       ).toJSON()
     );
@@ -630,16 +664,16 @@ describe('page_reordered_sidebar_to_sidebar event handler', () => {
   });
 
   it(`Move page from parent page to root level and the parent document is being viewed`, async () => {
-    const { spaceEventHandler, parentPage, childPage, socketEmitMockFn } = await socketSetup({
+    const { spaceEventHandler, parentPage, childPages, socketEmitMockFn } = await socketSetup({
       participants: true,
-      content: (childPage) => contentWithChildPageNode(childPage)
+      content: contentWithChildPageNode
     });
 
     await spaceEventHandler.onMessage({
       type: 'page_reordered_sidebar_to_sidebar',
       payload: {
         newParentId: null,
-        pageId: childPage.id
+        pageId: childPages[0].id
       }
     });
 
@@ -705,9 +739,9 @@ describe('page_reordered_sidebar_to_sidebar event handler', () => {
         _.p('1'),
         _.p('2'),
         _.page({
-          id: childPage!.id,
-          type: childPage!.type,
-          path: childPage!.path
+          id: childPage.id,
+          type: childPage.type,
+          path: childPage.path
         })
       ).toJSON()
     );
@@ -716,23 +750,23 @@ describe('page_reordered_sidebar_to_sidebar event handler', () => {
 
 describe('page_reordered_sidebar_to_editor event handler', () => {
   it(`Move nested page from the sidebar to the editor (on top of another nested page)`, async () => {
-    const { spaceEventHandler, docRooms, space, user, parentPage, childPage } = await socketSetup({
+    const { spaceEventHandler, docRooms, space, user, parentPage, childPages } = await socketSetup({
       participants: true,
-      content: (childPage) => contentWithChildPageNode(childPage)
+      content: contentWithChildPageNode
     });
 
-    const { childPage: childPage2 } = await createPageAndSetupDocRooms({
+    const { childPages: childPages2 } = await createPageAndSetupDocRooms({
       docRooms,
       spaceId: space.id,
       user,
-      content: (childPage) => contentWithChildPageNode(childPage)
+      content: contentWithChildPageNode
     });
 
     await spaceEventHandler.onMessage({
       type: 'page_reordered_sidebar_to_editor',
       payload: {
-        pageId: childPage!.id,
-        newParentId: childPage2!.id,
+        pageId: childPages[0].id,
+        newParentId: childPages2[0].id,
         dropPos: null
       }
     });
@@ -749,7 +783,7 @@ describe('page_reordered_sidebar_to_editor event handler', () => {
     const parentPageContent = parentPageDb.content as PageContent;
     const childPageDb = await prisma.page.findUniqueOrThrow({
       where: {
-        id: childPage!.id
+        id: childPages[0].id
       },
       select: {
         parentId: true
@@ -758,7 +792,7 @@ describe('page_reordered_sidebar_to_editor event handler', () => {
 
     const childPage2Db = await prisma.page.findUniqueOrThrow({
       where: {
-        id: childPage2!.id
+        id: childPages2[0].id
       },
       select: {
         content: true
@@ -766,37 +800,37 @@ describe('page_reordered_sidebar_to_editor event handler', () => {
     });
     const childPage2Content = childPage2Db.content as PageContent;
 
-    expect(childPageDb.parentId).toBe(childPage2!.id);
+    expect(childPageDb.parentId).toBe(childPages2[0].id);
     expect(parentPageContent).toMatchObject(regularContent);
     expect(childPage2Content).toMatchObject(
       _.doc(
         _.p(),
         _.page({
-          id: childPage!.id,
-          path: childPage!.path,
-          type: childPage!.type
+          id: childPages[0].id,
+          path: childPages[0].path,
+          type: childPages[0].type
         })
       ).toJSON()
     );
   });
 
   it(`Move nested page from the sidebar to the editor (below a nested page)`, async () => {
-    const { spaceEventHandler, docRooms, space, user, parentPage, childPage } = await socketSetup({
+    const { spaceEventHandler, docRooms, space, user, parentPage, childPages } = await socketSetup({
       participants: true,
-      content: (childPage) => contentWithChildPageNode(childPage)
+      content: contentWithChildPageNode
     });
 
-    const { parentPage: parentPage2, childPage: childPage2 } = await createPageAndSetupDocRooms({
+    const { parentPage: parentPage2, childPages: childPages2 } = await createPageAndSetupDocRooms({
       docRooms,
       spaceId: space.id,
       user,
-      content: (childPage) => contentWithChildPageNode(childPage)
+      content: contentWithChildPageNode
     });
 
     await spaceEventHandler.onMessage({
       type: 'page_reordered_sidebar_to_editor',
       payload: {
-        pageId: childPage!.id,
+        pageId: childPages[0].id,
         newParentId: parentPage2!.id,
         dropPos: 3
       }
@@ -824,7 +858,7 @@ describe('page_reordered_sidebar_to_editor event handler', () => {
     const parentPage2Content = parentPage2Db.content as PageContent;
     const childPageDb = await prisma.page.findUniqueOrThrow({
       where: {
-        id: childPage!.id
+        id: childPages[0].id
       },
       select: {
         parentId: true
@@ -837,14 +871,355 @@ describe('page_reordered_sidebar_to_editor event handler', () => {
       _.doc(
         _.p('1'),
         _.page({
-          id: childPage!.id,
-          path: childPage!.path,
-          type: childPage!.type
+          id: childPages[0].id,
+          path: childPages[0].path,
+          type: childPages[0].type
         }),
         _.page({
-          id: childPage2!.id
+          id: childPages2[0].id,
+          path: childPages2[0].path,
+          type: childPages2[0].type
         }),
         _.p('2')
+      ).toJSON()
+    );
+  });
+});
+
+describe('page_reordered_editor_to_editor event handler', () => {
+  it(`Move a nested page node from the editor to another nested page node in the editor`, async () => {
+    const { spaceEventHandler, parentPage, childPages } = await socketSetup({
+      participants: true,
+      content: contentWithChildPageNode,
+      childCount: 2
+    });
+
+    await spaceEventHandler.onMessage({
+      type: 'page_reordered_editor_to_editor',
+      payload: {
+        pageId: childPages[0].id,
+        newParentId: childPages[1].id,
+        currentParentId: parentPage.id,
+        draggedNode: {
+          type: 'page',
+          attrs: {
+            id: childPages[0].id
+          }
+        },
+        dragNodePos: 3
+      }
+    });
+
+    const parentPageDb = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: parentPage.id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    const parentPageContent = parentPageDb.content as PageContent;
+    const childPage1 = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: childPages[0].id
+      },
+      select: {
+        parentId: true
+      }
+    });
+
+    const childPage2 = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: childPages[1].id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    const childPage2Content = childPage2.content as PageContent;
+
+    expect(childPage1.parentId).toBe(childPages[1].id);
+    expect(parentPageContent).toMatchObject(
+      _.doc(
+        _.p('1'),
+        _.p('2'),
+        _.page({
+          id: childPages[1].id,
+          path: childPages[1].path,
+          type: childPages[1].type
+        }),
+        _.p('3')
+      ).toJSON()
+    );
+
+    expect(childPage2Content).toMatchObject(
+      _.doc(
+        _.p(),
+        _.page({
+          id: childPages[0].id,
+          path: childPages[0].path,
+          type: childPages[0].type
+        })
+      ).toJSON()
+    );
+  });
+
+  it(`Move a linked page node from the editor to a nested page node in the editor`, async () => {
+    const { spaceEventHandler, parentPage, childPages } = await socketSetup({
+      participants: true,
+      content: (childPage1, childPage2) =>
+        contentWithChildPageNode(
+          {
+            ...childPage1,
+            isLinkedPage: true
+          },
+          childPage2
+        ),
+      childCount: 2
+    });
+
+    await spaceEventHandler.onMessage({
+      type: 'page_reordered_editor_to_editor',
+      payload: {
+        pageId: childPages[0].id,
+        newParentId: childPages[1].id,
+        currentParentId: parentPage.id,
+        draggedNode: {
+          type: 'linkedPage',
+          attrs: {
+            id: childPages[0].id
+          }
+        },
+        dragNodePos: 3
+      }
+    });
+
+    const parentPageDb = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: parentPage.id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    const parentPageContent = parentPageDb.content as PageContent;
+    const childPage1 = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: childPages[0].id
+      },
+      select: {
+        parentId: true
+      }
+    });
+
+    const childPage2 = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: childPages[1].id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    const childPage2Content = childPage2.content as PageContent;
+
+    expect(childPage1.parentId).toBe(parentPage.id);
+    expect(parentPageContent).toMatchObject(
+      _.doc(
+        _.p('1'),
+        _.p('2'),
+        _.page({
+          id: childPages[1].id,
+          path: childPages[1].path,
+          type: childPages[1].type
+        }),
+        _.p('3')
+      ).toJSON()
+    );
+
+    expect(childPage2Content).toMatchObject(
+      _.doc(
+        _.p(),
+        _.linkedPage({
+          id: childPages[0].id,
+          path: childPages[0].path,
+          type: childPages[0].type
+        })
+      ).toJSON()
+    );
+  });
+
+  it(`Move a nested page node from the editor to another linked page node in the editor`, async () => {
+    const { spaceEventHandler, parentPage, childPages } = await socketSetup({
+      participants: true,
+      content: (childPage1, childPage2) =>
+        contentWithChildPageNode(childPage1, {
+          ...childPage2,
+          isLinkedPage: true
+        }),
+      childCount: 2
+    });
+
+    await spaceEventHandler.onMessage({
+      type: 'page_reordered_editor_to_editor',
+      payload: {
+        pageId: childPages[0].id,
+        newParentId: childPages[1].id,
+        currentParentId: parentPage.id,
+        draggedNode: {
+          type: 'page',
+          attrs: {
+            id: childPages[0].id
+          }
+        },
+        dragNodePos: 3
+      }
+    });
+
+    const parentPageDb = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: parentPage.id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    const parentPageContent = parentPageDb.content as PageContent;
+    const childPage1 = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: childPages[0].id
+      },
+      select: {
+        parentId: true
+      }
+    });
+
+    const childPage2 = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: childPages[1].id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    const childPage2Content = childPage2.content as PageContent;
+
+    expect(childPage1.parentId).toBe(childPages[1].id);
+    expect(parentPageContent).toMatchObject(
+      _.doc(
+        _.p('1'),
+        _.p('2'),
+        _.linkedPage({
+          id: childPages[1].id,
+          path: childPages[1].path,
+          type: childPages[1].type
+        }),
+        _.p('3')
+      ).toJSON()
+    );
+
+    expect(childPage2Content).toMatchObject(
+      _.doc(
+        _.p(),
+        _.page({
+          id: childPages[0].id,
+          path: childPages[0].path,
+          type: childPages[0].type
+        })
+      ).toJSON()
+    );
+  });
+
+  it(`Move a linked page node from the editor to another linked page node in the editor`, async () => {
+    const { spaceEventHandler, parentPage, childPages } = await socketSetup({
+      participants: true,
+      content: (childPage1, childPage2) =>
+        contentWithChildPageNode(
+          {
+            ...childPage1,
+            isLinkedPage: true
+          },
+          {
+            ...childPage2,
+            isLinkedPage: true
+          }
+        ),
+      childCount: 2
+    });
+
+    await spaceEventHandler.onMessage({
+      type: 'page_reordered_editor_to_editor',
+      payload: {
+        pageId: childPages[0].id,
+        newParentId: childPages[1].id,
+        currentParentId: parentPage.id,
+        draggedNode: {
+          type: 'linkedPage',
+          attrs: {
+            id: childPages[0].id
+          }
+        },
+        dragNodePos: 3
+      }
+    });
+
+    const parentPageDb = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: parentPage.id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    const parentPageContent = parentPageDb.content as PageContent;
+    const childPage1 = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: childPages[0].id
+      },
+      select: {
+        parentId: true
+      }
+    });
+
+    const childPage2 = await prisma.page.findUniqueOrThrow({
+      where: {
+        id: childPages[1].id
+      },
+      select: {
+        content: true
+      }
+    });
+
+    const childPage2Content = childPage2.content as PageContent;
+
+    expect(childPage1.parentId).toBe(parentPage.id);
+    expect(parentPageContent).toMatchObject(
+      _.doc(
+        _.p('1'),
+        _.p('2'),
+        _.linkedPage({
+          id: childPages[1].id,
+          path: childPages[1].path,
+          type: childPages[1].type
+        }),
+        _.p('3')
+      ).toJSON()
+    );
+
+    expect(childPage2Content).toMatchObject(
+      _.doc(
+        _.p(),
+        _.linkedPage({
+          id: childPages[0].id,
+          path: childPages[0].path,
+          type: childPages[0].type
+        })
       ).toJSON()
     );
   });

--- a/lib/websockets/__tests__/spaceEvents.spec.ts
+++ b/lib/websockets/__tests__/spaceEvents.spec.ts
@@ -141,6 +141,7 @@ async function socketSetup({
     docRooms
   );
   spaceEventHandler.userId = userId;
+  spaceEventHandler.spaceId = spaceId;
 
   return {
     docRooms,
@@ -292,6 +293,7 @@ describe('page delete event handler', () => {
       },
       parentPage.spaceId
     );
+
     expect(relayBroadcastMockFn).toHaveBeenNthCalledWith(
       2,
       {
@@ -716,6 +718,7 @@ describe('page_reordered_sidebar_to_sidebar event handler', () => {
       new Map()
     );
     spaceEventHandler.userId = userId;
+    spaceEventHandler.spaceId = spaceId;
 
     await spaceEventHandler.onMessage({
       type: 'page_reordered_sidebar_to_sidebar',

--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -4,6 +4,7 @@ import { prisma } from '@charmverse/core/prisma-client';
 import type { Socket } from 'socket.io';
 import { validate } from 'uuid';
 
+import { STATIC_PAGES } from 'components/common/PageLayout/components/Sidebar/utils/staticPages';
 import { archivePages } from 'lib/pages/archivePages';
 import { getPermissionsClient } from 'lib/permissions/api';
 import { applyStepsToNode } from 'lib/prosemirror/applyStepsToNode';
@@ -444,7 +445,7 @@ export class DocumentEventHandler {
                 if (node && node.type === 'page' && node.attrs) {
                   const { id: pageId, type: pageType = '', path: pagePath } = node.attrs;
                   // pagePath is null when the page is not a linked page
-                  if (pageId && pageType === null && pagePath === null) {
+                  if (pageId && pageType !== 'forum_category' && STATIC_PAGES.find((c) => c.path !== pagePath)) {
                     restoredPageIds.push(node.attrs?.id);
                   }
                 }
@@ -454,7 +455,7 @@ export class DocumentEventHandler {
               const node = room.node.resolve(ds.from).nodeAfter?.toJSON() as PageContent;
               if (node && node.attrs && node.type === 'page') {
                 const { id: pageId, type: pageType = '', path: pagePath } = node.attrs;
-                if (pageId && pageType === null && pagePath === null) {
+                if (pageId && pageType !== 'forum_category' && STATIC_PAGES.find((c) => c.path !== pagePath)) {
                   deletedPageIds.push(pageId);
                 }
               }
@@ -465,7 +466,7 @@ export class DocumentEventHandler {
                 const jsonNode = _node.toJSON() as PageContent;
                 if (jsonNode && jsonNode.type === 'page' && jsonNode.attrs) {
                   const { id: pageId, type: pageType = '', path: pagePath } = jsonNode.attrs;
-                  if (pageId && pageType === null && pagePath === null) {
+                  if (pageId && pageType !== 'forum_category' && STATIC_PAGES.find((c) => c.path !== pagePath)) {
                     deletedPageIds.push(pageId);
                   }
                 }

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -135,7 +135,7 @@ type PageReorderedSidebarToEditor = {
   type: 'page_reordered_sidebar_to_editor';
   payload: {
     pageId: string;
-    newParentId: string | null;
+    newParentId: string;
     dropPos: number | null;
   };
 };
@@ -144,13 +144,13 @@ type PageReorderedEditorToEditor = {
   type: 'page_reordered_editor_to_editor';
   payload: {
     pageId: string;
-    newParentId: string | null;
+    newParentId: string;
     draggedNode: {
       type: string;
       attrs?: Record<string, any>;
     };
     dragNodePos: number;
-    currentParentId: string | null;
+    currentParentId: string;
   };
 };
 

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -138,7 +138,7 @@ type PageReorderedSidebarToEditor = {
     pageId: string;
     newParentId: string | null;
     newIndex: number;
-    dropPos: number;
+    dropPos: number | null;
   };
 };
 

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -132,6 +132,7 @@ type PageReordered = {
     dropPos?: number;
     isLinkedPage?: boolean;
     dragPos?: number;
+    currentParentId?: string | null;
   };
 };
 

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -2,6 +2,7 @@
 
 import type { PageMeta } from '@charmverse/core/pages';
 import type { Page, Prisma, SubscriptionTier } from '@charmverse/core/prisma';
+import type { Node } from 'prosemirror-model';
 import type { Server, Socket } from 'socket.io';
 
 import type { Block } from 'lib/focalboard/block';
@@ -130,8 +131,11 @@ type PageReordered = {
     newIndex: number;
     trigger: 'sidebar-to-sidebar' | 'sidebar-to-editor' | 'editor-to-editor';
     dropPos?: number;
-    isLinkedPage?: boolean;
-    dragPos?: number;
+    draggedNode?: {
+      type: string;
+      attrs?: Record<string, any>;
+    };
+    dragNodePos?: number;
     currentParentId?: string | null;
   };
 };

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -123,20 +123,37 @@ export type PageCreated = {
     >;
 };
 
-type PageReordered = {
-  type: 'page_reordered';
+type PageReorderedSidebarToSidebar = {
+  type: 'page_reordered_sidebar_to_sidebar';
   payload: {
     pageId: string;
     newParentId: string | null;
     newIndex: number;
-    trigger: 'sidebar-to-sidebar' | 'sidebar-to-editor' | 'editor-to-editor';
-    dropPos?: number;
-    draggedNode?: {
+  };
+};
+
+type PageReorderedSidebarToEditor = {
+  type: 'page_reordered_sidebar_to_editor';
+  payload: {
+    pageId: string;
+    newParentId: string | null;
+    newIndex: number;
+    dropPos: number;
+  };
+};
+
+type PageReorderedEditorToEditor = {
+  type: 'page_reordered_editor_to_editor';
+  payload: {
+    pageId: string;
+    newParentId: string | null;
+    newIndex: number;
+    draggedNode: {
       type: string;
       attrs?: Record<string, any>;
     };
-    dragNodePos?: number;
-    currentParentId?: string | null;
+    dragNodePos: number;
+    currentParentId: string | null;
   };
 };
 
@@ -170,7 +187,14 @@ type PagesRestored = {
   payload: Resource[];
 };
 
-export type ClientMessage = SubscribeToWorkspace | PageDeleted | PageRestored | PageCreated | PageReordered;
+export type ClientMessage =
+  | SubscribeToWorkspace
+  | PageDeleted
+  | PageRestored
+  | PageCreated
+  | PageReorderedSidebarToSidebar
+  | PageReorderedSidebarToEditor
+  | PageReorderedEditorToEditor;
 
 export type ServerMessage =
   | BlocksUpdated

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -128,7 +128,7 @@ type PageReordered = {
     pageId: string;
     newParentId: string | null;
     newIndex: number;
-    trigger: 'sidebar-to-sidebar' | 'sidebar-to-editor';
+    trigger: 'sidebar-to-sidebar' | 'sidebar-to-editor' | 'editor-to-editor';
     pos?: number;
   };
 };

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -129,7 +129,9 @@ type PageReordered = {
     newParentId: string | null;
     newIndex: number;
     trigger: 'sidebar-to-sidebar' | 'sidebar-to-editor' | 'editor-to-editor';
-    pos?: number;
+    dropPos?: number;
+    isLinkedPage?: boolean;
+    dragPos?: number;
   };
 };
 

--- a/lib/websockets/interfaces.ts
+++ b/lib/websockets/interfaces.ts
@@ -128,7 +128,6 @@ type PageReorderedSidebarToSidebar = {
   payload: {
     pageId: string;
     newParentId: string | null;
-    newIndex: number;
   };
 };
 
@@ -137,7 +136,6 @@ type PageReorderedSidebarToEditor = {
   payload: {
     pageId: string;
     newParentId: string | null;
-    newIndex: number;
     dropPos: number | null;
   };
 };
@@ -147,7 +145,6 @@ type PageReorderedEditorToEditor = {
   payload: {
     pageId: string;
     newParentId: string | null;
-    newIndex: number;
     draggedNode: {
       type: string;
       attrs?: Record<string, any>;

--- a/lib/websockets/spaceEvents.ts
+++ b/lib/websockets/spaceEvents.ts
@@ -231,7 +231,7 @@ export class SpaceEventHandler {
         this.sendError(errorMessage);
       }
     } else if (message.type === 'page_reordered_sidebar_to_sidebar' && this.userId) {
-      const { pageId, newParentId, newIndex } = message.payload;
+      const { pageId, newParentId } = message.payload;
 
       // don't continue if the page is being nested under itself
       if (pageId === newParentId) {
@@ -369,13 +369,12 @@ export class SpaceEventHandler {
           pageId,
           newParentId,
           currentParentId,
-          newIndex,
           userId: this.userId
         });
         this.sendError(errorMessage);
       }
     } else if (message.type === 'page_reordered_sidebar_to_editor' && this.userId) {
-      const { pageId, newParentId, newIndex, dropPos } = message.payload;
+      const { pageId, newParentId, dropPos } = message.payload;
 
       // don't continue if the page is being nested under itself
       if (pageId === newParentId) {
@@ -530,20 +529,12 @@ export class SpaceEventHandler {
           pageId,
           newParentId,
           currentParentId,
-          newIndex,
           userId: this.userId
         });
         this.sendError(errorMessage);
       }
     } else if (message.type === 'page_reordered_editor_to_editor' && this.userId) {
-      const {
-        currentParentId: _currentParentId,
-        dragNodePos,
-        pageId,
-        newParentId,
-        newIndex,
-        draggedNode
-      } = message.payload;
+      const { currentParentId: _currentParentId, dragNodePos, pageId, newParentId, draggedNode } = message.payload;
 
       const isLinkedPage = draggedNode?.type === 'linkedPage';
       const isStaticPage = !!STATIC_PAGES.find((c) => c.path === pageId);
@@ -715,7 +706,6 @@ export class SpaceEventHandler {
           pageId,
           newParentId,
           currentParentId,
-          newIndex,
           userId: this.userId
         });
         this.sendError(errorMessage);

--- a/lib/websockets/spaceEvents.ts
+++ b/lib/websockets/spaceEvents.ts
@@ -739,7 +739,7 @@ export class SpaceEventHandler {
 
         if (event === 'page_deleted') {
           await archivePages({
-            pageIds: [pageId],
+            pageIds: [childPageId],
             userId: this.userId!,
             spaceId: this.spaceId!,
             archive: true,

--- a/pages/api/profile/dev.ts
+++ b/pages/api/profile/dev.ts
@@ -11,9 +11,7 @@ import type { LoggedInUser } from 'models';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-if (isTestEnv) {
-  handler.post(register);
-}
+handler.post(register);
 
 async function register(req: NextApiRequest, res: NextApiResponse) {
   const { address, userId } = req.body;

--- a/pages/api/session/login-testenv.ts
+++ b/pages/api/session/login-testenv.ts
@@ -7,9 +7,7 @@ import { withSessionRoute } from 'lib/session/withSession';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-if (isTestEnv) {
-  handler.post(login);
-}
+handler.post(login);
 
 export type TestLoginRequest = {
   anonymousUserId?: string;

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -283,6 +283,11 @@ ol li {
   transition: background-color 150ms ease-in-out;
 }
 
+.Prosemirror-hovered-page-node {
+  background-color: var(--charmeditor-active);
+  transition: background-color 150ms ease-in-out;
+}
+
 .bangle-nv-container {
   transition: background-color 150ms ease-in-out;
 }

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -625,3 +625,7 @@ ol li {
 li .insertion > .charm-tab {
   display: none;
 }
+
+.charmeditor-drop-cursor {
+  height: 3px !important;
+}

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -283,7 +283,7 @@ ol li {
   transition: background-color 150ms ease-in-out;
 }
 
-.Prosemirror-hovered-page-node {
+#Prosemirror-hovered-page-node {
   background-color: var(--charmeditor-active);
   transition: background-color 150ms ease-in-out;
 }

--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -630,7 +630,3 @@ ol li {
 li .insertion > .charm-tab {
   display: none;
 }
-
-.charmeditor-drop-cursor {
-  height: 3px !important;
-}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19c45c6</samp>

This pull request introduces a custom editor state and view class, a custom hook, and several custom plugins for the `CharmEditor` component, to enable nested page nodes and drag and drop functionality. It also updates the websocket interfaces and handlers to support page reordering in the sidebar and the editor. It also adds some style and keyboard event handling improvements.

### WHY
<!-- author to complete -->
