### PR TITLE
Disabled adding nested page in page comments

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewTitle.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewTitle.tsx
@@ -144,6 +144,7 @@ function ViewTitle(props: ViewTitleProps) {
             onContentChange={(content: ICharmEditorOutput) => {
               onDescriptionChange(content.doc);
             }}
+            disableNestedPages
             pageId={board.id}
             readOnly={props.readOnly}
           />

--- a/components/common/comments/Comment.tsx
+++ b/components/common/comments/Comment.tsx
@@ -152,7 +152,8 @@ export function Comment({
       placeholderText: 'What are your thoughts?',
       onContentChange: updateCommentContent,
       content: commentEditContent.doc,
-      isContentControlled: true
+      isContentControlled: true,
+      disableNestedPages: true
     };
 
     if (!inlineCharmEditor) {
@@ -247,6 +248,7 @@ export function Comment({
               key={isEditingComment.toString()}
               content={commentContent.doc}
               isContentControlled
+              disableNestedPages
             />
           )}
           {!comment.deletedAt && !replyingDisabled && (

--- a/components/common/comments/CommentForm.tsx
+++ b/components/common/comments/CommentForm.tsx
@@ -83,7 +83,8 @@ export function CommentForm({
       placeholderText: placeholder ?? 'What are your thoughts?',
       onContentChange: updatePostContent,
       content: postContent.doc,
-      isContentControlled: true
+      isContentControlled: true,
+      disableNestedPages: true
     };
 
     if (!inlineCharmEditor) {

--- a/pages/api/profile/dev.ts
+++ b/pages/api/profile/dev.ts
@@ -11,7 +11,9 @@ import type { LoggedInUser } from 'models';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-handler.post(register);
+if (isTestEnv) {
+  handler.post(register);
+}
 
 async function register(req: NextApiRequest, res: NextApiResponse) {
   const { address, userId } = req.body;

--- a/pages/api/session/login-testenv.ts
+++ b/pages/api/session/login-testenv.ts
@@ -7,7 +7,9 @@ import { withSessionRoute } from 'lib/session/withSession';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-handler.post(login);
+if (isTestEnv) {
+  handler.post(login);
+}
 
 export type TestLoginRequest = {
   anonymousUserId?: string;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f70a366</samp>

Prevent nested pages in markdown editors for comments and view titles. Add test environment variables and handlers for registration and login endpoints.

### WHY
<!-- author to complete -->
