### PR TITLE
deep clone evaluation steps when editing

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/EvaluationsReview.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/EvaluationsReview.tsx
@@ -1,4 +1,5 @@
 import { Collapse, Divider, Tooltip } from '@mui/material';
+import { cloneDeep } from 'lodash';
 import { useEffect, useState } from 'react';
 
 import LoadingComponent from 'components/common/LoadingComponent';
@@ -77,6 +78,11 @@ export function EvaluationsReview({
 
   const previousStepIndex = adjustedCurrentEvaluationIndex > 0 ? adjustedCurrentEvaluationIndex - 1 : null;
 
+  function openSettings(evaluation: ProposalEvaluationValues) {
+    // use clone deep to avoid changing deeply-nested objects like rubric criteria
+    setEvaluationInput(cloneDeep(evaluation));
+  }
+
   function closeSettings() {
     setEvaluationInput(null);
   }
@@ -153,7 +159,7 @@ export function EvaluationsReview({
                 proposalId={proposal?.id}
                 refreshProposal={refreshProposal}
                 evaluation={evaluation}
-                openSettings={() => setEvaluationInput({ ...evaluation })}
+                openSettings={() => openSettings(evaluation)}
               />
             }
           >


### PR DESCRIPTION
Fixes a bug where the rubric criteria details update in the sidebar before you click Save in the settings popup

![image](https://github.com/charmverse/app.charmverse.io/assets/305398/abf87b10-56df-4b0b-a20c-aea036c8efb8)
