### PR TITLE
Fix discord user trying to join a space through a token gate

### DIFF
--- a/components/common/SpaceAccessGate/components/TokenGate/hooks/useTokenGates.ts
+++ b/components/common/SpaceAccessGate/components/TokenGate/hooks/useTokenGates.ts
@@ -79,15 +79,13 @@ export function useTokenGates({
     setJoiningSpace(true);
 
     try {
-      if (account) {
-        await verifyTokenGateAndJoin({
-          commit: true,
-          spaceId: space.id,
-          tokens: tokenGateResult?.eligibleGates ?? [],
-          joinType,
-          walletAddress: account
-        });
-      }
+      await verifyTokenGateAndJoin({
+        commit: true,
+        spaceId: space.id,
+        tokens: tokenGateResult?.eligibleGates ?? [],
+        joinType,
+        walletAddress: account || ''
+      });
 
       showMessage(`You have joined the ${space.name} space.`, 'success');
 


### PR DESCRIPTION
The issue was the user did not have an account, it skipped the verification and jumped to the page where the user did not have access.