### PR TITLE
fix resizing columns on first row of document

### DIFF
--- a/components/common/CharmEditor/components/columnLayout/plugins/row.ts
+++ b/components/common/CharmEditor/components/columnLayout/plugins/row.ts
@@ -26,7 +26,7 @@ export function RowNodeView({ key, name, readOnly }: { key: PluginKey; name: str
 
             let index = 0;
 
-            if (startPos) {
+            if (typeof startPos === 'number') {
               // iterate the children of this node, which are 'columnBlock' type
               view.state.doc.nodesBetween(startPos, startPos + node.nodeSize, (child, pos) => {
                 if (child.type.name === 'columnBlock' && columnUpdates[index]) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ec2f92</samp>

Fix a bug in the column layout plugin of the `CharmEditor` component that could cause an error when resizing columns. Check the `startPos` variable for being a number before using it in `row.ts`.

### WHY
<!-- author to complete -->
