### PR TITLE
Rewards link

### DIFF
--- a/components/common/PageDialog/PageDialog.tsx
+++ b/components/common/PageDialog/PageDialog.tsx
@@ -52,7 +52,11 @@ function PageDialogBase(props: Props) {
   const { page, refreshPage } = usePage({ pageIdOrPath: pageId });
   const pagePermissions = page?.permissionFlags || new AvailablePagePermissions().full;
   const domain = router.query.domain as string;
-  const fullPageUrl = page?.path ? `/${domain}/${page?.path}` : null;
+  const fullPageUrl = page?.path
+    ? `/${domain}/${page?.path}`
+    : applicationContext
+    ? `/${domain}/rewards/applications/${applicationContext.applicationId}`
+    : null;
 
   const readOnlyPage = readOnly || !pagePermissions?.edit_content;
 
@@ -146,7 +150,7 @@ function PageDialogBase(props: Props) {
         page && <FullPageActionsMenuButton isInsideDialog page={page} onDelete={close} />
       }
       toolbar={
-        contentType === 'page' && (
+        (contentType === 'page' || contentType === 'application') && (
           <Box display='flex' justifyContent='space-between'>
             <Button
               data-test='open-as-page'

--- a/components/rewards/components/RewardStatusBadge.tsx
+++ b/components/rewards/components/RewardStatusBadge.tsx
@@ -20,57 +20,32 @@ import { RewardStatusChip } from './RewardChip';
 
 export interface IRewardBadgeProps {
   reward: Reward;
-  layout?: 'row' | 'stacked';
   truncate?: boolean;
   hideStatus?: boolean;
   showEmptyStatus?: boolean;
 }
-export function RewardStatusBadge({
-  truncate = false,
-  showEmptyStatus,
-  hideStatus,
-  reward,
-  layout = 'row'
-}: IRewardBadgeProps) {
-  const { space } = useCurrentSpace();
-
-  const rewardLink = `/${space?.domain}/rewards/${reward.id}`;
-
-  if (layout === 'row') {
-    return (
-      <Grid container direction='column' alignItems='center'>
-        <Grid item xs width='100%' display='flex' flexDirection='column' sx={{ alignItems: 'center' }}>
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'row',
-              flexWrap: 'wrap',
-              width: '100%',
-              justifyContent: 'space-between',
-              gap: 1,
-              alignItems: 'center',
-              minHeight: '30px'
-            }}
-          >
-            <RewardAmount reward={reward} truncate={truncate} />
-            {!hideStatus && <RewardStatusChip status={reward.status} showEmptyStatus={showEmptyStatus} />}
-          </Box>
-        </Grid>
-      </Grid>
-    );
-  } else {
-    return (
-      <Box sx={{ textAlign: 'right' }}>
-        <Box display='flex' alignItems='center' justifyContent='space-between'>
+export function RewardStatusBadge({ truncate = false, showEmptyStatus, hideStatus, reward }: IRewardBadgeProps) {
+  return (
+    <Grid container direction='column' alignItems='center'>
+      <Grid item xs width='100%' display='flex' flexDirection='column' sx={{ alignItems: 'center' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            width: '100%',
+            justifyContent: 'space-between',
+            gap: 1,
+            alignItems: 'center',
+            minHeight: '30px'
+          }}
+        >
           <RewardAmount reward={reward} truncate={truncate} />
-          <IconButton href={rewardLink} component={Link}>
-            <LaunchIcon fontSize='small' />
-          </IconButton>
+          {!hideStatus && <RewardStatusChip status={reward.status} showEmptyStatus={showEmptyStatus} />}
         </Box>
-        {hideStatus && <RewardStatusChip status={reward.status} showEmptyStatus={showEmptyStatus} />}
-      </Box>
-    );
-  }
+      </Grid>
+    </Grid>
+  );
 }
 
 export function RewardAmount({


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

- "Open as page" to applications inside dialog
- removed a case we don't use for RewardStatusBadge, which had an incorrect link to rewards
