### PR TITLE
Extend public api user search to allow userId

### DIFF
--- a/__integration-tests__/server/pages/api/v1/users/search.spec.ts
+++ b/__integration-tests__/server/pages/api/v1/users/search.spec.ts
@@ -110,6 +110,26 @@ describe('GET /api/v1/users/search', () => {
     );
   });
 
+  it('should search user by userId', async () => {
+    const response = (
+      await request(baseUrl)
+        .get(`/api/v1/users/search?&userId=${user3.id}`)
+        .set({ authorization: `Bearer ${superApiKey.token}` })
+        .send()
+        .expect(200)
+    ).body as PublicApiProposal[];
+
+    expect(response).toMatchObject(
+      expect.objectContaining({
+        id: user3.id,
+        wallet: user3Wallet,
+        email: email3,
+        avatar: '',
+        username: user3.username
+      })
+    );
+  });
+
   it('should fail if user is not found or is not a part of the space', async () => {
     const randomEmail = 'random@example.com';
     await createUserFromWallet({ email: randomEmail });

--- a/lib/public-api/interfaces.ts
+++ b/lib/public-api/interfaces.ts
@@ -23,7 +23,7 @@ export type BoardPropertyValue = string | string[] | number | null | boolean | R
  *          example: https://google.com/image.png
  *        wallet:
  *          type: string
- *          example: 0x7684F0170a3B37640423b1CD9d8Cb817Edf301aE
+ *          example: '0x7684F0170a3B37640423b1CD9d8Cb817Edf301aE'
  *        username:
  *          type: string
  *          example: testuser

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -227,3 +227,11 @@ export function stringSimilarity(str1?: string, str2?: string, gramSize: number 
   }
   return hits / total;
 }
+
+/**
+ * utility function to print an object in a readable format
+ */
+export function prettyPrint(obj: any) {
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(obj, null, 2));
+}

--- a/pages/api/v1/users/search.ts
+++ b/pages/api/v1/users/search.ts
@@ -11,7 +11,6 @@ const handler = superApiHandler();
 handler.get(searchUser);
 
 /**
- * @example https://github.com/jellydn/next-swagger-doc/blob/main/example/models/organization.ts
  *
  * @swagger
  * components:
@@ -24,7 +23,7 @@ handler.get(searchUser);
  *          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
  *        wallet:
  *          type: string
- *          example: 0x7684F0170a3B37640423b1CD9d8Cb817Edf301aE
+ *          example: '0x7684F0170a3B37640423b1CD9d8Cb817Edf301aE'
  *        username:
  *          type: string
  *          example: admin
@@ -47,6 +46,11 @@ type SearchUserResponseBody = UserProfile;
  *       - 'Partner API'
  *     parameters:
  *       - in: query
+ *         name: userId
+ *         schema:
+ *           type: string
+ *         description: User id to search by
+ *       - in: query
  *         name: email
  *         schema:
  *           type: string
@@ -67,13 +71,14 @@ type SearchUserResponseBody = UserProfile;
 async function searchUser(req: NextApiRequest, res: NextApiResponse<SearchUserResponseBody>) {
   const email = (req.query.email as string) || '';
   const wallet = (req.query.wallet as string) || '';
+  const userId = (req.query.userId as string) || '';
   const spaceIds = req.spaceIdRange;
 
   if (!spaceIds || !spaceIds.length) {
     throw new InvalidStateError('Space ID is undefined');
   }
 
-  const result = await searchUserProfile({ email, wallet, spaceIds });
+  const result = await searchUserProfile({ email, wallet, userId, spaceIds });
 
   return res.status(200).json(result);
 }


### PR DESCRIPTION
### WHAT

Requester can now pass a user id in user search endpoint

### WHY

Until now, the endpoint only accepted email or wallet