### PR TITLE
UX/UI improvements for structured proposal template

### DIFF
--- a/__e2e__/proposals/proposalFlow.spec.ts
+++ b/__e2e__/proposals/proposalFlow.spec.ts
@@ -74,7 +74,6 @@ test.describe.serial('Proposal Flow', () => {
     // Add reviewer user as reviewer
     await authorBrowserProposalPage.getSelectOption(proposalReviewer.id).click();
 
-    await authorBrowserProposalPage.page.pause();
     // save draft
     await expect(authorBrowserProposalPage.saveDraftButton).toBeEnabled();
     await authorBrowserProposalPage.saveDraftButton.click();

--- a/__e2e__/proposals/proposalFlow.spec.ts
+++ b/__e2e__/proposals/proposalFlow.spec.ts
@@ -74,6 +74,7 @@ test.describe.serial('Proposal Flow', () => {
     // Add reviewer user as reviewer
     await authorBrowserProposalPage.getSelectOption(proposalReviewer.id).click();
 
+    await authorBrowserProposalPage.page.pause();
     // save draft
     await expect(authorBrowserProposalPage.saveDraftButton).toBeEnabled();
     await authorBrowserProposalPage.saveDraftButton.click();

--- a/__e2e__/proposals/proposalTemplate.spec.ts
+++ b/__e2e__/proposals/proposalTemplate.spec.ts
@@ -112,8 +112,6 @@ test.describe.serial('Structured proposal template', () => {
 
     await expect(formField.addNewFormFieldButton).toBeVisible();
 
-    await formField.addNewFormFieldButton.click();
-
     await expect(proposalPage.saveDraftButton).toBeDisabled();
 
     await formField.getFormFieldNameInput().fill('Name');

--- a/components/common/form/FormField.tsx
+++ b/components/common/form/FormField.tsx
@@ -191,17 +191,14 @@ function ExpandedFormField({
         </Stack>
       )}
 
-      <Stack flexDirection='row' gap={0.5} alignItems='center'>
+      <Stack gap={0.5} flexDirection='row' alignItems='center'>
         <Switch
+          data-test='form-field-private-switch'
           size='small'
           checked={formField.private}
           onChange={(e) => updateFormField({ private: e.target.checked, id: formField.id })}
-          data-test='form-field-private-switch'
         />
-        <Stack>
-          <Typography>Private</Typography>
-          <Typography variant='caption'>Only Authors, Reviewers and Admins can see the input</Typography>
-        </Stack>
+        <Typography>Private (Authors & Reviewers can view)</Typography>
       </Stack>
     </>
   );

--- a/components/common/form/fields/FieldTypeRenderer.tsx
+++ b/components/common/form/fields/FieldTypeRenderer.tsx
@@ -55,27 +55,16 @@ export const FieldTypeRenderer = forwardRef<HTMLDivElement, Props>(
         return <FieldWrapper {...fieldProps} sx={fieldProps?.fieldWrapperSx} />;
       }
 
+      case 'multiselect':
       case 'select': {
         return (
           <SelectField
             {...(fieldProps as SelectProps)}
-            value={fieldProps.value as string}
+            error={fieldProps.error || (options ?? []).length === 0 ? 'Atleast one option is required' : undefined}
             ref={ref}
-            options={options}
-            onCreateOption={onCreateOption}
-            onDeleteOption={onDeleteOption}
-            onUpdateOption={onUpdateOption}
-          />
-        );
-      }
-
-      case 'multiselect': {
-        return (
-          <SelectField
-            {...(fieldProps as SelectProps)}
-            ref={ref}
+            placeholder={(options ?? []).length === 0 ? 'Create an option' : fieldProps.placeholder}
             value={fieldProps.value as string[]}
-            multiselect
+            multiselect={type === 'multiselect'}
             options={options}
             onCreateOption={onCreateOption}
             onDeleteOption={onDeleteOption}

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -123,7 +123,8 @@ export function NewProposalPage({
     errors: proposalFormFieldErrors,
     onFormChange
   } = useFormFields({
-    fields: proposalFormFields
+    // Only set the initial state with fields when we are creating a structured proposal
+    fields: isStructured && formInputs.type === 'proposal' ? proposalFormFields : []
   });
 
   function toggleCollapse(fieldId: string) {

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -101,19 +101,21 @@ export function NewProposalPage({
 
   const sourceTemplate = proposalTemplates?.find((template) => template.id === formInputs.proposalTemplateId);
   const isStructured = formInputs.proposalType === 'structured' || !!sourceTemplate?.formId;
-  const proposalFormFields = formInputs.formFields ??
-    sourceTemplate?.form?.formFields ?? [
-      {
-        type: 'short_text',
-        name: '',
-        description: emptyDocument,
-        index: 0,
-        options: [],
-        private: false,
-        required: true,
-        id: v4()
-      } as FormFieldInput
-    ];
+  const proposalFormFields = isStructured
+    ? formInputs.formFields ??
+      sourceTemplate?.form?.formFields ?? [
+        {
+          type: 'short_text',
+          name: '',
+          description: emptyDocument,
+          index: 0,
+          options: [],
+          private: false,
+          required: true,
+          id: v4()
+        } as FormFieldInput
+      ]
+    : [];
 
   const {
     control: proposalFormFieldControl,

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -6,7 +6,7 @@ import type { Theme } from '@mui/material';
 import { Box, Divider, useMediaQuery } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 import { useElementSize } from 'usehooks-ts';
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid, v4 } from 'uuid';
 
 import { useGetProposalWorkflows } from 'charmClient/hooks/spaces';
 import PageBanner from 'components/[pageId]/DocumentPage/components/PageBanner';
@@ -39,6 +39,7 @@ import { usePreventReload } from 'hooks/usePreventReload';
 import { useUser } from 'hooks/useUser';
 import type { ProposalFields } from 'lib/proposal/blocks/interfaces';
 import type { ProposalRubricCriteriaWithTypedParams } from 'lib/proposal/rubric/interfaces';
+import { emptyDocument } from 'lib/prosemirror/constants';
 import type { PageContent } from 'lib/prosemirror/interfaces';
 import { fontClassName } from 'theme/fonts';
 
@@ -100,7 +101,19 @@ export function NewProposalPage({
 
   const sourceTemplate = proposalTemplates?.find((template) => template.id === formInputs.proposalTemplateId);
   const isStructured = formInputs.proposalType === 'structured' || !!sourceTemplate?.formId;
-  const proposalFormFields = formInputs.formFields ?? sourceTemplate?.form?.formFields ?? [];
+  const proposalFormFields = formInputs.formFields ??
+    sourceTemplate?.form?.formFields ?? [
+      {
+        type: 'short_text',
+        name: '',
+        description: emptyDocument,
+        index: 0,
+        options: [],
+        private: false,
+        required: true,
+        id: v4()
+      } as FormFieldInput
+    ];
 
   const {
     control: proposalFormFieldControl,

--- a/components/proposals/components/NewProposalButton.tsx
+++ b/components/proposals/components/NewProposalButton.tsx
@@ -32,6 +32,8 @@ const ProposalTemplateMenu = styled(Stack)`
     transition: background-color 0.2s ease-in-out;
   }
   gap: ${({ theme }) => theme.spacing(1)};
+  flex-direction: row;
+  align-items: center;
 `;
 
 export function NewProposalButton() {
@@ -108,7 +110,6 @@ export function NewProposalButton() {
       />
 
       <Modal
-        size='fluid'
         title='Select a template type'
         open={proposalTemplateCreateModalState.isOpen}
         onClose={proposalTemplateCreateModalState.close}
@@ -118,23 +119,15 @@ export function NewProposalButton() {
             onClick={() => createTemplate('structured')}
             data-test='structured-proposal-template-menu'
           >
-            <Stack flexDirection='row' gap={1} alignItems='center'>
-              <WidgetsOutlinedIcon fontSize='large' />
-              <Typography variant='h5'>Structured Form</Typography>
-            </Stack>
-            <Typography variant='body2'>
-              Create a template using Forms, creating a structured data format for each proposal to conform to.
-            </Typography>
+            <WidgetsOutlinedIcon fontSize='large' />
+            <Typography variant='h6'>Form</Typography>
           </ProposalTemplateMenu>
           <ProposalTemplateMenu
             onClick={() => createTemplate('free_form')}
             data-test='free_form-proposal-template-menu'
           >
-            <Stack flexDirection='row' gap={1} alignItems='center'>
-              <DescriptionOutlinedIcon fontSize='large' />
-              <Typography variant='h5'>Free Form</Typography>
-            </Stack>
-            <Typography variant='body2'>Create a template using an open editor.</Typography>
+            <DescriptionOutlinedIcon fontSize='large' />
+            <Typography variant='h6'>Document</Typography>
           </ProposalTemplateMenu>
         </Stack>
       </Modal>

--- a/components/proposals/components/NewProposalButton.tsx
+++ b/components/proposals/components/NewProposalButton.tsx
@@ -42,7 +42,6 @@ export function NewProposalButton() {
   const { proposalCategoriesWithCreatePermission } = useProposalCategories();
   const isAdmin = useIsAdmin();
   const { pages } = usePages();
-  const isCharmverseSpace = useIsCharmverseSpace();
   const proposalTemplateCreateModalState = usePopupState({ variant: 'dialog' });
   // MUI Menu specific content
   const buttonRef = useRef<HTMLDivElement>(null);
@@ -100,7 +99,7 @@ export function NewProposalButton() {
         addPageFromTemplate={createFromTemplate}
         editTemplate={editTemplate}
         pages={proposalTemplatePages}
-        createTemplate={!isCharmverseSpace ? () => createTemplate('free_form') : proposalTemplateCreateModalState.open}
+        createTemplate={proposalTemplateCreateModalState.open}
         deleteTemplate={deleteProposalTemplate}
         anchorEl={buttonRef.current as Element}
         boardTitle='Proposals'

--- a/lib/spaces/countSpaceBlocks/countProposalBlocks.ts
+++ b/lib/spaces/countSpaceBlocks/countProposalBlocks.ts
@@ -1,4 +1,4 @@
-import type { FormField, Proposal } from '@charmverse/core/prisma-client';
+import type { Proposal } from '@charmverse/core/prisma-client';
 import { prisma } from '@charmverse/core/prisma-client';
 import _sum from 'lodash/sum';
 

--- a/scripts/countSpaceData.ts
+++ b/scripts/countSpaceData.ts
@@ -231,7 +231,8 @@ let record: OverallBlocksCount =  {
         "proposalPropertyValues": 0,
         "proposalCategories": 0,
         "proposalRubrics": 0,
-        "proposalRubricAnswers": 0
+        "proposalRubricAnswers": 0,
+        "proposalFormFields": 0
       }
     }
   },


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

1. Have Short Text Open By Default if user selects Form Template [Card](https://app.charmverse.io/charmverse/tech-task-list-49366552253645923?viewId=50d940bb-fdbd-40ba-9816-616d6138a663&cardId=9c1a1fc2-e489-46cd-8e33-63a2afc09422)
2. Update Private Labels on Input From [Card](https://app.charmverse.io/charmverse/tech-task-list-49366552253645923?viewId=50d940bb-fdbd-40ba-9816-616d6138a663&cardId=3e581421-8191-44b8-a65a-4c9226ccbd27)
3. Select/Multiselct Input UX updates [Card](https://app.charmverse.io/charmverse/tech-task-list-49366552253645923?viewId=50d940bb-fdbd-40ba-9816-616d6138a663&cardId=dc08744f-5247-462e-b6fd-1b8aa5f82d5e)
4. Update UX to template selection [Card](https://app.charmverse.io/charmverse/tech-task-list-49366552253645923?viewId=50d940bb-fdbd-40ba-9816-616d6138a663&cardId=f410f9b8-ccd6-42a2-888e-de3e33eb68f5)
5. Count proposal form fields as blocks

