### PR TITLE
Improve UX + bugfix for required member properties

### DIFF
--- a/components/_app/components/OnboardingEmailForm.tsx
+++ b/components/_app/components/OnboardingEmailForm.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Checkbox, FormControlLabel, FormGroup, TextField, Typography, Stack } from '@mui/material';
+import { Checkbox, FormControlLabel, FormGroup, TextField, Typography, Stack, Tooltip } from '@mui/material';
 import type { ChangeEvent } from 'react';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
@@ -9,21 +9,19 @@ import { Button } from 'components/common/Button';
 import Link from 'components/common/Link';
 import { useUser } from 'hooks/useUser';
 
+const emailSchema = yup.string().email().ensure().trim();
+
 export const schema = yup.object({
-  email: yup
-    .string()
-    .ensure()
-    .trim()
-    .email()
+  email: emailSchema
     .when('emailNewsletter', {
-      is: (val: boolean) => val === true,
-      then: () => yup.string().required('Unselect email options to proceed without email'),
-      otherwise: () => yup.string()
+      is: true,
+      then: () => emailSchema.required('Unselect email options to proceed without email'),
+      otherwise: () => emailSchema
     })
     .when('emailNotifications', {
       is: true,
-      then: () => yup.string().required('Unselect email options to proceed without email'),
-      otherwise: () => yup.string()
+      then: () => emailSchema.required('Unselect email options to proceed without email'),
+      otherwise: () => emailSchema
     }),
   emailNotifications: yup.boolean(),
   emailNewsletter: yup.boolean(),
@@ -46,8 +44,8 @@ export function OnboardingEmailForm({ onClick, spaceId }: { onClick: VoidFunctio
   } = useForm<FormValues>({
     defaultValues: {
       email: user?.email || '',
-      emailNewsletter: !!user?.emailNewsletter,
       emailNotifications: true,
+      emailNewsletter: !!user?.emailNewsletter,
       agreeTermsConditions: false
     },
     // mode: 'onChange',
@@ -117,9 +115,13 @@ export function OnboardingEmailForm({ onClick, spaceId }: { onClick: VoidFunctio
           />
         </FormGroup>
         <Stack flexDirection='row' gap={1} justifyContent='flex-end'>
-          <Button loading={isMutating} data-test='member-email-next' type='submit' disabled={!isValid}>
-            Next
-          </Button>
+          <Tooltip title={!agreeTermsConditions ? 'You must agree to the terms and conditions to continue' : ''}>
+            <div>
+              <Button loading={isMutating} data-test='member-email-next' type='submit' disabled={!isValid}>
+                Next
+              </Button>
+            </div>
+          </Tooltip>
         </Stack>
       </Stack>
     </form>

--- a/components/_app/components/UserOnboardingDialog.tsx
+++ b/components/_app/components/UserOnboardingDialog.tsx
@@ -34,9 +34,11 @@ type Step = 'email_step' | 'profile_step';
 export function UserOnboardingDialogGlobal() {
   const { space } = useCurrentSpace();
   const { user } = useUser();
+  const { getMemberById } = useMembers();
+  const member = user ? getMemberById(user.id) : null;
 
   // Wait for user to load before deciding what to show
-  if (!user || !space) {
+  if (!user || !space || !member || member.isGuest) {
     return null;
   }
 
@@ -45,14 +47,13 @@ export function UserOnboardingDialogGlobal() {
 
 function LoggedInUserOnboardingDialog({ user, spaceId }: { spaceId: string; user: LoggedInUser }) {
   const { showOnboardingFlow, completeOnboarding } = useOnboarding({ user, spaceId });
+  const { nonEmptyRequiredProperties } = useRequiredMemberProperties({
+    userId: user.id
+  });
 
   useEffect(() => {
     log.info('[user-journey] Show onboarding flow');
   }, []);
-
-  const { nonEmptyRequiredProperties } = useRequiredMemberProperties({
-    userId: user.id
-  });
 
   if (showOnboardingFlow) {
     return (


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

1. Skip triggering the required member properties modal for guest members
2. Show tooltip for cv onboarding modal's disabled button
3. Add a loading state to disable the button while member properties are being updated
4. Fixed bug when modal doesn't close even after filling and saving required member properties
