### PR TITLE
fix flaky test

### DIFF
--- a/testing/generateBoardStub.ts
+++ b/testing/generateBoardStub.ts
@@ -89,7 +89,7 @@ export function boardWithCardsArgs({
       {
         id: cardIds[0],
         deletedAt,
-        createdAt: '2022-08-25T17:19:05.413Z',
+        createdAt: '2022-08-25T17:19:00.413Z',
         createdBy,
         updatedAt: '2022-08-26T09:56:33.994Z',
         updatedBy: createdBy,
@@ -299,9 +299,9 @@ export function boardWithCardsArgs({
         : customProps?.cardPropertyValues?.[Constants.titleColumnId]) ?? cardPages[i % 2 === 0 ? 0 : 1].title;
 
     if (i % 2 === 0) {
-      cardPages.push({ ...cardPages[0], id: cardIds[i] || v4(), title });
+      cardPages.push({ ...cardPages[0], createdAt: new Date().toISOString(), id: cardIds[i] || v4(), title });
     } else {
-      cardPages.push({ ...cardPages[1], id: cardIds[i] || v4(), title });
+      cardPages.push({ ...cardPages[1], createdAt: new Date().toISOString(), id: cardIds[i] || v4(), title });
     }
   }
 


### PR DESCRIPTION
i thought i had included this in my original fix - we sort in the query but the extra cards were also using the same 'createdAT' as the original ones