### PR TITLE
save app build when testing chagnes in core

### DIFF
--- a/.github/workflows/test_new_core_pkg.yml
+++ b/.github/workflows/test_new_core_pkg.yml
@@ -23,11 +23,13 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install
         with:
+          save_cache: true
           core_pkg_version: ${{ inputs.core_pkg_version }}
 
       - name: Build app
         uses: ./.github/actions/build
         with:
+          save_cache: true
           REACT_APP_APP_ENV: 'test'
 
   integration-test:


### PR DESCRIPTION
I noticed that we were spending 5 minutes each test rebuilding the app when testing core