### PR TITLE
always retrieve reward blocks

### DIFF
--- a/hooks/useRewardBlocks.tsx
+++ b/hooks/useRewardBlocks.tsx
@@ -4,10 +4,8 @@ import { v4 } from 'uuid';
 
 import * as http from 'adapters/http';
 import { useDeleteRewardBlocks, useGetRewardBlocks, useUpdateRewardBlocks } from 'charmClient/hooks/rewards';
-import { useRewards } from 'components/rewards/hooks/useRewards';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useSnackbar } from 'hooks/useSnackbar';
-import type { Block } from 'lib/focalboard/block';
 import type { Board, BoardFields, IPropertyTemplate } from 'lib/focalboard/board';
 import type { BoardView } from 'lib/focalboard/boardView';
 import { DEFAULT_BOARD_BLOCK_ID } from 'lib/proposal/blocks/constants';
@@ -15,8 +13,7 @@ import type {
   RewardBlockInput,
   RewardBlockUpdateInput,
   RewardBlockWithTypedFields,
-  RewardPropertiesBlock,
-  RewardPropertiesBlockFields
+  RewardPropertiesBlock
 } from 'lib/rewards/blocks/interfaces';
 import { defaultRewardViews } from 'lib/rewards/blocks/views';
 
@@ -54,7 +51,6 @@ export const RewardBlocksContext = createContext<Readonly<RewardBlocksContextTyp
 
 export function RewardBlocksProvider({ children }: { children: ReactNode }) {
   const { space } = useCurrentSpace();
-  const { rewards } = useRewards();
   const { data: rewardBlocks, isLoading, mutate } = useGetRewardBlocks({ spaceId: space?.id });
   const { trigger: updateRewardBlocks } = useUpdateRewardBlocks(space?.id || '');
   const { trigger: deleteRewardBlocks } = useDeleteRewardBlocks(space?.id || '');

--- a/hooks/useRewardBlocks.tsx
+++ b/hooks/useRewardBlocks.tsx
@@ -55,11 +55,7 @@ export const RewardBlocksContext = createContext<Readonly<RewardBlocksContextTyp
 export function RewardBlocksProvider({ children }: { children: ReactNode }) {
   const { space } = useCurrentSpace();
   const { rewards } = useRewards();
-  const {
-    data: rewardBlocks,
-    isLoading,
-    mutate
-  } = useGetRewardBlocks({ spaceId: rewards?.length ? space?.id : undefined });
+  const { data: rewardBlocks, isLoading, mutate } = useGetRewardBlocks({ spaceId: space?.id });
   const { trigger: updateRewardBlocks } = useUpdateRewardBlocks(space?.id || '');
   const { trigger: deleteRewardBlocks } = useDeleteRewardBlocks(space?.id || '');
   const { showMessage } = useSnackbar();

--- a/pages/api/spaces/[id]/rewards/blocks/index.ts
+++ b/pages/api/spaces/[id]/rewards/blocks/index.ts
@@ -23,26 +23,15 @@ async function getRewardBlocksHandler(req: NextApiRequest, res: NextApiResponse<
   const spaceId = req.query.id as string;
   const blockId = req.query.blockId as string;
 
-  // Session may be undefined as non-logged in users can access this endpoint
-  const userId = req.session?.user?.id;
-
-  const { spaceRole } = await hasAccessToSpace({
-    spaceId,
-    userId
-  });
-
   const space = await prisma.space.findUniqueOrThrow({
     where: {
       id: spaceId
     },
     select: {
-      publicBountyBoard: true
+      publicBountyBoard: true,
+      publicProposals: true
     }
   });
-
-  if (!spaceRole && !space.publicBountyBoard) {
-    throw new ActionNotPermittedError(`You cannot access the rewards list`);
-  }
 
   const rewardBlocks = await getBlocks({
     spaceId,


### PR DESCRIPTION
If a user has no rewards, we were not requesting blocks from the DB at all. So anything they did would save but not appear when we requested teh blocks.

I also made it so we always allow access to the reward blocks of a space. I would have added another excpetion if you have public proposals, but this is just configuration and probably not a big deal. 