### PR TITLE
remove null values from page meta

### DIFF
--- a/pages/api/spaces/[id]/pages.ts
+++ b/pages/api/spaces/[id]/pages.ts
@@ -68,6 +68,11 @@ async function getPages(req: NextApiRequest, res: NextApiResponse<PageMeta[]>) {
     page.galleryImage = replaceS3Domain(page.galleryImage);
     page.headerImage = replaceS3Domain(page.headerImage);
     page.icon = replaceS3Domain(page.icon);
+    for (const [key, value] of Object.entries(page)) {
+      if (value === null) {
+        delete page[key as keyof PageMeta];
+      }
+    }
   });
 
   const createdPages: PageMeta[] = [];

--- a/pages/api/spaces/[id]/pages.ts
+++ b/pages/api/spaces/[id]/pages.ts
@@ -21,7 +21,6 @@ async function getPages(req: NextApiRequest, res: NextApiResponse<PageMeta[]>) {
 
   const spaceId = req.query.id as string;
   const { archived, limit, search } = req.query as any as PagesRequest;
-
   const accessiblePageIds = await permissionsApiClient.pages.getAccessiblePageIds({
     spaceId,
     userId,
@@ -29,7 +28,6 @@ async function getPages(req: NextApiRequest, res: NextApiResponse<PageMeta[]>) {
     limit,
     search
   });
-
   const pages: PageMeta[] = await prisma.page.findMany({
     where: {
       spaceId,
@@ -69,7 +67,7 @@ async function getPages(req: NextApiRequest, res: NextApiResponse<PageMeta[]>) {
     page.headerImage = replaceS3Domain(page.headerImage);
     page.icon = replaceS3Domain(page.icon);
     for (const [key, value] of Object.entries(page)) {
-      if (value === null) {
+      if (value === null || page[key as keyof PageMeta] === '') {
         delete page[key as keyof PageMeta];
       }
     }


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY
This shaves off 1.5MB of data being transferred for the CharmVerse pages endpoint. That brings it from 12.77 to 11.25