### PR TITLE
Fixed inline database calendar view drag and drop

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -104,7 +104,6 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
   const isSmallScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('lg'));
   const blocksDispatch = useAppDispatch();
   const [containerRef, { width: containerWidth }] = useElementSize();
-  const [editorState, setEditorState] = useState<EditorState | null>(null);
   const { creatingInlineReward } = useRewards();
 
   const pagePermissions = page.permissionFlags;
@@ -332,7 +331,6 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
                 pageType={page.type}
                 pagePermissions={pagePermissions ?? undefined}
                 onConnectionEvent={onConnectionEvent}
-                setEditorState={setEditorState}
                 snapshotProposalId={page.snapshotProposalId}
                 onParticipantUpdate={onParticipantUpdate}
                 style={{
@@ -426,7 +424,6 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
                       spaceId={page.spaceId}
                       proposalId={proposalId}
                       pagePermissions={pagePermissions}
-                      editorState={editorState}
                       sidebarView={sidebarView}
                       closeSidebar={closeSidebar}
                       openSidebar={setActiveView}

--- a/components/[pageId]/DocumentPage/components/Sidebar/PageSidebar.tsx
+++ b/components/[pageId]/DocumentPage/components/Sidebar/PageSidebar.tsx
@@ -1,13 +1,11 @@
 import type { PagePermissionFlags } from '@charmverse/core/permissions';
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { MessageOutlined, RateReviewOutlined } from '@mui/icons-material';
 import { Box, IconButton, Slide, SvgIcon, Tooltip, Typography } from '@mui/material';
-import type { EditorState } from 'prosemirror-state';
 import { memo } from 'react';
 import { RiChatCheckLine } from 'react-icons/ri';
 
-import { useGetAllReviewerUserIds, useGetProposalDetails } from 'charmClient/hooks/proposals';
+import { useGetProposalDetails } from 'charmClient/hooks/proposals';
 import type { PageSidebarView } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { MobileDialog } from 'components/common/MobileDialog/MobileDialog';
 import { useMdScreen } from 'hooks/useMediaScreens';
@@ -57,7 +55,6 @@ type SidebarProps = {
   pageId: string;
   spaceId: string;
   threads: Record<string, ThreadWithComments | undefined>;
-  editorState: EditorState | null;
   pagePermissions: PagePermissionFlags | null;
   sidebarView: PageSidebarView | null;
   openSidebar: (view: PageSidebarView) => void;
@@ -153,7 +150,6 @@ function SidebarContents({
   pageId,
   spaceId,
   pagePermissions,
-  editorState,
   threads,
   openSidebar,
   proposalId,
@@ -171,12 +167,7 @@ function SidebarContents({
         />
       )}
       {sidebarView === 'suggestions' && (
-        <SuggestionsSidebar
-          pageId={pageId}
-          spaceId={spaceId}
-          readOnly={!pagePermissions?.edit_content}
-          state={editorState}
-        />
+        <SuggestionsSidebar pageId={pageId} spaceId={spaceId} readOnly={!pagePermissions?.edit_content} />
       )}
       {sidebarView === 'comments' && (
         <CommentsSidebar openSidebar={openSidebar} threads={threads} canCreateComments={!!pagePermissions?.comment} />

--- a/components/[pageId]/DocumentPage/components/Sidebar/components/SuggestionsSidebar.tsx
+++ b/components/[pageId]/DocumentPage/components/Sidebar/components/SuggestionsSidebar.tsx
@@ -18,12 +18,10 @@ import { NoCommentsMessage } from './CommentsSidebar';
 
 export function SuggestionsSidebar({
   readOnly,
-  state,
   pageId,
   spaceId
 }: {
   readOnly: boolean;
-  state: EditorState | null;
   pageId: string;
   spaceId: string;
 }) {
@@ -39,18 +37,6 @@ export function SuggestionsSidebar({
       .flat();
     setSuggestions(marks);
   }, [view.state.doc]);
-
-  // listen to changes from selection (see CharmEditor)
-  useEffect(() => {
-    if (state) {
-      const marks = getEventsFromDoc({ state })
-        .map((r) => r.marks)
-        .flat();
-      setSuggestions(marks);
-    }
-  }, [state]);
-
-  // console.log('suggestions', suggestions);
 
   function clickAcceptAll() {
     acceptAll(view);

--- a/components/common/CharmEditor/CharmEditor.tsx
+++ b/components/common/CharmEditor/CharmEditor.tsx
@@ -194,7 +194,6 @@ type CharmEditorProps = {
   disableMention?: boolean;
   allowClickingFooter?: boolean;
   disableVideo?: boolean;
-  setEditorState?: (state: EditorState) => void; // this is used to pass the state to the suggestions sidebar
   threadIds?: string[];
 };
 
@@ -214,7 +213,6 @@ function CharmEditor({
   postId,
   containerWidth,
   pageType,
-  setEditorState,
   snapshotProposalId,
   pagePermissions,
   placeholderText,
@@ -292,8 +290,6 @@ function CharmEditor({
   const editorRef = useRef<HTMLDivElement>(null);
 
   function onSelectionSet(state: EditorState) {
-    // update state that triggers updates in the sidebar
-    setEditorState?.(state);
     // expand the sidebar if the user is selecting a suggestion
     setSidebarView?.((currentView) => {
       if (currentView) {


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

[Card](https://app.charmverse.io/charmverse/inline-db-calendar-view-can-t-move-events-to-new-dates-via-drag-and-drop-045683519793294325)
