### PR TITLE
dont allow duplicating proposals

### DIFF
--- a/components/common/PageActions/components/DuplicatePageAction.tsx
+++ b/components/common/PageActions/components/DuplicatePageAction.tsx
@@ -9,7 +9,7 @@ import { useRewards } from 'components/rewards/hooks/useRewards';
 import { useCharmRouter } from 'hooks/useCharmRouter';
 import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
 
-const excludedPageTypes: (PageType | undefined)[] = ['bounty_template'];
+const excludedPageTypes: (PageType | undefined)[] = ['bounty_template', 'proposal'];
 
 export function DuplicatePageAction({
   pageId,


### PR DESCRIPTION

### WHY
 per chris, users can copy/paste instead. The 'proper' way to do this, though, would be to update /new page with pageId and try to retrieve the inputs from the page