### PR TITLE
Save proposal template with a reward

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -412,6 +412,7 @@ function DocumentPage({ insideModal = false, page, savePage, readOnly = false, e
                     proposalPage={page}
                     proposal={proposal}
                     refreshProposal={refreshProposal}
+                    isProposalTemplate={page.type === 'proposal_template'}
                   />
                 )}
                 {reward && (

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -16,6 +16,7 @@ interface ProposalPropertiesProps {
   proposalPage: PageWithContent;
   proposal?: ProposalWithUsersAndRubric;
   refreshProposal: VoidFunction;
+  isProposalTemplate: boolean;
 }
 export function ProposalProperties({
   pageId,
@@ -23,7 +24,8 @@ export function ProposalProperties({
   readOnly,
   proposalPage,
   proposal,
-  refreshProposal
+  refreshProposal,
+  isProposalTemplate
 }: ProposalPropertiesProps) {
   const { trigger: updateProposal } = useUpdateProposal({ proposalId });
   const { showError } = useSnackbar();
@@ -89,6 +91,7 @@ export function ProposalProperties({
           rewardIds={proposal?.rewardIds}
           readOnlySelectedCredentialTemplates={readOnlySelectedCredentialTemplates}
           isStructuredProposal={!!proposal?.formId}
+          isProposalTemplate={isProposalTemplate}
         />
       </div>
     </Box>

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -383,6 +383,7 @@ export function NewProposalPage({
                       readOnlyCustomProperties={readOnlyCustomProperties}
                       readOnlySelectedCredentialTemplates={readOnlySelectedCredentialTemplates}
                       isStructuredProposal={isStructured}
+                      isProposalTemplate={!!isTemplate}
                     />
                   </div>
                 </div>
@@ -477,6 +478,7 @@ export function NewProposalPage({
                     reviewers={formInputs.evaluations.map((e) => e.reviewers.filter((r) => !r.systemRole)).flat()}
                     assignedSubmitters={formInputs.authors}
                     variant='solid_button'
+                    isProposalTemplate={isTemplate}
                     rewardIds={[]}
                     onSave={(pendingReward) => {
                       const isExisting = pendingRewards.find((reward) => reward.draftId === pendingReward.draftId);

--- a/components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase.tsx
@@ -43,6 +43,7 @@ type ProposalPropertiesProps = {
   rewardIds?: string[] | null;
   proposalId?: string;
   isStructuredProposal: boolean;
+  isProposalTemplate: boolean;
 };
 
 export function ProposalPropertiesBase({
@@ -56,7 +57,8 @@ export function ProposalPropertiesBase({
   readOnlyRewards,
   rewardIds,
   proposalId,
-  isStructuredProposal
+  isStructuredProposal,
+  isProposalTemplate
 }: ProposalPropertiesProps) {
   const { mappedFeatures } = useSpaceFeatures();
   const [detailsExpanded, setDetailsExpanded] = useState(proposalStatus === 'draft');
@@ -164,6 +166,7 @@ export function ProposalPropertiesBase({
               assignedSubmitters={proposalAuthorIds}
               rewardIds={rewardIds || []}
               readOnly={readOnlyRewards}
+              isProposalTemplate={isProposalTemplate}
               onSave={(pendingReward) => {
                 const isExisting = pendingRewards.find((reward) => reward.draftId === pendingReward.draftId);
                 if (!isExisting) {

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/AttachRewardButton.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/AttachRewardButton.tsx
@@ -6,10 +6,12 @@ import type { UpdateableRewardFields } from 'lib/rewards/updateRewardSettings';
 
 export function AttachRewardButton({
   createNewReward,
-  variant = 'card_property'
+  variant = 'card_property',
+  isProposalTemplate
 }: {
   createNewReward: VoidFunction;
   variant?: 'solid_button' | 'card_property';
+  isProposalTemplate?: boolean;
 }) {
   const { getFeatureTitle } = useSpaceFeatures();
   if (variant === 'card_property') {
@@ -29,17 +31,19 @@ export function AttachRewardButton({
 
 export function getDisabledTooltip({
   newPageValues,
-  rewardValues
+  rewardValues,
+  isProposalTemplate
 }: {
   newPageValues: NewPageValues | null;
   rewardValues: UpdateableRewardFields;
+  isProposalTemplate?: boolean;
 }) {
   let disabledTooltip: string | undefined;
   if (!newPageValues?.title) {
     disabledTooltip = 'Page title is required';
   } else if (!rewardValues.reviewers?.length) {
     disabledTooltip = 'Reviewer is required';
-  } else if (rewardValues.assignedSubmitters && rewardValues.assignedSubmitters.length === 0) {
+  } else if (rewardValues.assignedSubmitters && rewardValues.assignedSubmitters.length && !isProposalTemplate) {
     disabledTooltip = 'You need to assign at least one submitter';
   }
 

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
@@ -34,6 +34,7 @@ type Props = {
   assignedSubmitters: string[];
   requiredTemplateId?: string | null;
   variant?: 'solid_button' | 'card_property'; // solid_button is used for form proposals
+  isProposalTemplate?: boolean;
 };
 
 const rewardQueryKey = 'rewardId';
@@ -47,7 +48,8 @@ export function ProposalRewards({
   reviewers,
   assignedSubmitters,
   requiredTemplateId,
-  variant
+  variant,
+  isProposalTemplate
 }: Props) {
   useRewardsNavigation(rewardQueryKey);
 
@@ -298,6 +300,7 @@ export function ProposalRewards({
             templateId={newPageValues?.templateId}
             readOnlyTemplate={!!requiredTemplateId}
             selectTemplate={selectTemplate}
+            isProposalTemplate={isProposalTemplate}
           />
         </NewDocumentPage>
       </NewPageDialog>

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
@@ -278,7 +278,7 @@ export function ProposalRewards({
 
       <NewPageDialog
         contentUpdated={contentUpdated || isDirty}
-        disabledTooltip={getDisabledTooltip({ newPageValues, rewardValues })}
+        disabledTooltip={getDisabledTooltip({ newPageValues, rewardValues, isProposalTemplate })}
         isOpen={!!newPageValues}
         onClose={closeDialog}
         onSave={saveForm}

--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -4,7 +4,7 @@ import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import clsx from 'clsx';
 import { DateTime } from 'luxon';
 import type { ChangeEvent } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { PropertyLabel } from 'components/common/BoardEditor/components/properties/PropertyLabel';
 import { StyledFocalboardTextInput } from 'components/common/BoardEditor/components/properties/TextInput';
@@ -26,7 +26,7 @@ import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
 import type { RewardFieldsProp, RewardPropertiesField } from 'lib/rewards/blocks/interfaces';
 import type { RewardCreationData } from 'lib/rewards/createReward';
 import type { RewardTemplate } from 'lib/rewards/getRewardTemplates';
-import type { Reward, RewardWithUsers, RewardReviewer } from 'lib/rewards/interfaces';
+import type { Reward, RewardReviewer, RewardWithUsers } from 'lib/rewards/interfaces';
 import type { UpdateableRewardFields } from 'lib/rewards/updateRewardSettings';
 import { isTruthy } from 'lib/utilities/types';
 
@@ -108,7 +108,7 @@ export function RewardPropertiesForm({
   const template = rewardTemplates?.find((tpl) => tpl.page.id === templateId);
   const readOnlyReviewers = !isAdmin && (readOnly || !!template?.reward.reviewers?.length);
   const readOnlyDueDate = !isAdmin && (readOnly || !!template?.reward.dueDate);
-  const readOnlyApplicationType = !isAdmin && (readOnly || !!forcedApplicationType || !!template || isProposalTemplate);
+  const readOnlyApplicationType = !isAdmin && (readOnly || !!forcedApplicationType || !!template);
   const readOnlyProperties = !isAdmin && (readOnly || !!template);
   const readOnlyNumberAvailable = !isAdmin && (readOnly || typeof template?.reward.maxSubmissions === 'number');
   const readOnlyApplicantRoles = !isAdmin && (readOnly || !!template?.reward.allowedSubmitterRoles?.length);
@@ -310,7 +310,7 @@ export function RewardPropertiesForm({
                 Application Type
               </PropertyLabel>
               <RewardApplicationType
-                readOnly={readOnlyApplicationType}
+                readOnly={readOnlyApplicationType || isProposalTemplate}
                 value={rewardApplicationType}
                 onChange={setRewardApplicationType}
               />

--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -46,6 +46,7 @@ type Props = {
   readOnlyTemplate?: boolean;
   forcedApplicationType?: RewardApplicationType;
   rewardStatus?: BountyStatus | null;
+  isProposalTemplate?: boolean;
 };
 
 const getApplicationType = (values: UpdateableRewardFields, forcedApplicationType?: RewardApplicationType) => {
@@ -75,11 +76,13 @@ export function RewardPropertiesForm({
   templateId,
   readOnlyTemplate,
   forcedApplicationType,
-  rewardStatus
+  rewardStatus,
+  isProposalTemplate
 }: Props) {
   const [rewardApplicationType, setRewardApplicationTypeRaw] = useState<RewardApplicationType>(() =>
     getApplicationType(values, forcedApplicationType)
   );
+
   const { getFeatureTitle } = useSpaceFeatures();
   const [isDateTimePickerOpen, setIsDateTimePickerOpen] = useState(false);
   const [isExpanded, setIsExpanded] = useState(!!expandedByDefault);
@@ -295,13 +298,12 @@ export function RewardPropertiesForm({
                 open={isDateTimePickerOpen}
               />
             </Box>
-
             <Box display='flex' height='fit-content' flex={1} className='octo-propertyrow'>
               <PropertyLabel readOnly highlighted>
                 Application Type
               </PropertyLabel>
               <RewardApplicationType
-                readOnly={readOnly || !!forcedApplicationType}
+                readOnly={readOnly || !!forcedApplicationType || isProposalTemplate}
                 value={rewardApplicationType}
                 onChange={setRewardApplicationType}
               />
@@ -390,7 +392,7 @@ export function RewardPropertiesForm({
             )}
 
             {/* Select authors */}
-            {isAssignedReward && (
+            {isAssignedReward && !isProposalTemplate && (
               <Box display='flex' height='fit-content' flex={1} className='octo-propertyrow'>
                 <PropertyLabel readOnly required={!isTemplate && !readOnly} highlighted>
                   Assigned applicants

--- a/lib/proposal/createRewardsForProposal.ts
+++ b/lib/proposal/createRewardsForProposal.ts
@@ -66,11 +66,18 @@ export async function createRewardsForProposal({ proposalId, userId }: { userId:
     throw new InvalidStateError('There are no pending rewards for this proposal');
   }
 
+  const authors = await prisma.proposalAuthor.findMany({
+    where: {
+      proposalId: proposal.id
+    }
+  });
+
   let rewardsToCreate = [...pendingRewards];
   const rewardsPromises = rewardsToCreate.map(async ({ page, reward, draftId }) => {
     // create reward
     const { createdPageId } = await createReward({
       ...reward,
+      assignedSubmitters: reward.assignedSubmitters?.length ? reward.assignedSubmitters : authors.map((a) => a.userId),
       pageProps: page || {},
       spaceId: proposal.spaceId,
       userId,


### PR DESCRIPTION
### WHAT

Fix the proposal template so it can be saved as an reward, without immediately assigning the submitter

If assignee is changed, handle that. If not available, fall back to proposal authors

### WHY

<!-- why was this necessary? -->
