### PR TITLE
Fix udpating custom proerties for proposals and rewards from table view

### DIFF
--- a/lib/focalboard/utilities.ts
+++ b/lib/focalboard/utilities.ts
@@ -21,3 +21,13 @@ export function mapProposalStatusPropertyToDisplayValue({
     }))
   };
 }
+
+export function filterInternalProperties<T>(propertyMap: Record<string, any>): T {
+  return Object.entries(propertyMap).reduce((acc, [key, value]) => {
+    if (key.startsWith('__')) {
+      return acc;
+    }
+
+    return { ...acc, [key]: value };
+  }, {} as T);
+}

--- a/lib/proposal/blocks/__tests__/updateBlocks.spec.ts
+++ b/lib/proposal/blocks/__tests__/updateBlocks.spec.ts
@@ -1,0 +1,114 @@
+import { prisma } from '@charmverse/core/prisma-client';
+import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
+import { v4 } from 'uuid';
+
+import type { PropertyType } from 'lib/focalboard/board';
+import { createBlock } from 'lib/proposal/blocks/createBlock';
+import { getBlocks } from 'lib/proposal/blocks/getBlocks';
+import { updateBlocks } from 'lib/proposal/blocks/updateBlocks';
+
+describe('proposal blocks - updateBlocks', () => {
+  it('Should update properties block and proposal fields without internal properites', async () => {
+    const { user: adminUser, space } = await testUtilsUser.generateUserAndSpace({
+      isAdmin: true
+    });
+    const user = await testUtilsUser.generateSpaceUser({
+      spaceId: space.id,
+      isAdmin: false
+    });
+
+    const proposalCategory1 = await testUtilsProposals.generateProposalCategory({
+      spaceId: space.id
+    });
+
+    const textPropertId = v4();
+
+    const propertiesData = {
+      spaceId: space.id,
+      title: 'Properties',
+      type: 'board',
+      fields: {
+        cardProperties: [
+          {
+            id: textPropertId,
+            name: 'title',
+            type: 'string' as PropertyType,
+            options: []
+          },
+          {
+            id: v4(),
+            name: 'tag',
+            type: 'select' as PropertyType,
+            options: [
+              { id: v4(), color: 'red', value: 'apple' },
+              { id: v4(), color: 'blue', value: 'orange' }
+            ]
+          }
+        ]
+      }
+    };
+
+    const block = await createBlock({
+      userId: user.id,
+      data: propertiesData,
+      spaceId: space.id
+    });
+
+    const { page, ...proposal1 } = await testUtilsProposals.generateProposal({
+      categoryId: proposalCategory1.id,
+      spaceId: space.id,
+      userId: adminUser.id,
+      proposalStatus: 'discussion'
+    });
+
+    const propertiesUpdateData = {
+      id: block.id,
+      spaceId: space.id,
+      title: 'Update',
+      type: 'board',
+      fields: {
+        cardProperties: [
+          {
+            id: v4(),
+            name: 'tagz',
+            type: 'select' as PropertyType,
+            options: [
+              { id: v4(), color: 'red', value: 'apple' },
+              { id: v4(), color: 'blue', value: 'orange' }
+            ]
+          }
+        ]
+      }
+    };
+
+    const proposalPropertiesUpdateData = {
+      type: 'card',
+      id: proposal1.id,
+      fields: {
+        properties: {
+          __internal: '123',
+          __view: 'table',
+          [textPropertId]: 'test1337'
+        }
+      }
+    };
+
+    const updatedBlock = await updateBlocks({
+      blocksData: [propertiesUpdateData, proposalPropertiesUpdateData],
+      userId: user.id,
+      spaceId: space.id
+    });
+
+    expect(updatedBlock[0]).toMatchObject(propertiesUpdateData);
+
+    const blocks = await getBlocks({
+      spaceId: space.id
+    });
+
+    const udpatedProposal = await prisma.proposal.findUnique({ where: { id: proposal1.id } });
+
+    expect((udpatedProposal?.fields as any)?.properties).toMatchObject({ [textPropertId]: 'test1337' });
+
+    expect(blocks).toMatchObject([propertiesUpdateData]);
+  });
+});

--- a/lib/proposal/blocks/interfaces.ts
+++ b/lib/proposal/blocks/interfaces.ts
@@ -17,21 +17,6 @@ export type ProposalPropertiesBlock = ProposalBlock & {
 // TODO: Add other block types i.e. view.
 export type ProposalBlockWithTypedFields = ProposalPropertiesBlock;
 
-export type ProposalBlockInput = {
-  id?: string;
-  type: string;
-  spaceId?: string;
-  title?: string;
-  schema?: number;
-  fields?: ProposalPropertiesBlockFields;
-  parentId?: string;
-  rootId?: string;
-};
-
-export type ProposalBlockUpdateInput = ProposalBlockInput & {
-  id: string;
-};
-
 export type ProposalPropertyValue = string | string[] | number | TargetPermissionGroup<'user' | 'role'>[];
 
 export type ProposalPropertiesField = Record<string, ProposalPropertyValue>;
@@ -41,3 +26,18 @@ export type ProposalPropertyValues = { properties: ProposalPropertiesField };
 export type ProposalFields = ProposalPropertyValues;
 
 export type ProposalFieldsProp = { fields: ProposalFields };
+
+export type ProposalBlockInput = {
+  id?: string;
+  type: string;
+  spaceId?: string;
+  title?: string;
+  schema?: number;
+  fields?: ProposalPropertiesBlockFields | ProposalPropertyValues;
+  parentId?: string;
+  rootId?: string;
+};
+
+export type ProposalBlockUpdateInput = ProposalBlockInput & {
+  id: string;
+};

--- a/lib/proposal/blocks/updateBlocks.ts
+++ b/lib/proposal/blocks/updateBlocks.ts
@@ -1,7 +1,15 @@
+import { log } from '@charmverse/core/log';
 import { prisma } from '@charmverse/core/prisma-client';
 
-import type { ProposalBlockUpdateInput, ProposalBlockWithTypedFields } from 'lib/proposal/blocks/interfaces';
+import { filterInternalProperties } from 'lib/focalboard/utilities';
+import type {
+  ProposalBlockUpdateInput,
+  ProposalBlockWithTypedFields,
+  ProposalPropertiesField,
+  ProposalPropertyValues
+} from 'lib/proposal/blocks/interfaces';
 import { updateBlock } from 'lib/proposal/blocks/updateBlock';
+import { updateProposal } from 'lib/proposal/updateProposal';
 
 export async function updateBlocks({
   blocksData,
@@ -12,7 +20,29 @@ export async function updateBlocks({
   userId: string;
   spaceId: string;
 }) {
-  return prisma.$transaction(blocksData.map((data) => updateBlock({ data, userId, spaceId }))) as Promise<
+  const blocks = blocksData.filter((block) => block.type !== 'card');
+  const proposals = blocksData.filter((block) => block.type === 'card');
+
+  try {
+    const promises = proposals.map((proposal) =>
+      updateProposal({
+        proposalId: proposal.id,
+        fields: {
+          ...proposal.fields,
+          properties: filterInternalProperties<ProposalPropertiesField>(
+            (proposal.fields as ProposalPropertyValues).properties
+          )
+        }
+      })
+    );
+
+    await Promise.allSettled(promises);
+  } catch (error) {
+    log.error('Error updating proposal block fields', { error });
+    throw error;
+  }
+
+  return prisma.$transaction(blocks.map((data) => updateBlock({ data, userId, spaceId }))) as Promise<
     ProposalBlockWithTypedFields[]
   >;
 }

--- a/lib/rewards/blocks/__tests__/updateBlocks.spec.ts
+++ b/lib/rewards/blocks/__tests__/updateBlocks.spec.ts
@@ -1,0 +1,116 @@
+import { prisma } from '@charmverse/core/prisma-client';
+import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
+import { v4 } from 'uuid';
+
+import type { PropertyType } from 'lib/focalboard/board';
+import { createBlock } from 'lib/rewards/blocks/createBlock';
+import { getBlocks } from 'lib/rewards/blocks/getBlocks';
+import { updateBlocks } from 'lib/rewards/blocks/updateBlocks';
+import { createReward } from 'lib/rewards/createReward';
+
+describe('reward blocks - updateBlocks', () => {
+  it('Should update properties block and reward fields without internal properites', async () => {
+    const { user: adminUser, space } = await testUtilsUser.generateUserAndSpace({
+      isAdmin: true
+    });
+    const user = await testUtilsUser.generateSpaceUser({
+      spaceId: space.id,
+      isAdmin: false
+    });
+
+    const textPropertId = v4();
+
+    const propertiesData = {
+      spaceId: space.id,
+      title: 'Properties',
+      type: 'board',
+      fields: {
+        cardProperties: [
+          {
+            id: textPropertId,
+            name: 'title',
+            type: 'string' as PropertyType,
+            options: []
+          },
+          {
+            id: v4(),
+            name: 'tag',
+            type: 'select' as PropertyType,
+            options: [
+              { id: v4(), color: 'red', value: 'apple' },
+              { id: v4(), color: 'blue', value: 'orange' }
+            ]
+          }
+        ]
+      }
+    };
+
+    const block = await createBlock({
+      userId: user.id,
+      data: propertiesData,
+      spaceId: space.id
+    });
+
+    const { reward } = await createReward({
+      spaceId: space.id,
+      userId: adminUser.id,
+      customReward: 't-shirt',
+      fields: {
+        properties: {
+          [textPropertId]: 'test1',
+          [v4()]: 'test2'
+        }
+      }
+    });
+
+    const propertiesUpdateData = {
+      id: block.id,
+      spaceId: space.id,
+      title: 'Update',
+      type: 'board',
+      fields: {
+        cardProperties: [
+          {
+            id: v4(),
+            name: 'tagz',
+            type: 'select' as PropertyType,
+            options: [
+              { id: v4(), color: 'red', value: 'apple' },
+              { id: v4(), color: 'blue', value: 'orange' }
+            ]
+          }
+        ]
+      }
+    };
+
+    const proposalPropertiesUpdateData = {
+      type: 'card',
+      id: reward.id,
+      fields: {
+        properties: {
+          __internal: '123',
+          __view: 'table',
+          [textPropertId]: 'test1337'
+        }
+      }
+    };
+
+    const updatedBlock = await updateBlocks({
+      blocksData: [propertiesUpdateData, proposalPropertiesUpdateData],
+      userId: user.id,
+      spaceId: space.id
+    });
+
+    expect(updatedBlock[0]).toMatchObject(propertiesUpdateData);
+
+    const blocks = await getBlocks({
+      spaceId: space.id
+    });
+
+    const updatedReward = await prisma.bounty.findUnique({ where: { id: reward.id } });
+
+    expect((updatedReward?.fields as any)?.properties).toMatchObject({ [textPropertId]: 'test1337' });
+
+    expect(blocks).toMatchObject([propertiesUpdateData]);
+  });
+});

--- a/lib/rewards/blocks/interfaces.ts
+++ b/lib/rewards/blocks/interfaces.ts
@@ -21,21 +21,6 @@ export type RewardPropertiesBlock = RewardBlock & {
 // TODO: Add other block types i.e. view.
 export type RewardBlockWithTypedFields = RewardPropertiesBlock;
 
-export type RewardBlockInput = {
-  id?: string;
-  type: string;
-  spaceId?: string;
-  title?: string;
-  schema?: number;
-  fields?: RewardPropertiesBlockFields;
-  parentId?: string;
-  rootId?: string;
-};
-
-export type RewardBlockUpdateInput = RewardBlockInput & {
-  id: string;
-};
-
 export type RewardPropertyValue = CardPropertyValue | ApplicationMeta[] | TargetPermissionGroup<'user' | 'role'>[];
 
 export type RewardPropertiesField = Record<string, RewardPropertyValue>;
@@ -47,3 +32,18 @@ export type RewardFields = RewardPropertyValues;
 export type RewardFieldsProp = { fields: RewardFields };
 
 export type RewardCard = Card<RewardPropertyValue>;
+
+export type RewardBlockInput = {
+  id?: string;
+  type: string;
+  spaceId?: string;
+  title?: string;
+  schema?: number;
+  fields?: RewardPropertiesBlockFields | RewardPropertyValues;
+  parentId?: string;
+  rootId?: string;
+};
+
+export type RewardBlockUpdateInput = RewardBlockInput & {
+  id: string;
+};

--- a/lib/rewards/blocks/updateBlocks.ts
+++ b/lib/rewards/blocks/updateBlocks.ts
@@ -1,7 +1,15 @@
+import { log } from '@charmverse/core/log';
+import type { Prisma } from '@charmverse/core/prisma-client';
 import { prisma } from '@charmverse/core/prisma-client';
 
-import type { RewardBlockUpdateInput, RewardBlockWithTypedFields } from 'lib/rewards/blocks/interfaces';
+import { filterInternalProperties } from 'lib/focalboard/utilities';
+import type {
+  RewardBlockUpdateInput,
+  RewardBlockWithTypedFields,
+  RewardPropertyValues
+} from 'lib/rewards/blocks/interfaces';
 import { updateBlock } from 'lib/rewards/blocks/updateBlock';
+import { updateRewardSettings } from 'lib/rewards/updateRewardSettings';
 
 export async function updateBlocks({
   blocksData,
@@ -12,7 +20,29 @@ export async function updateBlocks({
   userId: string;
   spaceId: string;
 }) {
-  return prisma.$transaction(blocksData.map((data) => updateBlock({ data, userId, spaceId }))) as Promise<
+  const blocks = blocksData.filter((block) => block.type !== 'card');
+  const rewards = blocksData.filter((block) => block.type === 'card');
+
+  try {
+    const promises = rewards.map((reward) =>
+      updateRewardSettings({
+        rewardId: reward.id,
+        updateContent: {
+          fields: {
+            ...reward.fields,
+            properties: filterInternalProperties<Prisma.JsonValue>((reward.fields as RewardPropertyValues).properties)
+          }
+        }
+      })
+    );
+
+    await Promise.allSettled(promises);
+  } catch (error) {
+    log.error('Error updating reward block fields', { error });
+    throw error;
+  }
+
+  return prisma.$transaction(blocks.map((data) => updateBlock({ data, userId, spaceId }))) as Promise<
     RewardBlockWithTypedFields[]
   >;
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10edb80</samp>

This pull request refactors and updates the `proposal` and `rewards` modules to use the `focalboard` module for updating blocks and fields, and to improve the type safety and reusability of the code. It also adds new utility and test functions for filtering out internal properties and checking the update logic. The changes affect the files `lib/proposal/blocks/interfaces.ts`, `lib/proposal/blocks/updateBlocks.ts`, `lib/rewards/blocks/interfaces.ts`, `lib/rewards/blocks/updateBlocks.ts`, `lib/focalboard/utilities.ts`, `lib/proposal/blocks/__tests__/updateBlocks.spec.ts`, and `lib/rewards/blocks/__tests__/updateBlocks.spec.ts`. The purpose is to enhance the functionality and reliability of the proposal and reward features.

### WHY
Initial ticket: https://app.charmverse.io/charmverse/tech-task-list-49366552253645923

Turns out mutator sometimes needs to update not only blocks but also related proposal / reward. Added support for that + tests
