### PR TITLE
fix apis to review and clear reviews for evaluations

### DIFF
--- a/charmClient/hooks/proposals.ts
+++ b/charmClient/hooks/proposals.ts
@@ -4,7 +4,6 @@ import type {
   ProposalPermissionsSwitch,
   ProposalReviewerPool
 } from '@charmverse/core/permissions';
-import type { ProposalStatus } from '@charmverse/core/prisma-client';
 import type { ProposalWithUsers, ListProposalsRequest } from '@charmverse/core/proposals';
 
 import type {
@@ -12,12 +11,14 @@ import type {
   ProposalBlockUpdateInput,
   ProposalBlockWithTypedFields
 } from 'lib/proposal/blocks/interfaces';
+import type { ClearEvaluationResultRequest } from 'lib/proposal/clearEvaluationResult';
 import type { CreateProposalInput } from 'lib/proposal/createProposal';
 import type { RubricProposalsUserInfo } from 'lib/proposal/getProposalsEvaluatedByUser';
 import type { ProposalTemplate } from 'lib/proposal/getProposalTemplates';
 import type { ProposalWithUsersAndRubric } from 'lib/proposal/interface';
 import type { RubricAnswerUpsert } from 'lib/proposal/rubric/upsertRubricAnswers';
 import type { RubricCriteriaUpsert } from 'lib/proposal/rubric/upsertRubricCriteria';
+import type { ReviewEvaluationRequest } from 'lib/proposal/submitEvaluationResult';
 import type { UpdateProposalRequest } from 'lib/proposal/updateProposal';
 import type { UpdateEvaluationRequest } from 'lib/proposal/updateProposalEvaluation';
 import type { UpdateProposalLensPropertiesRequest } from 'lib/proposal/updateProposalLensProperties';
@@ -84,6 +85,14 @@ export function useUpdateProposalStatusOnly({ proposalId }: { proposalId: MaybeS
 
 export function useUpdateProposalEvaluation({ proposalId }: { proposalId: MaybeString }) {
   return usePUT<Partial<Omit<UpdateEvaluationRequest, 'proposalId'>>>(`/api/proposals/${proposalId}/evaluation`);
+}
+
+export function useSubmitEvaluationResult({ proposalId }: { proposalId: MaybeString }) {
+  return usePUT<Partial<Omit<ReviewEvaluationRequest, 'proposalId'>>>(`/api/proposals/${proposalId}/submit-result`);
+}
+
+export function useClearEvaluationResult({ proposalId }: { proposalId: MaybeString }) {
+  return usePUT<Partial<Omit<ClearEvaluationResultRequest, 'proposalId'>>>(`/api/proposals/${proposalId}/clear-result`);
 }
 
 export function useUpsertRubricCriteria({ proposalId }: { proposalId: MaybeString }) {

--- a/components/common/BoardEditor/focalboard/src/components/kanban/kanbanColumn.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/kanban/kanbanColumn.tsx
@@ -5,7 +5,7 @@ import type { Card } from 'lib/focalboard/card';
 
 type Props = {
   onDrop: (card: Card) => void;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 const KanbanColumn = React.memo((props: Props) => {

--- a/components/proposals/ProposalPage/components/ProposalStickyFooter/components/CompleteFeedbackButton.tsx
+++ b/components/proposals/ProposalPage/components/ProposalStickyFooter/components/CompleteFeedbackButton.tsx
@@ -1,6 +1,6 @@
 import { ArrowForwardIos } from '@mui/icons-material';
 
-import { useUpdateProposalEvaluation } from 'charmClient/hooks/proposals';
+import { useSubmitEvaluationResult } from 'charmClient/hooks/proposals';
 import { Button } from 'components/common/Button';
 import { useSnackbar } from 'hooks/useSnackbar';
 
@@ -14,13 +14,13 @@ export type Props = {
 
 export function CompleteFeedbackButton({ proposalId, hasMovePermission, currentStep, nextStep, onSubmit }: Props) {
   const { showMessage } = useSnackbar();
-  const { trigger: updateProposalEvaluation, isMutating } = useUpdateProposalEvaluation({ proposalId });
+  const { trigger, isMutating } = useSubmitEvaluationResult({ proposalId });
 
   const disabledTooltip = !hasMovePermission ? 'You do not have permission to move this proposal' : undefined;
 
   async function onMoveForward() {
     try {
-      await updateProposalEvaluation({
+      await trigger({
         evaluationId: currentStep?.id,
         result: 'pass'
       });

--- a/components/proposals/ProposalPage/components/ProposalStickyFooter/components/GoBackButton.tsx
+++ b/components/proposals/ProposalPage/components/ProposalStickyFooter/components/GoBackButton.tsx
@@ -2,7 +2,7 @@ import { ArrowBackIos } from '@mui/icons-material';
 import { Typography } from '@mui/material';
 import { useState } from 'react';
 
-import { useUpdateProposalEvaluation, useUpdateProposalStatusOnly } from 'charmClient/hooks/proposals';
+import { useClearEvaluationResult, useUpdateProposalStatusOnly } from 'charmClient/hooks/proposals';
 import { Button } from 'components/common/Button';
 import ModalWithButtons from 'components/common/Modal/ModalWithButtons';
 import { useSnackbar } from 'hooks/useSnackbar';
@@ -27,7 +27,7 @@ export function GoBackButton({
   const { trigger: updateProposalStatusOnly, isMutating: isSavingProposal } = useUpdateProposalStatusOnly({
     proposalId
   });
-  const { trigger: updateProposalEvaluation, isMutating: isSavingEvaluation } = useUpdateProposalEvaluation({
+  const { trigger: clearEvaluationResult, isMutating: isSavingEvaluation } = useClearEvaluationResult({
     proposalId
   });
   const disabledTooltip = !hasMovePermission
@@ -42,7 +42,7 @@ export function GoBackButton({
         // handle draft, which does not have a evaluation step to go to
         await updateProposalStatusOnly({ newStatus: 'draft' });
       } else {
-        await updateProposalEvaluation({ evaluationId: previousStep.id, result: null });
+        await clearEvaluationResult({ evaluationId: previousStep.id });
       }
     } catch (error) {
       showMessage((error as Error).message, 'error');
@@ -52,7 +52,7 @@ export function GoBackButton({
 
   function onClick() {
     // no confirmation needed for draft or feedback
-    if (!previousStep || previousStep.type === 'feedback') {
+    if (!previousStep) {
       goToPreviousStep();
     } else {
       setShowConfirmation(true);
@@ -81,7 +81,9 @@ export function GoBackButton({
         Back to {previousStep?.title || 'Draft'}
       </Button>
       <ModalWithButtons open={showConfirmation} buttonText='Continue' onClose={onCancel} onConfirm={goToPreviousStep}>
-        <Typography>Moving back will clear the result of the previous review and cannot be undone.</Typography>
+        <Typography>
+          Moving back will clear the result of the current and previous steps and cannot be undone.
+        </Typography>
       </ModalWithButtons>
     </>
   );

--- a/lib/proposal/clearEvaluationResult.ts
+++ b/lib/proposal/clearEvaluationResult.ts
@@ -1,0 +1,49 @@
+import { InvalidInputError } from '@charmverse/core/errors';
+import { log } from '@charmverse/core/log';
+import { prisma } from '@charmverse/core/prisma-client';
+
+export type ClearEvaluationResultRequest = {
+  proposalId: string;
+  evaluationId: string;
+};
+
+export async function clearEvaluationResult({ evaluationId, proposalId }: ClearEvaluationResultRequest) {
+  const proposal = await prisma.proposal.findUniqueOrThrow({
+    where: {
+      id: proposalId
+    },
+    include: {
+      evaluations: {
+        orderBy: {
+          index: 'asc'
+        }
+      }
+    }
+  });
+  const evaluationIndex = proposal.evaluations.findIndex((e) => e.id === evaluationId);
+  if (evaluationIndex < 0) {
+    throw new Error('Evaluation not found');
+  }
+  // Also reset all evaluations after this one
+  const evaluationsToReset = proposal.evaluations.slice(evaluationIndex);
+  if (evaluationsToReset.some((evaluation) => evaluation.type === 'vote')) {
+    throw new InvalidInputError('Cannot clear the results of a vote');
+  }
+  log.debug('Clearing the result of proposal evaluation', {
+    evaluationId,
+    proposalId,
+    stepsCleared: evaluationsToReset.length
+  });
+  await prisma.proposalEvaluation.updateMany({
+    where: {
+      id: {
+        in: evaluationsToReset.map((e) => e.id)
+      }
+    },
+    data: {
+      result: null,
+      decidedBy: null,
+      completedAt: null
+    }
+  });
+}

--- a/lib/proposal/submitEvaluationResult.ts
+++ b/lib/proposal/submitEvaluationResult.ts
@@ -1,0 +1,69 @@
+import { log } from '@charmverse/core/log';
+import type { ProposalEvaluationResult } from '@charmverse/core/prisma';
+import { prisma } from '@charmverse/core/prisma-client';
+import { getCurrentEvaluation } from '@charmverse/core/proposals';
+
+import { createVote as createVoteService } from 'lib/votes/createVote';
+import type { VoteDTO } from 'lib/votes/interfaces';
+
+import type { VoteSettings } from './interface';
+
+export type ReviewEvaluationRequest = {
+  decidedBy: string;
+  proposalId: string;
+  evaluationId: string;
+  result: ProposalEvaluationResult;
+};
+
+export async function submitEvaluationResult({ decidedBy, evaluationId, proposalId, result }: ReviewEvaluationRequest) {
+  await prisma.$transaction(async (tx) => {
+    await tx.proposalEvaluation.update({
+      where: {
+        id: evaluationId
+      },
+      data: {
+        result,
+        decidedBy,
+        completedAt: new Date()
+      }
+    });
+    // determine if we should create vote for the next stage
+    if (result === 'pass') {
+      const evaluations = await tx.proposalEvaluation.findMany({
+        where: {
+          proposalId
+        },
+        orderBy: {
+          index: 'asc'
+        }
+      });
+      const nextEvaluation = await getCurrentEvaluation(evaluations);
+      if (nextEvaluation.type === 'vote') {
+        const settings = nextEvaluation.voteSettings as VoteSettings;
+        if (!settings.publishToSnapshot) {
+          const page = await tx.page.findUniqueOrThrow({
+            where: { proposalId },
+            select: { id: true, spaceId: true }
+          });
+          const newVote: VoteDTO = {
+            evaluationId: nextEvaluation.id,
+            pageId: page.id,
+            spaceId: page.spaceId,
+            voteOptions: settings.options,
+            type: settings.type,
+            threshold: settings.threshold,
+            maxChoices: settings.maxChoices,
+            deadline: new Date(Date.now() + settings.durationDays * 24 * 60 * 60 * 1000),
+            createdBy: decidedBy,
+            title: '',
+            content: null,
+            contentText: '',
+            context: 'proposal'
+          };
+          await createVoteService(newVote);
+          log.info('Initiated vote for proposal', { proposalId, spaceId: page.spaceId, pageId: page.id });
+        }
+      }
+    }
+  });
+}

--- a/pages/api/proposals/[id]/clear-result.ts
+++ b/pages/api/proposals/[id]/clear-result.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
+
+import { ActionNotPermittedError, requireKeys, onError, onNoMatch } from 'lib/middleware';
+import { providePermissionClients } from 'lib/permissions/api/permissionsClientMiddleware';
+import { clearEvaluationResult } from 'lib/proposal/clearEvaluationResult';
+import type { ReviewEvaluationRequest } from 'lib/proposal/submitEvaluationResult';
+import { withSessionRoute } from 'lib/session/withSession';
+
+const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+
+handler
+  .use(providePermissionClients({ key: 'id', location: 'query', resourceIdType: 'proposal' }))
+  .use(requireKeys(['evaluationId'], 'body'))
+  .put(updateEvaluationResultndpoint);
+
+// for submitting a review or removing a previous one
+async function updateEvaluationResultndpoint(req: NextApiRequest, res: NextApiResponse) {
+  const proposalId = req.query.id as string;
+  const userId = req.session.user.id;
+
+  const { evaluationId } = req.body as ReviewEvaluationRequest;
+
+  // A proposal can only be updated when its in draft or discussion status and only the proposal author can update it
+  const proposalPermissions = await req.basePermissionsClient.proposals.computeProposalPermissions({
+    resourceId: proposalId,
+    useProposalEvaluationPermissions: true,
+    userId
+  });
+
+  if (!proposalPermissions.move) {
+    throw new ActionNotPermittedError(`You don't have permission to review this proposal.`);
+  }
+  await clearEvaluationResult({
+    proposalId,
+    evaluationId
+  });
+
+  return res.status(200).end();
+}
+
+export default withSessionRoute(handler);

--- a/pages/api/proposals/[id]/evaluation.ts
+++ b/pages/api/proposals/[id]/evaluation.ts
@@ -21,7 +21,7 @@ async function updateEvaluationEndpoint(req: NextApiRequest, res: NextApiRespons
   const proposalId = req.query.id as string;
   const userId = req.session.user.id;
 
-  const { evaluationId, result, reviewers } = req.body as UpdateEvaluationRequest;
+  const { evaluationId, reviewers } = req.body as UpdateEvaluationRequest;
 
   const proposal = await prisma.proposal.findUnique({
     where: {
@@ -59,7 +59,7 @@ async function updateEvaluationEndpoint(req: NextApiRequest, res: NextApiRespons
   // A proposal can only be updated when its in draft or discussion status and only the proposal author can update it
   const proposalPermissions = await req.basePermissionsClient.proposals.computeProposalPermissions({
     resourceId: proposal.id,
-    useProposalEvaluationPermissions: proposal?.status === 'published',
+    useProposalEvaluationPermissions: true,
     userId
   });
 
@@ -112,8 +112,6 @@ async function updateEvaluationEndpoint(req: NextApiRequest, res: NextApiRespons
   await updateProposalEvaluation({
     proposalId: proposal.id,
     evaluationId,
-    result,
-    decidedBy: result ? userId : undefined,
     voteSettings: req.body.voteSettings,
     reviewers
   });

--- a/pages/api/proposals/[id]/submit-result.ts
+++ b/pages/api/proposals/[id]/submit-result.ts
@@ -1,0 +1,48 @@
+import { prisma } from '@charmverse/core/prisma-client';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nc from 'next-connect';
+
+import { ActionNotPermittedError, requireKeys, onError, onNoMatch } from 'lib/middleware';
+import { providePermissionClients } from 'lib/permissions/api/permissionsClientMiddleware';
+import { clearEvaluationResult } from 'lib/proposal/clearEvaluationResult';
+import type { ReviewEvaluationRequest } from 'lib/proposal/submitEvaluationResult';
+import { submitEvaluationResult } from 'lib/proposal/submitEvaluationResult';
+import { withSessionRoute } from 'lib/session/withSession';
+
+const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
+
+handler
+  .use(providePermissionClients({ key: 'id', location: 'query', resourceIdType: 'proposal' }))
+  .use(requireKeys(['evaluationId', 'result'], 'body'))
+  .put(updateEvaluationResultndpoint);
+
+// for submitting a review or removing a previous one
+async function updateEvaluationResultndpoint(req: NextApiRequest, res: NextApiResponse) {
+  const proposalId = req.query.id as string;
+  const userId = req.session.user.id;
+
+  const { evaluationId, result } = req.body as ReviewEvaluationRequest;
+  // A proposal can only be updated when its in draft or discussion status and only the proposal author can update it
+  const proposalPermissions = await req.basePermissionsClient.proposals.computeProposalPermissions({
+    resourceId: proposalId,
+    useProposalEvaluationPermissions: true,
+    userId
+  });
+
+  if (!proposalPermissions.evaluate) {
+    throw new ActionNotPermittedError(`You don't have permission to review this proposal.`);
+  }
+  if (!result) {
+    throw new ActionNotPermittedError(`You must provide a result.`);
+  }
+  await submitEvaluationResult({
+    proposalId,
+    evaluationId,
+    result,
+    decidedBy: userId
+  });
+
+  return res.status(200).end();
+}
+
+export default withSessionRoute(handler);


### PR DESCRIPTION
### WHAT

Reviewers could not submit result

### WHY

The updateProposalstatus endpoint was checking for 'edit' permission. I broke out the logic to separate methods/endpoints to avoid conflicts like this in the future
