### PR TITLE
optimize the loading of page links if usePages is not loaded yet

### DIFF
--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -137,7 +137,7 @@ export default function NestedPage({ isLinkedPage = false, node, getPos }: NodeV
           />
         )}
       </div>
-      <StyledTypography>{pageTitle}</StyledTypography>
+      <StyledTypography>{pageTitle || ' '}</StyledTypography>
     </NestedPageContainer>
   );
 }


### PR DESCRIPTION
WHY
There can be significant delay waiting for pages to load, 100ms vs 1 second and Alex/Xandra asked if we could do something so that links to pages would show the titles faster. 

WHAT
I have a race between the requests to pages and getting a single page if pages have not loaded yet. Once they have loaded, we won't try to retrieve individual pages. Tested this by adding a timeout in the pages endpoint