### PR TITLE
Fix opening evaluation sidebar

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -167,7 +167,8 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
   const enableSuggestingMode = editMode === 'suggesting' && !readOnly && !!pagePermissions.comment;
   const isPageTemplate = page.type.includes('template');
   const enableComments = !isSharedPage && !enableSuggestingMode && !isPageTemplate && !!pagePermissions?.comment;
-  const showPageActionSidebar = sidebarView !== null && (sidebarView !== 'comments' || enableComments);
+  const showPageActionSidebar =
+    !!enableSidebar && sidebarView !== null && (sidebarView !== 'comments' || enableComments);
 
   const pageVote = Object.values(votes).find((v) => v.context === 'proposal');
 
@@ -239,8 +240,6 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
       if (highlightedCommentId || (isLargeScreen && unresolvedThreads.length)) {
         // commentSidebarOpened.current = true;
         return setActiveView('comments');
-      } else {
-        closeSidebar();
       }
     }
   }, [isLoadingThreads, page.id, enableSidebar, threadsPageId]);

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -238,7 +238,6 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
 
     if (!isLoadingThreads) {
       if (highlightedCommentId || (isLargeScreen && unresolvedThreads.length)) {
-        // commentSidebarOpened.current = true;
         return setActiveView('comments');
       }
     }

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -10,7 +10,6 @@ import { memo, useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import { useElementSize } from 'usehooks-ts';
 
 import { useGetReward } from 'charmClient/hooks/rewards';
-import { PageSidebar } from 'components/[pageId]/DocumentPage/components/Sidebar/PageSidebar';
 import AddBountyButton from 'components/common/BoardEditor/focalboard/src/components/cardDetail/AddBountyButton';
 import CardDetailProperties from 'components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties';
 import { blockLoad, databaseViewsLoad } from 'components/common/BoardEditor/focalboard/src/store/databaseBlocksLoad';
@@ -28,7 +27,6 @@ import { useRewards } from 'components/rewards/hooks/useRewards';
 import { useCharmEditor } from 'hooks/useCharmEditor';
 import { useCharmRouter } from 'hooks/useCharmRouter';
 import { useLgScreen } from 'hooks/useMediaScreens';
-import { usePageSidebar } from 'hooks/usePageSidebar';
 import { useThreads } from 'hooks/useThreads';
 import { useVotes } from 'hooks/useVotes';
 import type { PageWithContent } from 'lib/pages/interfaces';
@@ -45,7 +43,9 @@ import PageHeader, { getPageTop } from './components/PageHeader';
 import { PageTemplateBanner } from './components/PageTemplateBanner';
 import { ProposalBanner } from './components/ProposalBanner';
 import { ProposalProperties } from './components/ProposalProperties';
+import { PageSidebar } from './components/Sidebar/PageSidebar';
 import { useLastSidebarView } from './hooks/useLastSidebarView';
+import { usePageSidebar } from './hooks/usePageSidebar';
 
 // const BountyProperties = dynamic(() => import('./components/BountyProperties/BountyProperties'), { ssr: false });
 const RewardProperties = dynamic(
@@ -241,12 +241,6 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
       }
     }
   }, [isLoadingThreads, page.id, enableSidebar, threadsPageId]);
-
-  useEffect(() => {
-    saveSidebarView({
-      [page.id]: sidebarView
-    });
-  }, [saveSidebarView, sidebarView]);
 
   useEffect(() => {
     const defaultView = defaultSidebarView?.[page.id];

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -247,10 +247,10 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
 
   useEffect(() => {
     const defaultView = persistedActiveView?.[page.id];
-    if (defaultView) {
+    if (enableSidebar && defaultView) {
       setActiveView(defaultView);
     }
-  }, [!!persistedActiveView, page.id]);
+  }, [!!persistedActiveView, enableSidebar, page.id]);
 
   const openEvaluation = useCallback(() => {
     if (enableSidebar) {

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -44,7 +44,6 @@ import { PageTemplateBanner } from './components/PageTemplateBanner';
 import { ProposalBanner } from './components/ProposalBanner';
 import { ProposalProperties } from './components/ProposalProperties';
 import { PageSidebar } from './components/Sidebar/PageSidebar';
-import { useLastSidebarView } from './hooks/useLastSidebarView';
 import { usePageSidebar } from './hooks/usePageSidebar';
 
 // const BountyProperties = dynamic(() => import('./components/BountyProperties/BountyProperties'), { ssr: false });
@@ -94,7 +93,13 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
 
   const isLargeScreen = useLgScreen();
   const { navigateToSpacePath } = useCharmRouter();
-  const { activeView: sidebarView, setActiveView, closeSidebar } = usePageSidebar();
+  const {
+    activeView: sidebarView,
+    persistedActiveView,
+    persistActiveView,
+    setActiveView,
+    closeSidebar
+  } = usePageSidebar();
   const { editMode, setPageProps, printRef: _printRef } = useCharmEditor();
   const [connectionError, setConnectionError] = useState<Error | null>(null);
   const isSmallScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('lg'));
@@ -201,8 +206,6 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
     }
   }, [page.id, threadsPageId]);
 
-  const [defaultSidebarView, saveSidebarView] = useLastSidebarView();
-
   const threadIds = useMemo(
     () =>
       typeof page.type === 'string'
@@ -243,17 +246,17 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
   }, [isLoadingThreads, page.id, enableSidebar, threadsPageId]);
 
   useEffect(() => {
-    const defaultView = defaultSidebarView?.[page.id];
+    const defaultView = persistedActiveView?.[page.id];
     if (defaultView) {
       setActiveView(defaultView);
     }
-  }, [!!defaultSidebarView, page.id]);
+  }, [!!persistedActiveView, page.id]);
 
   const openEvaluation = useCallback(() => {
     if (enableSidebar) {
       setActiveView('proposal_evaluation');
     } else {
-      saveSidebarView({
+      persistActiveView({
         [page.id]: 'proposal_evaluation'
       });
       // go to full page view

--- a/components/[pageId]/DocumentPage/DocumentPageProviders.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPageProviders.tsx
@@ -1,6 +1,6 @@
+import { PageSidebarProvider } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { CharmEditorProvider } from 'hooks/useCharmEditor';
 import { CurrentPageProvider } from 'hooks/useCurrentPage';
-import { PageSidebarProvider } from 'hooks/usePageSidebar';
 import { ThreadsProvider } from 'hooks/useThreads';
 import { VotesProvider } from 'hooks/useVotes';
 

--- a/components/[pageId]/DocumentPage/components/Sidebar/PageSidebar.tsx
+++ b/components/[pageId]/DocumentPage/components/Sidebar/PageSidebar.tsx
@@ -8,9 +8,9 @@ import { memo } from 'react';
 import { RiChatCheckLine } from 'react-icons/ri';
 
 import { useGetAllReviewerUserIds, useGetProposalDetails } from 'charmClient/hooks/proposals';
+import type { PageSidebarView } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { MobileDialog } from 'components/common/MobileDialog/MobileDialog';
 import { useMdScreen } from 'hooks/useMediaScreens';
-import type { PageSidebarView } from 'hooks/usePageSidebar';
 import type { ProposalWithUsersAndRubric } from 'lib/proposal/interface';
 import type { ThreadWithComments } from 'lib/threads/interfaces';
 

--- a/components/[pageId]/DocumentPage/components/Sidebar/components/CommentsSidebar.tsx
+++ b/components/[pageId]/DocumentPage/components/Sidebar/components/CommentsSidebar.tsx
@@ -7,10 +7,10 @@ import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
 import React, { memo, useLayoutEffect, useMemo, useState } from 'react';
 
+import type { PageSidebarView } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { useEditorViewContext } from 'components/common/CharmEditor/components/@bangle.dev/react/hooks';
 import PageThread from 'components/common/CharmEditor/components/thread/PageThread';
 import { specRegistry } from 'components/common/CharmEditor/specRegistry';
-import type { PageSidebarView } from 'hooks/usePageSidebar';
 import type { CommentThreadsMap } from 'hooks/useThreads';
 import { useUser } from 'hooks/useUser';
 import { extractThreadIdsFromDoc } from 'lib/prosemirror/plugins/inlineComments/extractDeletedThreadIds';

--- a/components/[pageId]/DocumentPage/components/Sidebar/components/ProposalSidebar/ProposalSidebar.tsx
+++ b/components/[pageId]/DocumentPage/components/Sidebar/components/ProposalSidebar/ProposalSidebar.tsx
@@ -71,24 +71,21 @@ export function ProposalSidebar({ pageId, proposal, proposalId, refreshProposal 
     const tabs = [
       [
         'Evaluate',
-        <LoadingComponent key='evaluate' isLoading={!rubricCriteria}>
-          <RubricEvaluationForm
-            proposalId={proposalId!}
-            answers={myRubricAnswers}
-            draftAnswers={myDraftRubricAnswers}
-            criteriaList={rubricCriteria!}
-            onSubmit={onSubmitEvaluation}
-            disabled={!canAnswerRubric}
-          />
-        </LoadingComponent>,
+        <RubricEvaluationForm
+          key='evaluate'
+          proposalId={proposalId!}
+          answers={myRubricAnswers}
+          draftAnswers={myDraftRubricAnswers}
+          criteriaList={rubricCriteria!}
+          onSubmit={onSubmitEvaluation}
+          disabled={!canAnswerRubric}
+        />,
         { sx: { p: 0 } } // disable default padding of tab panel
       ] as TabConfig,
       canViewRubricAnswers &&
         ([
           'Results',
-          <LoadingComponent key='results' isLoading={!rubricCriteria}>
-            <RubricResults answers={proposal?.rubricAnswers ?? []} criteriaList={rubricCriteria || []} />
-          </LoadingComponent>,
+          <RubricResults key='results' answers={proposal?.rubricAnswers ?? []} criteriaList={rubricCriteria || []} />,
           { sx: { p: 0 } }
         ] as TabConfig)
     ].filter(isTruthy);
@@ -115,7 +112,8 @@ export function ProposalSidebar({ pageId, proposal, proposalId, refreshProposal 
           <MultiTabs activeTab={rubricView} setActiveTab={setRubricView} tabs={evaluationTabs} />
         </>
       )}
-      {evaluationTabs.length === 0 && (
+      {evaluationTabs.length === 0 && !proposal && <LoadingComponent isLoading={true} />}
+      {evaluationTabs.length === 0 && proposal && (
         <NoCommentsMessage
           icon={
             <SvgIcon

--- a/components/[pageId]/DocumentPage/hooks/useLastSidebarView.ts
+++ b/components/[pageId]/DocumentPage/hooks/useLastSidebarView.ts
@@ -1,5 +1,5 @@
+import type { PageSidebarView } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { useLocalStorage } from 'hooks/useLocalStorage';
-import type { PageSidebarView } from 'hooks/usePageSidebar';
 
 export function useLastSidebarView() {
   return useLocalStorage<Record<string, PageSidebarView | null>>('active-sidebar-view', {});

--- a/components/[pageId]/DocumentPage/hooks/usePageSidebar.tsx
+++ b/components/[pageId]/DocumentPage/hooks/usePageSidebar.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactNode, Dispatch, PropsWithChildren, SetStateAction } from 'react';
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
 import { useCurrentPage } from 'hooks/useCurrentPage';
@@ -9,28 +9,32 @@ export type PageSidebarView = 'comments' | 'suggestions' | 'proposal_evaluation'
 
 export type IPageSidebarContext = {
   activeView: PageSidebarView | null;
-  setActiveView: (view: PageSidebarView | null) => void;
+  setActiveView: (view: PageSidebarView | null | ((view: PageSidebarView | null) => PageSidebarView | null)) => void;
   isInsideDialog?: boolean;
   closeSidebar: () => void;
+  persistedActiveView: Record<string, PageSidebarView | null> | null;
+  persistActiveView: Dispatch<SetStateAction<Record<string, PageSidebarView | null> | null>>;
 };
 
 export const PageSidebarContext = createContext<IPageSidebarContext>({
   activeView: null,
   setActiveView: () => undefined,
-  closeSidebar: () => undefined
+  closeSidebar: () => undefined,
+  persistedActiveView: null,
+  persistActiveView: () => undefined
 });
 
 export function PageSidebarProvider({ children }: { children: ReactNode }) {
   const [activeView, setActiveView] = useState<IPageSidebarContext['activeView']>(null);
   const { currentPageId } = useCurrentPage();
-  const [, persistActiveView] = useLastSidebarView();
+  const [persistedActiveView, persistActiveView] = useLastSidebarView();
 
   function closeSidebar() {
     setActiveView(null);
   }
 
-  function _setActiveView(view: PageSidebarView | null) {
-    if (currentPageId) {
+  function _setActiveView(view: PageSidebarView | null | ((view: PageSidebarView | null) => PageSidebarView | null)) {
+    if (currentPageId && typeof view === 'string') {
       persistActiveView({
         [currentPageId]: view
       });
@@ -42,7 +46,9 @@ export function PageSidebarProvider({ children }: { children: ReactNode }) {
     () => ({
       activeView,
       setActiveView: _setActiveView,
-      closeSidebar
+      closeSidebar,
+      persistedActiveView,
+      persistActiveView
     }),
     [activeView, currentPageId, setActiveView]
   );

--- a/components/[pageId]/DocumentPage/hooks/usePageSidebar.tsx
+++ b/components/[pageId]/DocumentPage/hooks/usePageSidebar.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode, Dispatch, PropsWithChildren, SetStateAction } from 'react';
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode, Dispatch, SetStateAction } from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
 
 import { useCurrentPage } from 'hooks/useCurrentPage';
 
@@ -29,10 +29,6 @@ export function PageSidebarProvider({ children }: { children: ReactNode }) {
   const { currentPageId } = useCurrentPage();
   const [persistedActiveView, persistActiveView] = useLastSidebarView();
 
-  function closeSidebar() {
-    setActiveView(null);
-  }
-
   function _setActiveView(view: PageSidebarView | null | ((view: PageSidebarView | null) => PageSidebarView | null)) {
     if (currentPageId && typeof view === 'string') {
       persistActiveView({
@@ -40,6 +36,10 @@ export function PageSidebarProvider({ children }: { children: ReactNode }) {
       });
     }
     return setActiveView(view);
+  }
+
+  function closeSidebar() {
+    _setActiveView(null);
   }
 
   const value = useMemo<IPageSidebarContext>(

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -15,9 +15,9 @@ import { memo, useEffect, useRef, useState } from 'react';
 import { useSWRConfig } from 'swr';
 
 import charmClient from 'charmClient';
+import type { IPageSidebarContext } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import ErrorBoundary from 'components/common/errors/ErrorBoundary';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import type { IPageSidebarContext } from 'hooks/usePageSidebar';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { useUser } from 'hooks/useUser';
 import type { PageContent } from 'lib/prosemirror/interfaces';

--- a/components/common/PageActions/components/DocumentPageActionList.tsx
+++ b/components/common/PageActions/components/DocumentPageActionList.tsx
@@ -11,16 +11,15 @@ import Divider from '@mui/material/Divider';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { useRouter } from 'next/router';
 
 import charmClient from 'charmClient';
+import { usePageSidebar } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { Button } from 'components/common/Button';
 import { useProposalCategories } from 'components/proposals/hooks/useProposalCategories';
 import { useRewards } from 'components/rewards/hooks/useRewards';
 import { useCharmRouter } from 'hooks/useCharmRouter';
 import { useMembers } from 'hooks/useMembers';
 import { usePages } from 'hooks/usePages';
-import { usePageSidebar } from 'hooks/usePageSidebar';
 import { useSnackbar } from 'hooks/useSnackbar';
 import type { PageUpdates, PageWithContent } from 'lib/pages';
 import { fontClassName } from 'theme/fonts';

--- a/components/common/PageLayout/components/Header/components/ToggleEvaluationButton.tsx
+++ b/components/common/PageLayout/components/Header/components/ToggleEvaluationButton.tsx
@@ -2,8 +2,8 @@ import { IconButton, Tooltip } from '@mui/material';
 
 import { SIDEBAR_VIEWS } from 'components/[pageId]/DocumentPage/components/Sidebar/PageSidebar';
 import { useLastSidebarView } from 'components/[pageId]/DocumentPage/hooks/useLastSidebarView';
+import { usePageSidebar } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { useCharmRouter } from 'hooks/useCharmRouter';
-import { usePageSidebar } from 'hooks/usePageSidebar';
 
 export function ToggleEvaluationButton({ isInsideDialog, pageId }: { isInsideDialog?: boolean; pageId?: string }) {
   const { activeView, setActiveView } = usePageSidebar();

--- a/components/common/PageLayout/components/Header/components/ToggleEvaluationButton.tsx
+++ b/components/common/PageLayout/components/Header/components/ToggleEvaluationButton.tsx
@@ -1,14 +1,12 @@
 import { IconButton, Tooltip } from '@mui/material';
 
 import { SIDEBAR_VIEWS } from 'components/[pageId]/DocumentPage/components/Sidebar/PageSidebar';
-import { useLastSidebarView } from 'components/[pageId]/DocumentPage/hooks/useLastSidebarView';
 import { usePageSidebar } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { useCharmRouter } from 'hooks/useCharmRouter';
 
 export function ToggleEvaluationButton({ isInsideDialog, pageId }: { isInsideDialog?: boolean; pageId?: string }) {
-  const { activeView, setActiveView } = usePageSidebar();
+  const { activeView, setActiveView, persistActiveView } = usePageSidebar();
   const { navigateToSpacePath } = useCharmRouter();
-  const [, saveSidebarView] = useLastSidebarView();
 
   const isActive = activeView === 'proposal_evaluation';
 
@@ -21,7 +19,7 @@ export function ToggleEvaluationButton({ isInsideDialog, pageId }: { isInsideDia
       setActiveView('proposal_evaluation');
     } else if (pageId) {
       // set default sidebar and open full page
-      saveSidebarView({
+      persistActiveView({
         [pageId]: 'proposal_evaluation'
       });
       navigateToSpacePath(`/${pageId}`);

--- a/testing/customRender.tsx
+++ b/testing/customRender.tsx
@@ -74,7 +74,13 @@ export const customRenderWithContext = (
               }}
             >
               <PageSidebarContext.Provider
-                value={{ activeView: null, setActiveView: () => {}, closeSidebar: () => {} }}
+                value={{
+                  activeView: null,
+                  setActiveView: () => {},
+                  persistedActiveView: null,
+                  persistActiveView: () => {},
+                  closeSidebar: () => {}
+                }}
               >
                 {ui}
               </PageSidebarContext.Provider>

--- a/testing/customRender.tsx
+++ b/testing/customRender.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { SWRConfig } from 'swr';
 
-import { PageSidebarContext } from 'hooks/usePageSidebar';
+import { PageSidebarContext } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { SnackbarContext } from 'hooks/useSnackbar';
 import { SpacesContext } from 'hooks/useSpaces';
 import type { IContext } from 'hooks/useUser';


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY
What's supposed to happen is that we use local storage to open the sidebar when you get to full page. The current approach seems to overrides itself as you navigate between pages.