### PR TITLE
Check all users for memberships

### DIFF
--- a/lib/tokenGates/evaluateEligibility.ts
+++ b/lib/tokenGates/evaluateEligibility.ts
@@ -94,7 +94,10 @@ async function getTokenGateResults(tokenGate: TokenGateWithRoles, authSig: AuthS
   }
 }
 
-export async function getUnlockProtocolValidTokenGate(tokenGate: TokenGateWithRoles<'unlock'>, walletAddress: string) {
+export async function getUnlockProtocolValidTokenGate<T extends TokenGate<'unlock'>>(
+  tokenGate: T,
+  walletAddress: string
+) {
   const result = await getLockDetails({
     walletAddress,
     contract: tokenGate.conditions.contract,


### PR DESCRIPTION
Fix role id error - There were situations where we had only roleId.
Use Promise.allSettled to see all errors and prevent breaking on the first try.