### PR TITLE
Fix for adding rewards to a proposal

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/AttachRewardButton.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/AttachRewardButton.tsx
@@ -31,17 +31,19 @@ export function AttachRewardButton({
 
 export function getDisabledTooltip({
   newPageValues,
-  rewardValues
+  rewardValues,
+  isProposalTemplate
 }: {
   newPageValues: NewPageValues | null;
   rewardValues: UpdateableRewardFields;
+  isProposalTemplate: boolean;
 }) {
   let disabledTooltip: string | undefined;
   if (!newPageValues?.title) {
     disabledTooltip = 'Page title is required';
   } else if (!rewardValues.reviewers?.length) {
     disabledTooltip = 'Reviewer is required';
-  } else if (rewardValues.assignedSubmitters && rewardValues.assignedSubmitters.length === 0) {
+  } else if ((rewardValues.assignedSubmitters && rewardValues.assignedSubmitters.length === 0) || isProposalTemplate) {
     disabledTooltip = 'You need to assign at least one submitter';
   }
 

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/AttachRewardButton.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/AttachRewardButton.tsx
@@ -31,19 +31,17 @@ export function AttachRewardButton({
 
 export function getDisabledTooltip({
   newPageValues,
-  rewardValues,
-  isProposalTemplate
+  rewardValues
 }: {
   newPageValues: NewPageValues | null;
   rewardValues: UpdateableRewardFields;
-  isProposalTemplate?: boolean;
 }) {
   let disabledTooltip: string | undefined;
   if (!newPageValues?.title) {
     disabledTooltip = 'Page title is required';
   } else if (!rewardValues.reviewers?.length) {
     disabledTooltip = 'Reviewer is required';
-  } else if (rewardValues.assignedSubmitters && rewardValues.assignedSubmitters.length && !isProposalTemplate) {
+  } else if (rewardValues.assignedSubmitters && rewardValues.assignedSubmitters.length === 0) {
     disabledTooltip = 'You need to assign at least one submitter';
   }
 

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/AttachRewardButton.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/AttachRewardButton.tsx
@@ -43,7 +43,7 @@ export function getDisabledTooltip({
     disabledTooltip = 'Page title is required';
   } else if (!rewardValues.reviewers?.length) {
     disabledTooltip = 'Reviewer is required';
-  } else if ((rewardValues.assignedSubmitters && rewardValues.assignedSubmitters.length === 0) || isProposalTemplate) {
+  } else if (rewardValues.assignedSubmitters && rewardValues.assignedSubmitters.length === 0 && !isProposalTemplate) {
     disabledTooltip = 'You need to assign at least one submitter';
   }
 

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
@@ -245,20 +245,22 @@ export function ProposalRewards({
                         </Grid>
                       </Hidden>
 
-                      <Grid item xs={4} lg={2}>
-                        <Stack className='icons' sx={{ opacity: 0, transition: 'opacity 0.2s ease' }} direction='row'>
-                          <IconButton
-                            size='small'
-                            onClick={() => editReward({ reward, page, draftId })}
-                            disabled={readOnly}
-                          >
-                            <Edit color='secondary' fontSize='small' />
-                          </IconButton>
-                          <IconButton size='small' onClick={() => onDelete(draftId)} disabled={readOnly}>
-                            <Delete color='secondary' fontSize='small' />
-                          </IconButton>
-                        </Stack>
-                      </Grid>
+                      {!readOnly && (
+                        <Grid item xs={4} lg={2}>
+                          <Stack className='icons' sx={{ opacity: 0, transition: 'opacity 0.2s ease' }} direction='row'>
+                            <IconButton
+                              size='small'
+                              onClick={() => editReward({ reward, page, draftId })}
+                              disabled={readOnly}
+                            >
+                              <Edit color='secondary' fontSize='small' />
+                            </IconButton>
+                            <IconButton size='small' onClick={() => onDelete(draftId)} disabled={readOnly}>
+                              <Delete color='secondary' fontSize='small' />
+                            </IconButton>
+                          </Stack>
+                        </Grid>
+                      )}
                     </Grid>
                   </Stack>
                 </SelectPreviewContainer>
@@ -277,7 +279,7 @@ export function ProposalRewards({
 
       <NewPageDialog
         contentUpdated={contentUpdated || isDirty}
-        disabledTooltip={getDisabledTooltip({ newPageValues, rewardValues, isProposalTemplate })}
+        disabledTooltip={getDisabledTooltip({ newPageValues, rewardValues })}
         isOpen={!!newPageValues}
         onClose={closeDialog}
         onSave={saveForm}

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
@@ -279,7 +279,7 @@ export function ProposalRewards({
 
       <NewPageDialog
         contentUpdated={contentUpdated || isDirty}
-        disabledTooltip={getDisabledTooltip({ newPageValues, rewardValues })}
+        disabledTooltip={getDisabledTooltip({ newPageValues, rewardValues, isProposalTemplate: !!isProposalTemplate })}
         isOpen={!!newPageValues}
         onClose={closeDialog}
         onSave={saveForm}


### PR DESCRIPTION
I tried to add a reward to a proposal but it was telling me I needed to assign reviewers. I think checking for isProposalTemplate was added originally because we would make an exception and save them on the backend.