### PR TITLE
dont override default reward type for new rewards

### DIFF
--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -111,12 +111,15 @@ export function RewardPropertiesForm({
   }, []);
 
   useEffect(() => {
+    if (isNewReward) {
+      return;
+    }
     if (isTruthy(values?.customReward)) {
       setRewardType('Custom');
     } else if (!values?.rewardToken || !values?.rewardAmount || !values?.chainId) {
       setRewardType('None');
     }
-  }, [values?.customReward, values?.rewardAmount, values?.rewardToken, values?.chainId]);
+  }, [values?.customReward, values?.rewardAmount, values?.rewardToken, values?.chainId, isNewReward]);
 
   async function applyUpdates(updates: Partial<UpdateableRewardFields>) {
     if ('customReward' in updates) {

--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -83,8 +83,10 @@ export function RewardPropertiesForm({
   const { getFeatureTitle } = useSpaceFeatures();
   const [isDateTimePickerOpen, setIsDateTimePickerOpen] = useState(false);
   const [isExpanded, setIsExpanded] = useState(!!expandedByDefault);
-  const [rewardType, setRewardType] = useState(values?.customReward ? 'Custom' : ('Token' as RewardType));
-  const allowedSubmittersValue: RoleOption[] = (values?.allowedSubmitterRoles ?? []).map((id) => ({
+  const [rewardType, setRewardType] = useState<RewardType>(
+    values.customReward ? 'Custom' : isNewReward || values.rewardToken ? 'Token' : 'None'
+  );
+  const allowedSubmittersValue: RoleOption[] = (values.allowedSubmitterRoles ?? []).map((id) => ({
     id,
     group: 'role'
   }));
@@ -109,17 +111,6 @@ export function RewardPropertiesForm({
 
     setRewardApplicationTypeRaw(updatedType);
   }, []);
-
-  useEffect(() => {
-    if (isNewReward) {
-      return;
-    }
-    if (isTruthy(values?.customReward)) {
-      setRewardType('Custom');
-    } else if (!values?.rewardToken || !values?.rewardAmount || !values?.chainId) {
-      setRewardType('None');
-    }
-  }, [values?.customReward, values?.rewardAmount, values?.rewardToken, values?.chainId, isNewReward]);
 
   async function applyUpdates(updates: Partial<UpdateableRewardFields>) {
     if ('customReward' in updates) {


### PR DESCRIPTION
I removed a useEffect which was overriding the Token default.. It looks like 'values' used to be optional, but now that it's required i don't think we need a useEffect anymore.

I tested with each type, opening the modal it shows the correct type.