### PR TITLE
redirect user to login when trying to creat ea proposal template

### DIFF
--- a/hooks/useSharedPage.ts
+++ b/hooks/useSharedPage.ts
@@ -105,5 +105,6 @@ export function isForumPagePath(path: string): boolean {
 }
 
 export function isProposalsPagePath(path: string): boolean {
-  return path.startsWith(PROPOSALS_PATH);
+  // exclude new proposals for now. Maybe we should allow a sign-up button on the page?
+  return path.startsWith(PROPOSALS_PATH) && !path.endsWith('/new');
 }


### PR DESCRIPTION
If a space has public proposals enabled, we still need to redirect them to login if they want to submit a proposal