### PR TITLE
allow setting authors in proposal templates

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -90,7 +90,7 @@ export function ProposalProperties({
           proposalStatus={proposal?.status}
           pageId={pageId}
           proposalId={proposalId}
-          readOnlyAuthors={readOnlyProperties}
+          readOnlyAuthors={readOnlyProperties ?? !!sourceTemplate?.authors.length}
           proposalFormInputs={proposalFormInputs}
           setProposalFormInputs={onChangeProperties}
           readOnlyCustomProperties={readOnlyCustomProperties}

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -37,6 +37,7 @@ import { useMdScreen } from 'hooks/useMediaScreens';
 import { usePages } from 'hooks/usePages';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { usePreventReload } from 'hooks/usePreventReload';
+import { useUser } from 'hooks/useUser';
 import type { ProposalTemplate } from 'lib/proposal/getProposalTemplates';
 import type { ProposalRubricCriteriaWithTypedParams } from 'lib/proposal/rubric/interfaces';
 import { emptyDocument } from 'lib/prosemirror/constants';
@@ -65,7 +66,6 @@ export type ProposalPageAndPropertiesInput = ProposalPropertiesInput & {
 const StyledContainer = styled(PageEditorContainer)`
   margin-bottom: 180px;
 `;
-
 // Note: this component is only used before a page is saved to the DB
 export function NewProposalPage({
   isTemplate,
@@ -78,6 +78,7 @@ export function NewProposalPage({
 }) {
   const { navigateToSpacePath } = useCharmRouter();
   const { space: currentSpace } = useCurrentSpace();
+  const { user } = useUser();
   const [collapsedFieldIds, setCollapsedFieldIds] = useState<string[]>([]);
   const { activeView: sidebarView, setActiveView } = usePageSidebar();
   const { proposalTemplates, isLoadingTemplates } = useProposalTemplates();
@@ -173,7 +174,9 @@ export function NewProposalPage({
     const template = proposalTemplates?.find((t) => t.id === _templateId);
     if (template) {
       const formFields = template.form?.formFields ?? [];
+      const authors = Array.from(new Set([user!.id].concat(template.authors.map((author) => author.userId))));
       setFormInputs({
+        authors,
         content: template.page.content as PageContent,
         contentText: template.page.contentText,
         reviewers: template.reviewers.map((reviewer) => ({

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -310,6 +310,7 @@ export function NewProposalPage({
               proposalStatus='draft'
               proposalFormInputs={formInputs}
               setProposalFormInputs={setFormInputs}
+              readOnlyAuthors={!!sourceTemplate?.authors.length}
               readOnlyCustomProperties={readOnlyCustomProperties}
             />
           </div>

--- a/components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase.tsx
@@ -92,7 +92,11 @@ export function ProposalPropertiesBase({
               flexGrow: 1
             }}
           >
-            <PropertyLabel readOnly required={isNewProposal} highlighted>
+            <PropertyLabel
+              readOnly
+              required={isNewProposal && proposalFormInputs.type !== 'proposal_template'}
+              highlighted
+            >
               Author
             </PropertyLabel>
             <Box display='flex' flex={1}>

--- a/components/proposals/ProposalPage/components/ProposalStickyFooter/ProposalStickyFooter.tsx
+++ b/components/proposals/ProposalPage/components/ProposalStickyFooter/ProposalStickyFooter.tsx
@@ -34,7 +34,8 @@ export function ProposalStickyFooter({
     proposal: {
       type: 'proposal',
       title: page.title,
-      ...proposal
+      ...proposal,
+      authors: proposal.authors.map((a) => a.userId)
     }
   }).join('\n');
 

--- a/components/proposals/ProposalPage/hooks/useNewProposal.tsx
+++ b/components/proposals/ProposalPage/hooks/useNewProposal.tsx
@@ -97,7 +97,7 @@ export function getProposalErrors({
 }: {
   proposal: Pick<
     ProposalPageAndPropertiesInput,
-    'title' | 'type' | 'proposalTemplateId' | 'formFields' | 'content' | 'proposalType' | 'evaluations'
+    'authors' | 'title' | 'type' | 'proposalTemplateId' | 'formFields' | 'content' | 'proposalType' | 'evaluations'
   >;
   requireTemplates?: boolean;
 }) {
@@ -108,6 +108,9 @@ export function getProposalErrors({
 
   if (requireTemplates && proposal.type === 'proposal' && !proposal.proposalTemplateId) {
     errors.push('Template is required');
+  }
+  if (proposal.type === 'proposal' && proposal.authors.length === 0) {
+    errors.push('At least one author is required');
   }
 
   if (proposal.proposalType === 'structured') {
@@ -169,6 +172,7 @@ function emptyState({
     publishToLens: false,
     fields: { properties: {} },
     ...inputs,
-    authors: userId ? [userId] : []
+    // leave authors empty for proposals
+    authors: inputs.type !== 'proposal_template' && userId ? [userId] : []
   };
 }

--- a/lib/proposal/createProposal.ts
+++ b/lib/proposal/createProposal.ts
@@ -73,7 +73,8 @@ export async function createProposal({
   const proposalId = uuid();
   const proposalStatus: ProposalStatus = isDraft ? 'draft' : 'published';
 
-  const authorsList = arrayUtils.uniqueValues(authors ? [...authors, userId] : [userId]);
+  const defaultAuthorsList = pageProps?.type !== 'proposal_template' ? [userId] : [];
+  const authorsList = arrayUtils.uniqueValues([...(authors || []), ...defaultAuthorsList]);
 
   const workflow = workflowId
     ? ((await prisma.proposalWorkflow.findUnique({


### PR DESCRIPTION
Authors are no longer mandatory when creating a template. If you do set them, then they will be included in the authors list when using a template.

The following query will clear out author inputs from existing templates, I checked and there are 286 in production:
```
await prisma.proposalAuthor.deleteMany({
    where: {
      proposal: {
        page: {
          type: 'proposal_template'
        }
      }
    }
  });
  ```