### PR TITLE
Fixed adding custom proposal properties

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -1,9 +1,9 @@
 import type { Page } from '@charmverse/core/prisma';
 import type { Theme } from '@mui/material';
-import { useMediaQuery, Divider, Box } from '@mui/material';
+import { Box, Divider, useMediaQuery } from '@mui/material';
 import dynamic from 'next/dynamic';
 import type { EditorState } from 'prosemirror-state';
-import { memo, useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useElementSize } from 'usehooks-ts';
 
 import { useGetReward } from 'charmClient/hooks/rewards';
@@ -29,6 +29,7 @@ import { useCharmEditor } from 'hooks/useCharmEditor';
 import { useCharmRouter } from 'hooks/useCharmRouter';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useMdScreen } from 'hooks/useMediaScreens';
+import { ProposalBlocksProvider } from 'hooks/useProposalBlocks';
 import { useThreads } from 'hooks/useThreads';
 import { useUser } from 'hooks/useUser';
 import { useVotes } from 'hooks/useVotes';
@@ -435,7 +436,7 @@ function DocumentPage({
   const proposalAuthors = proposal ? [proposal.createdBy, ...proposal.authors.map((author) => author.userId)] : [];
 
   return (
-    <>
+    <ProposalBlocksProvider>
       {!!page?.deletedAt && (
         <AlertContainer showPageActionSidebar={showPageActionSidebar}>
           <PageDeleteBanner pageType={page.type} pageId={page.id} />
@@ -568,7 +569,7 @@ function DocumentPage({
           />
         )}
       </PrimaryColumn>
-    </>
+    </ProposalBlocksProvider>
   );
 }
 

--- a/lib/proposal/form/canAccessPrivateFields.ts
+++ b/lib/proposal/form/canAccessPrivateFields.ts
@@ -10,7 +10,7 @@ export async function canAccessPrivateFields({
   proposal
 }: {
   proposalId: string;
-  userId: string;
+  userId?: string;
   proposal?: Proposal & {
     authors: {
       proposalId: string;
@@ -18,6 +18,10 @@ export async function canAccessPrivateFields({
     }[];
   };
 }) {
+  if (!userId) {
+    return false;
+  }
+
   const checkProposal =
     proposal || (await prisma.proposal.findUnique({ where: { id: proposalId }, include: { authors: true } }));
 

--- a/lib/proposal/form/getProposalFormAnswers.ts
+++ b/lib/proposal/form/getProposalFormAnswers.ts
@@ -3,7 +3,7 @@ import { prisma } from '@charmverse/core/prisma-client';
 import { canAccessPrivateFields } from 'lib/proposal/form/canAccessPrivateFields';
 import { getProposalFormFields } from 'lib/proposal/form/getProposalFormFields';
 
-export async function getProposalFormAnswers({ proposalId, userId }: { userId: string; proposalId: string }) {
+export async function getProposalFormAnswers({ proposalId, userId }: { userId?: string; proposalId: string }) {
   const proposal = await prisma.proposal.findUniqueOrThrow({
     where: { id: proposalId },
     include: {
@@ -27,7 +27,9 @@ export async function getProposalFormAnswers({ proposalId, userId }: { userId: s
     return [];
   }
 
-  const canViewPrivateFields = await canAccessPrivateFields({ proposalId: proposal.id, userId, proposal });
+  const canViewPrivateFields = userId
+    ? await canAccessPrivateFields({ proposalId: proposal.id, userId, proposal })
+    : false;
   const accessibleFields = getProposalFormFields(proposal.form?.formFields, canViewPrivateFields);
   const accessibleFieldIds = accessibleFields?.map((field) => field.id);
 

--- a/lib/proposal/form/getProposalFormAnswers.ts
+++ b/lib/proposal/form/getProposalFormAnswers.ts
@@ -27,9 +27,7 @@ export async function getProposalFormAnswers({ proposalId, userId }: { userId?: 
     return [];
   }
 
-  const canViewPrivateFields = userId
-    ? await canAccessPrivateFields({ proposalId: proposal.id, userId, proposal })
-    : false;
+  const canViewPrivateFields = await canAccessPrivateFields({ proposalId: proposal.id, userId, proposal });
   const accessibleFields = getProposalFormFields(proposal.form?.formFields, canViewPrivateFields);
   const accessibleFieldIds = accessibleFields?.map((field) => field.id);
 

--- a/pages/api/proposals/[id]/form/answers.ts
+++ b/pages/api/proposals/[id]/form/answers.ts
@@ -39,35 +39,20 @@ async function getProposalFormAnswersHandler(req: NextApiRequest, res: NextApiRe
     throw new InvalidInputError(`Proposal ${proposalId} does not have a form`);
   }
 
-  if (userId) {
-    const permissions = await permissionsApiClient.proposals.computeProposalPermissions({
-      resourceId: proposalId,
-      userId
-    });
+  const permissions = await permissionsApiClient.proposals.computeProposalPermissions({
+    resourceId: proposalId,
+    userId
+  });
 
-    if (permissions.view !== true) {
-      const pagePermissions = proposal?.page?.id
-        ? await permissionsApiClient.pages.computePagePermissions({
-            resourceId: proposal.page.id,
-            userId
-          })
-        : null;
-      if (!pagePermissions?.read) {
-        throw new NotFoundError();
-      }
-    }
-  } else {
-    const space = await prisma.space.findUniqueOrThrow({
-      where: {
-        id: proposal.spaceId
-      },
-      select: {
-        publicProposals: true
-      }
-    });
+  if (permissions.view !== true) {
+    const pagePermissions = proposal?.page?.id
+      ? await permissionsApiClient.pages.computePagePermissions({
+          resourceId: proposal.page.id,
+          userId
+        })
+      : null;
 
-    const isProposalsPublic = space.publicProposals === true;
-    if (!isProposalsPublic) {
+    if (!pagePermissions?.read) {
       throw new NotFoundError();
     }
   }

--- a/pages/api/proposals/[id]/form/answers.ts
+++ b/pages/api/proposals/[id]/form/answers.ts
@@ -17,44 +17,57 @@ import { withSessionRoute } from 'lib/session/withSession';
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler
+  .get(getProposalFormAnswersHandler)
   .use(requireUser)
   .use(providePermissionClients({ key: 'id', location: 'query', resourceIdType: 'proposal' }))
-  .get(getProposalFormAnswersHandler)
   .put(upsertProposalFormAnswersHandler);
 
 async function getProposalFormAnswersHandler(req: NextApiRequest, res: NextApiResponse<FormFieldAnswer[]>) {
   const proposalId = req.query.id as string;
-  const userId = req.session.user.id;
+  const userId = req.session.user?.id;
 
-  const proposal = await prisma.proposal.findUnique({
+  const proposal = await prisma.proposal.findUniqueOrThrow({
     where: { id: proposalId },
-    include: {
-      authors: true,
+    select: {
+      formId: true,
+      spaceId: true,
       page: { select: { id: true, sourceTemplateId: true } }
     }
   });
-
-  if (!proposal) {
-    throw new NotFoundError();
-  }
 
   if (!proposal.formId) {
     throw new InvalidInputError(`Proposal ${proposalId} does not have a form`);
   }
 
-  const permissions = await permissionsApiClient.proposals.computeProposalPermissions({
-    resourceId: proposal?.id,
-    userId
-  });
+  if (userId) {
+    const permissions = await permissionsApiClient.proposals.computeProposalPermissions({
+      resourceId: proposalId,
+      userId
+    });
 
-  if (permissions.view !== true) {
-    const pagePermissions = proposal?.page?.id
-      ? await permissionsApiClient.pages.computePagePermissions({
-          resourceId: proposal.page.id,
-          userId
-        })
-      : null;
-    if (!pagePermissions?.read) {
+    if (permissions.view !== true) {
+      const pagePermissions = proposal?.page?.id
+        ? await permissionsApiClient.pages.computePagePermissions({
+            resourceId: proposal.page.id,
+            userId
+          })
+        : null;
+      if (!pagePermissions?.read) {
+        throw new NotFoundError();
+      }
+    }
+  } else {
+    const space = await prisma.space.findUniqueOrThrow({
+      where: {
+        id: proposal.spaceId
+      },
+      select: {
+        publicProposals: true
+      }
+    });
+
+    const isProposalsPublic = space.publicProposals === true;
+    if (!isProposalsPublic) {
       throw new NotFoundError();
     }
   }

--- a/pages/api/spaces/[id]/proposals/blocks/index.ts
+++ b/pages/api/spaces/[id]/proposals/blocks/index.ts
@@ -4,11 +4,7 @@ import nc from 'next-connect';
 import { onError, onNoMatch, requireSpaceMembership } from 'lib/middleware';
 import { deleteBlocks } from 'lib/proposal/blocks/deleteBlocks';
 import { getBlocks } from 'lib/proposal/blocks/getBlocks';
-import type {
-  ProposalBlockInput,
-  ProposalBlockUpdateInput,
-  ProposalBlockWithTypedFields
-} from 'lib/proposal/blocks/interfaces';
+import type { ProposalBlockUpdateInput, ProposalBlockWithTypedFields } from 'lib/proposal/blocks/interfaces';
 import { upsertBlocks } from 'lib/proposal/blocks/upsertBlocks';
 import { withSessionRoute } from 'lib/session/withSession';
 


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

1. Custom proposal properties couldn't be created before on a standalone page view. They were working from the proposals table page. The solution was a missing context provider
2. Proposal form field answers are available even when no user is logged in via public proposals table or public proposal
