### PR TITLE
create anonymous user id when tracking if one has not been assigned yet

### DIFF
--- a/pages/api/events/index.ts
+++ b/pages/api/events/index.ts
@@ -1,6 +1,7 @@
 import { log } from '@charmverse/core/log';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
+import { v4 as uuid } from 'uuid';
 
 import { trackUserAction } from 'lib/metrics/mixpanel/trackUserAction';
 import { recordDatabaseEvent, type EventInput } from 'lib/metrics/recordDatabaseEvent';
@@ -16,6 +17,11 @@ async function trackHandler(req: NextApiRequest, res: NextApiResponse<{ success:
   const request = req.body as EventInput;
 
   const { event: eventName, ...eventPayload } = request;
+
+  if (!req.session.anonymousUserId) {
+    req.session.anonymousUserId = uuid();
+    await req.session.save();
+  }
 
   const userId = req.session.user?.id ?? req.session.anonymousUserId;
   // Make sure to use userId from session


### PR DESCRIPTION
I noticed we logged "invalid track data" almost 300 times in the past week, and it's because no user id exists. I think it should be safe to create an id in this endpoint, wher normally we do it in api/profile. It's just probably a race condition