### PR TITLE
Refactor rewards navigation

### DIFF
--- a/components/common/PageDialog/PageDialog.tsx
+++ b/components/common/PageDialog/PageDialog.tsx
@@ -58,13 +58,10 @@ function PageDialogBase(props: Props) {
 
   const readOnlyPage = readOnly || !pagePermissions?.edit_content;
 
-  const contentType: ContentViewType | null = useMemo(() => {
-    if (applicationContext?.applicationId || (applicationContext?.isNewApplication && applicationContext?.pageId)) {
-      return 'application';
-    }
-
-    return pageId ? 'page' : null;
-  }, [applicationContext?.applicationId, applicationContext?.isNewApplication, applicationContext?.pageId, pageId]);
+  let contentType = pageId ? 'page' : null;
+  if (applicationContext?.applicationId || (applicationContext?.isNewApplication && applicationContext?.pageId)) {
+    contentType = 'application';
+  }
 
   // keep track if charmeditor is mounted. There is a bug that it calls the update method on closing the modal, but content is empty
   useEffect(() => {

--- a/components/rewards/components/RewardApplicationPage/RewardApplicationPage.tsx
+++ b/components/rewards/components/RewardApplicationPage/RewardApplicationPage.tsx
@@ -97,9 +97,7 @@ export function RewardApplicationPage({ applicationId, rewardId, closeDialog }: 
 
   function goToReward() {
     if (space && rewardPageContent) {
-      const { applicationId: _, ...restQuery } = query;
-
-      updateURLQuery(restQuery, true);
+      updateURLQuery({ applicationId: null });
     }
   }
 

--- a/components/rewards/hooks/useRewardsNavigation.ts
+++ b/components/rewards/hooks/useRewardsNavigation.ts
@@ -12,8 +12,7 @@ export function useRewardsNavigation() {
   } = useCharmRouter();
 
   const onClose = () => {
-    const { applicationId, isNewApplication, id, ...rest } = query;
-    updateURLQuery(rest, true);
+    updateURLQuery({ applicationId: null, isNewApplication: null, id: null });
   };
 
   useEffect(() => {

--- a/hooks/useCharmRouter.ts
+++ b/hooks/useCharmRouter.ts
@@ -27,17 +27,13 @@ export function useCharmRouter() {
       });
     },
     // update the URL, trigger a digest but do not re-run SSR
-    updateURLQuery(query: ParsedUrlQueryInput, replaceQuery = false) {
-      if (replaceQuery) {
-        // always keep space domain
-        const replacedQuery = router.query.domain ? { domain: router.query.domain, ...query } : query;
+    updateURLQuery(query: ParsedUrlQueryInput) {
+      // filter empty query params
+      const updatedQuery = Object.fromEntries(
+        Object.entries({ ...router.query, ...query }).filter(([_, v]) => v != null)
+      );
 
-        return router.push({ pathname: router.pathname, query: replacedQuery }, undefined, {
-          shallow: true
-        });
-      }
-
-      return router.push({ pathname: router.pathname, query: { ...router.query, ...query } }, undefined, {
+      return router.push({ pathname: router.pathname, query: updatedQuery }, undefined, {
         shallow: true
       });
     }

--- a/lib/utilities/browser.ts
+++ b/lib/utilities/browser.ts
@@ -129,8 +129,9 @@ export function getNewUrl(
 /**
  * update URL without Next.js re-rendering the page
  * source: https://github.com/vercel/next.js/discussions/18072
- *
  * To remove a param from the query, set it as null
+ *
+ * @deprecated - use useCharmRouter instead to update query params
  */
 export function setUrlWithoutRerender(
   pathname: string,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6d55f23</samp>

Refactored some components and hooks to use the `updateURLQuery` function from the `useCharmRouter` hook for updating the URL query parameters. Also improved the `updateURLQuery` function to filter out empty query parameters.

### WHY
<!-- author to complete -->
