### PR TITLE
Hide renamed title property in cards & views

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/calendar/fullCalendar.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/calendar/fullCalendar.tsx
@@ -13,7 +13,9 @@ import { useUserPreferences } from 'hooks/useUserPreferences';
 import type { Board, IPropertyTemplate } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';
 import type { Card } from 'lib/focalboard/card';
+import { isTruthy } from 'lib/utilities/types';
 
+import { Constants } from '../../constants';
 import mutator from '../../mutator';
 import type { DateProperty } from '../properties/dateRange/dateRange';
 import { createDatePropertyFromString } from '../properties/dateRange/dateRange';
@@ -70,7 +72,7 @@ function CalendarFullView(props: Props): JSX.Element | null {
     () =>
       activeView.fields.visiblePropertyIds
         .map((id) => board.fields.cardProperties.find((t) => t.id === id))
-        .filter((i) => i) as IPropertyTemplate[],
+        .filter((i) => isTruthy(i) && i.id !== Constants.titleColumnId) as IPropertyTemplate[],
     [board.fields.cardProperties, activeView.fields.visiblePropertyIds]
   );
 

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
@@ -14,6 +14,7 @@ import type { BoardView } from 'lib/focalboard/boardView';
 import type { Card } from 'lib/focalboard/card';
 import { isTruthy } from 'lib/utilities/types';
 
+import { Constants } from '../../constants';
 import type { Mutator } from '../../mutator';
 import defaultMutator from '../../mutator';
 import { IDType, Utils } from '../../utils';
@@ -252,6 +253,10 @@ function CardDetailProperties(props: Props) {
   return (
     <div className='octo-propertylist' data-test='card-detail-properties'>
       {board.fields?.cardProperties.map((propertyTemplate) => {
+        if (propertyTemplate.id === Constants.titleColumnId) {
+          return null;
+        }
+
         const readOnly = props.readOnly || props.readOnlyProperties?.includes(propertyTemplate.id) || false;
 
         return (

--- a/components/common/BoardEditor/focalboard/src/components/gallery/galleryCard.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/gallery/galleryCard.tsx
@@ -11,6 +11,7 @@ import type { Board, IPropertyTemplate } from 'lib/focalboard/board';
 import type { Card } from 'lib/focalboard/card';
 import { isTouchScreen } from 'lib/utilities/browser';
 
+import { Constants } from '../../constants';
 import { useSortable } from '../../hooks/sortable';
 import mutator from '../../mutator';
 import PropertyValueElement from '../propertyValueElement';
@@ -42,7 +43,9 @@ const GalleryCard = React.memo((props: Props) => {
   );
   const cardPage = pages[card.id];
 
-  const visiblePropertyTemplates = props.visiblePropertyTemplates || [];
+  const visiblePropertyTemplates = (props.visiblePropertyTemplates || []).filter(
+    (property) => property.id !== Constants.titleColumnId
+  );
 
   let className = props.isSelected ? 'GalleryCard selected' : 'GalleryCard';
   if (isOver) {

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanban.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanban.tsx
@@ -11,7 +11,9 @@ import type { Board, BoardGroup, IPropertyOption, IPropertyTemplate } from 'lib/
 import { proposalPropertyTypesList } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';
 import type { Card } from 'lib/focalboard/card';
+import { isTruthy } from 'lib/utilities/types';
 
+import { Constants } from '../../constants';
 import type { BlockChange } from '../../mutator';
 import mutator from '../../mutator';
 import { IDType, Utils } from '../../utils';
@@ -78,7 +80,8 @@ function Kanban(props: Props) {
   Utils.log(`${propertyValues.length} propertyValues`);
   const visiblePropertyTemplates = activeView.fields.visiblePropertyIds
     .map((id) => board.fields.cardProperties.find((t) => t.id === id))
-    .filter((i) => i) as IPropertyTemplate[];
+    .filter((i) => isTruthy(i) && i.id !== Constants.titleColumnId) as IPropertyTemplate[];
+
   const isManualSort = activeView.fields.sortOptions.length === 0;
 
   const propertyNameChanged = useCallback(


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88e5a89</samp>

Improved the UI and performance of the BoardEditor component by importing helper modules and removing redundant information from various subcomponents. Affected files include `fullCalendar.tsx`, `cardDetailProperties.tsx`, `galleryCard.tsx`, and `kanban.tsx`.

### WHY
[Card](https://app.charmverse.io/charmverse/properties-displayed-incorrectly-after-renaming-title-column-in-a-database-37666419001324347)
