### PR TITLE
Fix dragAndDrop e2e test

### DIFF
--- a/__e2e__/charmEditor/dragAndDrop.spec.ts
+++ b/__e2e__/charmEditor/dragAndDrop.spec.ts
@@ -82,7 +82,7 @@ test('Drag and drop one paragraph over another in the CharmEditor', async ({ doc
     }
   });
 
-  await documentPage.page.waitForTimeout(150);
+  await documentPage.page.waitForTimeout(500);
 
   const page = await prisma.page.findUniqueOrThrow({
     where: {

--- a/__e2e__/charmEditor/dragAndDrop.spec.ts
+++ b/__e2e__/charmEditor/dragAndDrop.spec.ts
@@ -82,7 +82,13 @@ test('Drag and drop one paragraph over another in the CharmEditor', async ({ doc
     }
   });
 
-  await documentPage.page.waitForTimeout(500);
+  await documentPage.page.waitForFunction(
+    () => document.querySelector('.bangle-editor')?.textContent === 'Item 2Item 1',
+    {},
+    {
+      timeout: 2500
+    }
+  );
 
   const page = await prisma.page.findUniqueOrThrow({
     where: {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d10f4f</samp>

Increased the `waitForTimeout` value in the `dragAndDrop.spec.ts` file to reduce flakiness in the charm editor end-to-end tests. This was part of a pull request to improve the test quality and reliability.

### WHY
<!-- author to complete -->
