### PR TITLE
show message to let user know that rubrics are only visible to reviewers

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -11,8 +11,8 @@ import {
   useUpsertRubricCriteria
 } from 'charmClient/hooks/proposals';
 import { useNotifications } from 'components/nexus/hooks/useNotifications';
-import type { ProposalPropertiesInput } from 'components/proposals/components/ProposalProperties/ProposalProperties';
-import { ProposalProperties as ProposalPropertiesBase } from 'components/proposals/components/ProposalProperties/ProposalProperties';
+import type { ProposalPropertiesInput } from 'components/proposals/components/ProposalProperties/ProposalPropertiesBase';
+import { ProposalPropertiesBase } from 'components/proposals/components/ProposalProperties/ProposalPropertiesBase';
 import { useProposalPermissions } from 'components/proposals/hooks/useProposalPermissions';
 import { useProposals } from 'components/proposals/hooks/useProposals';
 import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemplates';

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -19,8 +19,8 @@ import type { ProposalFields } from 'lib/proposal/blocks/interfaces';
 import type { PageContent } from 'lib/prosemirror/interfaces';
 import { fontClassName } from 'theme/fonts';
 
-import type { ProposalPropertiesInput } from '../ProposalProperties/ProposalProperties';
-import { ProposalProperties } from '../ProposalProperties/ProposalProperties';
+import type { ProposalPropertiesInput } from '../ProposalProperties/ProposalPropertiesBase';
+import { ProposalPropertiesBase } from '../ProposalProperties/ProposalPropertiesBase';
 
 export type ProposalPageAndPropertiesInput = ProposalPropertiesInput & {
   title?: string; // title is saved to the same state that's used in ProposalPage
@@ -125,7 +125,7 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated }: P
               />
               <div className='focalboard-body font-family-default'>
                 <div className='CardDetail content'>
-                  <ProposalProperties
+                  <ProposalPropertiesBase
                     isFromTemplate={isFromTemplateSource}
                     isTemplateRequired={isTemplateRequired}
                     readOnlyRubricCriteria={isFromTemplateSource}

--- a/components/proposals/components/ProposalProperties/ProposalPropertiesBase.tsx
+++ b/components/proposals/components/ProposalProperties/ProposalPropertiesBase.tsx
@@ -4,7 +4,7 @@ import type { PageType, ProposalEvaluationType, ProposalRubricCriteria, Proposal
 import type { ProposalReviewerInput } from '@charmverse/core/proposals';
 import { KeyboardArrowDown } from '@mui/icons-material';
 import type { Theme } from '@mui/material';
-import { Box, Card, Collapse, Divider, Grid, IconButton, Stack, Switch, Typography } from '@mui/material';
+import { Alert, Box, Card, Collapse, Divider, Grid, IconButton, Stack, Switch, Typography } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -96,7 +96,7 @@ type ProposalPropertiesProps = {
   readOnlyCustomProperties?: string[];
 };
 
-export function ProposalProperties({
+export function ProposalPropertiesBase({
   proposalLensLink,
   archived,
   canAnswerRubric,
@@ -596,6 +596,7 @@ export function ProposalProperties({
 
         {evaluationTabs.length > 0 && (
           <Card variant='outlined' sx={{ my: 2 }}>
+            <Alert severity='info'>Your evaluation is only viewable by the Reviewers assigned to this Proposal</Alert>
             <MultiTabs activeTab={rubricView} setActiveTab={setRubricView} tabs={evaluationTabs} />
           </Card>
         )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ad53a1</samp>

Refactored proposal properties logic and implemented evaluation functionality for proposals. Changed imports and usages of `ProposalProperties` and `ProposalPropertiesBase` components in various files.

### WHY
<!-- author to complete -->
<img width="732" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/d84b2266-c82f-4423-815c-0c589ba6f413">


https://work.charmverse.fyi/work.charmverse.fyi/tech-task-list-49366552253645923?cardId=53650a4c-adcc-461f-9b67-9078410094c3