### PR TITLE
Handle exporting empty database pages without throwing error

### DIFF
--- a/components/common/CharmEditor/components/@bangle.dev/core/bangle-editor-state.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/bangle-editor-state.ts
@@ -55,7 +55,8 @@ const createDocument = ({
     return schema.nodeFromJSON(content);
   }
 
-  if (typeof content === 'string') {
+  // Make sure document is present, otherwise it will throw an error
+  if (typeof content === 'string' && typeof window !== 'undefined') {
     const element = document.createElement('div');
     element.innerHTML = content.trim();
     return DOMParser.fromSchema(schema).parse(element, parseOptions);

--- a/components/common/CharmEditor/components/@bangle.dev/core/bangle-editor-state.ts
+++ b/components/common/CharmEditor/components/@bangle.dev/core/bangle-editor-state.ts
@@ -55,8 +55,7 @@ const createDocument = ({
     return schema.nodeFromJSON(content);
   }
 
-  // Make sure document is present, otherwise it will throw an error
-  if (typeof content === 'string' && typeof window !== 'undefined') {
+  if (typeof content === 'string') {
     const element = document.createElement('div');
     element.innerHTML = content.trim();
     return DOMParser.fromSchema(schema).parse(element, parseOptions);

--- a/components/common/PageActions/components/DatabasePageActionList.tsx
+++ b/components/common/PageActions/components/DatabasePageActionList.tsx
@@ -98,7 +98,7 @@ export function DatabasePageActionList({ pagePermissions, onComplete, page }: Pr
   async function exportZippedDatabase() {
     setExportingDatabase(true);
     try {
-      const exportName = `${boardPage?.title ?? 'Untitled'} database export.zip`;
+      const exportName = `${boardPage?.title ?? 'Untitled'} database export`;
 
       const generatedZip = await charmClient.pages.exportZippedDatabasePage({
         databaseId: pageId

--- a/lib/prosemirror/plugins/markdown/generateMarkdown.ts
+++ b/lib/prosemirror/plugins/markdown/generateMarkdown.ts
@@ -24,7 +24,7 @@ export async function generateMarkdown({
 
   const state = new BangleEditorState({
     specRegistry,
-    initialValue: content ? Node.fromJSON(specRegistry.schema, content) : emptyDocument,
+    initialValue: content ? Node.fromJSON(specRegistry.schema, content) : undefined,
     editorProps: {
       attributes: {
         example: 'value'

--- a/lib/prosemirror/plugins/markdown/generateMarkdown.ts
+++ b/lib/prosemirror/plugins/markdown/generateMarkdown.ts
@@ -5,6 +5,7 @@ import { BangleEditorState } from 'components/common/CharmEditor/components/@ban
 import { replaceNestedPages } from 'components/common/CharmEditor/components/nestedPage';
 import { specRegistry } from 'components/common/CharmEditor/specRegistry';
 import type { Member } from 'lib/members/interfaces';
+import { emptyDocument } from 'lib/prosemirror/constants';
 
 export type CharmMarkdownGeneratorOptions = {
   members?: Member[];
@@ -23,7 +24,7 @@ export async function generateMarkdown({
 
   const state = new BangleEditorState({
     specRegistry,
-    initialValue: content ? Node.fromJSON(specRegistry.schema, content) : '',
+    initialValue: content ? Node.fromJSON(specRegistry.schema, content) : emptyDocument,
     editorProps: {
       attributes: {
         example: 'value'

--- a/lib/prosemirror/plugins/markdown/generateMarkdown.ts
+++ b/lib/prosemirror/plugins/markdown/generateMarkdown.ts
@@ -22,19 +22,9 @@ export async function generateMarkdown({
 }): Promise<string> {
   const serializer = markdownSerializer(specRegistry);
 
-  const state = new BangleEditorState({
-    specRegistry,
-    initialValue: content ? Node.fromJSON(specRegistry.schema, content) : undefined,
-    editorProps: {
-      attributes: {
-        example: 'value'
-      }
-    }
-  });
-
   (serializer.options as any).charmOptions = generatorOptions;
 
-  let markdown = serializer.serialize(state.pmState.doc);
+  let markdown = content ? serializer.serialize(Node.fromJSON(specRegistry.schema, content)) : '';
 
   // Logic added here as the markdown serializer is synchronous
   markdown = await replaceNestedPages(markdown);

--- a/lib/prosemirror/plugins/markdown/generateMarkdown.ts
+++ b/lib/prosemirror/plugins/markdown/generateMarkdown.ts
@@ -1,11 +1,9 @@
 import { markdownSerializer } from '@bangle.dev/markdown';
 import { Node } from '@bangle.dev/pm';
 
-import { BangleEditorState } from 'components/common/CharmEditor/components/@bangle.dev/core/bangle-editor-state';
 import { replaceNestedPages } from 'components/common/CharmEditor/components/nestedPage';
 import { specRegistry } from 'components/common/CharmEditor/specRegistry';
 import type { Member } from 'lib/members/interfaces';
-import { emptyDocument } from 'lib/prosemirror/constants';
 
 export type CharmMarkdownGeneratorOptions = {
   members?: Member[];

--- a/pages/api/pages/[id]/export-database.ts
+++ b/pages/api/pages/[id]/export-database.ts
@@ -4,7 +4,6 @@ import nc from 'next-connect';
 
 import { loadAndGenerateCsv } from 'lib/focalboard/generateCsv';
 import { onError, onNoMatch, requireUser } from 'lib/middleware';
-import { providePermissionClients } from 'lib/permissions/api/permissionsClientMiddleware';
 import { generateMarkdown } from 'lib/prosemirror/plugins/markdown/generateMarkdown';
 import { withSessionRoute } from 'lib/session/withSession';
 import type { ContentToCompress, MarkdownPageToCompress } from 'lib/utilities/file';


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

1. Fix the exported zip name. Previously it was `.zip.zip`
2. Pass an empty prosemirror document to `BangleEditorState` if there is no content, rather than passing an empty string, as otherwise it would try use dom methods (which are not present in node env) and throw error.
