### PR TITLE
Fix dropdown icon not clickable when too close to the sidebar icon

### DIFF
--- a/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/SidebarSubmenu.tsx
@@ -195,7 +195,7 @@ export default function SidebarSubmenu({
           Sign out
         </MenuItem>
       </Menu>
-      <Box sx={{ position: 'absolute', right: 0 }} px={1.5}>
+      <Box sx={{ position: 'absolute', right: 0 }} pr={1}>
         {currentSpace && (
           <Tooltip title='Close sidebar' placement='bottom'>
             <IconButton onClick={closeSidebar} size='small'>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e48edea</samp>

Reduced right padding of close sidebar button in `SidebarSubmenu.tsx` to fix alignment and overlap issues. This is part of a pull request that enhances the sidebar layout for different screen sizes.

### WHY
[Task](https://app.charmverse.io/charmverse/dropdown-arrow-not-clickable-08390053215561322)
