### PR TITLE
better handle updates for  existing rewards

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
@@ -284,6 +284,7 @@ export function ProposalRewards({
         isSaving={isSavingReward}
       >
         <NewDocumentPage
+          key={newPageValues?.templateId}
           titlePlaceholder='Reward title (required)'
           values={newPageValues}
           onChange={updateNewPageValues}

--- a/components/rewards/components/NewInlineReward.tsx
+++ b/components/rewards/components/NewInlineReward.tsx
@@ -37,7 +37,7 @@ export function NewInlineReward({ pageId }: { pageId: string }) {
   }, []);
 
   return (
-    <Stack gap={1}>
+    <Stack gap={1} key={selectedTemplate}>
       <RewardPropertiesForm
         templateId={selectedTemplate}
         selectTemplate={selectTemplate}

--- a/components/rewards/hooks/useRewards.tsx
+++ b/components/rewards/hooks/useRewards.tsx
@@ -50,9 +50,19 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
   const updateReward = useCallback(
     async (rewardUpdate: RewardUpdate) => {
       if (rewardUpdate) {
-        await charmClient.rewards.updateReward(rewardUpdate);
+        const updated = await charmClient.rewards.updateReward(rewardUpdate);
 
-        mutateRewards();
+        mutateRewards(
+          (rData) => {
+            return rData?.map((reward) => {
+              if (reward.id === updated.id) {
+                return updated;
+              }
+              return reward;
+            });
+          },
+          { revalidate: false }
+        );
       }
     },
     [mutateRewards]

--- a/stories/Rewards/Pages/NewRewardPage.stories.tsx
+++ b/stories/Rewards/Pages/NewRewardPage.stories.tsx
@@ -15,7 +15,12 @@ export function RewardsPage() {
 
   return (
     <GlobalContext>
-      <NewDocumentPage titlePlaceholder='Title (required)' values={newPageValues} onChange={updateNewPageValues}>
+      <NewDocumentPage
+        key={newPageValues?.templateId}
+        titlePlaceholder='Title (required)'
+        values={newPageValues}
+        onChange={updateNewPageValues}
+      >
         <RewardPropertiesForm
           onChange={setRewardValues}
           values={rewardValues}


### PR DESCRIPTION
Reward type was not changing when selecting a different template. I also fixed updates - you can't even type in "Custom Reward" right now, because it is not beign debounced