### PR TITLE
Fixed card notifications issue with deleted person property

### DIFF
--- a/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
@@ -571,7 +571,7 @@ export function NotificationContent({
                 }}
               />
             )}
-            {notification.type === 'person_assigned' ? (
+            {notification.type === 'person_assigned' && notification.personProperty ? (
               <Stack my={1} gap={0.5}>
                 <Stack flexDirection='row' gap={0.5} alignItems='center'>
                   <PersonIcon fontSize='small' />

--- a/lib/mailer/emails/templates/NotificationTemplate.tsx
+++ b/lib/mailer/emails/templates/NotificationTemplate.tsx
@@ -100,7 +100,7 @@ function NotificationSection({
           </Text>
         </Column>
       </Row>
-      {notification.type === 'person_assigned' ? (
+      {notification.type === 'person_assigned' && notification.personProperty ? (
         <>
           <Row>
             <Column style={{ width: 50, verticalAlign: 'top' }} />

--- a/lib/notifications/cards/getCardNotifications.ts
+++ b/lib/notifications/cards/getCardNotifications.ts
@@ -74,12 +74,13 @@ export async function getCardNotifications({ id, userId }: QueryCondition): Prom
       spaceName: notificationMetadata.space.name,
       pageType: page.type,
       type: notification.type,
-      personProperty: notification.personPropertyId
-        ? {
-            id: notification.personPropertyId,
-            name: personPropertiesRecord[notification.personPropertyId].name
-          }
-        : null,
+      personProperty:
+        notification.personPropertyId && personPropertiesRecord[notification.personPropertyId]
+          ? {
+              id: notification.personPropertyId,
+              name: personPropertiesRecord[notification.personPropertyId].name
+            }
+          : null,
       archived: !!notificationMetadata.archivedAt,
       read: !!notificationMetadata.seenAt,
       group: 'card'

--- a/lib/notifications/interfaces.ts
+++ b/lib/notifications/interfaces.ts
@@ -71,7 +71,7 @@ export type CardNotification = NotificationBase & {
   personProperty: {
     id: string;
     name: string;
-  };
+  } | null;
   group: 'card';
 };
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a8a565</samp>

This pull request fixes some possible errors and inconsistencies in the notification system related to person properties. It adds conditions and checks to the notification content and section components in `NotificationsPopover.tsx` and `NotificationTemplate.tsx`, and to the `getCardNotifications` function in `getCardNotifications.ts`. It also updates the `CardNotification` interface in `interfaces.ts` to allow null person properties.

### WHY
<!-- author to complete -->
