### PR TITLE
fix links to avatars in emails to not use s3 url

### DIFF
--- a/lib/mailer/emails/templates/components/Avatar.tsx
+++ b/lib/mailer/emails/templates/components/Avatar.tsx
@@ -1,6 +1,7 @@
 import { Img } from '@react-email/img';
 
 import { stringToColor } from 'lib/utilities/strings';
+import { replaceS3Domain } from 'lib/utilities/url';
 
 import Text from './Text';
 
@@ -43,7 +44,7 @@ export default function Avatar({
         borderRadius: '50%',
         ...sizeStyleMap[size]
       }}
-      src={avatar}
+      src={replaceS3Domain(avatar)}
     />
   ) : (
     <Text


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

<!-- why was this necessary? -->
