### PR TITLE
fix events not being able to be dragged on inline calendars

### DIFF
--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -143,8 +143,6 @@ function CenterPanel(props: Props) {
   // filter cards by whats accessible
   const cardPages: CardPage[] = useMemo(() => {
     const result = _cards
-      // TODO: dont recreate the card objects, this causes re-rendering on all cards when any card/page is updated
-      // we need to figure another way to grab the page titles probably down-stream
       .map((card) => ({
         card,
         page: pages[card.id]!

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -122,18 +122,21 @@ export function InlineDatabase({ containerWidth, readOnly: readOnlyOverride, nod
     }, 500);
   }, [updatePage]);
 
-  const showCard = async (cardId: string | null, isTemplate?: boolean) => {
-    if (cardId === null) {
-      setShownCardId(null);
-      return;
-    }
+  const showCard = useCallback(
+    async (cardId: string | null, isTemplate?: boolean) => {
+      if (cardId === null) {
+        setShownCardId(null);
+        return;
+      }
 
-    if (currentView.fields.openPageIn === 'center_peek' || isTemplate) {
-      setShownCardId(cardId);
-    } else if (currentView.fields.openPageIn === 'full_page') {
-      navigateToSpacePath(`/${cardId}`);
-    }
-  };
+      if (currentView.fields.openPageIn === 'center_peek' || isTemplate) {
+        setShownCardId(cardId);
+      } else if (currentView.fields.openPageIn === 'full_page') {
+        navigateToSpacePath(`/${cardId}`);
+      }
+    },
+    [currentView?.fields.openPageIn, navigateToSpacePath, setShownCardId]
+  );
 
   function stopPropagation(e: KeyboardEvent | MouseEvent | ClipboardEvent) {
     e.stopPropagation();

--- a/hooks/useCharmRouter.ts
+++ b/hooks/useCharmRouter.ts
@@ -1,41 +1,45 @@
 import type { ParsedUrlQueryInput } from 'node:querystring';
 
 import { useRouter } from 'next/router';
+import { useMemo } from 'react';
 
 // utils for interacting with useRouter
 
 export function useCharmRouter() {
   const router = useRouter();
 
-  return {
-    router,
-    navigateToPath(pathname: string, query?: ParsedUrlQueryInput) {
-      return router.push({ pathname, query });
-    },
-    // automatically adds the space domain prefix to the pathname
-    navigateToSpacePath(pathname: string, query: ParsedUrlQueryInput = {}) {
-      return router.push({
-        pathname: `/[domain]${pathname}`,
-        query: { ...query, domain: router.query.domain }
-      });
-    },
-    // update the URL, trigger a digest but do not re-run SSR
-    clearURLQuery() {
-      const query = router.query.domain ? { domain: router.query.domain } : undefined;
-      return router.push({ pathname: router.pathname, query }, undefined, {
-        shallow: true
-      });
-    },
-    // update the URL, trigger a digest but do not re-run SSR
-    updateURLQuery(query: ParsedUrlQueryInput) {
-      // filter empty query params
-      const updatedQuery = Object.fromEntries(
-        Object.entries({ ...router.query, ...query }).filter(([_, v]) => v != null)
-      );
+  return useMemo(
+    () => ({
+      router,
+      navigateToPath(pathname: string, query?: ParsedUrlQueryInput) {
+        return router.push({ pathname, query });
+      },
+      // automatically adds the space domain prefix to the pathname
+      navigateToSpacePath(pathname: string, query: ParsedUrlQueryInput = {}) {
+        return router.push({
+          pathname: `/[domain]${pathname}`,
+          query: { ...query, domain: router.query.domain }
+        });
+      },
+      // update the URL, trigger a digest but do not re-run SSR
+      clearURLQuery() {
+        const query = router.query.domain ? { domain: router.query.domain } : undefined;
+        return router.push({ pathname: router.pathname, query }, undefined, {
+          shallow: true
+        });
+      },
+      // update the URL, trigger a digest but do not re-run SSR
+      updateURLQuery(query: ParsedUrlQueryInput) {
+        // filter empty query params
+        const updatedQuery = Object.fromEntries(
+          Object.entries({ ...router.query, ...query }).filter(([_, v]) => v != null)
+        );
 
-      return router.push({ pathname: router.pathname, query: updatedQuery }, undefined, {
-        shallow: true
-      });
-    }
-  };
+        return router.push({ pathname: router.pathname, query: updatedQuery }, undefined, {
+          shallow: true
+        });
+      }
+    }),
+    [router]
+  );
 }


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY
I am not sure why this works! I was just looking at what React components are rendering during drag and drop on an inline db and noticed CenterPanel was rendering due to 'showCard' prop, so I added a useCallback around it. Now I can drag the event fine. I can't really explain it, but we should be memoizing it anyway