### PR TITLE
fix chips not expanding in seleect field

### DIFF
--- a/components/common/form/fields/SelectField.tsx
+++ b/components/common/form/fields/SelectField.tsx
@@ -161,7 +161,7 @@ export const SelectField = forwardRef<HTMLDivElement, Props>(
             );
           }}
           renderTags={(value, getTagProps) => (
-            <Stack flexDirection='row' gap={1}>
+            <Stack flexDirection='row' gap={1} flexGrow={1}>
               {value.map((option, index) => (
                 // eslint-disable-next-line react/jsx-key
                 <Chip


### PR DESCRIPTION
When there's only one chip, the stack container collapses and you can't read the chip:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/771841ae-48c0-42bf-b2f7-097213287c47)
