### PR TITLE
allow editing vote settings and rubric criteria when using a template

### DIFF
--- a/components/proposals/ProposalPage/components/EvaluationSettingsSidebar/EvaluationSettingsSidebar.tsx
+++ b/components/proposals/ProposalPage/components/EvaluationSettingsSidebar/EvaluationSettingsSidebar.tsx
@@ -39,20 +39,15 @@ export function EvaluationSettingsSidebar({
           {proposal?.evaluations?.map((evaluation, index) => {
             // find matching template step, and allow editing if there were no reviewers set
             const matchingTemplateStep = proposalTemplate?.evaluations?.find((e) => e.title === evaluation.title);
-            const templateHasNoReviewers = matchingTemplateStep?.reviewers?.length === 0;
-            // reviewers are already readOnly if a template was used, so long as reviewers were set
-            const readOnlyReviewers = readOnly || (!!templateId && !templateHasNoReviewers);
-            // rubric criteria should be editable but authors and reviewers, unless a template was used
-            const readOnlyRubricCriteria = (readOnly && !isReviewer) || !!templateId;
             return (
               <EvaluationStepRow key={evaluation.id} expanded result={null} index={index + 1} title={evaluation.title}>
                 {/* <Divider sx={{ my: 1 }} /> */}
                 {evaluation.type !== 'feedback' && (
                   <EvaluationStepSettings
-                    readOnly={readOnly}
-                    readOnlyReviewers={readOnlyReviewers}
-                    readOnlyRubricCriteria={readOnlyRubricCriteria}
                     evaluation={evaluation}
+                    evaluationTemplate={matchingTemplateStep}
+                    isReviewer={isReviewer}
+                    readOnly={readOnly}
                     onChange={(updated) => {
                       onChangeEvaluation?.(evaluation.id, updated);
                     }}

--- a/components/proposals/ProposalPage/components/EvaluationSettingsSidebar/components/EvaluationStepSettings.tsx
+++ b/components/proposals/ProposalPage/components/EvaluationSettingsSidebar/components/EvaluationStepSettings.tsx
@@ -5,6 +5,7 @@ import type { SelectOption } from 'components/common/BoardEditor/components/prop
 import { UserAndRoleSelect } from 'components/common/BoardEditor/components/properties/UserAndRoleSelect';
 import { allMembersSystemRole } from 'components/settings/proposals/components/EvaluationPermissions';
 import type { ProposalEvaluationInput } from 'lib/proposal/createProposal';
+import type { PopulatedEvaluation } from 'lib/proposal/interface';
 
 import { RubricCriteria } from './RubricCriteriaSettings';
 import type { RangeProposalCriteria } from './RubricCriteriaSettings';
@@ -17,31 +18,27 @@ export type ProposalEvaluationValues = Omit<ProposalEvaluationInput, 'permission
 
 type Props = {
   evaluation: ProposalEvaluationValues;
+  evaluationTemplate?: Pick<PopulatedEvaluation, 'reviewers' | 'rubricCriteria' | 'voteSettings'>;
   onChange: (criteria: Partial<ProposalEvaluationValues>) => void;
   readOnly: boolean;
-  readOnlyReviewers: boolean;
-  readOnlyRubricCriteria: boolean;
+  isReviewer?: boolean;
 };
 
-export function EvaluationStepSettings({
-  evaluation,
-  onChange,
-  readOnly,
-  readOnlyReviewers,
-  readOnlyRubricCriteria
-}: Props) {
-  const reviewerOptions = evaluation.reviewers
-    // .filter((reviewer) => reviewer.group === 'role' || reviewer.group === 'user')
-    .map((reviewer) => ({
-      group: reviewer.roleId ? 'role' : reviewer.userId ? 'user' : 'system_role',
-      id: (reviewer.roleId ?? reviewer.userId ?? reviewer.systemRole) as string
-    }));
+export function EvaluationStepSettings({ evaluation, evaluationTemplate, isReviewer, onChange, readOnly }: Props) {
+  // reviewers are also readOnly when using a template with reviewers pre-selected
+  const readOnlyReviewers = readOnly || !!evaluationTemplate?.reviewers?.length;
+  // rubric criteria should also be editable by reviewers, and not if a template with rubric critera was used
+  const readOnlyRubricCriteria = (readOnly && !isReviewer) || !!evaluationTemplate?.rubricCriteria.length;
+  // vote settings are also readonly when using a template with vote settings pre-selected
+  const readOnlyVoteSettings = readOnly || !!evaluationTemplate?.voteSettings;
+  const reviewerOptions = evaluation.reviewers.map((reviewer) => ({
+    group: reviewer.roleId ? 'role' : reviewer.userId ? 'user' : 'system_role',
+    id: (reviewer.roleId ?? reviewer.userId ?? reviewer.systemRole) as string
+  }));
 
   function handleOnChangeReviewers(reviewers: SelectOption[]) {
     onChange({
       reviewers: reviewers.map((r) => ({
-        // id: r.group !== 'system_role' ? r.id : undefined, // system roles dont have ids
-        // evaluationId: r.evaluationId,
         roleId: r.group === 'role' ? r.id : null,
         systemRole: r.group === 'system_role' ? (r.id as ProposalSystemRole) : null,
         userId: r.group === 'user' ? r.id : null
@@ -61,7 +58,7 @@ export function EvaluationStepSettings({
           data-test={`proposal-${evaluation.type}-select`}
           emptyPlaceholderContent='Select user or role'
           value={reviewerOptions as SelectOption[]}
-          readOnly={readOnly || readOnlyReviewers}
+          readOnly={readOnlyReviewers}
           systemRoles={[allMembersSystemRole]}
           variant='outlined'
           onChange={handleOnChangeReviewers}
@@ -91,7 +88,7 @@ export function EvaluationStepSettings({
       )}
       {evaluation.type === 'vote' && (
         <VoteSettings
-          readOnly={readOnly || readOnlyReviewers}
+          readOnly={readOnlyVoteSettings}
           value={evaluation.voteSettings}
           onChange={(voteSettings) =>
             onChange({

--- a/components/proposals/ProposalPage/components/EvaluationSidebar/components/EvaluationStepSettingsModal.tsx
+++ b/components/proposals/ProposalPage/components/EvaluationSidebar/components/EvaluationStepSettingsModal.tsx
@@ -25,19 +25,13 @@ export function EvaluationStepSettingsModal({
   const evaluationInputError = evaluationInput && getEvaluationFormError(evaluationInput);
   // find matching template step, and allow editing if there were no reviewers set
   const matchingTemplateStep = proposalTemplate?.evaluations?.find((e) => e.title === evaluationInput.title);
-  const templateHasNoReviewers = matchingTemplateStep?.reviewers?.length === 0;
-  // reviewers are already readOnly if a template was used, so long as reviewers were set
-  const readOnlyReviewers = !!templateId && !templateHasNoReviewers;
-  // rubric criteria should be editable but authors and reviewers, unless a template was used
-  const readOnlyRubricCriteria = !!templateId;
   return (
     <Modal open onClose={close} title={`Edit ${evaluationInput?.title}`}>
       <Box mb={1}>
         <EvaluationStepSettings
-          readOnly={false}
-          readOnlyReviewers={readOnlyReviewers}
-          readOnlyRubricCriteria={readOnlyRubricCriteria}
           evaluation={evaluationInput}
+          evaluationTemplate={matchingTemplateStep}
+          readOnly={false}
           onChange={updateEvaluation}
         />
       </Box>


### PR DESCRIPTION
What

If a template doesn't have the step set up, then we can let the author customize the values. 

Why
This is how reviewer input behaved in the previous status flow. Also in the near future, we're going to make it so that adding a step to workflows will add steps to all its templates, but we won't know what reviewers to add, and we decided this is a simpler approach than trying to validate templates and prevent usrs from using them.