### PR TITLE
Feat/saving snapshot proposal expiry

### DIFF
--- a/background/tasks/updateProposalStatus/task.ts
+++ b/background/tasks/updateProposalStatus/task.ts
@@ -10,9 +10,13 @@ export async function task() {
     const proposalsToUpdate = await prisma.proposal.findMany({
       where: {
         status: 'vote_active',
-        snapshotProposalExpiry: {
-          not: null,
-          lte: new Date()
+        evaluations: {
+          some: {
+            snapshotExpiry: {
+              not: null,
+              lte: new Date()
+            }
+          }
         }
       }
     });

--- a/background/tasks/updateProposalStatus/task.ts
+++ b/background/tasks/updateProposalStatus/task.ts
@@ -7,37 +7,6 @@ export async function task() {
   log.debug('Running Proposal status cron job');
 
   try {
-    const proposalsToUpdate = await prisma.proposal.findMany({
-      where: {
-        status: 'vote_active',
-        evaluations: {
-          some: {
-            snapshotExpiry: {
-              not: null,
-              lte: new Date()
-            }
-          }
-        }
-      }
-    });
-
-    await prisma.proposal.updateMany({
-      where: {
-        id: {
-          in: proposalsToUpdate.map((proposal) => proposal.id)
-        }
-      },
-      data: {
-        status: 'vote_closed'
-      }
-    });
-
-    count('cron.proposal-status.expired-snapshot-votes', proposalsToUpdate.length);
-  } catch (error: any) {
-    log.error(`Error expiring proposals: ${error.stack || error.message || error}`, { error });
-  }
-
-  try {
     const stepsToUpdate = await prisma.proposalEvaluation.findMany({
       where: {
         result: null,

--- a/lib/proposal/__tests__/updateProposalStatus.spec.ts
+++ b/lib/proposal/__tests__/updateProposalStatus.spec.ts
@@ -180,32 +180,4 @@ describe('updateProposalStatus', () => {
       })
     ).rejects.toBeInstanceOf(InvalidStateError);
   });
-
-  it('should save the snapshot expiry date when changing the status of the proposal to vote active if it was exported to snapshot', async () => {
-    const { id: proposalId, pageId } = await createProposalWithUsers({
-      spaceId: space.id,
-      proposalStatus: 'reviewed',
-      userId: user.id,
-      authors: [],
-      reviewers: [reviewer.id, { type: 'role', roleId: reviewerRole.id }]
-    });
-
-    await prisma.page.update({
-      where: {
-        id: pageId
-      },
-      data: {
-        // https://snapshot.org/#/olympusdao.eth/proposal/0x3236041d0857f7548c8da12f3890c6f590a016f02fd2f100230e1b8cbcfed078
-        snapshotProposalId: '0x3236041d0857f7548c8da12f3890c6f590a016f02fd2f100230e1b8cbcfed078'
-      }
-    });
-
-    const proposal = await updateProposalStatus({
-      proposalId,
-      newStatus: 'vote_active',
-      userId: user.id
-    });
-
-    expect(proposal.snapshotProposalExpiry?.toISOString()).toMatch('2022-10-13T20:55:51');
-  });
 });

--- a/lib/proposal/updateProposalStatus.ts
+++ b/lib/proposal/updateProposalStatus.ts
@@ -3,8 +3,6 @@ import { prisma } from '@charmverse/core/prisma-client';
 
 import { InvalidStateError } from 'lib/middleware';
 import { getPermissionsClient } from 'lib/permissions/api';
-import { getSnapshotProposal } from 'lib/snapshot/getProposal';
-import { coerceToMilliseconds } from 'lib/utilities/dates';
 import { InvalidInputError } from 'lib/utilities/errors';
 import { WebhookEventNames } from 'lib/webhookPublisher/interfaces';
 import { publishProposalEvent } from 'lib/webhookPublisher/publishEvent';
@@ -88,10 +86,6 @@ export async function updateProposalStatus({
     }
   });
 
-  const snapshotProposalId = proposalInfo?.page?.snapshotProposalId;
-
-  const snapshotProposal = snapshotProposalId ? await getSnapshotProposal(snapshotProposalId) : null;
-
   return prisma.$transaction(async (tx) => {
     if (proposalInfo) {
       await publishProposalEvent({
@@ -108,8 +102,7 @@ export async function updateProposalStatus({
         id: proposalId
       },
       data: {
-        status: newStatus,
-        snapshotProposalExpiry: snapshotProposal?.end ? new Date(coerceToMilliseconds(snapshotProposal.end)) : undefined
+        status: newStatus
       },
       include: {
         authors: true,

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@bangle.dev/tooltip": "^0.31.6",
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
-    "@charmverse/core": "^0.16.2",
+    "@charmverse/core": " 0.16.3-rc-feat-remove-sna.0",
     "@column-resizer/core": "^1.0.2",
     "@datadog/browser-logs": "^4.42.2",
     "@datadog/browser-rum": "^4.42.2",

--- a/pages/api/proposals/[id]/snapshot.ts
+++ b/pages/api/proposals/[id]/snapshot.ts
@@ -7,7 +7,9 @@ import { onError, onNoMatch, requireKeys, requireUser } from 'lib/middleware';
 import { getPage } from 'lib/pages/server';
 import { providePermissionClients } from 'lib/permissions/api/permissionsClientMiddleware';
 import { withSessionRoute } from 'lib/session/withSession';
+import { getSnapshotProposal } from 'lib/snapshot/getProposal';
 import { hasAccessToSpace } from 'lib/users/hasAccessToSpace';
+import { coerceToMilliseconds } from 'lib/utilities/dates';
 import { DataNotFoundError } from 'lib/utilities/errors';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
@@ -44,12 +46,15 @@ async function recordSnapshotInfo(req: NextApiRequest, res: NextApiResponse<Page
     throw error;
   }
 
+  const snapshotProposal = snapshotProposalId ? await getSnapshotProposal(snapshotProposalId) : null;
+
   await prisma.proposalEvaluation.update({
     where: {
       id: evaluationId
     },
     data: {
-      snapshotId: snapshotProposalId
+      snapshotId: snapshotProposalId,
+      snapshotExpiry: snapshotProposal?.end ? new Date(coerceToMilliseconds(snapshotProposal.end)) : null
     }
   });
 

--- a/scripts/manualSnapshotUpdate.ts
+++ b/scripts/manualSnapshotUpdate.ts
@@ -9,8 +9,7 @@ export async function updateSnapshot(proposalId: string, snapshotProposalId: str
       snapshotProposalId,
       proposal: {
         update: {
-          status: 'vote_active',
-          snapshotProposalExpiry: new Date(2023, 1, 26, 7, 22)
+          status: 'vote_active'
         }
       }
     },

--- a/scripts/migrations/2023_12_29_convertProposals.ts
+++ b/scripts/migrations/2023_12_29_convertProposals.ts
@@ -72,7 +72,7 @@ async function convertProposals({ offset = 0 }: { offset?: number } = {}) {
           type: vote?.type || 'Approval',
           options: vote?.voteOptions.map((o) => o.name) || ['Yes', 'No', 'Abstain'],
           maxChoices: vote?.maxChoices || 1,
-          publishToSnapshot: !!p.snapshotProposalExpiry || !!p.page?.snapshotProposalId,
+          publishToSnapshot: !!p.page?.snapshotProposalId,
           durationDays: vote ? Math.ceil((vote.deadline.getTime() - vote.createdAt.getTime()) / 1000 / 60 / 60 / 24) : 5
         };
         const result = votePassed ? 'pass' : voteFailed ? 'fail' : null;
@@ -136,7 +136,6 @@ async function convertProposals({ offset = 0 }: { offset?: number } = {}) {
               completedAt: result ? completedAt || new Date() : null,
               proposalId: p.id,
               snapshotId: p.page?.snapshotProposalId,
-              snapshotExpiry: p.snapshotProposalExpiry,
               voteId: vote?.id,
               voteSettings,
               reviewers: p.category

--- a/seedData/proposalTemplates.ts
+++ b/seedData/proposalTemplates.ts
@@ -498,7 +498,6 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
       archived: false,
       reviewedAt: null,
       categoryId: '4532b730-f8fa-4925-a056-4d1b175d0d67',
-      snapshotProposalExpiry: null,
       evaluationType: 'vote',
       category: {
         id: '4532b730-f8fa-4925-a056-4d1b175d0d67',
@@ -1632,7 +1631,6 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
       reviewedAt: null,
       archived: false,
       categoryId: '4532b730-f8fa-4925-a056-4d1b175d0d67',
-      snapshotProposalExpiry: null,
       category: {
         id: '4532b730-f8fa-4925-a056-4d1b175d0d67',
         spaceId: '30bfda0c-19a6-463d-bef7-daccbf433a04',
@@ -2053,7 +2051,6 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
       reviewedAt: null,
       archived: false,
       categoryId: '4532b730-f8fa-4925-a056-4d1b175d0d67',
-      snapshotProposalExpiry: null,
       category: {
         id: '4532b730-f8fa-4925-a056-4d1b175d0d67',
         spaceId: '30bfda0c-19a6-463d-bef7-daccbf433a04',
@@ -2402,7 +2399,6 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
       reviewedAt: null,
       archived: false,
       categoryId: 'f5527a96-4f10-4986-b5c5-7b4292d8c222',
-      snapshotProposalExpiry: null,
       category: {
         id: 'f5527a96-4f10-4986-b5c5-7b4292d8c222',
         spaceId: '30bfda0c-19a6-463d-bef7-daccbf433a04',
@@ -3093,7 +3089,6 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
       reviewedAt: null,
       archived: false,
       categoryId: 'fc1c1130-1f02-414a-86fb-505bc5061bb5',
-      snapshotProposalExpiry: null,
       category: {
         id: 'fc1c1130-1f02-414a-86fb-505bc5061bb5',
         spaceId: '30bfda0c-19a6-463d-bef7-daccbf433a04',
@@ -3782,7 +3777,6 @@ const templates: Omit<ExportedPage, StandardFields>[] = [
       reviewedAt: null,
       archived: false,
       categoryId: 'fc1c1130-1f02-414a-86fb-505bc5061bb5',
-      snapshotProposalExpiry: null,
       category: {
         id: 'fc1c1130-1f02-414a-86fb-505bc5061bb5',
         spaceId: '30bfda0c-19a6-463d-bef7-daccbf433a04',

--- a/testing/mocks/proposal.ts
+++ b/testing/mocks/proposal.ts
@@ -24,7 +24,6 @@ export function createMockProposal(
     reviewedBy: null,
     draftRubricAnswers: [],
     rubricAnswers: [],
-    snapshotProposalExpiry: null,
     spaceId: '',
     status: 'draft',
     fields: null,


### PR DESCRIPTION
### WHAT

- saving snapshot expiry date when creating new proposal
- remove snapshot expiry field from proposal and use one from evaluation


NOTE: tests are failing jsut due to wrong types in permissions. WIll be fixed once core pr is merged
