### PR TITLE
Fix and update reward templates

### DIFF
--- a/components/rewards/components/NewRewardButton.tsx
+++ b/components/rewards/components/NewRewardButton.tsx
@@ -70,15 +70,19 @@ export function NewRewardButton({ showPage }: { showPage: (pageId: string) => vo
   }
   let disabledTooltip: string | undefined;
 
+  const isTemplate = newPageValues?.type === 'bounty_template';
   if (!newPageValues?.title) {
     disabledTooltip = 'Page title is required';
-  } else if (!rewardValues.reviewers?.length) {
-    disabledTooltip = 'Reviewer is required';
-  } else if (
-    !rewardValues.customReward &&
-    (!rewardValues.rewardToken || !rewardValues.rewardAmount || !rewardValues.chainId)
-  ) {
-    disabledTooltip = 'Reward is required';
+  } else if (!isTemplate) {
+    // these values are not required for templates
+    if (!rewardValues.reviewers?.length) {
+      disabledTooltip = 'Reviewer is required';
+    } else if (
+      !rewardValues.customReward &&
+      (!rewardValues.rewardToken || !rewardValues.rewardAmount || !rewardValues.chainId)
+    ) {
+      disabledTooltip = 'Reward is required';
+    }
   }
 
   return (
@@ -114,7 +118,13 @@ export function NewRewardButton({ showPage }: { showPage: (pageId: string) => vo
         isSaving={isSavingReward}
       >
         <NewDocumentPage titlePlaceholder='Title (required)' values={newPageValues} onChange={updateNewPageValues}>
-          <RewardPropertiesForm onChange={setRewardValues} values={rewardValues} isNewReward expandedByDefault />
+          <RewardPropertiesForm
+            onChange={setRewardValues}
+            values={rewardValues}
+            isNewReward
+            isTemplate={isTemplate}
+            expandedByDefault
+          />
         </NewDocumentPage>
       </NewPageDialog>
     </>

--- a/components/rewards/components/RewardProperties/RewardProperties.tsx
+++ b/components/rewards/components/RewardProperties/RewardProperties.tsx
@@ -84,6 +84,7 @@ export function RewardProperties(props: {
         onChange={applyRewardUpdates}
         readOnly={readOnly}
         expandedByDefault={expandedRewardProperties}
+        isTemplate={isTemplate}
       />
 
       {!isTemplate && (

--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -304,7 +304,7 @@ export function RewardPropertiesForm({
 
             {rewardType === 'Custom' && (
               <Box display='flex' height='fit-content' flex={1} className='octo-propertyrow'>
-                <PropertyLabel readOnly highlighted>
+                <PropertyLabel readOnly highlighted required={isNewReward}>
                   Custom Reward
                 </PropertyLabel>
 

--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -32,6 +32,7 @@ type Props = {
   pageId?: string;
   refreshPermissions?: VoidFunction;
   isNewReward?: boolean;
+  isTemplate?: boolean;
   expandedByDefault?: boolean;
 };
 
@@ -41,6 +42,7 @@ export function RewardPropertiesForm({
   readOnly,
   useDebouncedInputs,
   isNewReward,
+  isTemplate,
   pageId,
   refreshPermissions,
   expandedByDefault
@@ -145,7 +147,7 @@ export function RewardPropertiesForm({
         <Collapse in={isExpanded} timeout='auto' unmountOnExit>
           <>
             <Box display='flex' height='fit-content' flex={1} className='octo-propertyrow'>
-              <PropertyLabel readOnly highlighted required={isNewReward}>
+              <PropertyLabel readOnly highlighted required={isNewReward && !isTemplate}>
                 Reviewer
               </PropertyLabel>
               <UserAndRoleSelect
@@ -291,7 +293,7 @@ export function RewardPropertiesForm({
 
             {rewardType === 'Token' && (
               <Box display='flex' height='fit-content' flex={1} className='octo-propertyrow'>
-                <PropertyLabel readOnly highlighted required={isNewReward}>
+                <PropertyLabel readOnly highlighted required={isNewReward && !isTemplate}>
                   Reward Token
                 </PropertyLabel>
                 <RewardTokenProperty
@@ -304,7 +306,7 @@ export function RewardPropertiesForm({
 
             {rewardType === 'Custom' && (
               <Box display='flex' height='fit-content' flex={1} className='octo-propertyrow'>
-                <PropertyLabel readOnly highlighted required={isNewReward}>
+                <PropertyLabel readOnly highlighted required={isNewReward && !isTemplate}>
                   Custom Reward
                 </PropertyLabel>
 

--- a/components/rewards/hooks/useNewReward.tsx
+++ b/components/rewards/hooks/useNewReward.tsx
@@ -3,7 +3,6 @@ import { useCallback, useState } from 'react';
 
 import { useCreateReward } from 'charmClient/hooks/rewards';
 import { EMPTY_PAGE_VALUES } from 'components/common/PageDialog/hooks/useNewPage';
-import { useRewards } from 'components/rewards/hooks/useRewards';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useSnackbar } from 'hooks/useSnackbar';
 import type { RewardPageProps } from 'lib/rewards/createReward';
@@ -16,7 +15,6 @@ export function useNewReward() {
   const [contentUpdated, setContentUpdated] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [rewardValues, setRewardValuesRaw] = useState<UpdateableRewardFields>(emptyState());
-  const { mutateRewards } = useRewards();
   const { trigger: createRewardTrigger } = useCreateReward();
 
   const setRewardValues = useCallback((partialFormInputs: Partial<UpdateableRewardFields>) => {
@@ -57,13 +55,6 @@ export function useNewReward() {
             throw err;
           })
           .then((reward) => {
-            mutateRewards(
-              (data) => {
-                if (!reward) return data;
-                return [...(data || []), reward];
-              },
-              { revalidate: false }
-            );
             setContentUpdated(false);
             return reward;
           })
@@ -74,7 +65,7 @@ export function useNewReward() {
         return createdReward;
       }
     },
-    [createRewardTrigger, rewardValues, mutateRewards, currentSpace, showMessage]
+    [createRewardTrigger, rewardValues, currentSpace, showMessage]
   );
 
   return {

--- a/components/rewards/hooks/useRewards.tsx
+++ b/components/rewards/hooks/useRewards.tsx
@@ -6,7 +6,6 @@ import charmClient from 'charmClient';
 import { useGetRewards } from 'charmClient/hooks/rewards';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePages } from 'hooks/usePages';
-import { useUser } from 'hooks/useUser';
 import { useWebSocketClient } from 'hooks/useWebSocketClient';
 import type { RewardWithUsers } from 'lib/rewards/interfaces';
 import type { RewardUpdate } from 'lib/rewards/updateRewardSettings';
@@ -37,7 +36,6 @@ export const RewardsContext = createContext<Readonly<RewardsContextType>>({
 export function RewardsProvider({ children }: { children: ReactNode }) {
   const { pages, loadingPages } = usePages();
   const { space } = useCurrentSpace();
-  const { user } = useUser();
 
   const { data, mutate: mutateRewards, isLoading } = useGetRewards({ spaceId: space?.id });
   const [creatingInlineReward, setCreatingInlineReward] = useState<boolean>(false);

--- a/components/settings/roles/components/RolePermissions/RolePermissions.tsx
+++ b/components/settings/roles/components/RolePermissions/RolePermissions.tsx
@@ -292,7 +292,7 @@ export function RolePermissions({ targetGroup, id, callback = () => null }: Prop
             {targetGroup !== 'space' && (
               <PermissionToggle
                 data-test='space-operation-deleteAnyBounty'
-                label='Delete any bounty'
+                label='Delete any reward'
                 defaultChecked={!isFreeSpace && !!assignedPermissions?.deleteAnyBounty}
                 disabled={disableModifications}
                 onChange={(ev) => {


### PR DESCRIPTION
### WHAT

- make all fields optional for reward templates
- fix: reward templates are appearing in the main board

### WHY

[<!-- why was this necessary? -->
](https://discord.com/channels/894960387743698944/1176944385678643301/1176944385678643301)