### PR TITLE
Fix to name in email notification

### DIFF
--- a/lib/notifications/mailer/sendNotificationEmail.ts
+++ b/lib/notifications/mailer/sendNotificationEmail.ts
@@ -202,9 +202,9 @@ async function sendEmail({
   });
 
   notification.createdBy.username = await getMemberUsernameBySpaceRole({ spaceRoleId: notificationAuthorSpaceRole.id });
-  user.username = await getMemberUsernameBySpaceRole({ spaceRoleId: notificationTargetSpaceRole.id });
+  const primaryIdentity = await getMemberUsernameBySpaceRole({ spaceRoleId: notificationTargetSpaceRole.id });
 
-  const template = emails.getPendingNotificationEmail(notification, user);
+  const template = emails.getPendingNotificationEmail(notification, { ...user, username: primaryIdentity });
   const result = await mailer.sendEmail({
     to: {
       displayName: user.username,


### PR DESCRIPTION
Issue
In email, the "to" is the user who sent it instead of the one that received it.