### PR TITLE
When pasting a link to a page in CV, convert it to a page mention

### DIFF
--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -63,11 +63,11 @@ import {
   inlinePalettePluginKey,
   floatingMenuPluginKey,
   linkedPagePluginKey,
+  linksPluginKey,
   mentionPluginKey,
   emojiPluginKey,
   actionsPluginKey,
   inlineCommentPluginKey,
-  linksPluginKey,
   charmEditorPlugins
 } from './plugins';
 import { specRegistry } from './specRegistry';
@@ -386,6 +386,7 @@ function CharmEditor({
       isContentControlled={isContentControlled}
       initialContent={content}
       enableSuggestions={enableSuggestingMode}
+      linksPluginKey={linksPluginKey}
       onParticipantUpdate={onParticipantUpdate}
       trackChanges
       readOnly={readOnly}

--- a/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
@@ -296,7 +296,7 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
         })
       );
     }
-  }, [editor?.view.state, isLoadingRef.current, loadingPages]);
+  }, [isLoadingRef.current, loadingPages]);
 
   if (nodeViews.length > 0 && renderNodeViews == null) {
     throw new Error('When using nodeViews, you must provide renderNodeViews callback');

--- a/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
@@ -5,6 +5,7 @@ import { objectUid } from '@bangle.dev/utils';
 import { log } from '@charmverse/core/log';
 import type { PageType } from '@charmverse/core/prisma-client';
 import styled from '@emotion/styled';
+import type { PluginKey } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
 import type { MouseEvent, RefObject } from 'react';
 import React, { useEffect, useImperativeHandle, useRef, useState } from 'react';
@@ -17,6 +18,7 @@ import type { BangleEditorProps as CoreBangleEditorProps } from 'components/comm
 import type { FrontendParticipant } from 'components/common/CharmEditor/components/fiduswriter/collab';
 import { undoEventName } from 'components/common/CharmEditor/utils';
 import LoadingComponent from 'components/common/LoadingComponent';
+import { usePages } from 'hooks/usePages';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { getThreadsKey } from 'hooks/useThreads';
 import { useUser } from 'hooks/useUser';
@@ -49,6 +51,7 @@ interface BangleEditorProps<PluginMetadata = any> extends CoreBangleEditorProps<
   pageId?: string;
   children?: React.ReactNode;
   renderNodeViews?: RenderNodeViewsFunction;
+  linksPluginKey?: PluginKey;
   className?: string;
   style?: React.CSSProperties;
   editorRef?: RefObject<HTMLDivElement>;
@@ -77,6 +80,7 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
     isContentControlled,
     initialContent,
     focusOnInit,
+    linksPluginKey,
     pmViewOpts,
     renderNodeViews,
     className,
@@ -97,6 +101,7 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
   focusOnInit = focusOnInit ?? (!readOnly && !isTouchScreen());
   const renderRef = useRef<HTMLDivElement>(null);
   const { user } = useUser();
+  const { pages, loadingPages } = usePages();
   const enableFidusEditor = Boolean(user && pageId && trackChanges && !isContentControlled);
   const isLoadingRef = useRef(enableFidusEditor);
   const useSockets = user && pageId && trackChanges && (!readOnly || enableComments) && !isContentControlled;
@@ -274,6 +279,24 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
     const timer = setTimeout(() => setShowLoader(true), 300);
     return () => clearTimeout(timer);
   }, [setShowLoader]);
+
+  useEffect(() => {
+    /// wait for isLoadingRef.current so that we set meta after fiduseditor has init
+    if (editor?.view && !isLoadingRef.current && !loadingPages && linksPluginKey) {
+      // pass in a list of page paths and ids for the link component to check during input
+      const pageMap = Object.entries(pages).reduce<Record<string, string>>((acc, [key, page]) => {
+        if (page) {
+          acc[page.path] = page.id;
+        }
+        return acc;
+      }, {});
+      editor.view.dispatch(
+        editor.view.state.tr.setMeta(linksPluginKey, {
+          pages: pageMap
+        })
+      );
+    }
+  }, [editor?.view.state, isLoadingRef.current, loadingPages]);
 
   if (nodeViews.length > 0 && renderNodeViews == null) {
     throw new Error('When using nodeViews, you must provide renderNodeViews callback');

--- a/components/common/CharmEditor/components/link/link.plugins.ts
+++ b/components/common/CharmEditor/components/link/link.plugins.ts
@@ -39,7 +39,6 @@ export function plugins({ key }: { key: PluginKey }) {
         },
         apply(tr, pluginState) {
           const meta = tr.getMeta(key);
-          // console.log('apply state', key, pluginState, meta, pages);
           if (meta === undefined) {
             return pluginState;
           }

--- a/components/common/CharmEditor/components/link/link.ts
+++ b/components/common/CharmEditor/components/link/link.ts
@@ -6,6 +6,7 @@ import { InputRule, Plugin } from '@bangle.dev/pm';
 import { mapSlice, matchAllPlus } from '@bangle.dev/utils';
 import type { Node } from 'prosemirror-model';
 import type { PluginKey } from 'prosemirror-state';
+import { v4 } from 'uuid';
 
 import { insertNode } from 'lib/prosemirror/insertNode';
 
@@ -87,7 +88,8 @@ function pasteLink(regexp: RegExp) {
   });
 }
 
-function replaceLinkWithPage(key: PluginKey) {
+// convert links into page mentions
+function replaceLinkWithPageMention(key: PluginKey) {
   return new Plugin({
     props: {
       handlePaste: function handlePastedLink(view, _, slice) {
@@ -104,7 +106,7 @@ function replaceLinkWithPage(key: PluginKey) {
             const pagePathMaybe = url.split('/').pop() || '';
             const foundPageId = pageMap[pagePathMaybe];
             if (foundPageId) {
-              insertNode('linkedPage', view.state, view.dispatch, view, { id: foundPageId });
+              insertNode('mention', view.state, view.dispatch, view, { id: v4(), type: 'page', value: foundPageId });
               return true;
             }
           }
@@ -149,7 +151,7 @@ export function linkPlugins({ key }: { key: PluginKey }) {
     return [
       autoLinkInputRule(type),
       pasteLink(LINK_REGEX),
-      replaceLinkWithPage(key),
+      replaceLinkWithPageMention(key),
       markPasteRule(LINK_REGEX, type, (match) => ({ href: match }))
     ];
   };

--- a/components/common/CharmEditor/components/link/link.ts
+++ b/components/common/CharmEditor/components/link/link.ts
@@ -4,6 +4,10 @@ import { link } from '@bangle.dev/base-components';
 import type { MarkType, Schema } from '@bangle.dev/pm';
 import { InputRule, Plugin } from '@bangle.dev/pm';
 import { mapSlice, matchAllPlus } from '@bangle.dev/utils';
+import type { Node } from 'prosemirror-model';
+import type { PluginKey } from 'prosemirror-state';
+
+import { insertNode } from 'lib/prosemirror/insertNode';
 
 export const linkPluginName = 'link';
 
@@ -13,7 +17,8 @@ export const linkPluginName = 'link';
 const URL_REGEX =
   /(^|\s)(((http|https|ftp):\/\/)?(?:[^\s.:/]+\.)+(?:aaa|aarp|abarth|abb|abbott|abbvie|abc|able|abogado|abudhabi|ac|academy|accenture|accountant|accountants|aco|actor|ad|adac|ads|adult|ae|aeg|aero|aetna|af|afamilycompany|afl|africa|ag|agakhan|agency|ai|aig|airbus|airforce|airtel|akdn|al|alfaromeo|alibaba|alipay|allfinanz|allstate|ally|alsace|alstom|am|amazon|americanexpress|americanfamily|amex|amfam|amica|amsterdam|analytics|android|anquan|anz|ao|aol|apartments|app|apple|aq|aquarelle|ar|arab|aramco|archi|army|arpa|art|arte|as|asda|asia|associates|at|athleta|attorney|au|auction|audi|audible|audio|auspost|author|auto|autos|avianca|aw|aws|ax|axa|az|azure|ba|baby|baidu|banamex|bananarepublic|band|bank|bar|barcelona|barclaycard|barclays|barefoot|bargains|baseball|basketball|bauhaus|bayern|bb|bbc|bbt|bbva|bcg|bcn|bd|be|beats|beauty|beer|bentley|berlin|best|bestbuy|bet|bf|bg|bh|bharti|bi|bible|bid|bike|bing|bingo|bio|biz|bj|black|blackfriday|blockbuster|blog|bloomberg|blue|bm|bms|bmw|bn|bnpparibas|bo|boats|boehringer|bofa|bom|bond|boo|book|booking|bosch|bostik|boston|bot|boutique|box|br|bradesco|bridgestone|broadway|broker|brother|brussels|bs|bt|budapest|bugatti|build|builders|business|buy|buzz|bv|bw|by|bz|bzh|ca|cab|cafe|cal|call|calvinklein|cam|camera|camp|cancerresearch|canon|capetown|capital|capitalone|car|caravan|cards|care|career|careers|cars|casa|case|cash|casino|cat|catering|catholic|cba|cbn|cbre|cbs|cc|cd|center|ceo|cern|cf|cfa|cfd|cg|ch|chanel|channel|charity|chase|chat|cheap|chintai|christmas|chrome|church|ci|cipriani|circle|cisco|citadel|citi|citic|city|cityeats|ck|cl|claims|cleaning|click|clinic|clinique|clothing|cloud|club|clubmed|cm|cn|co|coach|codes|coffee|college|cologne|com|comcast|commbank|community|company|compare|computer|comsec|condos|construction|consulting|contact|contractors|cooking|cookingchannel|cool|coop|corsica|country|coupon|coupons|courses|cpa|cr|credit|creditcard|creditunion|cricket|crown|crs|cruise|cruises|csc|cu|cuisinella|cv|cw|cx|cy|cymru|cyou|cz|dabur|dad|dance|data|date|dating|datsun|day|dclk|dds|de|deal|dealer|deals|degree|delivery|dell|deloitte|delta|democrat|dental|dentist|desi|design|dev|dhl|diamonds|diet|digital|direct|directory|discount|discover|dish|diy|dj|dk|dm|dnp|do|docs|doctor|dog|domains|dot|download|drive|dtv|dubai|duck|dunlop|dupont|durban|dvag|dvr|dz|earth|eat|ec|eco|edeka|edu|education|ee|eg|email|emerck|energy|engineer|engineering|enterprises|epson|equipment|er|ericsson|erni|es|esq|estate|et|etisalat|eu|eurovision|eus|events|exchange|expert|exposed|express|extraspace|fage|fail|fairwinds|faith|family|fan|fans|farm|farmers|fashion|fast|fedex|feedback|ferrari|ferrero|fi|fiat|fidelity|fido|film|final|finance|financial|fire|firestone|firmdale|fish|fishing|fit|fitness|fj|fk|flickr|flights|flir|florist|flowers|fly|fm|fo|foo|food|foodnetwork|football|ford|forex|forsale|forum|foundation|fox|fr|free|fresenius|frl|frogans|frontdoor|frontier|ftr|fujitsu|fun|fund|furniture|futbol|fyi|ga|gal|gallery|gallo|gallup|game|games|gap|garden|gay|gb|gbiz|gd|gdn|ge|gea|gent|genting|george|gf|gg|ggee|gh|gi|gift|gifts|gives|giving|gl|glade|glass|gle|global|globo|gm|gmail|gmbh|gmo|gmx|gn|godaddy|gold|goldpoint|golf|goo|goodyear|goog|google|gop|got|gov|gp|gq|gr|grainger|graphics|gratis|green|gripe|grocery|group|gs|gt|gu|guardian|gucci|guge|guide|guitars|guru|gw|gy|hair|hamburg|hangout|haus|hbo|hdfc|hdfcbank|health|healthcare|help|helsinki|here|hermes|hgtv|hiphop|hisamitsu|hitachi|hiv|hk|hkt|hm|hn|hockey|holdings|holiday|homedepot|homegoods|homes|homesense|honda|horse|hospital|host|hosting|hot|hoteles|hotels|hotmail|house|how|hr|hsbc|ht|hu|hughes|hyatt|hyundai|ibm|icbc|ice|icu|id|ie|ieee|ifm|ikano|il|im|imamat|imdb|immo|immobilien|in|inc|industries|infiniti|info|ing|ink|institute|insurance|insure|int|international|intuit|investments|io|ipiranga|iq|ir|irish|is|ismaili|ist|istanbul|it|itau|itv|jaguar|java|jcb|je|jeep|jetzt|jewelry|jio|jll|jm|jmp|jnj|jo|jobs|joburg|jot|joy|jp|jpmorgan|jprs|juegos|juniper|kaufen|kddi|ke|kerryhotels|kerrylogistics|kerryproperties|kfh|kg|kh|ki|kia|kim|kinder|kindle|kitchen|kiwi|km|kn|koeln|komatsu|kosher|kp|kpmg|kpn|kr|krd|kred|kuokgroup|kw|ky|kyoto|kz|la|lacaixa|lamborghini|lamer|lancaster|lancia|land|landrover|lanxess|lasalle|lat|latino|latrobe|law|lawyer|lb|lc|lds|lease|leclerc|lefrak|legal|lego|lexus|lgbt|li|lidl|life|lifeinsurance|lifestyle|lighting|like|lilly|limited|limo|lincoln|linde|link|lipsy|live|living|lixil|lk|llc|llp|loan|loans|locker|locus|loft|lol|london|lotte|lotto|love|lpl|lplfinancial|lr|ls|lt|ltd|ltda|lu|lundbeck|luxe|luxury|lv|ly|ma|macys|madrid|maif|maison|makeup|man|management|mango|map|market|marketing|markets|marriott|marshalls|maserati|mattel|mba|mc|mckinsey|md|me|med|media|meet|melbourne|meme|memorial|men|menu|merckmsd|mg|mh|miami|microsoft|mil|mini|mint|mit|mitsubishi|mk|ml|mlb|mls|mm|mma|mn|mo|mobi|mobile|moda|moe|moi|mom|monash|money|monster|mormon|mortgage|moscow|moto|motorcycles|mov|movie|mp|mq|mr|ms|msd|mt|mtn|mtr|mu|museum|mutual|mv|mw|mx|my|mz|na|nab|nagoya|name|natura|navy|nba|nc|ne|nec|net|netbank|netflix|network|neustar|new|news|next|nextdirect|nexus|nf|nfl|ng|ngo|nhk|ni|nico|nike|nikon|ninja|nissan|nissay|nl|no|nokia|northwesternmutual|norton|now|nowruz|nowtv|np|nr|nra|nrw|ntt|nu|nyc|nz|obi|observer|off|office|okinawa|olayan|olayangroup|oldnavy|ollo|om|omega|one|ong|onl|online|ooo|open|oracle|orange|org|organic|origins|osaka|otsuka|ott|ovh|pa|page|panasonic|paris|pars|partners|parts|party|passagens|pay|pccw|pe|pet|pf|pfizer|pg|ph|pharmacy|phd|philips|phone|photo|photography|photos|physio|pics|pictet|pictures|pid|pin|ping|pink|pioneer|pizza|pk|pl|place|play|playstation|plumbing|plus|pm|pn|pnc|pohl|poker|politie|porn|post|pr|pramerica|praxi|press|prime|pro|prod|productions|prof|progressive|promo|properties|property|protection|pru|prudential|ps|pt|pub|pw|pwc|py|qa|qpon|quebec|quest|qvc|racing|radio|raid|re|read|realestate|realtor|realty|recipes|red|redstone|redumbrella|rehab|reise|reisen|reit|reliance|ren|rent|rentals|repair|report|republican|rest|restaurant|review|reviews|rexroth|rich|richardli|ricoh|ril|rio|rip|rmit|ro|rocher|rocks|rodeo|rogers|room|rs|rsvp|ru|rugby|ruhr|run|rw|rwe|ryukyu|sa|saarland|safe|safety|sakura|sale|salon|samsclub|samsung|sandvik|sandvikcoromant|sanofi|sap|sarl|sas|save|saxo|sb|sbi|sbs|sc|sca|scb|schaeffler|schmidt|scholarships|school|schule|schwarz|science|scjohnson|scot|sd|se|search|seat|secure|security|seek|select|sener|services|ses|seven|sew|sex|sexy|sfr|sg|sh|shangrila|sharp|shaw|shell|shia|shiksha|shoes|shop|shopping|shouji|show|showtime|si|silk|sina|singles|site|sj|sk|ski|skin|sky|skype|sl|sling|sm|smart|smile|sn|sncf|so|soccer|social|softbank|software|sohu|solar|solutions|song|sony|soy|spa|space|sport|spot|sr|srl|ss|st|stada|staples|star|statebank|statefarm|stc|stcgroup|stockholm|storage|store|stream|studio|study|style|su|sucks|supplies|supply|support|surf|surgery|suzuki|sv|swatch|swiftcover|swiss|sx|sy|sydney|systems|sz|tab|taipei|talk|taobao|target|tatamotors|tatar|tattoo|tax|taxi|tc|tci|td|tdk|team|tech|technology|tel|temasek|tennis|teva|tf|tg|th|thd|theater|theatre|tiaa|tickets|tienda|tiffany|tips|tires|tirol|tj|tjmaxx|tjx|tk|tkmaxx|tl|tm|tmall|tn|to|today|tokyo|tools|top|toray|toshiba|total|tours|town|toyota|toys|tr|trade|trading|training|travel|travelchannel|travelers|travelersinsurance|trust|trv|tt|tube|tui|tunes|tushu|tv|tvs|tw|tz|ua|ubank|ubs|ug|uk|unicom|university|uno|uol|ups|us|uy|uz|va|vacations|vana|vanguard|vc|ve|vegas|ventures|verisign|versicherung|vet|vg|vi|viajes|video|vig|viking|villas|vin|vip|virgin|visa|vision|viva|vivo|vlaanderen|vn|vodka|volkswagen|volvo|vote|voting|voto|voyage|vu|vuelos|wales|walmart|walter|wang|wanggou|watch|watches|weather|weatherchannel|webcam|weber|website|wed|wedding|weibo|weir|wf|whoswho|wien|wiki|williamhill|win|windows|wine|winners|wme|wolterskluwer|woodside|work|works|world|wow|ws|wtc|wtf|xbox|xerox|xfinity|xihuan|xin|xn--11b4c3d|xn--1ck2e1b|xn--1qqw23a|xn--2scrj9c|xn--30rr7y|xn--3bst00m|xn--3ds443g|xn--3e0b707e|xn--3hcrj9c|xn--3oq18vl8pn36a|xn--3pxu8k|xn--42c2d9a|xn--45br5cyl|xn--45brj9c|xn--45q11c|xn--4dbrk0ce|xn--4gbrim|xn--54b7fta0cc|xn--55qw42g|xn--55qx5d|xn--5su34j936bgsg|xn--5tzm5g|xn--6frz82g|xn--6qq986b3xl|xn--80adxhks|xn--80ao21a|xn--80aqecdr1a|xn--80asehdb|xn--80aswg|xn--8y0a063a|xn--90a3ac|xn--90ae|xn--90ais|xn--9dbq2a|xn--9et52u|xn--9krt00a|xn--b4w605ferd|xn--bck1b9a5dre4c|xn--c1avg|xn--c2br7g|xn--cck2b3b|xn--cckwcxetd|xn--cg4bki|xn--clchc0ea0b2g2a9gcd|xn--czr694b|xn--czrs0t|xn--czru2d|xn--d1acj3b|xn--d1alf|xn--e1a4c|xn--eckvdtc9d|xn--efvy88h|xn--fct429k|xn--fhbei|xn--fiq228c5hs|xn--fiq64b|xn--fiqs8s|xn--fiqz9s|xn--fjq720a|xn--flw351e|xn--fpcrj9c3d|xn--fzc2c9e2c|xn--fzys8d69uvgm|xn--g2xx48c|xn--gckr3f0f|xn--gecrj9c|xn--gk3at1e|xn--h2breg3eve|xn--h2brj9c|xn--h2brj9c8c|xn--hxt814e|xn--i1b6b1a6a2e|xn--imr513n|xn--io0a7i|xn--j1aef|xn--j1amh|xn--j6w193g|xn--jlq480n2rg|xn--jlq61u9w7b|xn--jvr189m|xn--kcrx77d1x4a|xn--kprw13d|xn--kpry57d|xn--kput3i|xn--l1acc|xn--lgbbat1ad8j|xn--mgb9awbf|xn--mgba3a3ejt|xn--mgba3a4f16a|xn--mgba7c0bbn0a|xn--mgbaakc7dvf|xn--mgbaam7a8h|xn--mgbab2bd|xn--mgbah1a3hjkrd|xn--mgbai9azgqp6j|xn--mgbayh7gpa|xn--mgbbh1a|xn--mgbbh1a71e|xn--mgbc0a9azcg|xn--mgbca7dzdo|xn--mgbcpq6gpa1a|xn--mgberp4a5d4ar|xn--mgbgu82a|xn--mgbi4ecexp|xn--mgbpl2fh|xn--mgbt3dhd|xn--mgbtx2b|xn--mgbx4cd0ab|xn--mix891f|xn--mk1bu44c|xn--mxtq1m|xn--ngbc5azd|xn--ngbe9e0a|xn--ngbrx|xn--node|xn--nqv7f|xn--nqv7fs00ema|xn--nyqy26a|xn--o3cw4h|xn--ogbpf8fl|xn--otu796d|xn--p1acf|xn--p1ai|xn--pgbs0dh|xn--pssy2u|xn--q7ce6a|xn--q9jyb4c|xn--qcka1pmc|xn--qxa6a|xn--qxam|xn--rhqv96g|xn--rovu88b|xn--rvc1e0am3e|xn--s9brj9c|xn--ses554g|xn--t60b56a|xn--tckwe|xn--tiq49xqyj|xn--unup4y|xn--vermgensberater-ctb|xn--vermgensberatung-pwb|xn--vhquv|xn--vuq861b|xn--w4r85el8fhu5dnra|xn--w4rs40l|xn--wgbh1c|xn--wgbl6a|xn--xhq521b|xn--xkc2al3hye2a|xn--xkc2dl3a5ee0h|xn--y9a3aq|xn--yfro4i67o|xn--ygbi2ammx|xn--zfr164b|xxx|xyz|yachts|yahoo|yamaxun|yandex|ye|yodobashi|yoga|yokohama|you|youtube|yt|yun|za|zappos|zara|zero|zip|zm|zone|zuerich|zw))\s$/;
 
-export function autoLinkInputRule(type: MarkType) {
+// handle links as they are typed
+function autoLinkInputRule(type: MarkType) {
   return new InputRule(URL_REGEX, (state, match, start, end) => {
     if (!match[0]) {
       return null;
@@ -54,7 +59,8 @@ export function autoLinkInputRule(type: MarkType) {
   });
 }
 
-export function pasteLink(regexp: RegExp) {
+// insert links when text is selected
+function pasteLink(regexp: RegExp) {
   return new Plugin({
     props: {
       handlePaste: function handlePastedLink(view, rawEvent) {
@@ -81,7 +87,36 @@ export function pasteLink(regexp: RegExp) {
   });
 }
 
-export function markPasteRule(regexp: RegExp, type: MarkType, getAttrs: (...params: any[]) => any) {
+function replaceLinkWithPage(key: PluginKey) {
+  return new Plugin({
+    props: {
+      handlePaste: function handlePastedLink(view, _, slice) {
+        let url = '';
+        slice.content.descendants((node) => {
+          const linkMark = node.marks.find((mark) => mark.type.name === 'link');
+          if (linkMark) {
+            url = linkMark.attrs.href;
+          }
+        });
+        if (url) {
+          const pageMap = key.getState(view.state).pages;
+          if (pageMap) {
+            const pagePathMaybe = url.split('/').pop() || '';
+            const foundPageId = pageMap[pagePathMaybe];
+            if (foundPageId) {
+              insertNode('linkedPage', view.state, view.dispatch, view, { id: foundPageId });
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+    }
+  });
+}
+
+// handle pasted text and wrap with link marks
+function markPasteRule(regexp: RegExp, type: MarkType, getAttrs: (...params: any[]) => any) {
   return new Plugin({
     props: {
       transformPasted: function transformPasted(slice) {
@@ -94,7 +129,7 @@ export function markPasteRule(regexp: RegExp, type: MarkType, getAttrs: (...para
           return matches.map(({ start, end, match, subString }) => {
             let newNode = node.cut(start, end);
             if (match) {
-              const attrs = getAttrs instanceof Function ? getAttrs(subString) : getAttrs;
+              const attrs = getAttrs(subString);
               newNode = newNode.mark(type.create(attrs).addToSet(node.marks));
             }
             return newNode;
@@ -105,14 +140,16 @@ export function markPasteRule(regexp: RegExp, type: MarkType, getAttrs: (...para
   });
 }
 
-const LINK_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-zA-Z]{2,}\b([-a-zA-Z0-9@:%_'"+.~#?&//=]*)/g;
+const LINK_REGEX =
+  /(http|https|ftp)?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}(\.[a-zA-Z]{2,}\b)?([-a-zA-Z0-9@:%_'"+.~#?&//=]*)/g;
 
-export function linkPlugins() {
+export function linkPlugins({ key }: { key: PluginKey }) {
   return ({ schema }: { schema: Schema }) => {
     const type = schema.marks[linkPluginName];
     return [
       autoLinkInputRule(type),
       pasteLink(LINK_REGEX),
+      replaceLinkWithPage(key),
       markPasteRule(LINK_REGEX, type, (match) => ({ href: match }))
     ];
   };

--- a/components/common/CharmEditor/components/link/link.ts
+++ b/components/common/CharmEditor/components/link/link.ts
@@ -100,7 +100,7 @@ function replaceLinkWithPageMention(key: PluginKey) {
             url = linkMark.attrs.href;
           }
         });
-        if (url) {
+        if (url && url.includes(window.location.origin)) {
           const pageMap = key.getState(view.state).pages;
           if (pageMap) {
             const pagePathMaybe = url.split('/').pop() || '';

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -79,7 +79,6 @@ export default function NestedPage({
     pageTitle = 'No access';
   }
   const pageId = documentPage?.id || staticPage?.path || forumCategoryPage?.id;
-
   const pagePath = documentPage ? `${space?.domain}/${documentPage.path}` : '';
   const staticPath = staticPage ? `${space?.domain}/${staticPage.path}` : '';
   const categoryPath = forumCategoryPage ? `${space?.domain}/forum/${forumCategoryPage.path}` : '';

--- a/scripts/blacklistSpace.ts
+++ b/scripts/blacklistSpace.ts
@@ -4,7 +4,7 @@ import { prisma } from '@charmverse/core/prisma-client';
  * Use this script to retrieve and blacklist a space
  */
 
-const spaceDomain = 'file';
+const spaceDomain = 'life';
 
 async function search(domain: string) {
   const space = await prisma.space.findUniqueOrThrow({
@@ -47,7 +47,7 @@ function userRow(
   user: { id: string; createdAt: Date; username: string; email: string | null; wallets: { address: string }[] },
   isAdmin: boolean
 ) {
-  const email = user.email && user.username !== user.email ? ` ${user.email}` : '';
+  const email = user.email && user.username !== user.email ? `${user.email}` : '';
   const wallet = user.wallets.map((w) => w.address).join(', ');
   return `${user.username}${email}${wallet ? ' ' + wallet : ''}${
     isAdmin ? ' (admin)' : ''
@@ -66,8 +66,6 @@ async function deleteSpace(domain: string) {
   console.log('Deleted space', result);
 }
 
-// search(spaceDomain)
-//   .then(() => process.exit())
-//   .catch((err) => console.error(err));
+search(spaceDomain).then(() => process.exit());
 
-deleteSpace(spaceDomain).then(() => process.exit());
+//deleteSpace(spaceDomain).then(() => process.exit());

--- a/scripts/blacklistSpace.ts
+++ b/scripts/blacklistSpace.ts
@@ -4,7 +4,7 @@ import { prisma } from '@charmverse/core/prisma-client';
  * Use this script to retrieve and blacklist a space
  */
 
-const spaceDomain = 'life';
+const spaceDomain = 'file';
 
 async function search(domain: string) {
   const space = await prisma.space.findUniqueOrThrow({
@@ -47,7 +47,7 @@ function userRow(
   user: { id: string; createdAt: Date; username: string; email: string | null; wallets: { address: string }[] },
   isAdmin: boolean
 ) {
-  const email = user.email && user.username !== user.email ? `${user.email}` : '';
+  const email = user.email && user.username !== user.email ? ` ${user.email}` : '';
   const wallet = user.wallets.map((w) => w.address).join(', ');
   return `${user.username}${email}${wallet ? ' ' + wallet : ''}${
     isAdmin ? ' (admin)' : ''
@@ -66,6 +66,8 @@ async function deleteSpace(domain: string) {
   console.log('Deleted space', result);
 }
 
-search(spaceDomain).then(() => process.exit());
+// search(spaceDomain)
+//   .then(() => process.exit())
+//   .catch((err) => console.error(err));
 
-//deleteSpace(spaceDomain).then(() => process.exit());
+deleteSpace(spaceDomain).then(() => process.exit());


### PR DESCRIPTION
### WHY

When working on custom domains, it includes my custom domain. I want it to just be a 'relative' link. I think this is better UX too since we pull up the correct page title.