### PR TITLE
Fix zora chain nft error and title display

### DIFF
--- a/lib/blockchain/provider/zora/getNFT.ts
+++ b/lib/blockchain/provider/zora/getNFT.ts
@@ -26,7 +26,7 @@ export async function getNFT({
   const response = await provider.token({
     token: {
       address,
-      tokenId
+      tokenId: String(tokenId)
     },
     network: {
       network: ZDKNetwork.Zora,

--- a/lib/blockchain/provider/zora/getNFT.ts
+++ b/lib/blockchain/provider/zora/getNFT.ts
@@ -26,7 +26,7 @@ export async function getNFT({
   const response = await provider.token({
     token: {
       address,
-      tokenId: String(tokenId)
+      tokenId
     },
     network: {
       network: ZDKNetwork.Zora,

--- a/lib/blockchain/updateTokenGateDetails.ts
+++ b/lib/blockchain/updateTokenGateDetails.ts
@@ -1,8 +1,8 @@
-import { LIT_CHAINS } from '@lit-protocol/constants';
 import type { UnifiedAccessControlConditions } from '@lit-protocol/types';
 import { getChainById } from 'connectors/chains';
 
 import type { TokenGateWithRoles } from 'lib/tokenGates/interfaces';
+import { LIT_CHAINS } from 'lib/tokenGates/utils';
 import { getTokenMetadata } from 'lib/tokens/getTokenMetadata';
 
 import { getNFT } from './getNFTs';
@@ -33,7 +33,7 @@ export async function updateTokenGateDetails(tokenGates: TokenGateWithRoles[] | 
             });
 
             if (nft) {
-              const nftName = hasTokenId ? nft.title || nft.contractName : nft.contractName;
+              const nftName = nft.title || nft.contractName;
               return {
                 ...condition,
                 name: nftName,

--- a/lib/blockchain/updateTokenGateDetails.ts
+++ b/lib/blockchain/updateTokenGateDetails.ts
@@ -23,7 +23,7 @@ export async function updateTokenGateDetails(tokenGates: TokenGateWithRoles[] | 
 
           if (isNft) {
             const hasTokenId = !!condition.parameters[0] && Number(condition.parameters[0]) >= 0;
-            const tokenId = hasTokenId ? condition.parameters[0] : 1;
+            const tokenId = hasTokenId ? String(condition.parameters[0]) : '1';
             const chainDetails = getChainById(LIT_CHAINS[condition.chain].chainId);
 
             const nft = await getNFT({

--- a/lib/tokenGates/humanizeConditions.ts
+++ b/lib/tokenGates/humanizeConditions.ts
@@ -1,27 +1,12 @@
 import { log } from '@charmverse/core/log';
-import { ALL_LIT_CHAINS, LIT_CHAINS } from '@lit-protocol/constants';
 import type { HumanizedAccsProps } from '@lit-protocol/types';
 import type { TypographyProps } from '@mui/material/Typography';
 import { formatEther, isAddress } from 'viem';
-import { base } from 'viem/chains';
 
 import { shortWalletAddress } from 'lib/utilities/blockchain';
 import { isTruthy } from 'lib/utilities/types';
 
-// Add missing info for Base
-LIT_CHAINS.base = {
-  contractAddress: null,
-  chainId: base.id,
-  name: base.name,
-  symbol: 'ETH',
-  decimals: 18,
-  rpcUrls: base.rpcUrls.default.http.slice(),
-  blockExplorerUrls: [base.blockExplorers.default.url],
-  type: null,
-  vmType: 'EVM'
-};
-
-ALL_LIT_CHAINS.base = LIT_CHAINS.base;
+import { ALL_LIT_CHAINS } from './utils';
 
 const humanizeComparator = (comparator: string) => {
   const list: Record<string, string> = {

--- a/lib/tokenGates/utils.ts
+++ b/lib/tokenGates/utils.ts
@@ -1,4 +1,6 @@
+import { ALL_LIT_CHAINS as ALL_LIT_CHAINS_ORIGINAL, LIT_CHAINS as LIT_CHAINS_ORIGINAL } from '@lit-protocol/constants';
 import type { AccsDefaultParams } from '@lit-protocol/types';
+import { base, zora } from 'viem/chains';
 
 import type { TokenGateAccessType } from 'lib/tokenGates/interfaces';
 
@@ -31,3 +33,30 @@ export function getAccessType(condition: AccsDefaultParams): TokenGateAccessType
 export function getAccessTypes(conditions: AccsDefaultParams[]): TokenGateAccessType[] {
   return conditions.map((c) => getAccessType(c));
 }
+
+const baseChain = {
+  contractAddress: null,
+  chainId: base.id,
+  name: base.name,
+  symbol: 'ETH',
+  decimals: 18,
+  rpcUrls: base.rpcUrls.default.http.slice(),
+  blockExplorerUrls: [base.blockExplorers.default.url],
+  type: null,
+  vmType: 'EVM'
+};
+
+const zoraChain = {
+  contractAddress: null,
+  chainId: zora.id,
+  name: zora.name,
+  symbol: zora.nativeCurrency.symbol,
+  decimals: zora.nativeCurrency.decimals,
+  rpcUrls: zora.rpcUrls.default.http.slice(),
+  blockExplorerUrls: [zora.blockExplorers.default.url],
+  type: null,
+  vmType: 'EVM'
+};
+
+export const ALL_LIT_CHAINS = Object.assign(ALL_LIT_CHAINS_ORIGINAL, { base: baseChain, zora: zoraChain });
+export const LIT_CHAINS = Object.assign(LIT_CHAINS_ORIGINAL, { base: baseChain, zora: zoraChain });


### PR DESCRIPTION
Fix:
- zora was not on the LIT_CHAINS list
- zora tokenId was sent as a number instead of a string. The ZDK was throwing an error.
- nft titles