### PR TITLE
Fixed snackbar close ux

### DIFF
--- a/components/common/Snackbar.tsx
+++ b/components/common/Snackbar.tsx
@@ -57,35 +57,37 @@ export default function CustomizedSnackbar(props: CustomizedSnackbarProps) {
 
   const open = isOpenProp ?? isOpen;
 
+  if (!open) {
+    return null;
+  }
+
   return (
     <Stack spacing={2} sx={{ width: '100%', position: 'fixed', zIndex: 5000 }}>
-      {open && (
-        <Snackbar
-          open={open}
-          autoHideDuration={autoHideDuration}
-          anchorOrigin={originProp ?? origin}
-          onClose={handleClose}
-          sx={{
-            '& .MuiAlert-action': {
-              alignItems: 'center',
-              gap: 1
-            }
-          }}
+      <Snackbar
+        open
+        autoHideDuration={autoHideDuration}
+        anchorOrigin={originProp ?? origin}
+        onClose={handleClose}
+        sx={{
+          '& .MuiAlert-action': {
+            alignItems: 'center',
+            gap: 1
+          }
+        }}
+      >
+        <Alert
+          action={[
+            ...(actionsProp || actions || []),
+            <IconButton key='clear' onClick={handleCloseProp ?? (handleClose as any)} color='inherit'>
+              <ClearIcon fontSize='small' />
+            </IconButton>
+          ]}
+          severity={severityProp ?? severity}
+          sx={{ width: '100%', alignItems: 'center' }}
         >
-          <Alert
-            action={[
-              ...(actionsProp || actions || []),
-              <IconButton key='clear' onClick={handleCloseProp ?? (handleClose as any)} color='inherit'>
-                <ClearIcon fontSize='small' />
-              </IconButton>
-            ]}
-            severity={severityProp ?? severity}
-            sx={{ width: '100%', alignItems: 'center' }}
-          >
-            {messageProp ?? message}
-          </Alert>
-        </Snackbar>
-      )}
+          {messageProp ?? message}
+        </Alert>
+      </Snackbar>
     </Stack>
   );
 }

--- a/components/common/Snackbar.tsx
+++ b/components/common/Snackbar.tsx
@@ -31,7 +31,6 @@ export default function CustomizedSnackbar(props: CustomizedSnackbarProps) {
     severity,
     message,
     actions,
-    origin,
     handleClose,
     isOpen,
     autoHideDuration = props.autoHideDuration ?? 5000
@@ -51,20 +50,14 @@ export default function CustomizedSnackbar(props: CustomizedSnackbarProps) {
     handleClose: handleCloseProp,
     isOpen: isOpenProp,
     message: messageProp,
-    origin: originProp,
+    origin: originProp = { vertical: 'bottom', horizontal: 'left' },
     severity: severityProp
   } = props;
-
-  const open = isOpenProp ?? isOpen;
-
-  if (!open) {
-    return null;
-  }
 
   return (
     <Stack spacing={2} sx={{ width: '100%', position: 'fixed', zIndex: 5000 }}>
       <Snackbar
-        open
+        open={isOpenProp ?? isOpen}
         autoHideDuration={autoHideDuration}
         anchorOrigin={originProp ?? origin}
         onClose={handleClose}

--- a/components/common/Snackbar.tsx
+++ b/components/common/Snackbar.tsx
@@ -55,33 +55,37 @@ export default function CustomizedSnackbar(props: CustomizedSnackbarProps) {
     severity: severityProp
   } = props;
 
+  const open = isOpenProp ?? isOpen;
+
   return (
     <Stack spacing={2} sx={{ width: '100%', position: 'fixed', zIndex: 5000 }}>
-      <Snackbar
-        open={isOpenProp ?? isOpen}
-        autoHideDuration={autoHideDuration}
-        anchorOrigin={originProp ?? origin}
-        onClose={handleClose}
-        sx={{
-          '& .MuiAlert-action': {
-            alignItems: 'center',
-            gap: 1
-          }
-        }}
-      >
-        <Alert
-          action={[
-            ...(actionsProp || actions || []),
-            <IconButton key='clear' onClick={handleCloseProp ?? (handleClose as any)} color='inherit'>
-              <ClearIcon fontSize='small' />
-            </IconButton>
-          ]}
-          severity={severityProp ?? severity}
-          sx={{ width: '100%', alignItems: 'center' }}
+      {open && (
+        <Snackbar
+          open={open}
+          autoHideDuration={autoHideDuration}
+          anchorOrigin={originProp ?? origin}
+          onClose={handleClose}
+          sx={{
+            '& .MuiAlert-action': {
+              alignItems: 'center',
+              gap: 1
+            }
+          }}
         >
-          {messageProp ?? message}
-        </Alert>
-      </Snackbar>
+          <Alert
+            action={[
+              ...(actionsProp || actions || []),
+              <IconButton key='clear' onClick={handleCloseProp ?? (handleClose as any)} color='inherit'>
+                <ClearIcon fontSize='small' />
+              </IconButton>
+            ]}
+            severity={severityProp ?? severity}
+            sx={{ width: '100%', alignItems: 'center' }}
+          >
+            {messageProp ?? message}
+          </Alert>
+        </Snackbar>
+      )}
     </Stack>
   );
 }

--- a/hooks/useSnackbar.tsx
+++ b/hooks/useSnackbar.tsx
@@ -64,12 +64,9 @@ export function SnackbarProvider({ children }: { children: ReactNode }) {
       setAutoHideDuration,
       isOpen,
       handleClose,
-      showMessage: (msg: ReactNode, newSeverity?: AlertColor, anchorOrigin?: SnackbarOrigin) => {
+      showMessage: (msg: ReactNode, newSeverity?: AlertColor) => {
         newSeverity = newSeverity ?? 'info';
         setIsOpen(true);
-        if (anchorOrigin) {
-          setOrigin(anchorOrigin);
-        }
         setSeverity(newSeverity);
         setMessage(msg);
       },

--- a/hooks/useSnackbar.tsx
+++ b/hooks/useSnackbar.tsx
@@ -7,7 +7,6 @@ type IContext = {
   actions?: ReactNode[];
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   message: ReactNode;
-  origin: SnackbarOrigin;
   setMessage: Dispatch<SetStateAction<ReactNode>>;
   severity: AlertColor;
   setSeverity: Dispatch<SetStateAction<AlertColor>>;
@@ -23,7 +22,6 @@ export const SnackbarContext = createContext<Readonly<IContext>>({
   isOpen: false,
   actions: [],
   message: null,
-  origin: { vertical: 'bottom', horizontal: 'left' },
   setIsOpen: () => {},
   setMessage: () => {},
   setSeverity: () => {},
@@ -37,7 +35,6 @@ export const SnackbarContext = createContext<Readonly<IContext>>({
 export function SnackbarProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(true);
   const [actions, setActions] = useState<ReactNode[]>([]);
-  const [origin, setOrigin] = useState<SnackbarOrigin>({ vertical: 'bottom', horizontal: 'left' });
   const [severity, setSeverity] = useState<AlertColor>('info');
   const [message, setMessage] = useState<null | ReactNode>(null);
   const [autoHideDuration, setAutoHideDuration] = useState<null | number>(5000);
@@ -45,10 +42,7 @@ export function SnackbarProvider({ children }: { children: ReactNode }) {
   const resetState = () => {
     setIsOpen(false);
     setActions([]);
-    setOrigin({ vertical: 'bottom', horizontal: 'left' });
-    setMessage(null);
     setAutoHideDuration(5000);
-    setSeverity('info');
   };
 
   const handleClose: SnackbarProps['onClose'] = (_, reason) => {
@@ -72,14 +66,13 @@ export function SnackbarProvider({ children }: { children: ReactNode }) {
       },
       actions,
       message,
-      origin,
       severity,
       setActions,
       setSeverity,
       setIsOpen,
       setMessage
     }),
-    [isOpen, message, origin, severity]
+    [isOpen, message, autoHideDuration, actions, severity]
   );
 
   return <SnackbarContext.Provider value={value}>{children}</SnackbarContext.Provider>;

--- a/hooks/useSnackbar.tsx
+++ b/hooks/useSnackbar.tsx
@@ -60,9 +60,9 @@ export function SnackbarProvider({ children }: { children: ReactNode }) {
       handleClose,
       showMessage: (msg: ReactNode, newSeverity?: AlertColor) => {
         newSeverity = newSeverity ?? 'info';
-        setIsOpen(true);
-        setSeverity(newSeverity);
         setMessage(msg);
+        setSeverity(newSeverity);
+        setIsOpen(true);
       },
       actions,
       message,

--- a/testing/customRender.tsx
+++ b/testing/customRender.tsx
@@ -62,10 +62,6 @@ export const customRenderWithContext = (
                 showMessage: () => {},
                 actions: [],
                 message: null,
-                origin: {
-                  vertical: 'bottom',
-                  horizontal: 'left'
-                },
                 severity: 'info',
                 setActions: () => {},
                 setSeverity: () => {},


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

Previously when the snackbar was about to close, we showed the initial state (info and empty message), which created a bad UX. Check out this loom recording, first portion is with the update, 2nd portion is what we have currently.

https://www.loom.com/share/d0ef1bb91ae641ee90c832bde7ef6870?sid=13b3008c-fdce-4761-bd9e-8997d3bfff41
