### PR TITLE
Fixed inline database calendar view drag and drop

### DIFF
--- a/components/common/CharmEditor/components/suggestions/suggestions.plugins.tsx
+++ b/components/common/CharmEditor/components/suggestions/suggestions.plugins.tsx
@@ -28,7 +28,7 @@ export function plugins({ onSelectionSet, key }: { onSelectionSet?: (state: Edit
         },
         apply(tr, prev, oldState, state) {
           // react to when something is clicked, or when a selection is set by the sidebar component
-          if (tr.selectionSet || oldState.selection.eq(state.selection)) {
+          if (tr.selectionSet || !oldState.selection.eq(state.selection)) {
             onSelectionSet?.(state);
           }
           return prev;


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

[Card](https://app.charmverse.io/charmverse/inline-db-calendar-view-can-t-move-events-to-new-dates-via-drag-and-drop-045683519793294325)
