### PR TITLE
Fix tests and fix components to enable evaluation_closed > evaluation_active

### DIFF
--- a/__e2e__/proposals/proposalFlow.spec.ts
+++ b/__e2e__/proposals/proposalFlow.spec.ts
@@ -1,7 +1,10 @@
-import { testUtilsProposals } from '@charmverse/core/test';
-import { test, expect } from '@playwright/test';
+import type { Space, User } from '@charmverse/core/prisma-client';
+import { prisma } from '@charmverse/core/prisma-client';
+import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
+import { expect } from '@playwright/test';
 import { ProposalPage } from '__e2e__/po/proposalPage.po';
 import { ProposalsListPage } from '__e2e__/po/proposalsList.po';
+import { test } from '__e2e__/utils/test';
 
 import type { PageWithProposal } from 'lib/pages';
 import { PROPOSAL_STATUS_LABELS } from 'lib/proposal/proposalStatusTransition';
@@ -10,28 +13,39 @@ import { generateUserAndSpace, loginBrowserUser } from '../utils/mocks';
 
 test.describe.serial('Proposal Flow', () => {
   // create reusable pages we can reuse between tests
-  let proposalListPage: ProposalsListPage;
-  let proposalPage: ProposalPage;
 
+  let authorBrowserProposalListPage: ProposalsListPage;
+  let authorBrowserProposalPage: ProposalPage;
+
+  let pageWithProposal: PageWithProposal;
   let proposalId: string;
-  let userId: string;
+
+  let proposalAuthor: User;
+  let proposalReviewer: User;
+  let space: Space;
 
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
-    proposalListPage = new ProposalsListPage(page);
-    proposalPage = new ProposalPage(page);
+
+    ({ space, user: proposalAuthor } = await generateUserAndSpace({}));
+    proposalReviewer = await testUtilsUser.generateSpaceUser({ spaceId: space.id });
+    await prisma.spaceRole.update({
+      where: { spaceUser: { userId: proposalReviewer.id, spaceId: space.id } },
+      data: { onboarded: true }
+    });
+
+    authorBrowserProposalListPage = new ProposalsListPage(page);
+    authorBrowserProposalPage = new ProposalPage(page);
   });
 
   test('A user can create a draft proposal', async () => {
     // Initial setup
-    const { space, user } = await generateUserAndSpace();
-
-    userId = user.id;
-
     await loginBrowserUser({
-      browserPage: proposalListPage.page,
-      userId
+      browserPage: authorBrowserProposalListPage.page,
+      userId: proposalAuthor.id
     });
+
+    await authorBrowserProposalListPage.goToProposals(space.domain);
 
     const category = await testUtilsProposals.generateProposalCategory({
       spaceId: space.id,
@@ -44,70 +58,81 @@ test.describe.serial('Proposal Flow', () => {
       ]
     });
 
-    await proposalListPage.goToProposals(space.domain);
-    await proposalListPage.waitForProposalsList();
-    await expect(proposalListPage.emptyState).toBeVisible();
-    await proposalListPage.createProposalButton.click();
+    await authorBrowserProposalListPage.goToProposals(space.domain);
+    await authorBrowserProposalListPage.waitForProposalsList();
+    await expect(authorBrowserProposalListPage.emptyState).toBeVisible();
+    await authorBrowserProposalListPage.createProposalButton.click();
 
-    await proposalPage.waitForDialog();
-    await expect(proposalPage.saveDraftButton).toBeDisabled();
+    await authorBrowserProposalPage.waitForDialog();
+    await expect(authorBrowserProposalPage.saveDraftButton).toBeDisabled();
 
     // enter required fields
-    await proposalPage.documentTitle.type('Proposal title');
-    await proposalPage.categorySelect.click();
-    await proposalPage.getSelectOption(category.id).click();
-    await proposalPage.charmEditor.scrollIntoViewIfNeeded();
-    await proposalPage.charmEditor.type('Proposal content');
-    await proposalPage.reviewerSelect.click();
-    await proposalPage.getSelectOption(userId).click();
+    await authorBrowserProposalPage.documentTitle.type('Proposal title');
+    await authorBrowserProposalPage.categorySelect.click();
+    await authorBrowserProposalPage.getSelectOption(category.id).click();
+    await authorBrowserProposalPage.charmEditor.scrollIntoViewIfNeeded();
+    await authorBrowserProposalPage.charmEditor.type('Proposal content');
+    await authorBrowserProposalPage.reviewerSelect.click();
+    // Add reviewer user as reviewer
+    await authorBrowserProposalPage.getSelectOption(proposalReviewer.id).click();
 
     // save draft
-    await expect(proposalPage.saveDraftButton).toBeEnabled();
-    await proposalPage.saveDraftButton.click();
+    await expect(authorBrowserProposalPage.saveDraftButton).toBeEnabled();
+    await authorBrowserProposalPage.saveDraftButton.click();
 
-    const response = await proposalPage.waitForJsonResponse<PageWithProposal>('**/api/proposals');
-    proposalId = response.proposal.id;
+    const response = await authorBrowserProposalPage.waitForJsonResponse<PageWithProposal>('**/api/proposals');
+    pageWithProposal = response;
+    proposalId = pageWithProposal.proposal.id;
 
     // verify we are on the saved view
-    await expect(proposalPage.openAsPageButton).toBeVisible();
-    await expect(proposalPage.nextStatusButton).toBeEnabled();
+    await expect(authorBrowserProposalPage.openAsPageButton).toBeVisible();
+    await expect(authorBrowserProposalPage.nextStatusButton).toBeEnabled();
 
     // verify that the page list was updated
-    await proposalPage.closeDialog();
-    await expect(proposalListPage.emptyState).not.toBeVisible();
-    const proposalRow = proposalListPage.getProposalRowLocator(proposalId);
+    await authorBrowserProposalPage.closeDialog();
+    await expect(authorBrowserProposalListPage.emptyState).not.toBeVisible();
+    const proposalRow = authorBrowserProposalListPage.getProposalRowLocator(proposalId);
     await expect(proposalRow).toBeVisible();
   });
 
-  test('A user can move draft proposal to feedback', async () => {
-    await proposalListPage.openProposalCard(proposalId);
+  test('A proposal author can move draft proposal to feedback', async () => {
+    await authorBrowserProposalListPage.openProposalCard(proposalId);
 
-    await expect(proposalPage.dialog).toBeVisible();
-    await expect(proposalPage.nextStatusButton).toHaveText(PROPOSAL_STATUS_LABELS.discussion);
+    await expect(authorBrowserProposalPage.dialog).toBeVisible();
+    await expect(authorBrowserProposalPage.nextStatusButton).toHaveText(PROPOSAL_STATUS_LABELS.discussion);
 
-    await proposalPage.nextStatusButton.click();
-    await proposalPage.confirmStatusButton.click();
-    await expect(proposalPage.currentStatus).toHaveText(PROPOSAL_STATUS_LABELS.discussion);
+    await authorBrowserProposalPage.nextStatusButton.click();
+    await authorBrowserProposalPage.confirmStatusButton.click();
+    await expect(authorBrowserProposalPage.currentStatus).toHaveText(PROPOSAL_STATUS_LABELS.discussion);
   });
-  test('A user can move feedback to In Review', async () => {
-    await expect(proposalPage.nextStatusButton).toHaveText(PROPOSAL_STATUS_LABELS.review);
-    await proposalPage.nextStatusButton.click();
-    await proposalPage.confirmStatusButton.click();
-    await expect(proposalPage.currentStatus).toHaveText(PROPOSAL_STATUS_LABELS.review);
+  test('A proposalAuthor can move feedback to In Review', async () => {
+    await expect(authorBrowserProposalPage.nextStatusButton).toHaveText(PROPOSAL_STATUS_LABELS.review);
+    await authorBrowserProposalPage.nextStatusButton.click();
+    await authorBrowserProposalPage.confirmStatusButton.click();
+    await expect(authorBrowserProposalPage.currentStatus).toHaveText(PROPOSAL_STATUS_LABELS.review);
   });
 
-  test.skip('A user can move feedback to Reviewed', async () => {
+  test('A reviewer can move feedback to Reviewed', async ({ proposalPage }) => {
+    await loginBrowserUser({
+      browserPage: proposalPage.page,
+      userId: proposalReviewer.id
+    });
+    await proposalPage.goToPage({ domain: space.domain, path: pageWithProposal.path });
+    await proposalPage.waitForDocumentPage({ domain: space.domain, path: pageWithProposal.path });
+
     await expect(proposalPage.nextStatusButton).toHaveText(PROPOSAL_STATUS_LABELS.reviewed);
     await proposalPage.nextStatusButton.click();
     await proposalPage.confirmStatusButton.click();
     await expect(proposalPage.currentStatus).toHaveText(PROPOSAL_STATUS_LABELS.reviewed);
   });
 
-  test.skip('A user can create a vote', async () => {
-    await expect(proposalPage.nextStatusButton).toHaveText(PROPOSAL_STATUS_LABELS.vote_active);
-    await proposalPage.nextStatusButton.click();
-    await proposalPage.confirmStatusButton.click();
-    await proposalPage.createVoteButton.click();
-    await expect(proposalPage.voteContainer).toBeVisible();
+  test('A proposal author can create a vote', async () => {
+    await authorBrowserProposalPage.closeDialog();
+    await authorBrowserProposalPage.goToPage({ domain: space.domain, path: pageWithProposal.path });
+    await expect(authorBrowserProposalPage.nextStatusButton).toHaveText(PROPOSAL_STATUS_LABELS.vote_active);
+    await authorBrowserProposalPage.nextStatusButton.click();
+    await authorBrowserProposalPage.confirmStatusButton.click();
+    await authorBrowserProposalPage.createVoteButton.click();
+    await expect(authorBrowserProposalPage.voteContainer).toBeVisible();
   });
 });

--- a/__e2e__/utils/test.ts
+++ b/__e2e__/utils/test.ts
@@ -1,4 +1,6 @@
 import { test as base } from '@playwright/test';
+import { ProposalPage } from '__e2e__/po/proposalPage.po';
+import { ProposalsListPage } from '__e2e__/po/proposalsList.po';
 
 import { BountyBoardPage } from '../po/bountyBoard.po';
 import { DocumentPage } from '../po/document.po';
@@ -6,11 +8,15 @@ import { DocumentPage } from '../po/document.po';
 type Fixtures = {
   bountyBoardPage: BountyBoardPage;
   documentPage: DocumentPage;
+  proposalListPage: ProposalsListPage;
+  proposalPage: ProposalPage;
 };
 
 export const test = base.extend<Fixtures>({
   bountyBoardPage: ({ page }, use) => use(new BountyBoardPage(page)),
-  documentPage: ({ page }, use) => use(new DocumentPage(page))
+  documentPage: ({ page }, use) => use(new DocumentPage(page)),
+  proposalListPage: ({ page }, use) => use(new ProposalsListPage(page)),
+  proposalPage: ({ page }, use) => use(new ProposalPage(page))
 });
 
 export { chromium, expect } from '@playwright/test';

--- a/__integration-tests__/server/pages/api/proposals/[id]/status.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/[id]/status.spec.ts
@@ -107,10 +107,11 @@ describe('PUT /api/proposals/[id]/status - Update proposal status', () => {
       .expect(400);
   });
 
-  it.skip('should successfully update the status of proposal and return 200', async () => {
+  it('should successfully update the status of proposal and return 200', async () => {
     const proposalPage = await createProposalWithUsers({
       spaceId: space.id,
       userId: author.id,
+      proposalStatus: 'discussion',
       authors: [],
       reviewers: [reviewer.id]
     });

--- a/lib/notifications/proposals/__tests__/createProposalNotifications.spec.ts
+++ b/lib/notifications/proposals/__tests__/createProposalNotifications.spec.ts
@@ -15,7 +15,7 @@ import { createNotificationsFromEvent } from '../../createNotificationsFromEvent
 import { createProposalNotifications } from '../createProposalNotifications';
 
 describe(`Test proposal events and notifications`, () => {
-  it.skip(`Should create proposal notifications for proposal.status_changed event`, async () => {
+  it(`Should create proposal notifications for proposal.status_changed event`, async () => {
     const { space } = await generateUserAndSpace();
     const author1 = await generateUser();
     await addUserToSpace({
@@ -231,11 +231,10 @@ describe(`Test proposal events and notifications`, () => {
     expect(proposalReviewStatusChangedMember2Notification).toBeFalsy();
 
     // Move to reviewed status
-
     await updateProposalStatus({
       newStatus: 'reviewed',
       proposalId: proposal.id,
-      userId: author1.id
+      userId: reviewer.id
     });
 
     await createProposalNotifications({

--- a/lib/proposal/proposalStatusTransition.ts
+++ b/lib/proposal/proposalStatusTransition.ts
@@ -77,9 +77,11 @@ export function previousProposalStatusUpdateMessage(status: ProposalStatus) {
     case 'draft':
       return 'In the Draft stage, only authors and administrators can view and edit the proposal.';
     case 'discussion':
-      return 'Rejecting this proposal will return it to the Discussion stage for further consideration.';
+      return 'This proposal will return to the Discussion stage for further consideration before review can proceed again.';
     case 'review':
       return 'In the Review stage, the Proposal is visible to Members. Reviewer approval is required to proceed to the voting stage.';
+    case 'evaluation_active':
+      return 'Moving back to Evaluation active will enable reviewers to add new evaluations to this proposal.';
     default:
       return null;
   }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2df703</samp>

The pull request adds and updates tests for the proposal flow, which has new statuses and notification logic. It includes end-to-end tests for creating and reviewing proposals, unit tests for proposal notifications, and integration tests for proposal status updates. It also modifies the message function for proposal status transitions to handle the new statuses.

### WHY
Fix tests related to proposal flow and fix a UI bug that prevented evaluation closed > evaluation active