### PR TITLE
fix comment sidebar opening for notifications

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -223,7 +223,11 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
     if (!enableSidebar) {
       return;
     }
-    const highlightedCommentId = new URLSearchParams(window.location.search).get('commentId');
+    let highlightedCommentId = new URLSearchParams(window.location.search).get('commentId');
+    // hack to handle improperly-created URLs from notifications
+    if (highlightedCommentId === 'undefined') {
+      highlightedCommentId = null;
+    }
     const unresolvedThreads = Object.values(threads)
       .filter((thread) => !thread?.resolved)
       .filter(isTruthy);

--- a/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/NotificationsPopover.tsx
@@ -31,7 +31,6 @@ import type { Member } from 'lib/members/interfaces';
 import { getNotificationMetadata } from 'lib/notifications/getNotificationMetadata';
 import type { Notification } from 'lib/notifications/interfaces';
 import type { MarkNotifications } from 'lib/notifications/markNotifications';
-import type { LoggedInUser } from 'models';
 
 import { sidebarItemStyles } from './SidebarButton';
 
@@ -126,8 +125,9 @@ export function NotificationsPopover({
   isLoading: boolean;
 }) {
   const { user } = useUser();
-  const { members } = useMembers();
-  const currentMember = members.find((member) => member.id === user?.id);
+
+  const { membersRecord } = useMembers();
+  const currentMember = user?.id ? membersRecord[user.id] : undefined;
   const theme = useTheme();
   const [inboxState, setInboxState] = useState<'unread' | 'unarchived'>('unarchived');
   const [activeTab, setActiveState] = useState<'Inbox' | 'Archived'>('Inbox');
@@ -163,8 +163,6 @@ export function NotificationsPopover({
         readUnArchivedNotifications: _readUnArchivedNotifications
       };
     }, [notifications]);
-
-  const { membersRecord } = useMembers();
 
   const markNotifications = async (payload: MarkNotifications) => {
     await charmClient.notifications.markNotifications(payload);

--- a/lib/notifications/getNotificationUrl.ts
+++ b/lib/notifications/getNotificationUrl.ts
@@ -20,19 +20,19 @@ function getUrlSearchParamsFromNotificationType(
     case 'comment.created':
     case 'comment.replied':
     case 'comment.mention.created': {
-      urlSearchParams.set('commentId', notification.commentId!);
+      addSearchParam('commentId', notification.commentId);
       break;
     }
     case 'inline_comment.created':
     case 'inline_comment.replied':
     case 'inline_comment.mention.created': {
-      urlSearchParams.set('inlineCommentId', notification.inlineCommentId!);
+      addSearchParam('inlineCommentId', notification.inlineCommentId);
       break;
     }
     case 'application_comment.created':
     case 'application_comment.replied':
     case 'application_comment.mention.created': {
-      urlSearchParams.set('commentId', notification.applicationCommentId!);
+      addSearchParam('commentId', notification.applicationCommentId);
       break;
     }
     default: {
@@ -41,7 +41,13 @@ function getUrlSearchParamsFromNotificationType(
   }
 
   if (notification.type.includes('mention')) {
-    urlSearchParams.set('mentionId', notification.mentionId!);
+    addSearchParam('mentionId', notification.mentionId);
+  }
+
+  function addSearchParam(param: string, value?: string | null) {
+    if (value) {
+      urlSearchParams.set(param, value);
+    }
   }
 
   const query = urlSearchParams.toString();


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

We have to check if a value exists before using `urlSearchParams.set('commentId', commentId)`, otherwise the toString() method returns `?commentId=undefined`. This results in the comment sidebar opening whenever someone leaves a comment at the bottom of a page, because commentId is null/undefined.
