### PR TITLE
Refetch tokengates after creation

### DIFF
--- a/components/common/TokenGateModal/hooks/useTokenGateModalContext.tsx
+++ b/components/common/TokenGateModal/hooks/useTokenGateModalContext.tsx
@@ -6,7 +6,6 @@ import type {
 } from '@lit-protocol/types';
 import type { ReactNode } from 'react';
 import { createContext, useContext, useMemo, useState } from 'react';
-import { mutate } from 'swr';
 import { v4 as uuid } from 'uuid';
 
 import useLitProtocol from 'adapters/litProtocol/hooks/useLitProtocol';
@@ -59,7 +58,15 @@ export const TokenGateModalContext = createContext<Readonly<IContext>>({
   error: undefined
 });
 
-export function TokenGateModalProvider({ children, onClose }: { children: ReactNode; onClose: () => void }) {
+export function TokenGateModalProvider({
+  children,
+  onClose,
+  refreshTokenGates
+}: {
+  children: ReactNode;
+  onClose: () => void;
+  refreshTokenGates: () => void;
+}) {
   const [displayedPage, setDisplayedPage] = useState<DisplayedPage>('home');
   const [unifiedAccessControlConditions, setUnifiedAccessControlConditions] = useState<UnifiedAccessControlConditions>(
     []
@@ -138,7 +145,7 @@ export function TokenGateModalProvider({ children, onClose }: { children: ReactN
         id: tokenGateId
       });
 
-      mutate(`/api/token-gates`);
+      refreshTokenGates();
     }
 
     resetModal();
@@ -161,7 +168,7 @@ export function TokenGateModalProvider({ children, onClose }: { children: ReactN
         id
       });
 
-      mutate(`/api/token-gates`);
+      refreshTokenGates();
       resetModal();
       onClose();
     }

--- a/components/settings/invites/components/TokenGates/TokenGates.tsx
+++ b/components/settings/invites/components/TokenGates/TokenGates.tsx
@@ -25,11 +25,11 @@ export function TokenGates({ isAdmin, space, popupState }: TokenGatesProps) {
         isAdmin={isAdmin}
         tokenGates={data}
         refreshTokenGates={async () => {
-          mutate();
+          await mutate();
         }}
       />
       <Modal open={isOpenTokenGateModal} onClose={closeTokenGateModal} size='large'>
-        <TokenGateModalProvider onClose={closeTokenGateModal}>
+        <TokenGateModalProvider onClose={closeTokenGateModal} refreshTokenGates={() => mutate()}>
           <TokenGateModal />
         </TokenGateModalProvider>
       </Modal>

--- a/lib/blockchain/updateLocksDetails.ts
+++ b/lib/blockchain/updateLocksDetails.ts
@@ -6,11 +6,8 @@ export async function updateLocksDetails<T extends { conditions: Pick<Lock, 'con
 ): Promise<T[]> {
   const updatedUnlockProtocolGates = await Promise.all(
     unlockTokenGates.map(async (gate) => {
-      const lock = await getLockDetails(
-        { contract: gate.conditions.contract, chainId: gate.conditions.chainId },
-        false
-      );
-      return { ...gate, ...lock };
+      const lock = await getLockDetails({ contract: gate.conditions.contract, chainId: gate.conditions.chainId }, true);
+      return { ...gate, conditions: lock };
     })
   );
 


### PR DESCRIPTION
Fix for refetching token gates after we create them.

Looks like mutate() from swr doesn't work.