### PR TITLE
fix CSS for lists with multiple paragraph children

### DIFF
--- a/components/common/CharmEditor/components/listItemNew/czi-list.scss
+++ b/components/common/CharmEditor/components/listItemNew/czi-list.scss
@@ -37,7 +37,7 @@ html {
 }
 
 /* https://css-tricks.com/numbering-in-style/ */
-.ProseMirror ul li > span > p::before {
+.ProseMirror ul li > span > p:first-child::before {
   color: var(--czi-list-style-color);
 
   /* content: '\2022'; */
@@ -74,7 +74,7 @@ html {
   counter-reset: none;
 }
 
-.ProseMirror ol > li > span > p::before {
+.ProseMirror ol > li > span > p:first-child::before {
   /*
    * Note that this CSS Rule will not work in MS-Edge 15:
    * - MS-Edge 15 does not supported using CSS variable isnide pseudo element
@@ -98,20 +98,20 @@ html {
 }
 
 
-.ProseMirror ul[data-indent='7'] li > span > p::before,
-.ProseMirror ul[data-indent='4'] li > span > p::before,
-.ProseMirror ul[data-indent='1'] li > span > p::before {
+.ProseMirror ul[data-indent='7'] li > span > p:first-child::before,
+.ProseMirror ul[data-indent='4'] li > span > p:first-child::before,
+.ProseMirror ul[data-indent='1'] li > span > p:first-child::before {
   content: '◦'; /* circle */
 }
 
-.ProseMirror ul[data-indent='5'] li > span > p::before,
-.ProseMirror ul[data-indent='2'] li > span > p::before {
+.ProseMirror ul[data-indent='5'] li > span > p:first-child::before,
+.ProseMirror ul[data-indent='2'] li > span > p:first-child::before {
   content: '▪'; /* square */
 }
 
-.ProseMirror ul[data-indent='6'] li > span > p::before,
-.ProseMirror ul[data-indent='3'] li > span > p::before,
-.ProseMirror ul[data-indent='0'] li > span > p::before {
+.ProseMirror ul[data-indent='6'] li > span > p:first-child::before,
+.ProseMirror ul[data-indent='3'] li > span > p:first-child::before,
+.ProseMirror ul[data-indent='0'] li > span > p:first-child::before {
   content: '•'; /* circle */
 }
 
@@ -128,7 +128,7 @@ html {
       outline: none;
       position: absolute;
     }
-    & > span > p::before {
+    & > span > p:first-child::before {
       display: none;
     }
   }

--- a/scripts/exportData/importPageToDev.ts
+++ b/scripts/exportData/importPageToDev.ts
@@ -15,9 +15,12 @@ import { v4 as uuid } from 'uuid';
  *  ➜ Uploaded records
  */
 
-const originalPagePath = 'page-34568528710225044';
-const destinationSpaceDomain = 'criminal-brown-canid';
-const destinationUserName = '0x6652…97e2';
+// Details for production environment
+const originalPagePath = 'page-16724275028991964';
+
+// Detais for developer environment
+const destinationSpaceDomain = 'rich-magenta-peacock';
+const destinationUserName = 'mattcasey.eth';
 
 const fileName = `./page-backup-05-22.json`;
 const pathName = path.join(process.cwd(), fileName);
@@ -58,6 +61,8 @@ async function importData(data: RestoreData) {
 
   const pageToRestore = {
     ...data.page,
+    proposalId: null,
+    parentId: null,
     diffs: undefined,
     id: newPageId,
     path: data.page.path + '-restored-' + Date.now(),


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb1f5c4</samp>

This pull request fixes a list item bug in the `CharmEditor` component and adds a feature to the `importPageToDev.ts` script. The bug fix improves the appearance of lists with multiple paragraphs, and the feature allows importing pages from production to developer spaces.

### WHY
When converting old pages to new ones, it's possible for one LI tag to have multiple P tags. This is not possible to create with the newer component, but we still want to support it