### PR TITLE
Prevent reordering flows from a template

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -157,8 +157,8 @@ export function ProposalProperties({
   const onChangeRubricCriteriaDebounced = useCallback(debounce(onChangeRubricCriteria, 300), [proposal?.status]);
   const readOnlyCategory = !isAdmin && (!proposalPermissions?.edit || !!proposal?.page?.sourceTemplateId);
   const readOnlyReviewers = readOnlyProperties || (!isAdmin && sourceTemplate && sourceTemplate.reviewers.length > 0);
-  // rubric criteria can always be updated by reviewers and admins
-  const readOnlyRubricCriteria = (readOnlyProperties || isFromTemplateSource) && !(isAdmin || isReviewer);
+  // rubric criteria can always be updated by reviewers and admins, but criteria from a template are only editable by admin
+  const readOnlyRubricCriteria = !isAdmin && ((readOnlyProperties && !isReviewer) || isFromTemplateSource);
 
   const canSeeEvaluation =
     (proposal?.status === 'evaluation_active' || proposal?.status === 'evaluation_closed') && isReviewer;

--- a/components/proposals/components/ProposalProperties/components/ProposalRubricCriteriaInput.tsx
+++ b/components/proposals/components/ProposalProperties/components/ProposalRubricCriteriaInput.tsx
@@ -144,6 +144,9 @@ export function ProposalRubricCriteriaInput({
     }
   }
   async function changeOptionsOrder(draggedProperty: string, droppedOnProperty: string) {
+    if (readOnly) {
+      return;
+    }
     const newOrder = [...criteriaList];
     const propIndex = newOrder.findIndex((val) => val.id === draggedProperty); // find the property that was dragged
     const deletedElements = newOrder.splice(propIndex, 1); // remove the dragged property from the array
@@ -161,12 +164,15 @@ export function ProposalRubricCriteriaInput({
           key={criteria.id}
           name='rubric-option'
           itemId={criteria.id}
+          draggable={!readOnly}
           changeOrderHandler={changeOptionsOrder}
         >
           <CriteriaRow display='flex' alignItems='flex-start' gap={1} mb={1}>
-            <div className='drag-indicator show-on-hover'>
-              <DragIndicator color='secondary' fontSize='small' />
-            </div>
+            {!readOnly && (
+              <div className='drag-indicator show-on-hover'>
+                <DragIndicator color='secondary' fontSize='small' />
+              </div>
+            )}
             <TextInput
               inputProps={{ autoFocus: true }}
               displayType='details'


### PR DESCRIPTION
### WHAT

If proposal comes from a template, don't allow non admin to reorder criteria

### WHY

Author was able to reorder criteria, which makes it more difficult for reviewers of multiple proposals using the same template