### PR TITLE
update github deployment action which runs on node 12

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -116,15 +116,14 @@ jobs:
           fi
 
       - name: Create a github deployment
-        uses: bobheadxi/deployments@v0.5.2
+        uses: bobheadxi/deployments@v1
         id: deployment
         with:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ env.STAGE }}
           ref: ${{ github.head_ref }}
-          no_override: false
-          transient: true
+          override: true
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -138,17 +137,19 @@ jobs:
           cat files_to_zip.txt | zip --symlinks -r@ deploy.zip
           aws s3 sync .next/static/ s3://charm.cdn/webapp-assets/_next/static/
 
-      - name: Deploy to staging
+      - name: Deploy to stagings
         id: cdk_deploy
         run: |
           npm install aws-cdk aws-cdk-lib --no-audit --no-fund
           npm run deploy:staging
 
       - name: update the github deployment status
-        uses: bobheadxi/deployments@v0.5.2
+        uses: bobheadxi/deployments@v1
         if: always()
         with:
+          env: ${{ steps.deployment.outputs.env }}
           step: finish
+          override: false
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}


### PR DESCRIPTION
Got a warning on recent build: https://github.com/charmverse/app.charmverse.io/actions/runs/7351818862


> The following actions uses node12 which is deprecated and will be forced to run on node16: bobheadxi/deployments@v0.5.2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
