### PR TITLE
Moving inserted pages w/in column leads to duplicate pages existing in both places

### DIFF
--- a/lib/websockets/documentEvents/documentEvents.ts
+++ b/lib/websockets/documentEvents/documentEvents.ts
@@ -44,7 +44,7 @@ type SocketSessionData = AuthenticatedSocketData & {
 };
 
 function isValidPageNode(node: PageContent): node is PageContent & { attrs: Record<string, string> } {
-  const { id: pageId, type: pageType = '', path: pagePath } = node.attrs ?? {};
+  const { id: pageId, type: pageType = '', path: pagePath } = node?.attrs ?? {};
   return Boolean(
     isUUID(pageId) &&
       node.attrs &&

--- a/lib/websockets/spaceEvents.ts
+++ b/lib/websockets/spaceEvents.ts
@@ -655,7 +655,7 @@ export class SpaceEventHandler {
     }
 
     // Find the position of the referenced page node in the parent page content
-    documentNode.forEach((node, nodePos) => {
+    documentNode.descendants((node, nodePos) => {
       if (node.type.name === 'page' && node.attrs.id === childPageId) {
         position = nodePos;
         return false;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2fa29c2</samp>

This pull request improves the websockets code that handles document and space events in the web app. It fixes a bug in `documentEvents.ts` that could cause a null pointer exception, and it optimizes the node traversal in `spaceEvents.ts` by using the `descendants` method.

### WHY
[Card](https://app.charmverse.io/charmverse/moving-inserted-pages-w-in-column-leads-to-duplicate-pages-existing-in-both-places-12486165114121484)
