### PR TITLE
Fix address not working in token gate modal

### DIFF
--- a/components/common/form/fields/TextInputField.tsx
+++ b/components/common/form/fields/TextInputField.tsx
@@ -10,15 +10,7 @@ export const TextInputField = forwardRef<HTMLDivElement, Props>(
   ({ label, iconLabel, inline, error, multiline = false, required, value, ...inputProps }, ref) => {
     return (
       <FieldWrapper required={required} label={label} inline={inline} iconLabel={iconLabel}>
-        <TextField
-          fullWidth
-          required={required}
-          error={!!error}
-          multiline={multiline}
-          {...inputProps}
-          value={value || ''}
-          ref={ref}
-        />
+        <TextField fullWidth required={required} error={!!error} multiline={multiline} {...inputProps} ref={ref} />
       </FieldWrapper>
     );
   }


### PR DESCRIPTION
The custom TextField is not working anymore because of an update from a few days ago.