### PR TITLE
Fix Proposal rewards override

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase.tsx
@@ -156,7 +156,9 @@ export function ProposalPropertiesBase({
           rewardIds={rewardIds || []}
           readOnly={readOnlyRewards}
           onSave={(pendingReward) => {
-            const isExisting = pendingRewards.find((reward) => reward.draftId === pendingReward.draftId);
+            const isExisting = pendingRewards.find(
+              (reward) => reward.draftId && pendingReward.draftId && reward.draftId === pendingReward.draftId
+            );
             if (!isExisting) {
               setProposalFormInputs({
                 fields: {


### PR DESCRIPTION
We need to make sure that we compare valid draftIds. 
In some cases draftId is an empty string.