### PR TITLE
Bug fixes for milestones

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
@@ -118,15 +118,21 @@ export function ProposalRewards({
     updateURLQuery({ [rewardQueryKey]: pageId });
   }
 
-  function selectTemplate(template: RewardTemplate) {
-    setRewardValues(template.reward);
-    updateNewPageValues({
-      ...template.page,
-      content: template.page.content as any,
-      title: undefined,
-      type: 'bounty',
-      templateId: template.page.id
-    });
+  function selectTemplate(template: RewardTemplate | null) {
+    if (template) {
+      setRewardValues(template.reward);
+      updateNewPageValues({
+        ...template.page,
+        content: template.page.content as any,
+        title: undefined,
+        type: 'bounty',
+        templateId: template.page.id
+      });
+    } else {
+      updateNewPageValues({
+        templateId: undefined
+      });
+    }
   }
 
   // kind of hacky.. support applying a template when one is provided from the proposal template

--- a/components/proposals/ProposalPage/components/TemplateSelect.tsx
+++ b/components/proposals/ProposalPage/components/TemplateSelect.tsx
@@ -35,6 +35,7 @@ export function TemplateSelect({ disabled, displayType, options, value, onChange
   return (
     <TagSelect
       wrapColumn
+      showEmpty
       displayType={displayType}
       readOnly={disabled}
       options={propertyOptions}

--- a/components/rewards/components/NewInlineReward.tsx
+++ b/components/rewards/components/NewInlineReward.tsx
@@ -14,22 +14,22 @@ export function NewInlineReward({ pageId }: { pageId: string }) {
   const { refreshPage } = usePages();
   const [selectedTemplate, setSelectedTemplate] = useState<string | undefined>();
 
-  function resetForm() {
-    clearRewardValues();
-  }
-
   async function saveForm() {
     const success = await createReward({ linkedPageId: pageId });
     if (success) {
-      resetForm();
+      clearRewardValues();
       setCreatingInlineReward(false);
       refreshPage(pageId);
     }
   }
 
-  function selectTemplate(template: RewardTemplate) {
-    setRewardValues(template.reward);
-    setSelectedTemplate(template.page.id);
+  function selectTemplate(template: RewardTemplate | null) {
+    if (template) {
+      setRewardValues(template.reward);
+      setSelectedTemplate(template.page.id);
+    } else {
+      setSelectedTemplate(undefined);
+    }
   }
 
   useEffect(() => {
@@ -45,7 +45,6 @@ export function NewInlineReward({ pageId }: { pageId: string }) {
         values={rewardValues}
         expandedByDefault
         isNewReward
-        resetTemplate={() => setSelectedTemplate(undefined)}
       />
       <Stack direction='row' alignItems='center' justifyContent='flex-end' flex={1} gap={1}>
         <Button onClick={() => setCreatingInlineReward(false)} variant='outlined' color='secondary'>

--- a/components/rewards/components/NewRewardButton.tsx
+++ b/components/rewards/components/NewRewardButton.tsx
@@ -76,22 +76,21 @@ export function NewRewardButton({ showPage }: { showPage: (pageId: string) => vo
     setRewardValues(template.reward);
   }
 
-  function selectTemplate(template: RewardTemplate) {
-    const templateContentChanged = template.page.content !== newPageValues?.content;
+  function selectTemplate(template: RewardTemplate | null) {
+    if (template) {
+      const templateContentChanged = template.page.content !== newPageValues?.content;
 
-    if (newPageValues?.contentText.length !== 0 && templateContentChanged) {
-      overrideContentModalPopupState.open();
+      if (newPageValues?.contentText.length !== 0 && templateContentChanged) {
+        overrideContentModalPopupState.open();
+      } else {
+        createRewardFromTemplate(template);
+      }
     } else {
-      createRewardFromTemplate(template);
+      updateNewPageValues({
+        templateId: undefined
+      });
     }
-    setSelectedTemplate(template ?? null);
-  }
-
-  function resetTemplate() {
-    setSelectedTemplate(null);
-    updateNewPageValues({
-      templateId: undefined
-    });
+    setSelectedTemplate(template);
   }
 
   let disabledTooltip: string | undefined;
@@ -159,7 +158,6 @@ export function NewRewardButton({ showPage }: { showPage: (pageId: string) => vo
             expandedByDefault
             selectTemplate={selectTemplate}
             templateId={newPageValues?.templateId}
-            resetTemplate={resetTemplate}
           />
         </NewDocumentPage>
       </NewPageDialog>

--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -41,10 +41,9 @@ type Props = {
   isNewReward?: boolean;
   isTemplate?: boolean;
   expandedByDefault?: boolean;
-  selectTemplate: (template: RewardTemplate) => void;
+  selectTemplate: (template: RewardTemplate | null) => void;
   templateId?: string;
   readOnlyTemplate?: boolean;
-  resetTemplate?: VoidFunction;
   forcedApplicationType?: RewardApplicationType;
   rewardStatus?: BountyStatus | null;
 };
@@ -75,7 +74,6 @@ export function RewardPropertiesForm({
   selectTemplate,
   templateId,
   readOnlyTemplate,
-  resetTemplate,
   forcedApplicationType,
   rewardStatus
 }: Props) {
@@ -236,7 +234,7 @@ export function RewardPropertiesForm({
                       value={templateId ? { id: templateId } : null}
                       onChange={(templatePage) => {
                         if (!templatePage) {
-                          resetTemplate?.();
+                          selectTemplate(null);
                         }
                         const template = rewardTemplates.find((_template) => _template.page.id === templatePage?.id);
                         if (template && selectTemplate) {


### PR DESCRIPTION
- allow unsetting reward template when it doesnt come from a proposal template
- we were not always pulling in template properties when you added a reward at first
- show "Empty" for empty template properties