### PR TITLE
Fix markdown export for inline palette mark

### DIFF
--- a/components/common/CharmEditor/components/inlinePalette/inlinePalette.ts
+++ b/components/common/CharmEditor/components/inlinePalette/inlinePalette.ts
@@ -31,6 +31,12 @@ function specFactory(): BaseRawMarkSpec {
     options: {
       ..._spec.options,
       trigger
+    },
+    markdown: {
+      toMarkdown: {
+        open: '',
+        close: ''
+      }
     }
   };
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4d570e</samp>

Added `markdown` property to `specFactory` function in `inlinePalette.ts` to handle nodes without markdown syntax. This enables the inline palette to support emojis and mentions.

### WHY
Fix markdown (which does not allow user to publish proposal to snapshot)
