### PR TITLE
convert page documents on read only view as well

### DIFF
--- a/lib/prosemirror/conversions/convertOldListNodes.ts
+++ b/lib/prosemirror/conversions/convertOldListNodes.ts
@@ -138,3 +138,7 @@ export async function convertAndSavePage<
 
   return { page };
 }
+
+export function convertDoc(content: any) {
+  return content ? convertDocument(getNodeFromJson(content)).doc : null;
+}

--- a/pages/api/pages/[id]/index.ts
+++ b/pages/api/pages/[id]/index.ts
@@ -15,6 +15,7 @@ import { generatePageQuery } from 'lib/pages/server/generatePageQuery';
 import { updatePage } from 'lib/pages/server/updatePage';
 import { getPermissionsClient } from 'lib/permissions/api';
 import { providePermissionClients } from 'lib/permissions/api/permissionsClientMiddleware';
+import { convertDoc } from 'lib/prosemirror/conversions/convertOldListNodes';
 import { withSessionRoute } from 'lib/session/withSession';
 import { hasAccessToSpace } from 'lib/users/hasAccessToSpace';
 import { UndesirableOperationError } from 'lib/utilities/errors';
@@ -68,6 +69,8 @@ async function getPageRoute(req: NextApiRequest, res: NextApiResponse<PageWithCo
     ...page,
     permissionFlags: permissions
   };
+
+  result.content = convertDoc(result.content) as any;
 
   return res.status(200).json(result);
 }

--- a/pages/api/pages/[id]/index.ts
+++ b/pages/api/pages/[id]/index.ts
@@ -70,7 +70,11 @@ async function getPageRoute(req: NextApiRequest, res: NextApiResponse<PageWithCo
     permissionFlags: permissions
   };
 
-  result.content = convertDoc(result.content) as any;
+  try {
+    result.content = convertDoc(result.content) as any;
+  } catch (error) {
+    log.error('Could not convert page with old lists', { pageId: result.id, error });
+  }
 
   return res.status(200).json(result);
 }

--- a/scripts/exportData/importPageToDev.ts
+++ b/scripts/exportData/importPageToDev.ts
@@ -16,10 +16,10 @@ import { v4 as uuid } from 'uuid';
  */
 
 // Details for production environment
-const originalPagePath = 'page-16724275028991964';
+const originalPagePath = 'page-7220252559428284';
 
 // Detais for developer environment
-const destinationSpaceDomain = 'rich-magenta-peacock';
+const destinationSpaceDomain = 'cute-azure-mastodon';
 const destinationUserName = 'mattcasey.eth';
 
 const fileName = `./page-backup-05-22.json`;
@@ -79,7 +79,8 @@ async function importData(data: RestoreData) {
     prisma.pagePermission.create({
       data: {
         pageId: newPageId,
-        permissionLevel: 'full_access'
+        permissionLevel: 'view',
+        spaceId: space.id
       }
     }),
     prisma.pageDiff.createMany({


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c228612</samp>

This pull request implements a function to convert old list nodes in page content to the new schema using ProseMirror. It also updates the API module and the import script to use this function and fix some parameters.

### WHY
<!-- author to complete -->
