### PR TITLE
allow admins and reviewers to change evaluation type

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -70,7 +70,8 @@ export function ProposalProperties({
   // further restrict readOnly if user cannot update proposal properties specifically
   const readOnlyProperties = readOnly || !(pagePermissions?.edit_content || isAdmin);
   const canAnswerRubric = proposalPermissions?.evaluate;
-  const canViewRubricAnswers = isAdmin || !!(user?.id && reviewerUserIds?.includes(user.id));
+  const isReviewer = !!(user?.id && reviewerUserIds?.includes(user.id));
+  const canViewRubricAnswers = isAdmin || isReviewer;
   const isFromTemplateSource = Boolean(proposal?.page?.sourceTemplateId);
   const isTemplate = proposalPage.type === 'proposal_template';
   const sourceTemplate = isFromTemplateSource
@@ -160,6 +161,8 @@ export function ProposalProperties({
   const onChangeRubricCriteriaDebounced = useCallback(debounce(onChangeRubricCriteria, 300), [proposal?.status]);
   const readOnlyCategory = !isAdmin && (!proposalPermissions?.edit || !!proposal?.page?.sourceTemplateId);
   const readOnlyReviewers = readOnlyProperties || (!isAdmin && sourceTemplate && sourceTemplate.reviewers.length > 0);
+  // rubric criteria can always be updated by reviewers and admins
+  const readOnlyRubricCriteria = (readOnlyProperties || isFromTemplateSource) && !(isAdmin || isReviewer);
 
   return (
     <>
@@ -174,7 +177,7 @@ export function ProposalProperties({
         readOnlyAuthors={readOnlyProperties}
         readOnlyCategory={readOnlyCategory}
         isAdmin={isAdmin}
-        readOnlyRubricCriteria={readOnlyProperties || isFromTemplateSource}
+        readOnlyRubricCriteria={readOnlyRubricCriteria}
         readOnlyProposalEvaluationType={
           readOnlyProperties ||
           // dont let users change type after status moves to Feedback, and forward

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -128,7 +128,7 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated }: P
                   <ProposalPropertiesBase
                     isFromTemplate={isFromTemplateSource}
                     isTemplateRequired={isTemplateRequired}
-                    readOnlyRubricCriteria={isFromTemplateSource}
+                    readOnlyRubricCriteria={isFromTemplateSource && !isAdmin}
                     readOnlyReviewers={readOnlyReviewers}
                     readOnlyProposalEvaluationType={isFromTemplateSource}
                     proposalStatus='draft'

--- a/components/proposals/components/ProposalDialog/NewProposalPage.tsx
+++ b/components/proposals/components/ProposalDialog/NewProposalPage.tsx
@@ -15,6 +15,7 @@ import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemp
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { usePreventReload } from 'hooks/usePreventReload';
+import { useUser } from 'hooks/useUser';
 import type { ProposalFields } from 'lib/proposal/blocks/interfaces';
 import type { PageContent } from 'lib/prosemirror/interfaces';
 import { fontClassName } from 'theme/fonts';
@@ -45,9 +46,11 @@ const StyledContainer = styled(Container)`
 export function NewProposalPage({ setFormInputs, formInputs, contentUpdated }: Props) {
   const { space: currentSpace } = useCurrentSpace();
   const [, { width: containerWidth }] = useElementSize();
+  const { user } = useUser();
   const isSmallScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('lg'));
   const [readOnlyEditor, setReadOnlyEditor] = useState(false);
   const isAdmin = useIsAdmin();
+  const isReviewer = formInputs.reviewers?.some((r) => r.id === user?.id);
 
   usePreventReload(contentUpdated);
 
@@ -55,6 +58,8 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated }: P
 
   const isFromTemplateSource = Boolean(formInputs.proposalTemplateId);
   const isTemplateRequired = Boolean(currentSpace?.requireProposalTemplate);
+  // rubric criteria can always be updated by reviewers and admins
+  const readOnlyRubricCriteria = isFromTemplateSource && !(isAdmin || isReviewer);
 
   useEffect(() => {
     if (isTemplateRequired) {
@@ -128,7 +133,7 @@ export function NewProposalPage({ setFormInputs, formInputs, contentUpdated }: P
                   <ProposalPropertiesBase
                     isFromTemplate={isFromTemplateSource}
                     isTemplateRequired={isTemplateRequired}
-                    readOnlyRubricCriteria={isFromTemplateSource && !isAdmin}
+                    readOnlyRubricCriteria={readOnlyRubricCriteria}
                     readOnlyReviewers={readOnlyReviewers}
                     readOnlyProposalEvaluationType={isFromTemplateSource}
                     proposalStatus='draft'

--- a/components/proposals/components/ProposalProperties/components/ProposalEvaluationTypeSelect.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalEvaluationTypeSelect.tsx
@@ -35,7 +35,7 @@ export function ProposalEvaluationTypeSelect({ readOnly, readOnlyMessage, value,
     <TagSelect
       wrapColumn
       readOnly={readOnly}
-      readOnlyMessage={readOnlyMessage}
+      readOnlyMessage={readOnly && readOnlyMessage ? readOnlyMessage : undefined}
       options={evaluationTypeOptions}
       propertyValue={value}
       onChange={onValueChange}

--- a/components/proposals/hooks/useProposalTemplates.tsx
+++ b/components/proposals/hooks/useProposalTemplates.tsx
@@ -37,9 +37,17 @@ export function useProposalTemplates({ load } = { load: true }) {
       );
     }
 
+    function handleCreateEvent(createdPages: WebSocketPayload<'pages_created'>) {
+      if (createdPages.some((page) => page.type === 'proposal_template')) {
+        mutate();
+      }
+    }
+
     const unsubscribeFromPageDeletes = subscribe('pages_deleted', handleDeleteEvent);
+    const unsubscribeFromPageCreated = subscribe('pages_created', handleCreateEvent);
     return () => {
       unsubscribeFromPageDeletes();
+      unsubscribeFromPageCreated();
     };
   }, [mutate, subscribe]);
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bbc35cb</samp>

This pull request enhances the user-based access control and the rubric criteria editing features for the proposal pages. It refactors some logic and variables, adds new conditions and hooks, and fixes a minor UI issue. It also improves the proposal templates synchronization with the `useProposalTemplates` hook.

### WHY
<!-- author to complete -->
