### PR TITLE
Remove goerli url for gnosis safe

### DIFF
--- a/connectors/chains.ts
+++ b/connectors/chains.ts
@@ -95,7 +95,6 @@ const RPC: Record<string, IChainDetails> = {
     alchemyUrl: 'https://eth-goerli.g.alchemy.com',
     rpcUrls: ['https://goerli-light.eth.linkpool.io/'],
     blockExplorerUrls: ['https://goerli.etherscan.io/'],
-    gnosisUrl: 'https://safe-transaction-goerli.safe.global',
     iconUrl: '/images/cryptoLogos/ethereum-eth-logo.svg',
     testnet: true,
     shortName: 'gor',


### PR DESCRIPTION
The url https://safe-transaction-goerli.safe.global doesn't work anymore to get the users safes.