### PR TITLE
fix page title not updating between pages

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -393,7 +393,7 @@ function DocumentPage({
               <PageHeader
                 headerImage={page.headerImage}
                 // Commented for now, as we need to preserve cursor position between re-renders caused by updating this
-                // key={page.title}
+                key={page.id}
                 icon={page.icon}
                 title={page.title}
                 updatedAt={page.updatedAt.toString()}
@@ -407,8 +407,7 @@ function DocumentPage({
               />
             ) : (
               <PageTitleInput
-                // Commented for now, as we need to preserve cursor position between re-renders caused by updating this
-                // key={page.title}
+                key={page.id}
                 value={page.title}
                 focusDocumentEditor={focusDocumentEditor}
                 updatedAt={page.updatedAt.toString()}


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY
I think this broke when i moved the page title outside the Charmeditor, which uses page id as its key. A really weird case to test - and it only would happen when the page you go to is older, because the page title udpates based on page updated date