### PR TITLE
hot fix for reward templates that use None

### DIFF
--- a/components/[pageId]/DocumentPage/components/RewardProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/RewardProperties.tsx
@@ -75,7 +75,6 @@ export function RewardProperties(props: {
   if (!currentReward) {
     return null;
   }
-
   return (
     <Stack flex={1}>
       <RewardPropertiesForm

--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -83,9 +83,13 @@ export function RewardPropertiesForm({
   const { getFeatureTitle } = useSpaceFeatures();
   const [isDateTimePickerOpen, setIsDateTimePickerOpen] = useState(false);
   const [isExpanded, setIsExpanded] = useState(!!expandedByDefault);
+  // Token type rules:
+  // If it is a new reward and not using a template, use Token
+  // If neither rewardToken nor customReward is set, use None
   const [rewardType, setRewardType] = useState<RewardType>(
-    values.customReward ? 'Custom' : isNewReward || values.rewardToken ? 'Token' : 'None'
+    values.customReward ? 'Custom' : values.rewardToken ? 'Token' : isNewReward && !templateId ? 'Token' : 'None'
   );
+
   const allowedSubmittersValue: RoleOption[] = (values.allowedSubmitterRoles ?? []).map((id) => ({
     id,
     group: 'role'


### PR DESCRIPTION
We had "Token" be default, but we dont actually store this any place. It is just derived from the fact that you don't have a rewardToken or customReward. So we need to take into account if the reward is new but coming from a template, where both would be unset