### PR TITLE
remove feedback step as default

### DIFF
--- a/components/settings/proposals/SpaceProposalSettings.tsx
+++ b/components/settings/proposals/SpaceProposalSettings.tsx
@@ -14,7 +14,6 @@ import LoadingComponent from 'components/common/LoadingComponent';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
-import { getDefaultFeedbackEvaluation } from 'lib/proposal/workflows/defaultEvaluation';
 
 import Legend from '../Legend';
 
@@ -40,7 +39,7 @@ export function SpaceProposalSettings({ space }: { space: Space }) {
       createdAt: new Date(),
       title: '',
       spaceId: space.id,
-      evaluations: [getDefaultFeedbackEvaluation()],
+      evaluations: [],
       ...workflow,
       isNew: true,
       id: uuid(),

--- a/lib/proposal/workflows/defaultWorkflows.ts
+++ b/lib/proposal/workflows/defaultWorkflows.ts
@@ -27,7 +27,6 @@ export const getDefaultWorkflows: (spaceId: string) => ProposalWorkflowTyped[] =
     createdAt: new Date(),
     title: 'Decision Matrix',
     evaluations: [
-      getDefaultFeedbackEvaluation(),
       getDefaultEvaluation({
         title: 'Review',
         type: 'pass_fail'
@@ -45,7 +44,6 @@ export const getDefaultWorkflows: (spaceId: string) => ProposalWorkflowTyped[] =
     createdAt: new Date(),
     title: 'Grant Applications',
     evaluations: [
-      getDefaultFeedbackEvaluation(),
       getDefaultEvaluation({
         title: 'Rubric evaluation',
         type: 'rubric'


### PR DESCRIPTION
We are keeping Feedback for Vote-related flows, but it should not be included for rubrics and not as a default step when creating a workflow