### PR TITLE
Support copy/pasting images into comment replies

### DIFF
--- a/components/[pageId]/Comments/PageComments.tsx
+++ b/components/[pageId]/Comments/PageComments.tsx
@@ -58,7 +58,7 @@ export function PageComments({ page, permissions }: Props) {
   async function createComment(comment: CommentContent) {
     const _createdComment = await addComment(comment);
     setCreatedComment(_createdComment);
-    if (isProposal && proposal?.lensPostLink && !isPublishingToLens) {
+    if (isProposal && proposal?.lensPostLink && !isPublishingToLens && publishCommentsToLens) {
       const lensProfileSetup = await setupLensProfile();
       if (lensProfileSetup) {
         setIsPublishingToLens(true);

--- a/components/common/comments/CommentForm.tsx
+++ b/components/common/comments/CommentForm.tsx
@@ -8,6 +8,7 @@ import InlineCharmEditor from 'components/common/CharmEditor/InlineCharmEditor';
 import UserDisplay from 'components/common/UserDisplay';
 import { useUser } from 'hooks/useUser';
 import type { CommentContent } from 'lib/comments';
+import { checkIsContentEmpty } from 'lib/prosemirror/checkIsContentEmpty';
 
 import { LoadingIcon } from '../LoadingComponent';
 
@@ -116,7 +117,11 @@ export function CommentForm({
               )}
             </>
           )}
-          <Button data-test='comment-button' disabled={!postContent.rawText || disabled} onClick={createPostComment}>
+          <Button
+            data-test='comment-button'
+            disabled={checkIsContentEmpty(postContent.doc) || disabled}
+            onClick={createPostComment}
+          >
             Comment
           </Button>
         </Stack>

--- a/components/common/comments/CommentReply.tsx
+++ b/components/common/comments/CommentReply.tsx
@@ -2,11 +2,12 @@ import { Stack, Box, Typography, Switch } from '@mui/material';
 import { useState } from 'react';
 
 import { Button } from 'components/common/Button';
+import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/InlineCharmEditor';
-import InlineCharmEditor from 'components/common/CharmEditor/InlineCharmEditor';
 import type { CreateCommentPayload } from 'components/common/comments/interfaces';
 import UserDisplay from 'components/common/UserDisplay';
 import { useUser } from 'hooks/useUser';
+import { checkIsContentEmpty } from 'lib/prosemirror/checkIsContentEmpty';
 
 import { LoadingIcon } from '../LoadingComponent';
 
@@ -66,15 +67,18 @@ export function CommentReply({
       <Box display='flex' gap={1} flexDirection='row' alignItems='flex-start'>
         <UserDisplay user={user} hideName={true} />
         <Stack gap={1} width='100%'>
-          <InlineCharmEditor
+          <CharmEditor
             colorMode='dark'
             style={{
-              minHeight: 100
+              minHeight: 100,
+              left: 0
             }}
             key={editorKey}
             content={postContent.doc}
             onContentChange={updateCommentContent}
             placeholderText='What are your thoughts?'
+            disableNestedPages
+            disableRowHandles
           />
 
           <Stack flexDirection='row' justifyContent='flex-end' alignItems='center'>
@@ -99,7 +103,7 @@ export function CommentReply({
               <Button variant='outlined' color='secondary' onClick={onCancelComment}>
                 Cancel
               </Button>
-              <Button disabled={!postContent.rawText} onClick={createCommentReply}>
+              <Button disabled={checkIsContentEmpty(postContent.doc)} onClick={createCommentReply}>
                 Reply
               </Button>
             </Stack>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64ab17f</samp>

Refactor comment input components to use `CharmEditor` and improve button logic. This enhances the user experience and consistency of commenting features.

### WHY
[Card](https://app.charmverse.io/charmverse/suport-copy-pasting-images-into-comment-replies-2925067154744121)
