### PR TITLE
Fix broken unit tests

### DIFF
--- a/lib/pages/__tests__/comments/syncPageComments.spec.ts
+++ b/lib/pages/__tests__/comments/syncPageComments.spec.ts
@@ -22,7 +22,9 @@ jest.mock('lib/lens/lensClient', () => ({
 describe('syncPageComments', () => {
   it(`Should sync lens post comment to CharmVerse`, async () => {
     const lensUser1 = {
-      handle: v4().split(' ')[0],
+      handle: {
+        fullHandle: v4().split(' ')[0]
+      },
       coverPicture: {
         __typename: 'MediaSet',
         original: {
@@ -32,7 +34,9 @@ describe('syncPageComments', () => {
     };
 
     const lensUser2 = {
-      handle: v4().split(' ')[0],
+      handle: {
+        fullHandle: v4().split(' ')[0]
+      },
       convertPicture: {
         __typename: 'NftImage',
         uri: 'ipfs://123'
@@ -42,6 +46,7 @@ describe('syncPageComments', () => {
     const lensComment1 = {
       id: v4(),
       profile: lensUser1,
+      by: lensUser1,
       metadata: {
         content: 'Lens Comment 1'
       }
@@ -50,6 +55,7 @@ describe('syncPageComments', () => {
     const lensComment2 = {
       id: v4(),
       profile: lensUser2,
+      by: lensUser2,
       metadata: {
         content: 'Lens Comment 2'
       }
@@ -58,6 +64,7 @@ describe('syncPageComments', () => {
     const lensComment3 = {
       id: v4(),
       profile: lensUser2,
+      by: lensUser2,
       metadata: {
         content: 'Lens Comment 3'
       }
@@ -66,6 +73,7 @@ describe('syncPageComments', () => {
     const lensComment4 = {
       id: v4(),
       profile: lensUser1,
+      by: lensUser1,
       metadata: {
         content: 'Lens Comment 4'
       }
@@ -74,6 +82,7 @@ describe('syncPageComments', () => {
     const lensComment1NestedComment1 = {
       id: v4(),
       profile: lensUser1,
+      by: lensUser1,
       metadata: {
         content: 'Lens Comment 1 Nested Comment 1'
       }
@@ -82,6 +91,7 @@ describe('syncPageComments', () => {
     const lensComment1NestedComment2 = {
       id: v4(),
       profile: lensUser2,
+      by: lensUser2,
       metadata: {
         content: 'Lens Comment 1 Nested Comment 2'
       }
@@ -90,6 +100,7 @@ describe('syncPageComments', () => {
     const lensComment1NestedComment3 = {
       id: v4(),
       profile: lensUser2,
+      by: lensUser2,
       metadata: {
         content: 'Lens Comment 1 Nested Comment 3'
       }
@@ -98,6 +109,7 @@ describe('syncPageComments', () => {
     const lensComment2NestedComment1 = {
       id: v4(),
       profile: lensUser1,
+      by: lensUser1,
       metadata: {
         content: 'Lens Comment 2 Nested Comment 1'
       }
@@ -285,13 +297,13 @@ describe('syncPageComments', () => {
 
     const charmverseLensUser1 = await prisma.user.findFirstOrThrow({
       where: {
-        username: `${lensUser1.handle}-lens-imported`
+        username: `${lensUser1.handle.fullHandle.toLowerCase()}-lens-imported`
       }
     });
 
     const charmverseLensUser2 = await prisma.user.findFirstOrThrow({
       where: {
-        username: `${lensUser2.handle}-lens-imported`
+        username: `${lensUser2.handle.fullHandle.toLowerCase()}-lens-imported`
       }
     });
 

--- a/lib/permissions/proposals/__tests__/computeProposalFlowPermissions.spec.ts
+++ b/lib/permissions/proposals/__tests__/computeProposalFlowPermissions.spec.ts
@@ -40,7 +40,7 @@ describe('computeProposalFlowPermissions', () => {
       userId: author.id
     });
 
-    expect(flowFlags.draft).toBe(true);
+    expect(flowFlags.discussion).toBe(true);
   });
 
   it('Proposal reviewer should be able to change the proposal status from review to reviewed', async () => {

--- a/lib/utilities/__tests__/browser.spec.ts
+++ b/lib/utilities/__tests__/browser.spec.ts
@@ -1,24 +1,25 @@
 import { getNewUrl, getSubdomainPath } from '../browser';
 
 describe('getNewUrl()', () => {
-  const baseUrl = 'https://google.com/search?q=3531422';
+  const urlBase = 'https://google.com';
+  const url = `${urlBase}/search?q=3531422`;
 
   it('should add a property to the query string', () => {
-    const result = getNewUrl({ cardId: 'baz' }, baseUrl);
+    const result = getNewUrl({ cardId: 'baz' }, url, urlBase);
 
-    expect(result.toString()).toBe(`${baseUrl}&cardId=baz`);
+    expect(result.toString()).toBe(`${url}&cardId=baz`);
   });
 
   it('should replace a property from the query string', () => {
-    const result = getNewUrl({ cardId: 'baz' }, `${baseUrl}&cardId=foo`);
+    const result = getNewUrl({ cardId: 'baz' }, `${url}&cardId=foo`, urlBase);
 
-    expect(result.toString()).toEqual(`${baseUrl}&cardId=baz`);
+    expect(result.toString()).toEqual(`${url}&cardId=baz`);
   });
 
   it('should remove a property from the query string', () => {
-    const result = getNewUrl({ cardId: null }, `${baseUrl}&cardId=foo`);
+    const result = getNewUrl({ cardId: null }, `${url}&cardId=foo`, urlBase);
 
-    expect(result.toString()).toEqual(baseUrl);
+    expect(result.toString()).toEqual(url);
   });
 });
 

--- a/lib/utilities/browser.ts
+++ b/lib/utilities/browser.ts
@@ -113,10 +113,14 @@ function scrollIntoViewIfNeededPolyfill(element: HTMLElement, centerIfNeeded?: b
 }
 
 // @source: https://stackoverflow.com/questions/5999118/how-can-i-add-or-update-a-query-string-parameter
-export function getNewUrl(params: Record<string, string | null>, currentUrl = window.location.href) {
+export function getNewUrl(
+  params: Record<string, string | null>,
+  currentUrl = window.location.href,
+  urlBase = window.location.origin
+) {
   return addQueryToUrl({
     url: currentUrl || window.location.href,
-    urlBase: window.location.origin,
+    urlBase: urlBase || window.location.origin,
     query: params,
     replace: true
   });


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c515162</samp>

Renamed and updated some test files to match the new Lens API schema and the CharmVerse username convention. Added support for syncing comments from Lens posts to CharmVerse pages.

### WHY
Three unit tests are now broken and they are only being triggered when `test_new_core_pkg` workflow is run, not our regular CI. One of them is for lens comments sync, another one is for proposal flow flag permission, and the last one is due to window not available in `browser.spec.ts` 
