### PR TITLE
Fix proposal reward property ui

### DIFF
--- a/components/proposals/components/ProposalRewards/ProposalRewards.tsx
+++ b/components/proposals/components/ProposalRewards/ProposalRewards.tsx
@@ -14,6 +14,7 @@ import {
 } from 'components/proposals/components/ProposalRewards/AttachRewardButton';
 import { RewardTokenInfo } from 'components/rewards/components/RewardProperties/components/RewardTokenInfo';
 import { RewardPropertiesForm } from 'components/rewards/components/RewardProperties/RewardPropertiesForm';
+import { RewardAmount } from 'components/rewards/components/RewardStatusBadge';
 import { useNewReward } from 'components/rewards/hooks/useNewReward';
 import { useRewardPage } from 'components/rewards/hooks/useRewardPage';
 import { useRewards } from 'components/rewards/hooks/useRewards';
@@ -191,17 +192,16 @@ export function ProposalRewards({
                         <Hidden lgDown>
                           <Grid item xs={5}>
                             <Stack alignItems='center' direction='row' height='100%'>
-                              {reward.customReward ? (
-                                <Typography component='span' variant='subtitle1' fontWeight='normal'>
-                                  {reward.customReward}
-                                </Typography>
-                              ) : (
-                                <RewardTokenInfo
-                                  chainId={reward.chainId || null}
-                                  symbolOrAddress={reward.rewardToken || null}
-                                  rewardAmount={reward.rewardAmount || null}
-                                />
-                              )}
+                              <RewardAmount
+                                reward={{
+                                  chainId: reward.chainId || null,
+                                  customReward: reward.customReward || null,
+                                  rewardAmount: reward.rewardAmount || null,
+                                  rewardToken: reward.rewardToken || null
+                                }}
+                                truncate={true}
+                                typographyProps={{ variant: 'body2', fontWeight: 'normal', fontSize: 'normal' }}
+                              />
                             </Stack>
                           </Grid>
                         </Hidden>

--- a/components/proposals/components/ProposalRewards/ProposalRewards.tsx
+++ b/components/proposals/components/ProposalRewards/ProposalRewards.tsx
@@ -200,6 +200,7 @@ export function ProposalRewards({
                                   rewardToken: reward.rewardToken || null
                                 }}
                                 truncate={true}
+                                truncatePrecision={2}
                                 typographyProps={{ variant: 'body2', fontWeight: 'normal', fontSize: 'normal' }}
                               />
                             </Stack>

--- a/components/rewards/components/RewardStatusBadge.tsx
+++ b/components/rewards/components/RewardStatusBadge.tsx
@@ -49,10 +49,12 @@ export function RewardStatusBadge({ truncate = false, showEmptyStatus, hideStatu
 export function RewardAmount({
   reward,
   truncate = false,
+  truncatePrecision = 4,
   typographyProps
 }: {
   reward: Pick<Reward, 'rewardAmount' | 'rewardToken' | 'chainId' | 'customReward'>;
   truncate?: boolean;
+  truncatePrecision?: number;
   typographyProps?: TypographyProps;
 }) {
   const [paymentMethods] = usePaymentMethods();
@@ -86,7 +88,7 @@ export function RewardAmount({
 
   const truncatedAmount = () => {
     try {
-      return millify(rewardAmount, { precision: 4 });
+      return millify(rewardAmount, { precision: truncatePrecision });
     } catch (error) {
       return 'Invalid number';
     }

--- a/components/rewards/components/RewardStatusBadge.tsx
+++ b/components/rewards/components/RewardStatusBadge.tsx
@@ -1,16 +1,14 @@
 import type { Bounty as Reward } from '@charmverse/core/prisma';
-import LaunchIcon from '@mui/icons-material/LaunchOutlined';
 import RewardIcon from '@mui/icons-material/RequestPageOutlined';
-import { IconButton, Stack, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
+import Typography, { type TypographyProps } from '@mui/material/Typography';
 import { getChainById } from 'connectors/chains';
 import millify from 'millify';
-import Link from 'next/link';
 
 import TokenLogo from 'components/common/TokenLogo';
-import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePaymentMethods } from 'hooks/usePaymentMethods';
 import { getTokenInfo } from 'lib/tokens/tokenData';
 import { fancyTrim } from 'lib/utilities/strings';
@@ -50,10 +48,12 @@ export function RewardStatusBadge({ truncate = false, showEmptyStatus, hideStatu
 
 export function RewardAmount({
   reward,
-  truncate = false
+  truncate = false,
+  typographyProps
 }: {
   reward: Pick<Reward, 'rewardAmount' | 'rewardToken' | 'chainId' | 'customReward'>;
   truncate?: boolean;
+  typographyProps?: TypographyProps;
 }) {
   const [paymentMethods] = usePaymentMethods();
 
@@ -62,7 +62,7 @@ export function RewardAmount({
       <Tooltip title={reward.customReward}>
         <Stack flexDirection='row' gap={0.5} alignItems='center'>
           <RewardIcon fontSize='small' color='secondary' />
-          <Typography>{fancyTrim(reward.customReward, 15)}</Typography>
+          <Typography {...typographyProps}>{fancyTrim(reward.customReward, 15)}</Typography>
         </Stack>
       </Tooltip>
     );
@@ -106,6 +106,7 @@ export function RewardAmount({
               }}
               mr={0.5}
               variant='caption'
+              {...typographyProps}
             >
               Reward not set
             </Typography>
@@ -124,13 +125,12 @@ export function RewardAmount({
             </Box>
             <Typography
               component='span'
-              sx={{
-                fontWeight: 600
-              }}
+              fontWeight='600'
               variant='h6'
               fontSize={18}
               data-test='reward-amount'
               textTransform='uppercase'
+              {...typographyProps}
             >
               {truncate ? truncatedAmount() : rewardAmount} {tokenInfo.isContract && tokenInfo.tokenSymbol}
             </Typography>


### PR DESCRIPTION
https://app.charmverse.io/charmverse/large-reward-number-in-proposal-breaks-formatting-4962506545590897

Before
<img width="570" alt="Screenshot 2024-01-24 at 12 46 23" src="https://github.com/charmverse/app.charmverse.io/assets/25636858/fbdcc489-303e-44ef-acf6-6891222c0558">

After
<img width="577" alt="Screenshot 2024-01-24 at 12 35 49" src="https://github.com/charmverse/app.charmverse.io/assets/25636858/1753e7be-056b-4d49-ae90-ba4e826e6356">
