### PR TITLE
add default rubric criteria when setting up a new proposal

### DIFF
--- a/__e2e__/proposals/proposalEvaluationCreation.spec.ts
+++ b/__e2e__/proposals/proposalEvaluationCreation.spec.ts
@@ -133,8 +133,6 @@ test.describe.serial('Proposal Evaluation', () => {
     // Configure rubric
     await proposalPage.selectEvaluationReviewer('rubric', 'space_member' as ProposalSystemRole);
 
-    await proposalPage.addRubricCriteriaButton.click();
-
     await proposalPage.editRubricCriteriaLabel.fill(settingsToTest.rubricLabel);
     await proposalPage.editRubricCriteriaDescription.fill(settingsToTest.rubricDescription);
     await proposalPage.editRubricCriteriaMinScore.fill(settingsToTest.rubricMinScore.toString());

--- a/__e2e__/proposals/proposalEvaluationCreation.spec.ts
+++ b/__e2e__/proposals/proposalEvaluationCreation.spec.ts
@@ -184,7 +184,6 @@ test.describe.serial('Proposal Evaluation', () => {
         proposalId: proposal.id,
         title: settingsToTest.evaluationFeedbackTitle,
         reviewers: [],
-        rubricCriteria: [],
         permissions: expect.arrayContaining(
           proposalEvaluationPermissions[0].permissions.map((p) => expect.objectContaining(p))
         )
@@ -244,8 +243,7 @@ test.describe.serial('Proposal Evaluation', () => {
       result: null,
       snapshotExpiry: null,
       snapshotId: null,
-      title: settingsToTest.evaluationPassFailTitle,
-      rubricCriteria: []
+      title: settingsToTest.evaluationPassFailTitle
     });
 
     expect(proposal.evaluations[3]).toMatchObject({
@@ -277,8 +275,7 @@ test.describe.serial('Proposal Evaluation', () => {
         publishToSnapshot: false,
         threshold: settingsToTest.votePassThreshold,
         type: 'Approval'
-      },
-      rubricCriteria: []
+      }
     });
   });
 });

--- a/__e2e__/proposals/proposalEvaluationTemplatesCreation.spec.ts
+++ b/__e2e__/proposals/proposalEvaluationTemplatesCreation.spec.ts
@@ -162,8 +162,6 @@ test.describe.serial('Proposal Evaluation', () => {
     // Configure rubric
     await proposalPage.selectEvaluationReviewer('rubric', 'space_member' as ProposalSystemRole);
 
-    await proposalPage.addRubricCriteriaButton.click();
-
     await proposalPage.editRubricCriteriaLabel.fill(settingsToTest.rubricLabel);
     await proposalPage.editRubricCriteriaDescription.fill(settingsToTest.rubricDescription);
     await proposalPage.editRubricCriteriaMinScore.fill(settingsToTest.rubricMinScore.toString());

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -216,12 +216,14 @@ export function NewProposalPage({
         const existingStep = (template?.evaluations || formInputs.evaluations).find(
           (e) => e.title === evaluation.title
         );
+        const rubricCriteria = (
+          evaluation.type === 'rubric' ? existingStep?.rubricCriteria || [getNewCriteria()] : []
+        ) as ProposalRubricCriteriaWithTypedParams[];
         return {
           id: evaluation.id,
           index,
           reviewers: existingStep?.reviewers || [],
-          rubricCriteria:
-            existingStep?.rubricCriteria || ([getNewCriteria()] as ProposalRubricCriteriaWithTypedParams[]),
+          rubricCriteria,
           title: evaluation.title,
           type: evaluation.type,
           result: null,

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -43,6 +43,7 @@ import { emptyDocument } from 'lib/prosemirror/constants';
 import type { PageContent } from 'lib/prosemirror/interfaces';
 import { fontClassName } from 'theme/fonts';
 
+import { getNewCriteria } from './components/EvaluationSettingsSidebar/components/RubricCriteriaSettings';
 import type { ProposalPropertiesInput } from './components/ProposalProperties/ProposalPropertiesBase';
 import { ProposalPropertiesBase } from './components/ProposalProperties/ProposalPropertiesBase';
 import { TemplateSelect } from './components/TemplateSelect';
@@ -219,7 +220,8 @@ export function NewProposalPage({
           id: evaluation.id,
           index,
           reviewers: existingStep?.reviewers || [],
-          rubricCriteria: existingStep?.rubricCriteria || ([] as ProposalRubricCriteriaWithTypedParams[]),
+          rubricCriteria:
+            existingStep?.rubricCriteria || ([getNewCriteria()] as ProposalRubricCriteriaWithTypedParams[]),
           title: evaluation.title,
           type: evaluation.type,
           result: null,

--- a/components/proposals/ProposalPage/components/EvaluationSettingsSidebar/components/EvaluationStepSettings.tsx
+++ b/components/proposals/ProposalPage/components/EvaluationSettingsSidebar/components/EvaluationStepSettings.tsx
@@ -8,7 +8,7 @@ import { useIsAdmin } from 'hooks/useIsAdmin';
 import type { ProposalEvaluationInput } from 'lib/proposal/createProposal';
 import type { PopulatedEvaluation } from 'lib/proposal/interface';
 
-import { RubricCriteria } from './RubricCriteriaSettings';
+import { RubricCriteriaSettings } from './RubricCriteriaSettings';
 import type { RangeProposalCriteria } from './RubricCriteriaSettings';
 import { VoteSettings } from './VoteSettings';
 
@@ -75,7 +75,7 @@ export function EvaluationStepSettings({ evaluation, evaluationTemplate, isRevie
             </Typography>
           </FormLabel>
           <Box display='flex' flex={1} flexDirection='column'>
-            <RubricCriteria
+            <RubricCriteriaSettings
               readOnly={readOnlyRubricCriteria}
               value={evaluation.rubricCriteria as RangeProposalCriteria[]}
               onChange={(rubricCriteria) =>

--- a/components/proposals/ProposalPage/components/EvaluationSettingsSidebar/components/RubricCriteriaSettings.tsx
+++ b/components/proposals/ProposalPage/components/EvaluationSettingsSidebar/components/RubricCriteriaSettings.tsx
@@ -7,7 +7,6 @@ import { v4 as uuid } from 'uuid';
 
 import { AddAPropertyButton } from 'components/common/BoardEditor/components/properties/AddAProperty';
 import { TextInput } from 'components/common/BoardEditor/components/properties/TextInput';
-import { Button } from 'components/common/Button';
 import { DraggableListItem } from 'components/common/DraggableListItem';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import ReactDndProvider from 'components/common/ReactDndProvider';
@@ -73,25 +72,27 @@ export const CriteriaRow = styled(Box)`
   }
 `;
 
-export function RubricCriteria({ readOnly, readOnlyMessage, value, onChange, proposalStatus, answers }: Props) {
-  const [criteriaList, setCriteriaList] = useState<RangeProposalCriteria[]>([]);
+export function getNewCriteria({ parameters }: Partial<RangeProposalCriteria> = {}): RangeProposalCriteria {
+  return {
+    id: uuid(),
+    index: -1,
+    description: '',
+    title: '',
+    type: 'range',
+    parameters: parameters || { min: 1, max: 5 }
+  };
+}
 
+export function RubricCriteriaSettings({ readOnly, readOnlyMessage, value, onChange, proposalStatus, answers }: Props) {
+  const [criteriaList, setCriteriaList] = useState<RangeProposalCriteria[]>(value);
   const [rubricCriteriaIdToDelete, setRubricCriteriaIdToDelete] = useState<string | null>(null);
 
   function addCriteria() {
     if (readOnly) {
       return;
     }
-    const lastCriteria = criteriaList[criteriaList.length - 1]?.parameters;
-    const parameters = { min: lastCriteria?.min || 1, max: lastCriteria?.max || 5 };
-    const newCriteria: RangeProposalCriteria = {
-      id: uuid(),
-      index: -1,
-      description: '',
-      title: '',
-      type: 'range',
-      parameters
-    };
+    const lastCriteria = criteriaList[criteriaList.length - 1];
+    const newCriteria = getNewCriteria(lastCriteria);
     const updatedList = [...criteriaList, newCriteria];
     setCriteriaList(updatedList);
   }


### PR DESCRIPTION
This adds default rubric criteria when creating a proposal.

It does not work when you change workflows in draft state, but that wasn't the primary request, and it's more difficult since updating workflow just syncs the backend and there's no clear event when to add a default empty value.