### PR TITLE
Fixed page icon/emoji offset

### DIFF
--- a/components/[pageId]/DocumentPage/components/PageHeader.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeader.tsx
@@ -6,7 +6,7 @@ import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined
 import EmojiEmotionsOutlinedIcon from '@mui/icons-material/EmojiEmotionsOutlined';
 import ImageIcon from '@mui/icons-material/Image';
 import type { ListItemButtonProps } from '@mui/material';
-import { ClickAwayListener, ListItemButton, Menu, Stack } from '@mui/material';
+import { ListItemButton, Menu } from '@mui/material';
 import Box from '@mui/material/Box';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';

--- a/components/common/BoardEditor/focalboard/src/components/__snapshots__/centerPanel.spec.tsx.snap
+++ b/components/common/BoardEditor/focalboard/src/components/__snapshots__/centerPanel.spec.tsx.snap
@@ -315,7 +315,7 @@ exports[`components/centerPanel return centerPanel and click on card to show car
                         >
                           <div>
                             <div
-                              class="css-emwlh8"
+                              class="css-jm1ma0"
                             >
                               <img
                                 src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -370,7 +370,7 @@ exports[`components/centerPanel return centerPanel and click on card to show car
                         >
                           <div>
                             <div
-                              class="css-emwlh8"
+                              class="css-jm1ma0"
                             >
                               <img
                                 src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"

--- a/components/common/BoardEditor/focalboard/src/components/gallery/__snapshots__/galleryCard.spec.tsx.snap
+++ b/components/common/BoardEditor/focalboard/src/components/gallery/__snapshots__/galleryCard.spec.tsx.snap
@@ -39,7 +39,7 @@ exports[`src/components/gallery/GalleryCard without block content should match s
         class="gallery-title"
       >
         <div
-          class="css-emwlh8"
+          class="css-jm1ma0"
         >
           <img
             src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"

--- a/components/common/BoardEditor/focalboard/src/components/kanban/__snapshots__/kanban.spec.tsx.snap
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/__snapshots__/kanban.spec.tsx.snap
@@ -220,7 +220,7 @@ exports[`src/component/kanban/kanban return kanban and click on KanbanCalculatio
                 >
                   <div>
                     <div
-                      class="css-emwlh8"
+                      class="css-jm1ma0"
                     >
                       <img
                         src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -275,7 +275,7 @@ exports[`src/component/kanban/kanban return kanban and click on KanbanCalculatio
                 >
                   <div>
                     <div
-                      class="css-emwlh8"
+                      class="css-jm1ma0"
                     >
                       <img
                         src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -652,7 +652,7 @@ exports[`src/component/kanban/kanban should match snapshot 1`] = `
                 >
                   <div>
                     <div
-                      class="css-emwlh8"
+                      class="css-jm1ma0"
                     >
                       <img
                         src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -707,7 +707,7 @@ exports[`src/component/kanban/kanban should match snapshot 1`] = `
                 >
                   <div>
                     <div
-                      class="css-emwlh8"
+                      class="css-jm1ma0"
                     >
                       <img
                         src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -792,7 +792,7 @@ exports[`src/component/kanban/kanban should match snapshot 1`] = `
                 >
                   <div>
                     <div
-                      class="css-emwlh8"
+                      class="css-jm1ma0"
                     >
                       <img
                         src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"

--- a/components/common/BoardEditor/focalboard/src/components/kanban/__snapshots__/kanbanCard.spec.tsx.snap
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/__snapshots__/kanbanCard.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`src/components/kanban/kanbanCard return kanbanCard and click on delete 
         >
           <div>
             <div
-              class="css-emwlh8"
+              class="css-jm1ma0"
             >
               <img
                 src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -108,7 +108,7 @@ exports[`src/components/kanban/kanbanCard should match snapshot 1`] = `
         >
           <div>
             <div
-              class="css-emwlh8"
+              class="css-jm1ma0"
             >
               <img
                 src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -151,7 +151,7 @@ exports[`src/components/kanban/kanbanCard should match snapshot with readonly 1`
         >
           <div>
             <div
-              class="css-emwlh8"
+              class="css-jm1ma0"
             >
               <img
                 src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"

--- a/components/common/BoardEditor/focalboard/src/components/table/__snapshots__/table.spec.tsx.snap
+++ b/components/common/BoardEditor/focalboard/src/components/table/__snapshots__/table.spec.tsx.snap
@@ -314,7 +314,7 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
                   style="align-self: flex-start; align-items: flex-start;"
                 >
                   <div
-                    class="css-emwlh8"
+                    class="css-jm1ma0"
                   >
                     <img
                       src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -452,7 +452,7 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
                   style="align-self: flex-start; align-items: flex-start;"
                 >
                   <div
-                    class="css-emwlh8"
+                    class="css-jm1ma0"
                   >
                     <img
                       src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -992,7 +992,7 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 2`
                   style="align-self: flex-start; align-items: flex-start;"
                 >
                   <div
-                    class="css-emwlh8"
+                    class="css-jm1ma0"
                   >
                     <img
                       src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -1124,7 +1124,7 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 2`
                   style="align-self: flex-start; align-items: flex-start;"
                 >
                   <div
-                    class="css-emwlh8"
+                    class="css-jm1ma0"
                   >
                     <img
                       src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -1661,7 +1661,7 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
                   style="align-self: flex-start; align-items: flex-start;"
                 >
                   <div
-                    class="css-emwlh8"
+                    class="css-jm1ma0"
                   >
                     <img
                       src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -1799,7 +1799,7 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
                   style="align-self: flex-start; align-items: flex-start;"
                 >
                   <div
-                    class="css-emwlh8"
+                    class="css-jm1ma0"
                   >
                     <img
                       src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -2339,7 +2339,7 @@ exports[`components/table/Table extended should match snapshot with UpdatedBy 1`
                   style="align-self: flex-start; align-items: flex-start;"
                 >
                   <div
-                    class="css-emwlh8"
+                    class="css-jm1ma0"
                   >
                     <img
                       src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"
@@ -2471,7 +2471,7 @@ exports[`components/table/Table extended should match snapshot with UpdatedBy 1`
                   style="align-self: flex-start; align-items: flex-start;"
                 >
                   <div
-                    class="css-emwlh8"
+                    class="css-jm1ma0"
                   >
                     <img
                       src="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f4da.svg"

--- a/components/common/BoardEditor/focalboard/src/components/table/__snapshots__/tableRow.spec.tsx.snap
+++ b/components/common/BoardEditor/focalboard/src/components/table/__snapshots__/tableRow.spec.tsx.snap
@@ -41,7 +41,7 @@ exports[`components/table/TableRow should match snapshot 1`] = `
             style="align-self: flex-start; align-items: flex-start;"
           >
             <div
-              class="css-emwlh8"
+              class="css-jm1ma0"
             >
               <svg
                 aria-hidden="true"
@@ -138,7 +138,7 @@ exports[`components/table/TableRow should match snapshot, collapsed tree 1`] = `
             style="align-self: flex-start; align-items: flex-start;"
           >
             <div
-              class="css-emwlh8"
+              class="css-jm1ma0"
             >
               <svg
                 aria-hidden="true"
@@ -235,7 +235,7 @@ exports[`components/table/TableRow should match snapshot, display properties 1`]
             style="align-self: flex-start; align-items: flex-start;"
           >
             <div
-              class="css-emwlh8"
+              class="css-jm1ma0"
             >
               <svg
                 aria-hidden="true"
@@ -380,7 +380,7 @@ exports[`components/table/TableRow should match snapshot, isSelected 1`] = `
             style="align-self: flex-start; align-items: flex-start;"
           >
             <div
-              class="css-emwlh8"
+              class="css-jm1ma0"
             >
               <svg
                 aria-hidden="true"
@@ -458,7 +458,7 @@ exports[`components/table/TableRow should match snapshot, read-only 1`] = `
             style="align-self: flex-start; align-items: flex-start;"
           >
             <div
-              class="css-emwlh8"
+              class="css-jm1ma0"
             >
               <svg
                 aria-hidden="true"
@@ -556,7 +556,7 @@ exports[`components/table/TableRow should match snapshot, resizing column 1`] = 
             style="align-self: flex-start; align-items: flex-start;"
           >
             <div
-              class="css-emwlh8"
+              class="css-jm1ma0"
             >
               <svg
                 aria-hidden="true"

--- a/components/common/Emoji.tsx
+++ b/components/common/Emoji.tsx
@@ -9,9 +9,6 @@ import { isMac } from 'lib/utilities/browser';
 type ImgSize = 'large' | 'small';
 
 export const Emoji = styled.div<{ size?: ImgSize }>`
-  /* font family taken from Notion */
-  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', NotoColorEmoji, 'Noto Color Emoji', 'Segoe UI Symbol',
-    'Android Emoji', EmojiSymbols;
   font-size: ${({ size }) => (size === 'large' ? '78px' : 'inherit')};
   overflow: hidden;
   white-space: nowrap;
@@ -38,13 +35,6 @@ export const Emoji = styled.div<{ size?: ImgSize }>`
       `;
     }
   }}
-  span {
-    height: 100%;
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
   img {
     border-radius: ${({ size }) => (size === 'large' ? '6px' : '3px')};
     height: ${({ size }) => (size === 'large' ? '100%' : '18px')};
@@ -81,7 +71,6 @@ function EmojiIcon({
     iconContent = (
       <img
         src={icon}
-        // Transferred from notion
         style={{
           objectFit: 'cover'
         }}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 579aad1</samp>

Removed unused or problematic code from some components to improve emoji rendering and fix a TypeScript error. The changes affected the `Emoji`, `EmojiIcon`, and `ImgSize` components in `components/common/Emoji.tsx` and the `PageHeader` component in `components/[pageId]/DocumentPage/components/PageHeader.tsx`.

### WHY
[Card](https://app.charmverse.io/charmverse/top-cut-off-page-icon-emojis-49182963884593733)
