### PR TITLE
fix code for lens profile

### DIFF
--- a/components/settings/account/hooks/useLensProfile.ts
+++ b/components/settings/account/hooks/useLensProfile.ts
@@ -87,8 +87,7 @@ export function useLensProfile() {
   const authenticated = sessionData?.authenticated ?? false;
   const sessionProfile = sessionData?.type === SessionType.WithProfile ? sessionData?.profile : null;
   const { handlerLensError } = useHandleLensError();
-
-  const wallet = user?.wallets?.[0].address;
+  const wallet = user?.wallets[0]?.address;
   const { data: profilesData, loading: isLoadingProfiles } = useProfiles({
     where: {
       ownedBy: wallet ? [wallet] : account ? [account] : null


### PR DESCRIPTION
This blew up when user.wallets is an empty array. was caught by e2e