### PR TITLE
fix adding properties on proposals

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -31,7 +31,6 @@ import { useCharmEditor } from 'hooks/useCharmEditor';
 import { useCharmRouter } from 'hooks/useCharmRouter';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useMdScreen } from 'hooks/useMediaScreens';
-import { ProposalBlocksProvider } from 'hooks/useProposalBlocks';
 import { useThreads } from 'hooks/useThreads';
 import { useUser } from 'hooks/useUser';
 import { useVotes } from 'hooks/useVotes';
@@ -366,7 +365,7 @@ function DocumentPage({
   const proposalAuthors = proposal ? [proposal.createdBy, ...proposal.authors.map((author) => author.userId)] : [];
 
   return (
-    <ProposalBlocksProvider>
+    <>
       {!!page?.deletedAt && (
         <AlertContainer showPageActionSidebar={showPageActionSidebar}>
           <PageDeleteBanner pageType={page.type} pageId={page.id} />
@@ -558,7 +557,7 @@ function DocumentPage({
           <ProposalStickyFooter proposal={proposal} refreshProposal={refreshProposal} />
         )}
       </PrimaryColumn>
-    </ProposalBlocksProvider>
+    </>
   );
 }
 

--- a/components/[pageId]/DocumentPage/DocumentPageProviders.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPageProviders.tsx
@@ -1,6 +1,7 @@
 import { PageSidebarProvider } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { CharmEditorProvider } from 'hooks/useCharmEditor';
 import { CurrentPageProvider } from 'hooks/useCurrentPage';
+import { ProposalBlocksProvider } from 'hooks/useProposalBlocks';
 import { ThreadsProvider } from 'hooks/useThreads';
 import { VotesProvider } from 'hooks/useVotes';
 
@@ -9,11 +10,13 @@ export function DocumentPageProviders({ children }: { children: React.ReactNode 
   return (
     <CurrentPageProvider>
       <CharmEditorProvider>
-        <ThreadsProvider>
-          <VotesProvider>
-            <PageSidebarProvider>{children}</PageSidebarProvider>
-          </VotesProvider>
-        </ThreadsProvider>
+        <ProposalBlocksProvider>
+          <ThreadsProvider>
+            <VotesProvider>
+              <PageSidebarProvider>{children}</PageSidebarProvider>
+            </VotesProvider>
+          </ThreadsProvider>
+        </ProposalBlocksProvider>
       </CharmEditorProvider>
     </CurrentPageProvider>
   );

--- a/components/proposals/ProposalsPageProviders.tsx
+++ b/components/proposals/ProposalsPageProviders.tsx
@@ -1,13 +1,15 @@
+import type { ReactNode } from 'react';
+
 import { PageDialogProvider } from 'components/common/PageDialog/hooks/usePageDialog';
 import { PageDialogGlobal } from 'components/common/PageDialog/PageDialogGlobal';
 import { ProposalDialogProvider } from 'components/proposals/components/ProposalDialog/hooks/useProposalDialog';
 import { ProposalsProvider } from 'components/proposals/hooks/useProposals';
-import { ProposalsBoardProvider } from 'components/proposals/hooks/useProposalsBoard';
-import { ProposalsPage } from 'components/proposals/ProposalsPage';
 import { DbViewSettingsProvider } from 'hooks/useLocalDbViewSettings';
 import { ProposalBlocksProvider } from 'hooks/useProposalBlocks';
 
-export function ProposalsPageWithProviders({ title: proposalTitle }: { title: string }) {
+import { ProposalsBoardProvider } from './hooks/useProposalsBoard';
+
+export function ProposalsPageProviders({ children }: { children: ReactNode }) {
   return (
     <PageDialogProvider>
       <ProposalsProvider>
@@ -15,8 +17,7 @@ export function ProposalsPageWithProviders({ title: proposalTitle }: { title: st
           <ProposalBlocksProvider>
             <ProposalsBoardProvider>
               <ProposalDialogProvider>
-                <ProposalsPage title={proposalTitle} />
-
+                {children}
                 <PageDialogGlobal />
               </ProposalDialogProvider>
             </ProposalsBoardProvider>

--- a/pages/[domain]/proposals/index.tsx
+++ b/pages/[domain]/proposals/index.tsx
@@ -1,6 +1,7 @@
 import { useTrackPageView } from 'charmClient/hooks/track';
 import getPageLayout from 'components/common/PageLayout/getLayout';
-import { ProposalsPageWithProviders } from 'components/proposals/ProposalsPageWithProviders';
+import { ProposalsPage } from 'components/proposals/ProposalsPage';
+import { ProposalsPageProviders } from 'components/proposals/ProposalsPageProviders';
 import { useStaticPageTitle } from 'hooks/usePageTitle';
 import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
 
@@ -11,7 +12,11 @@ export default function ProposalsPageComponent() {
 
   useStaticPageTitle(proposalTitle);
 
-  return <ProposalsPageWithProviders title={proposalTitle} />;
+  return (
+    <ProposalsPageProviders>
+      <ProposalsPage title={proposalTitle} />
+    </ProposalsPageProviders>
+  );
 }
 
 ProposalsPageComponent.getLayout = getPageLayout;

--- a/stories/ProposalsPage/ProposalsPageStory.tsx
+++ b/stories/ProposalsPage/ProposalsPageStory.tsx
@@ -1,6 +1,7 @@
 import { rest } from 'msw';
 
-import { ProposalsPageWithProviders } from 'components/proposals/ProposalsPageProviders';
+import { ProposalsPage } from 'components/proposals/ProposalsPage';
+import { ProposalsPageProviders } from 'components/proposals/ProposalsPageProviders';
 import { createMockPage } from 'testing/mocks/page';
 import { createMockProposal } from 'testing/mocks/proposal';
 import { builders as _, jsonDoc } from 'testing/prosemirror/builders';
@@ -8,7 +9,11 @@ import { builders as _, jsonDoc } from 'testing/prosemirror/builders';
 import { members, proposalCategories, userProfile } from '../lib/mockData';
 
 export function ProposalsPageStory() {
-  return <ProposalsPageWithProviders title='Proposals' />;
+  return (
+    <ProposalsPageProviders>
+      <ProposalsPage title='Proposals' />
+    </ProposalsPageProviders>
+  );
 }
 
 // Data and api mocks

--- a/stories/ProposalsPage/ProposalsPageStory.tsx
+++ b/stories/ProposalsPage/ProposalsPageStory.tsx
@@ -1,6 +1,6 @@
 import { rest } from 'msw';
 
-import { ProposalsPageWithProviders } from 'components/proposals/ProposalsPageWithProviders';
+import { ProposalsPageWithProviders } from 'components/proposals/ProposalsPageProviders';
 import { createMockPage } from 'testing/mocks/page';
 import { createMockProposal } from 'testing/mocks/proposal';
 import { builders as _, jsonDoc } from 'testing/prosemirror/builders';


### PR DESCRIPTION
User cannot add properties on the new proposal page, which uses NewProposalPage. Seems like the blocks provider belongs inside DocumentPageProviders