### PR TITLE
Disable opening poll modal when opening post cards

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -81,7 +81,7 @@ export interface DocumentPageProps {
 function DocumentPage({ page, refreshPage, savePage, readOnly = false }: DocumentPageProps) {
   const { cancelVote, castVote, deleteVote, updateDeadline, votes, isLoading } = useVotes({ pageId: page.id });
 
-  const { activeView: sidebarView, isInsideDialog } = usePageSidebar();
+  const { activeView: sidebarView } = usePageSidebar();
   const { editMode, setPageProps, printRef: _printRef } = useCharmEditor();
   const [connectionError, setConnectionError] = useState<Error | null>(null);
   const isSmallScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('lg'));

--- a/components/common/CharmEditor/components/poll/PollComponent.tsx
+++ b/components/common/CharmEditor/components/poll/PollComponent.tsx
@@ -62,9 +62,7 @@ export function PollNodeView({
           snapshotProposalId={snapshotProposalId || null}
         />
         <div
-          onClick={(e) => {
-            // e.stopPropagation();
-            // e.preventDefault();
+          onClick={() => {
             setShowModal(true);
           }}
         >
@@ -102,5 +100,6 @@ export function PollNodeView({
     );
   }
 
-  return null;
+  // If the poll id in the node attribute doesn't point to any vote, return an empty div
+  return <div />;
 }

--- a/components/common/CharmEditor/components/poll/PollComponent.tsx
+++ b/components/common/CharmEditor/components/poll/PollComponent.tsx
@@ -24,7 +24,10 @@ export function PollNodeView({
   deleteNode
 }: CharmNodeViewProps) {
   const { pollId } = node.attrs as { pollId: string | null };
-  const { votes, cancelVote, castVote, deleteVote, isLoading, updateDeadline } = useVotes({ pageId, postId });
+  const { votes, cancelVote, castVote, deleteVote, isLoading, updateDeadline } = useVotes({
+    pageId,
+    postId
+  });
 
   const autoOpen = node.marks.some((mark) => mark.type.name === 'tooltip-marker');
 
@@ -40,17 +43,12 @@ export function PollNodeView({
     });
     setShowModal(false);
   }
-  if (!pollId || !votes[pollId]) {
-    if (isLoading) {
-      return (
-        <VotesWrapper>
-          <LoadingComponent />
-        </VotesWrapper>
-      );
-    }
+
+  if (!pollId) {
     if (readOnly) {
       return <div />;
     }
+
     return (
       <>
         <CreateVoteModal
@@ -79,18 +77,30 @@ export function PollNodeView({
         </div>
       </>
     );
+  } else if (isLoading) {
+    if (readOnly) {
+      return <div />;
+    }
+
+    return (
+      <VotesWrapper>
+        <LoadingComponent />
+      </VotesWrapper>
+    );
+  } else if (votes[pollId]) {
+    return (
+      <VoteDetail
+        cancelVote={cancelVote}
+        castVote={castVote}
+        deleteVote={deleteVote}
+        detailed={false}
+        // This makes sure that if something goes wrong in loading state, we won't stop users who should be able to vote from voting
+        disableVote={(pagePermissions && !pagePermissions.comment) || (postPermissions && !postPermissions.add_comment)}
+        vote={votes[pollId]}
+        updateDeadline={updateDeadline}
+      />
+    );
   }
 
-  return (
-    <VoteDetail
-      cancelVote={cancelVote}
-      castVote={castVote}
-      deleteVote={deleteVote}
-      detailed={false}
-      // This makes sure that if something goes wrong in loading state, we won't stop users who should be able to vote from voting
-      disableVote={(pagePermissions && !pagePermissions.comment) || (postPermissions && !postPermissions.add_comment)}
-      vote={votes[pollId]}
-      updateDeadline={updateDeadline}
-    />
-  );
+  return null;
 }

--- a/hooks/usePageSidebar.tsx
+++ b/hooks/usePageSidebar.tsx
@@ -7,7 +7,6 @@ import { useLgScreen } from 'hooks/useMediaScreens';
 import type { ThreadWithCommentsAndAuthors } from 'lib/threads/interfaces';
 
 import { useThreads } from './useThreads';
-import { useVotes } from './useVotes';
 
 export type PageAction = 'comments' | 'suggestions';
 
@@ -27,7 +26,6 @@ export function PageSidebarProvider({ children, isInsideDialog }: { children: Re
   const isLargeScreen = useLgScreen();
   const { currentPageId } = useCurrentPage();
   const { isValidating: isValidatingInlineComments } = useThreads();
-  const { isValidating: isValidatingInlineVotes } = useVotes({ pageId: currentPageId });
   const { cache } = useSWRConfig();
   const [activeView, setActiveView] = useState<IPageSidebarContext['activeView']>(null);
   const commentPageActionToggledOnce = useRef<boolean>(false);
@@ -45,7 +43,7 @@ export function PageSidebarProvider({ children, isInsideDialog }: { children: Re
         return;
       }
 
-      if (currentPageId && !isValidatingInlineComments && !isValidatingInlineVotes) {
+      if (currentPageId && !isValidatingInlineComments) {
         const cachedInlineCommentData: ThreadWithCommentsAndAuthors[] | undefined = cache.get(
           `pages/${currentPageId}/threads`
         )?.data as ThreadWithCommentsAndAuthors[] | undefined;
@@ -63,7 +61,7 @@ export function PageSidebarProvider({ children, isInsideDialog }: { children: Re
       }
     }
     setDefaultPageSidebar();
-  }, [isInsideDialog, isValidatingInlineComments, isValidatingInlineVotes, currentPageId]);
+  }, [isInsideDialog, isValidatingInlineComments, currentPageId]);
 
   const value = useMemo<IPageSidebarContext>(
     () => ({

--- a/hooks/useVotes.tsx
+++ b/hooks/useVotes.tsx
@@ -17,7 +17,6 @@ type ParentData = {
 };
 
 type IContext = {
-  isValidating: boolean;
   isLoading: boolean;
   setParent: (parent: ParentData | null) => void;
   votes: Record<string, ExtendedVote>;
@@ -29,7 +28,6 @@ type IContext = {
 };
 
 const VotesContext = createContext<Readonly<IContext>>({
-  isValidating: true,
   isLoading: true,
   votes: {},
   setParent: () => undefined,
@@ -103,7 +101,7 @@ export function VotesProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const { data, isValidating } = useSWR(
+  const { data } = useSWR(
     () => (parent ? `pages/${parent.pageId || parent.postId}/votes` : null),
     async () => charmClient.votes.getVotesByPage(parent!),
     {
@@ -202,7 +200,6 @@ export function VotesProvider({ children }: { children: ReactNode }) {
   const value: IContext = useMemo(
     () => ({
       votes,
-      isValidating,
       isLoading,
       castVote,
       createVote,
@@ -211,7 +208,7 @@ export function VotesProvider({ children }: { children: ReactNode }) {
       updateDeadline,
       setParent
     }),
-    [votes, isValidating]
+    [votes]
   );
 
   return <VotesContext.Provider value={value}>{children}</VotesContext.Provider>;


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 999a29d</samp>

Refactored and simplified the code for the poll and voting features in the `CharmEditor` and `DocumentPage` components. Removed unused variables and types from the `useVotes` hook and the `PollComponent`.

### WHY
[Card](https://app.charmverse.io/charmverse/opening-a-forum-post-with-a-poll-shows-poll-creation-dialog-for-a-split-second-49881997491780106)
