### PR TITLE
Open card after creating and remove cardId from url after closing

### DIFF
--- a/__e2e__/database/createAndEditDatabase.spec.ts
+++ b/__e2e__/database/createAndEditDatabase.spec.ts
@@ -110,6 +110,8 @@ test.describe.serial('Edit database select properties', async () => {
     // Leave time for all creation processes to happen
     await page.waitForTimeout(500);
 
+    await databasePage.closeModal.click();
+
     const card = await prisma.page.findFirstOrThrow({ where: { parentId: databasePageId } });
 
     const { closedSelect, openSelect } = databasePage.getTablePropertySelectLocator({

--- a/components/[pageId]/DatabasePage/DatabasePage.tsx
+++ b/components/[pageId]/DatabasePage/DatabasePage.tsx
@@ -123,6 +123,7 @@ export function DatabasePage({ page, setPage, readOnly = false, pagePermissions 
   const showCard = useCallback(
     async (cardId: string | null, isTemplate?: boolean) => {
       if (cardId === null) {
+        updateURLQuery({ cardId: null });
         setShownCardId(null);
         return;
       }

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -386,7 +386,8 @@ function CenterPanel(props: Props) {
   const kanbanAddCard = useCallback(
     (groupByOptionId?: string) => {
       addCard({
-        groupByOptionId
+        groupByOptionId,
+        show: true
       });
     },
     [addCard]


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

1. Open the card based on the "Open page in" field of the current view
2. Remove `cardId` after closing card