### PR TITLE
Valdiate mixpanel

### DIFF
--- a/lib/metrics/mixpanel/trackUserAction.ts
+++ b/lib/metrics/mixpanel/trackUserAction.ts
@@ -1,18 +1,26 @@
 import { log } from '@charmverse/core/log';
 
+import { isUUID } from 'lib/utilities/strings';
+
 import type { MixpanelEventMap, MixpanelEventName, MixpanelTrackBase } from './interfaces';
 import { mixpanel } from './mixpanel';
-import { eventNameToHumanFormat, paramsToHumanFormat } from './utils';
+import { eventNameToHumanFormat, paramsToHumanFormat, validateMixPanelEvent } from './utils';
 
 export function trackUserAction<T extends MixpanelEventName>(eventName: T, params: MixpanelEventMap[T]) {
   const { userId, ...restParams } = params;
-
   // map userId prop to distinct_id required by mixpanel to recognize the user
   const mixpanelTrackParams: MixpanelTrackBase = {
     distinct_id: userId,
     ...paramsToHumanFormat(restParams)
   };
+
   const humanReadableEventName = eventNameToHumanFormat(eventName);
+
+  const validEvent = validateMixPanelEvent(mixpanelTrackParams);
+  if (!validEvent) {
+    log.warn(`Failed to send event ${eventName}`, { userId, params });
+    return;
+  }
 
   try {
     mixpanel?.track(humanReadableEventName, mixpanelTrackParams);

--- a/lib/metrics/mixpanel/utils.ts
+++ b/lib/metrics/mixpanel/utils.ts
@@ -1,6 +1,8 @@
 import { capitalize } from 'lodash';
 
-import type { MixpanelEventName } from './interfaces';
+import { isUUID } from 'lib/utilities/strings';
+
+import type { MixpanelEventName, MixpanelTrackBase } from './interfaces';
 
 // format event_name to Event name
 export function eventNameToHumanFormat(eventName: MixpanelEventName) {
@@ -21,4 +23,12 @@ export function paramsToHumanFormat(params: Record<string, any>) {
   });
 
   return humanReadableParams;
+}
+
+export function validateMixPanelEvent(params: MixpanelTrackBase) {
+  if (isUUID(params.distinct_id)) {
+    return 'spaceId' in params && params.spaceId === 'string' ? isUUID(params.spaceId) : true;
+  } else {
+    return false;
+  }
 }

--- a/lib/metrics/mixpanel/utils.ts
+++ b/lib/metrics/mixpanel/utils.ts
@@ -27,7 +27,14 @@ export function paramsToHumanFormat(params: Record<string, any>) {
 
 export function validateMixPanelEvent(params: MixpanelTrackBase) {
   if (isUUID(params.distinct_id)) {
-    return 'spaceId' in params && params.spaceId === 'string' ? isUUID(params.spaceId) : true;
+    if ('spaceId' in params && params.spaceId === 'string' && !isUUID(params.spaceId)) {
+      return false;
+    }
+    if ('pageId' in params && params.pageId === 'string' && !isUUID(params.pageId)) {
+      return false;
+    }
+
+    return true;
   } else {
     return false;
   }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9517aa1</samp>

Improved mixpanel event validation and organization. Refactored `trackUserAction` to use `validateMixPanelEvent` from `utils.ts` and moved `eventNameToHumanFormat` to a separate file.

### WHY
Validate distinct_id and spaceId if it is available before sending an event.
