### PR TITLE
Wrapping text form fields

### DIFF
--- a/components/common/form/FormField.tsx
+++ b/components/common/form/FormField.tsx
@@ -167,6 +167,8 @@ function ExpandedFormField({
         focusOnInit={false}
       />
       <FieldTypeRenderer
+        rows={undefined}
+        maxRows={10}
         type={formField.type as any}
         onCreateOption={onCreateOption}
         onDeleteOption={onDeleteOption}

--- a/components/common/form/FormFieldsInput.tsx
+++ b/components/common/form/FormFieldsInput.tsx
@@ -160,6 +160,8 @@ function FormFieldsInputBase({
               render={({ field }) => (
                 <FieldTypeRenderer
                   {...field}
+                  rows={undefined}
+                  maxRows={10}
                   value={(field.value ?? '') as FormFieldValue}
                   placeholder={fieldTypePlaceholderRecord[formField.type]}
                   labelEndAdornment={
@@ -193,7 +195,7 @@ function FormFieldsInputBase({
                   }
                   description={formField.description as PageContent}
                   disabled={disabled}
-                  type={formField.type}
+                  type={formField.type === 'short_text' ? 'text_multiline' : formField.type}
                   label={formField.name}
                   options={formField.options as SelectOptionType[]}
                   error={errors[formField.id] as any}

--- a/components/common/form/fields/FieldTypeRenderer.tsx
+++ b/components/common/form/fields/FieldTypeRenderer.tsx
@@ -10,6 +10,11 @@ import { DateInputField } from './DateInputField';
 import { LabelField } from './LabelField';
 import { PersonInputField } from './PersonInputField';
 
+type TextInputConfig = {
+  rows?: number;
+  maxRows?: number;
+};
+
 type TextProps = {
   type: Exclude<FieldType, 'select' | 'multiselect'>;
 } & FieldProps &
@@ -20,7 +25,10 @@ type SelectProps = {
 } & FieldProps &
   Required<ControlFieldProps>;
 
-type Props = TextProps | SelectProps;
+type Props = (Omit<TextProps, 'type'> | Omit<SelectProps, 'type'>) & {
+  type: FieldType;
+  textInputConfig?: TextInputConfig;
+} & TextInputConfig;
 
 export const FieldTypeRenderer = forwardRef<HTMLDivElement, Props>(
   ({ type, options, onCreateOption, onDeleteOption, onUpdateOption, ...fieldProps }: Props, ref) => {
@@ -31,13 +39,13 @@ export const FieldTypeRenderer = forwardRef<HTMLDivElement, Props>(
       case 'phone':
       case 'short_text':
       case 'wallet': {
-        return <TextInputField {...fieldProps} ref={ref} />;
+        return <TextInputField rows={1} maxRows={1} {...fieldProps} ref={ref} multiline />;
       }
       case 'long_text': {
         return <CharmEditorInputField {...fieldProps} />;
       }
       case 'text_multiline': {
-        return <TextInputField {...fieldProps} ref={ref} multiline rows={3} />;
+        return <TextInputField rows={3} {...fieldProps} ref={ref} multiline />;
       }
       case 'number': {
         return <NumberInputField {...fieldProps} fullWidth ref={ref} />;

--- a/components/common/form/fields/TextInputField.tsx
+++ b/components/common/form/fields/TextInputField.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from 'react';
 import { FieldWrapper } from 'components/common/form/fields/FieldWrapper';
 import type { ControlFieldProps, FieldProps } from 'components/common/form/interfaces';
 
-type Props = ControlFieldProps & FieldProps & { multiline?: boolean; rows?: number };
+type Props = ControlFieldProps & FieldProps & { multiline?: boolean; rows?: number; maxRows?: number };
 
 export const TextInputField = forwardRef<HTMLDivElement, Props>(
   (


### PR DESCRIPTION
https://app.charmverse.io/charmverse/short-text-in-form-fields-should-wrap-4928057783714157

Added a way to simply override rows / maxRows in text field renderer. Setting them to undefined will default to multiline text input with 1 line by default

<img width="624" alt="Screenshot 2024-02-08 at 11 52 34" src="https://github.com/charmverse/app.charmverse.io/assets/5198394/816e7fbe-dfe0-4037-a256-0b87a834f7ed">
