### PR TITLE
Fix non-logged in user redirect

### DIFF
--- a/lib/session/__tests__/getDefaultPageForSpace.spec.ts
+++ b/lib/session/__tests__/getDefaultPageForSpace.spec.ts
@@ -206,7 +206,7 @@ describe('getDefaultPageForSpace - non logged in user', () => {
 
     const redirect = await getDefaultPageForSpace({ space: updatedSpace, userId: undefined });
 
-    expect(redirect).toEqual(`join?domain=${updatedSpace.domain}`);
+    expect(redirect).toEqual(null);
   });
 
   it('should return the join page if there is no home page', async () => {
@@ -214,7 +214,19 @@ describe('getDefaultPageForSpace - non logged in user', () => {
 
     const redirect = await getDefaultPageForSpace({ space, userId: undefined });
 
-    expect(redirect).toEqual(`join?domain=${space.domain}`);
+    expect(redirect).toEqual(null);
+  });
+
+  it('should return main custom domain page (login) if there is no homepage', async () => {
+    const { space, user } = await testUtilsUser.generateUserAndSpace();
+    const updatedSpace = await prisma.space.update({
+      where: { id: space.id },
+      data: { customDomain: 'test.charm.fyi' }
+    });
+
+    const redirect = await getDefaultPageForSpace({ space: updatedSpace, userId: undefined, host: 'test.charm.fyi' });
+
+    expect(redirect).toEqual(null);
   });
 });
 

--- a/pages/[domain]/index.tsx
+++ b/pages/[domain]/index.tsx
@@ -35,7 +35,15 @@ export const getServerSideProps: GetServerSideProps = withSessionSsr(async (cont
 
   // 2. send user to default page for the space
 
-  let destination = await getDefaultPageForSpace({ host: context.req.headers.host, space, userId: sessionUserId });
+  const pageRedirect = await getDefaultPageForSpace({ host: context.req.headers.host, space, userId: sessionUserId });
+
+  if (pageRedirect == null) {
+    return {
+      props: {}
+    };
+  }
+
+  let destination = pageRedirect;
 
   // append existing query params, lie 'account' or 'subscription'
   Object.keys(context.query).forEach((key) => {


### PR DESCRIPTION
### WHAT

Non logged in users ended up on space join page instead of login.

Update for non logged in user flow 
- if there is no public homepage return null instead of  redirect path
- in server side props fallback to original logic (return empty props) if redirect is null
- this will use route guard to redirect to login on the frontend

### WHY

<!-- why was this necessary? -->
