### PR TITLE
Update mixpanel space profiles with block counts

### DIFF
--- a/background/cron.ts
+++ b/background/cron.ts
@@ -1,6 +1,8 @@
 import { log } from '@charmverse/core/log';
 import cron from 'node-cron';
 
+import { updateSpacesMixpanelProfilesTask } from 'background/tasks/updateSpacesMixpanelProfilesTask';
+
 import app from './healthCheck/app';
 import { countAllSpacesBlocksTask } from './tasks/countAllSpacesBlocksTask';
 import { task as archiveTask } from './tasks/deleteArchivedPages';
@@ -33,6 +35,7 @@ cron.schedule('*/30 * * * *', refreshBountyApplications);
 
 // Count blocks in all spaces
 cron.schedule('*/30 * * * *', countAllSpacesBlocksTask);
+cron.schedule('*/30 * * * *', updateSpacesMixpanelProfilesTask);
 
 // Sync summon space roles every day at midnight
 cron.schedule('0 0 * * *', syncSummonSpacesRoles);

--- a/background/cron.ts
+++ b/background/cron.ts
@@ -35,7 +35,9 @@ cron.schedule('*/30 * * * *', refreshBountyApplications);
 
 // Count blocks in all spaces
 cron.schedule('*/30 * * * *', countAllSpacesBlocksTask);
-cron.schedule('*/30 * * * *', updateSpacesMixpanelProfilesTask);
+
+// Update space mixpanel profiles once a day at 1am
+cron.schedule('0 1 * * *', updateSpacesMixpanelProfilesTask);
 
 // Sync summon space roles every day at midnight
 cron.schedule('0 0 * * *', syncSummonSpacesRoles);

--- a/background/tasks/updateSpacesMixpanelProfilesTask.ts
+++ b/background/tasks/updateSpacesMixpanelProfilesTask.ts
@@ -1,0 +1,46 @@
+import { prisma } from '@charmverse/core/prisma-client';
+
+import {
+  updateMixpanelGroupProfiles,
+  type SpaceWithMixpanelProfile
+} from 'lib/metrics/mixpanel/updateMixpanelGroupProfiles';
+import { getTrackGroupProfile } from 'lib/metrics/mixpanel/updateTrackGroupProfile';
+import { getSpaceBlockCount } from 'lib/spaces/getSpaceBlockCount';
+
+const perBatch = 1000;
+export async function updateSpacesMixpanelProfiles({ offset = 0 }: { offset?: number } = {}): Promise<void> {
+  // Load limited number of spaces at a time
+  const spaces = await prisma.space.findMany({
+    skip: offset,
+    take: perBatch,
+    orderBy: {
+      id: 'asc'
+    }
+  });
+
+  const spaceProfiles: SpaceWithMixpanelProfile[] = [];
+
+  for (const space of spaces) {
+    let blockCount = 0;
+    try {
+      const blockCountInfo = await getSpaceBlockCount({ spaceId: space.id });
+      blockCount = blockCountInfo.count;
+    } catch (e) {
+      // no block information
+    }
+
+    const profile = getTrackGroupProfile({ space, blockCount });
+    spaceProfiles.push({ space, profile });
+  }
+
+  await updateMixpanelGroupProfiles(spaceProfiles);
+
+  if (spaces.length > 0) {
+    return updateSpacesMixpanelProfiles({ offset: offset + perBatch });
+  }
+}
+
+export async function updateSpacesMixpanelProfilesTask(): Promise<void> {
+  // Wrapped function since Cron will call the method with the date
+  await updateSpacesMixpanelProfiles();
+}

--- a/lib/metrics/mixpanel/updateMixpanelGroupProfiles.ts
+++ b/lib/metrics/mixpanel/updateMixpanelGroupProfiles.ts
@@ -1,0 +1,42 @@
+import { POST } from '@charmverse/core/http';
+import { log } from '@charmverse/core/log';
+import type { Space } from '@charmverse/core/prisma-client';
+
+import type { MixPanelSpaceProfile } from 'lib/metrics/mixpanel/updateTrackGroupProfile';
+
+const mixpanelApiKey = process.env.MIXPANEL_API_KEY;
+
+// Mixpanel sdk does not support batch group updates so we need to build request manually
+// https://developer.mixpanel.com/reference/group-batch-update
+
+const BATCH_UPDATE_URL = 'https://api.mixpanel.com/groups#group-batch-update';
+const DEFAULT_HEADERS = {
+  Accept: 'text/plain',
+  'Content-Type': 'application/json'
+};
+
+export type SpaceWithMixpanelProfile = {
+  space: Space;
+  profile: MixPanelSpaceProfile;
+};
+
+export async function updateMixpanelGroupProfiles(profiles: SpaceWithMixpanelProfile[]) {
+  if (!mixpanelApiKey) {
+    throw new Error('MIXPANEL_API_KEY is not set');
+  }
+
+  const data = profiles.map(({ space, profile }) => {
+    return {
+      $token: mixpanelApiKey,
+      $group_key: 'Space Id',
+      $group_id: space.id,
+      $set: profile
+    };
+  });
+
+  try {
+    await POST(BATCH_UPDATE_URL, data, { headers: DEFAULT_HEADERS });
+  } catch (e) {
+    log.warn('Failed to  batch update mixpanel group profiles', { error: e });
+  }
+}

--- a/lib/metrics/mixpanel/updateTrackGroupProfile.ts
+++ b/lib/metrics/mixpanel/updateTrackGroupProfile.ts
@@ -3,24 +3,33 @@ import type { Space } from '@charmverse/core/prisma';
 
 import { mixpanel } from './mixpanel';
 
-type MixPanelSpaceProfile = {
+export type MixPanelSpaceProfile = {
   $created: string | Date;
   $name: string;
   'Space Created By': string;
   'Space Updated At': string | Date;
   'Space Block Quota': number;
+  'Space Block Count'?: number;
   'Space Origin'?: string;
 };
 
 export async function updateTrackGroupProfile(space: Space, spaceOrigin?: string) {
   try {
-    mixpanel?.groups.set('Space Id', space.id, getTrackGroupProfile(space, spaceOrigin));
+    mixpanel?.groups.set('Space Id', space.id, getTrackGroupProfile({ space, spaceOrigin }));
   } catch (e) {
     log.warn(`Failed to update mixpanel profile for group id ${space.id}`);
   }
 }
 
-export function getTrackGroupProfile(space: Space, spaceOrigin?: string) {
+export function getTrackGroupProfile({
+  space,
+  spaceOrigin,
+  blockCount
+}: {
+  space: Space;
+  spaceOrigin?: string;
+  blockCount?: number;
+}) {
   const spaceProfile: MixPanelSpaceProfile = {
     $created: space.createdAt,
     $name: space.name,
@@ -28,6 +37,10 @@ export function getTrackGroupProfile(space: Space, spaceOrigin?: string) {
     'Space Updated At': space.updatedAt,
     'Space Block Quota': space.blockQuota
   };
+
+  if (blockCount) {
+    spaceProfile['Space Block Count'] = blockCount;
+  }
 
   if (spaceOrigin) {
     spaceProfile['Space Origin'] = spaceOrigin;

--- a/scripts/updateMixpanelBlockCounts.ts
+++ b/scripts/updateMixpanelBlockCounts.ts
@@ -1,0 +1,9 @@
+import { updateSpacesMixpanelProfilesTask } from "background/tasks/updateSpacesMixpanelProfilesTask";
+
+export async function updateMixpanelBlockCounts() {
+  await updateSpacesMixpanelProfilesTask();
+}
+
+updateMixpanelBlockCounts().then(() => {
+  console.log('Done.')
+})


### PR DESCRIPTION
### WHAT

Update mixpanel space profiles with block counts  in a cron job. It uses mixpanel batch endpoint to update 1000 spaces at time