### PR TITLE
Show parent board title chip for reward cards

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -84,14 +84,23 @@ export interface DocumentPageProps {
   savePage: (p: Partial<Page>) => void;
   readOnly?: boolean;
   close?: VoidFunction;
+  insideModal?: boolean;
   enableSidebar?: boolean;
 }
 
-function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, enableSidebar }: DocumentPageProps) {
+function DocumentPage({
+  insideModal = false,
+  page,
+  refreshPage,
+  savePage,
+  readOnly = false,
+  close,
+  enableSidebar
+}: DocumentPageProps) {
   const { cancelVote, castVote, deleteVote, updateDeadline, votes, isLoading } = useVotes({ pageId: page.id });
 
   const isLargeScreen = useLgScreen();
-  const { navigateToSpacePath } = useCharmRouter();
+  const { navigateToSpacePath, router } = useCharmRouter();
   const {
     activeView: sidebarView,
     persistedActiveView,
@@ -158,8 +167,8 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
   const pageTop = getPageTop(page);
 
   const { threads, isLoading: isLoadingThreads, currentPageId: threadsPageId } = useThreads();
-  const router = useRouter();
   const isSharedPage = router.pathname.startsWith('/share');
+  const isRewardsPage = router.pathname === '/[domain]/rewards';
   const { data: reward } = useGetReward({ rewardId: page.bountyId });
   const fontFamilyClassName = `font-family-${page.fontFamily}${page.fontSizeSmall ? ' font-size-small' : ''}`;
 
@@ -354,6 +363,17 @@ function DocumentPage({ page, refreshPage, savePage, readOnly = false, close, en
                   readOnly={readOnly || !!enableSuggestingMode}
                   setPage={savePage}
                   readOnlyTitle={!!page.syncWithPageId}
+                  parentInfo={
+                    board
+                      ? {
+                          title: board.title,
+                          id: board.id
+                        }
+                      : null
+                  }
+                  showParentChip={
+                    !!(page.type === 'card' && page.bountyId && page.parentId && board && insideModal && isRewardsPage)
+                  }
                 />
                 {page.type === 'proposal' && !isLoading && page.snapshotProposalId && (
                   <Box my={2} className='font-family-default'>

--- a/components/[pageId]/DocumentPage/components/PageHeader.tsx
+++ b/components/[pageId]/DocumentPage/components/PageHeader.tsx
@@ -6,7 +6,7 @@ import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined
 import EmojiEmotionsOutlinedIcon from '@mui/icons-material/EmojiEmotionsOutlined';
 import ImageIcon from '@mui/icons-material/Image';
 import type { ListItemButtonProps } from '@mui/material';
-import { ListItemButton, Menu } from '@mui/material';
+import { Chip, ListItemButton, Menu } from '@mui/material';
 import Box from '@mui/material/Box';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -16,6 +16,7 @@ import { BlockIcons } from 'components/common/BoardEditor/focalboard/src/blockIc
 import { randomEmojiList } from 'components/common/BoardEditor/focalboard/src/emojiList';
 import { CustomEmojiPicker } from 'components/common/CustomEmojiPicker';
 import EmojiIcon from 'components/common/Emoji';
+import { useCharmRouter } from 'hooks/useCharmRouter';
 import { randomIntFromInterval } from 'lib/utilities/random';
 
 import { randomBannerImage } from './PageBanner';
@@ -73,6 +74,8 @@ type PageHeaderProps = {
   updatedAt: string;
   readOnlyTitle?: boolean;
   placeholder?: string;
+  showParentChip?: boolean;
+  parentInfo?: { title: string; id: string } | null;
 };
 
 function PageHeader({
@@ -83,8 +86,11 @@ function PageHeader({
   title,
   updatedAt,
   readOnlyTitle,
-  placeholder
+  placeholder,
+  parentInfo,
+  showParentChip
 }: PageHeaderProps) {
+  const { navigateToSpacePath } = useCharmRouter();
   function updateTitle(page: { title: string; updatedAt: any }) {
     setPage(page);
   }
@@ -95,13 +101,23 @@ function PageHeader({
 
   return (
     <>
-      <PageHeaderControls
-        addPageHeader={addPageHeader}
-        headerImage={headerImage}
-        icon={icon}
-        readOnly={readOnly}
-        setPage={setPage}
-      />
+      {showParentChip && parentInfo ? (
+        <Chip
+          label={parentInfo.title}
+          size='small'
+          onClick={() => {
+            navigateToSpacePath(`/${parentInfo.id}`);
+          }}
+        />
+      ) : (
+        <PageHeaderControls
+          addPageHeader={addPageHeader}
+          headerImage={headerImage}
+          icon={icon}
+          readOnly={readOnly}
+          setPage={setPage}
+        />
+      )}
       <PageTitleInput
         readOnly={readOnly || readOnlyTitle}
         value={title}

--- a/components/common/PageDialog/PageDialog.tsx
+++ b/components/common/PageDialog/PageDialog.tsx
@@ -175,7 +175,14 @@ function PageDialogBase(props: Props) {
       onClose={close}
     >
       {page && contentType === 'page' && (
-        <DocumentPage page={page} savePage={savePage} refreshPage={refreshPage} readOnly={readOnlyPage} close={close} />
+        <DocumentPage
+          insideModal
+          page={page}
+          savePage={savePage}
+          refreshPage={refreshPage}
+          readOnly={readOnlyPage}
+          close={close}
+        />
       )}
       {contentType === 'application' && applicationContext && (
         <RewardApplicationPage


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

Conditions:
1. Must be inside the modal view
2. Must be in the rewards page (Since its obvious what the parent board is when opening a reward attached card in a regular database)
3. Must be of card type but has a reward attached

![image](https://github.com/charmverse/app.charmverse.io/assets/34683631/89efe6a4-abf4-4d4b-9858-54a354658472)

