### PR TITLE
increase max old memory in production webapp

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       [
         'sh',
         '-c',
-        'npm run prisma:deploy && npx react-env --path .env -- node --require dd-trace/init node_modules/.bin/next start --keepAliveTimeout 70000 & npm run ceramic:graphql'
+        'npm run prisma:deploy && npx react-env --path .env -- node --max-old-space-size=8192 --require dd-trace/init node_modules/.bin/next start --keepAliveTimeout 70000 & npm run ceramic:graphql'
       ]
     # environment:
     #   - FORCE_SUBDOMAINS=true


### PR DESCRIPTION
we are crashing around 4GB, best guess is that the max memory is not high enough. We're running on 16GB instances so 8GB shuld be fine to try