### PR TITLE
Fix empty tag not showing in details

### DIFF
--- a/components/common/BoardEditor/components/properties/TagSelect/TagSelect.tsx
+++ b/components/common/BoardEditor/components/properties/TagSelect/TagSelect.tsx
@@ -225,7 +225,7 @@ export function TagSelect({
         options={selectOptions}
         size='small'
         emptyMessage={props.emptyMessage}
-        showEmpty={showEmpty}
+        showEmpty={showEmpty || displayType === 'details'}
       />
     </SelectPreviewContainer>
   );


### PR DESCRIPTION
### WHAT

Fix empty multiselect in card details view

### WHY

<!-- why was this necessary? -->
