### PR TITLE
Open card property menu on clicking handler

### DIFF
--- a/components/common/BoardEditor/components/cardProperties/CardDetailProperty.tsx
+++ b/components/common/BoardEditor/components/cardProperties/CardDetailProperty.tsx
@@ -84,6 +84,7 @@ export function CardDetailProperty({
         <Box>
           <PropertyNameContainer
             className='octo-propertyname'
+            {...bindTrigger(changePropertyPopupState)}
             sx={{
               opacity: isDragging ? 0.5 : 1,
               transition: `background-color 150ms ease-in-out`,
@@ -91,7 +92,7 @@ export function CardDetailProperty({
             }}
           >
             <DragIndicatorIcon className='icons' fontSize='small' color='secondary' />
-            <Button {...bindTrigger(changePropertyPopupState)}>{property.name}</Button>
+            <Button>{property.name}</Button>
           </PropertyNameContainer>
           <Menu {...bindMenu(changePropertyPopupState)}>
             <PropertyMenu

--- a/components/common/BoardEditor/focalboard/src/widgets/propertyMenu.tsx
+++ b/components/common/BoardEditor/focalboard/src/widgets/propertyMenu.tsx
@@ -2,7 +2,7 @@ import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import { ListItemIcon, Menu, MenuItem, TextField, Typography, Stack } from '@mui/material';
 import { bindMenu, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import type { IPropertyTemplate, PropertyType } from 'lib/focalboard/board';


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

[Card](https://app.charmverse.io/charmverse/delete-option-not-coming-up-from-block-handle-on-proposal-custom-property-6017166448466353)
