### PR TITLE
dont throw an error if private key does not exist for credentials

### DIFF
--- a/lib/credentials/queriesAndMutations.ts
+++ b/lib/credentials/queriesAndMutations.ts
@@ -123,7 +123,10 @@ export async function getCharmverseCredentialsByWallets({
 }: {
   wallets: string[];
 }): Promise<EASAttestationWithFavorite[]> {
-  const credentialWalletAddress = new Wallet(credentialsWalletPrivateKey as string).address.toLowerCase();
+  if (typeof credentialsWalletPrivateKey !== 'string') {
+    return [];
+  }
+  const credentialWalletAddress = new Wallet(credentialsWalletPrivateKey).address.toLowerCase();
   if (!wallets.length) {
     return [];
   }


### PR DESCRIPTION
I am getting this locally when looking at member profile settings. It could also be a warning, but i just return an empty list instead to reduce noise. lemme know if u want a warning:
```
 error: Error loading Charmverse Ceramic credentials for user 96cb5266-c546-4db8-8b3e-25551c118eb0 {
[next]   error: TypeError: Cannot read properties of undefined (reading 'toHexString')
[next]       at isHexable (/Users/matt/charmverse/app.charmverse.io/node_modules/@ethersproject/bytes/lib/index.js:9:21)
[next]       at hexlify (/Users/matt/charmverse/app.charmverse.io/node_modules/@ethersproject/bytes/lib/index.js:175:9)
[next]       at new SigningKey (/Users/matt/charmverse/app.charmverse.io/node_modules/@ethersproject/signing-key/lib/index.js:20:82)
[next]       at new Wallet (/Users/matt/charmverse/app.charmverse.io/node_modules/@ethersproject/wallet/lib/index.js:120:36)
[next]       at getCharmverseCredentialsByWallets (webpack-internal:///(api)/./lib/credentials/queriesAndMutations.ts:97:37)
[next]       at getAllUserCredentials (webpack-internal:///(api)/./lib/credentials/getAllUserCredentials.ts:41:96)
[next]       at async Array.getCredentialsController (webpack-internal:///(api)/./pages/api/credentials/index.ts:26:25),
[next]   userId: '96cb5266-c546-4db8-8b3e-25551c118eb0'
[next] }
```