### PR TITLE
fix computing permissions for reward milestones

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalStickyFooter/components/PublishRewardsButton.tsx
+++ b/components/proposals/ProposalPage/components/ProposalStickyFooter/components/PublishRewardsButton.tsx
@@ -28,7 +28,7 @@ export function PublishRewardsButton({ proposalId, disabled, onSubmit }: Props) 
       onSubmit();
       // mutateRewards();
     } catch (e) {
-      showMessage(`Error creating ${rewardsTitle}`, 'error');
+      showMessage((e as any).message, 'error');
     }
   }
 


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY
We need to check 'evaluate' for the new flow. By calling permissions api, we get this for free. We should be able to remove isProposalReviewer() once Mo's work is complete