### PR TITLE
Misc updates to public rewards and proposals view option

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewLayoutOptions.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/viewSidebar/viewLayoutOptions.tsx
@@ -4,6 +4,8 @@ import type { IntlShape } from 'react-intl';
 import { injectIntl } from 'react-intl';
 
 import SelectMenu from 'components/common/Menu';
+import { useHasMemberLevel } from 'hooks/useHasMemberLevel';
+import { useIsAdmin } from 'hooks/useIsAdmin';
 import type { Board, IPropertyTemplate } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';
 import { createBoardView } from 'lib/focalboard/boardView';
@@ -28,7 +30,7 @@ interface LayoutOptionsProps {
 
 function LayoutOptions(props: LayoutOptionsProps) {
   const dispatch = useAppDispatch();
-
+  const isAdmin = useIsAdmin();
   const intl = props.intl;
   const hideLayoutSelectOptions = props.hideLayoutSelectOptions ?? false;
   const activeView = props.view;
@@ -157,6 +159,7 @@ function LayoutOptions(props: LayoutOptionsProps) {
           Open pages in
         </Typography>
         <SelectMenu
+          disabled={!isAdmin}
           buttonSize='small'
           selectedValue={activeView.fields.openPageIn ?? 'center_peek'}
           options={[

--- a/components/common/Menu.tsx
+++ b/components/common/Menu.tsx
@@ -22,6 +22,7 @@ interface Props {
   options: MenuOption[];
   closeOnSelect?: boolean;
   buttonSize?: string;
+  disabled?: boolean;
 }
 
 export default function SelectMenu({
@@ -31,7 +32,8 @@ export default function SelectMenu({
   loading = false,
   title,
   closeOnSelect = true,
-  buttonSize
+  buttonSize,
+  disabled
 }: Props) {
   const popupState = usePopupState({ variant: 'popover', popupId: `menu-${v4()}` });
 
@@ -47,7 +49,7 @@ export default function SelectMenu({
       <Button
         color='secondary'
         variant='outlined'
-        disabled={loading}
+        disabled={loading || disabled}
         loading={loading}
         size={buttonSize}
         endIcon={!loading && <KeyboardArrowDownIcon fontSize='small' />}
@@ -74,6 +76,7 @@ export default function SelectMenu({
                   popupState.close();
                 }
               }}
+              disabled={loading || disabled}
             >
               <StyledListItemText primary={primary} secondary={secondary} />
             </MenuItem>

--- a/components/proposals/ProposalsPage.tsx
+++ b/components/proposals/ProposalsPage.tsx
@@ -27,6 +27,7 @@ import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useHasMemberLevel } from 'hooks/useHasMemberLevel';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useIsFreeSpace } from 'hooks/useIsFreeSpace';
+import { useUser } from 'hooks/useUser';
 
 import { useProposalDialog } from './components/ProposalDialog/hooks/useProposalDialog';
 import type { ProposalPageAndPropertiesInput } from './components/ProposalDialog/NewProposalPage';
@@ -42,7 +43,7 @@ export function ProposalsPage({ title }: { title: string }) {
   const canSeeProposals = hasAccess || isFreeSpace || currentSpace?.publicProposals === true;
   const { navigateToSpacePath, updateURLQuery } = useCharmRouter();
   const isAdmin = useIsAdmin();
-
+  const { user } = useUser();
   const { props, showProposal, hideProposal } = useProposalDialog();
   const { board: activeBoard, views, cardPages, activeView, cards } = useProposalsBoard();
   const router = useRouter();
@@ -143,13 +144,15 @@ export function ProposalsPage({ title }: { title: string }) {
               viewSortPopup={viewSortPopup}
             />
 
-            <ViewHeaderActionsMenu
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                setShowSidebar(!showSidebar);
-              }}
-            />
+            {user && (
+              <ViewHeaderActionsMenu
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setShowSidebar(!showSidebar);
+                }}
+              />
+            )}
           </Stack>
           <Divider />
 

--- a/components/proposals/components/ProposalCategoriesList.tsx
+++ b/components/proposals/components/ProposalCategoriesList.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { Button } from 'components/common/Button';
 import { ColorSelectMenu } from 'components/common/form/ColorSelectMenu';
 import FieldLabel from 'components/common/form/FieldLabel';
+import { hoverIconsStyle } from 'components/common/Icons/hoverIconsStyle';
 import Modal from 'components/common/Modal';
 import { ProposalCategoryChip } from 'components/proposals/components/ProposalChip';
 import { ProposalCategoryContextMenu } from 'components/proposals/components/ProposalViewOptions/components/ProposalCategoryContextMenu';
@@ -21,6 +22,10 @@ const ColorBox = styled(Box)`
   height: 40px;
   border-radius: 4px;
   cursor: pointer;
+`;
+
+const StyledMenuItem = styled(MenuItem)`
+  ${hoverIconsStyle({ marginForIcons: false })}
 `;
 
 export function ProposalCategoriesList() {
@@ -53,7 +58,7 @@ export function ProposalCategoriesList() {
     <>
       <MenuList>
         {categories.map((category) => (
-          <MenuItem
+          <StyledMenuItem
             data-test={`proposal-category-${category.id}`}
             key={category.id}
             value={category.id}
@@ -61,7 +66,7 @@ export function ProposalCategoriesList() {
           >
             <ProposalCategoryChip size='small' color={category.color} title={category.title} />
             <ProposalCategoryContextMenu category={category} key={category.id} />
-          </MenuItem>
+          </StyledMenuItem>
         ))}
 
         <Button

--- a/components/proposals/components/ProposalViewOptions/components/ProposalCategoryContextMenu.tsx
+++ b/components/proposals/components/ProposalViewOptions/components/ProposalCategoryContextMenu.tsx
@@ -121,7 +121,7 @@ export function ProposalCategoryContextMenu({ category }: Props) {
   return (
     <>
       <PopperPopup popupContent={popupContent} onClose={onSave}>
-        <IconButton data-test={`open-category-context-menu-${category.id}`} size='small'>
+        <IconButton data-test={`open-category-context-menu-${category.id}`} size='small' className='icons'>
           <MoreHorizIcon fontSize='small' />
         </IconButton>
       </PopperPopup>

--- a/components/rewards/components/NewRewardButton.tsx
+++ b/components/rewards/components/NewRewardButton.tsx
@@ -4,6 +4,7 @@ import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useRef } from 'react';
 
 import charmClient from 'charmClient';
+import { useGetRewardPermissions } from 'charmClient/hooks/rewards';
 import { Button } from 'components/common/Button';
 import { NewDocumentPage } from 'components/common/PageDialog/components/NewDocumentPage';
 import { useNewPage } from 'components/common/PageDialog/hooks/useNewPage';
@@ -11,6 +12,7 @@ import { NewPageDialog } from 'components/common/PageDialog/NewPageDialog';
 import { TemplatesMenu } from 'components/common/TemplatesMenu';
 import { RewardPropertiesForm } from 'components/rewards/components/RewardProperties/RewardPropertiesForm';
 import { useNewReward } from 'components/rewards/hooks/useNewReward';
+import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import type { PageContent } from 'lib/prosemirror/interfaces';
 
@@ -25,10 +27,13 @@ export function NewRewardButton({ showPage }: { showPage: (pageId: string) => vo
   const buttonRef = useRef<HTMLDivElement>(null);
   const popupState = usePopupState({ variant: 'popover', popupId: 'templates-menu' });
   const { templates, isLoading } = useRewardTemplates();
+  const [currentSpacePermissions] = useCurrentSpacePermissions();
 
   function deleteTemplate(pageId: string) {
     return charmClient.deletePage(pageId);
   }
+
+  const isDisabled = !currentSpacePermissions?.createBounty;
 
   function createTemplate() {
     openNewPage({
@@ -88,10 +93,10 @@ export function NewRewardButton({ showPage }: { showPage: (pageId: string) => vo
   return (
     <>
       <ButtonGroup variant='contained' ref={buttonRef}>
-        <Button data-test='create-suggest-bounty' onClick={createNewReward}>
+        <Button disabled={isDisabled} data-test='create-suggest-bounty' onClick={createNewReward}>
           Create
         </Button>
-        <Button data-test='reward-template-select' size='small' onClick={popupState.open}>
+        <Button disabled={isDisabled} data-test='reward-template-select' size='small' onClick={popupState.open}>
           <KeyboardArrowDown />
         </Button>
       </ButtonGroup>


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

1. Completely hide view option (...) if no user is logged in
2. Disable create new reward button without permission
3. Disable changing the "Open page in" option without being an admin
4. Hide proposal category options ellipsis until hover (just like forum categories)

[Discussion](https://discord.com/channels/894960387743698944/1016422398964269076/1178318289043214367)
