### PR TITLE
Disable auto proposal lens publish

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -110,7 +110,7 @@ export function ProposalProperties({
 
   async function updateProposalStatus(newStatus: ProposalStatus) {
     if (proposal && newStatus !== proposal.status) {
-      if (account && newStatus === 'discussion' && proposalPage && !proposal.lensPostLink) {
+      if (account && newStatus === 'discussion' && proposalPage && !proposal.lensPostLink && proposal.publishToLens) {
         const lensProfileSetup = await setupLensProfile();
         if (lensProfileSetup) {
           setIsPublishingToLens(true);

--- a/stories/ProposalsPage/Proposals.stories.tsx
+++ b/stories/ProposalsPage/Proposals.stories.tsx
@@ -1,3 +1,7 @@
+import { isProdEnv } from '@bangle.dev/utils';
+import { production, development, LensProvider } from '@lens-protocol/react-web';
+import type { LensConfig } from '@lens-protocol/react-web';
+import { bindings } from '@lens-protocol/wagmi';
 import { Box, Paper } from '@mui/material';
 import { rest } from 'msw';
 import type { ReactNode } from 'react';
@@ -39,6 +43,11 @@ const reduxStore = mockStateStore([], {
   }
 });
 
+const lensConfig: LensConfig = {
+  bindings: bindings(),
+  environment: isProdEnv ? production : development
+};
+
 function Context({ children }: { children: ReactNode }) {
   // mock the current space since it usually relies on the URL
   const spaceContext = useRef<ICurrentSpaceContext>({
@@ -50,7 +59,9 @@ function Context({ children }: { children: ReactNode }) {
     <UserProvider>
       <CurrentSpaceContext.Provider value={spaceContext.current}>
         <MembersProvider>
-          <Provider store={reduxStore}>{children}</Provider>
+          <Provider store={reduxStore}>
+            <LensProvider config={lensConfig}>{children}</LensProvider>
+          </Provider>
         </MembersProvider>
       </CurrentSpaceContext.Provider>
     </UserProvider>

--- a/stories/Settings/Settings.stories.tsx
+++ b/stories/Settings/Settings.stories.tsx
@@ -1,9 +1,13 @@
+import type { LensConfig } from '@lens-protocol/react-web';
+import { LensProvider, development, production } from '@lens-protocol/react-web';
+import { bindings } from '@lens-protocol/wagmi';
 import { Paper } from '@mui/material';
 import { rest } from 'msw';
 import type { ReactNode } from 'react';
 import { useRef, useState } from 'react';
 
 import { SettingsContent } from 'components/settings/SettingsContent';
+import { isProdEnv } from 'config/constants';
 import type { ICurrentSpaceContext } from 'hooks/useCurrentSpace';
 import { CurrentSpaceContext } from 'hooks/useCurrentSpace';
 import { MemberPropertiesProvider } from 'hooks/useMemberProperties';
@@ -21,6 +25,11 @@ const space = spaces[0];
 
 space.notificationToggles = {
   rewards: false
+};
+
+const lensConfig: LensConfig = {
+  bindings: bindings(),
+  environment: isProdEnv ? production : development
 };
 
 function Context({ children }: { children: ReactNode }) {
@@ -45,7 +54,9 @@ function Context({ children }: { children: ReactNode }) {
         <CurrentSpaceContext.Provider value={spaceContext.current}>
           <MembersProvider>
             <MemberPropertiesProvider>
-              <Paper>{children}</Paper>
+              <LensProvider config={lensConfig}>
+                <Paper>{children}</Paper>
+              </LensProvider>
             </MemberPropertiesProvider>
           </MembersProvider>
         </CurrentSpaceContext.Provider>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c76ff2</samp>

Added a condition to `updateProposalStatus` to check the `publishToLens` flag before posting to Lens. This improves performance and user privacy.

### WHY
<!-- author to complete -->
