### PR TITLE
dont wait 2 seconds before sending app_loaded event

### DIFF
--- a/hooks/useAppLoadedEvent.ts
+++ b/hooks/useAppLoadedEvent.ts
@@ -10,7 +10,9 @@ export function useAppLoadedEvent() {
   const { isLoaded } = useUser();
   const { space, isLoading: isSpaceLoading } = useCurrentSpace();
 
-  const debouncedTrackAction = useRef(debounce(charmClient.track.trackAction, 2000)).current;
+  const debouncedTrackAction = useRef(
+    debounce(charmClient.track.trackAction, 2000, { leading: true, trailing: false })
+  ).current;
 
   const trackAppLoaded = useCallback(() => {
     if (isLoaded && !isSpaceLoading) {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9b9756</samp>

Improved app load tracking by using `leading` and `trailing` options of `debounce` function in `hooks/useAppLoadedEvent.ts`. This prevents duplicate or delayed tracking events for the same app load action.

### WHY
We are seeing app_loaded is not account for all active users when looking at page_views. Based on Datadog RUM, we have sessions that are less than 2 seconds, so this could explain it. The debounce options trigger the function immediately, and only 2 seconds after that.