### PR TITLE
Bug fix for propoals words in Credentials

### DIFF
--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -5,21 +5,24 @@ import { usePopupState, bindMenu, bindTrigger } from 'material-ui-popup-state/ho
 import type { ReactNode } from 'react';
 
 export type ContextMenuProps = Pick<MenuProps, 'anchorOrigin' | 'transformOrigin'> & {
+  iconColor?: 'secondary';
+  iconSize?: 'small';
   popupId: string;
   children: ReactNode;
 };
 
-export function ContextMenu({ popupId, children, ...menuProps }: ContextMenuProps) {
+export function ContextMenu({ iconColor, iconSize, popupId, children, ...menuProps }: ContextMenuProps) {
   const popupState = usePopupState({ variant: 'popover', popupId });
 
+  // Wrapping in a div ensures that IconButton is a full circle and not an oval in some flex situations
   return (
-    <>
+    <div>
       <IconButton size='small' {...bindTrigger(popupState)}>
-        <MoreHoriz fontSize='small' />
+        <MoreHoriz color={iconColor} fontSize={iconSize} />
       </IconButton>
       <Menu {...bindMenu(popupState)} onClick={popupState.close} {...menuProps}>
         {children}
       </Menu>
-    </>
+    </div>
   );
 }

--- a/components/common/PageLayout/components/LoggedOutButtons.tsx
+++ b/components/common/PageLayout/components/LoggedOutButtons.tsx
@@ -20,6 +20,7 @@ export function LoggedOutButtons() {
   return (
     <Box display='flex'>
       <ContextMenu
+        iconSize='small'
         popupId='user-menu'
         anchorOrigin={{
           vertical: 'bottom',

--- a/components/settings/credentials/components/CredentialEventToggle.tsx
+++ b/components/settings/credentials/components/CredentialEventToggle.tsx
@@ -2,7 +2,9 @@ import type { CredentialEventType } from '@charmverse/core/prisma';
 import { Box, FormControlLabel, Switch } from '@mui/material';
 
 import { Typography } from 'components/common/Typography';
+import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
 import { credentialLabelMap } from 'lib/credentials/constants';
+import type { FeatureTitleVariation } from 'lib/features/getFeatureTitle';
 
 export type CredentialToggled = {
   credentialEvent: CredentialEventType;
@@ -15,12 +17,16 @@ type ToggleProps = {
   disabled?: boolean;
   credentialEvent: CredentialEventType;
 };
-export const credentialDescriptionMap: Record<CredentialEventType, string> = {
-  proposal_created: 'Issue when a proposal is published',
-  proposal_approved: 'Issue when a proposal is approved'
+
+type LabelFn = (getFeatureTitle: (featureWord: FeatureTitleVariation) => string) => string;
+
+const credentialDescriptionMap: Partial<Record<CredentialEventType, LabelFn>> = {
+  proposal_created: (map) => `Issue when a ${map('proposal')} is published`,
+  proposal_approved: (map) => `Issue when a ${map('proposal')} is approved`
 };
 
 export function CredentialEventToggle({ checked, onChange, disabled, credentialEvent }: ToggleProps) {
+  const { getFeatureTitle } = useSpaceFeatures();
   return (
     <Box display='flex' justifyContent='flex-start' alignItems='center' gap={2}>
       <FormControlLabel
@@ -42,12 +48,12 @@ export function CredentialEventToggle({ checked, onChange, disabled, credentialE
         }
         label={
           <Typography fontWeight='bold' sx={{ minWidth: '100px' }}>
-            {credentialLabelMap[credentialEvent]}
+            {credentialLabelMap[credentialEvent]?.(getFeatureTitle)}
           </Typography>
         }
         labelPlacement='end'
       />
-      <Typography>{credentialDescriptionMap[credentialEvent]}</Typography>
+      <Typography>{credentialDescriptionMap[credentialEvent]?.(getFeatureTitle)}</Typography>
     </Box>
   );
 }

--- a/components/settings/credentials/components/CredentialTemplateDialog.tsx
+++ b/components/settings/credentials/components/CredentialTemplateDialog.tsx
@@ -143,14 +143,13 @@ function CredentialTemplateForm({
             />
           </Box>
           <ProposalCredentialPreview credential={getValues() as ProposalCredentialToPreview} />
-          <Stack flexDirection='row' gap={1} justifyContent='flex-start'>
+          <Stack flexDirection='row' gap={1} justifyContent='flex-end'>
             <Button loading={isSaving} size='large' type='submit' disabled={Object.keys(errors).length !== 0}>
               Save
             </Button>
           </Stack>
         </Stack>
       </form>
-      <Divider />
     </Box>
   );
 }

--- a/components/settings/credentials/components/CredentialTemplateDialog.tsx
+++ b/components/settings/credentials/components/CredentialTemplateDialog.tsx
@@ -142,7 +142,7 @@ function CredentialTemplateForm({
               onChange={(events) => setValue('credentialEvents', events)}
             />
           </Box>
-          {isValid && <ProposalCredentialPreview credential={getValues() as ProposalCredentialToPreview} />}
+          <ProposalCredentialPreview credential={getValues() as ProposalCredentialToPreview} />
           <Stack flexDirection='row' gap={1} justifyContent='flex-start'>
             <Button loading={isSaving} size='large' type='submit' disabled={Object.keys(errors).length !== 0}>
               Save

--- a/components/settings/credentials/components/CredentialTemplateRow.tsx
+++ b/components/settings/credentials/components/CredentialTemplateRow.tsx
@@ -1,16 +1,16 @@
 import type { CredentialTemplate } from '@charmverse/core/prisma-client';
-import { useTheme } from '@emotion/react';
 import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import MedalIcon from '@mui/icons-material/WorkspacePremium';
-import { Box, IconButton, ListItemButton, ListItemText, Popover, Tooltip, useMediaQuery } from '@mui/material';
+import { Box, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
 import Chip from '@mui/material/Chip';
 import { usePopupState } from 'material-ui-popup-state/hooks';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 
+import { ContextMenu } from 'components/common/ContextMenu';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
 import { useIsAdmin } from 'hooks/useIsAdmin';
+import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
 import { credentialLabelMap } from 'lib/credentials/constants';
 
 export function CredentialTemplateRow({
@@ -22,7 +22,7 @@ export function CredentialTemplateRow({
   onClickEdit: (template: CredentialTemplate) => void;
   onClickDelete: (templateId: string) => void;
 }) {
-  const theme = useTheme();
+  const { getFeatureTitle } = useSpaceFeatures();
 
   const isAdmin = useIsAdmin();
 
@@ -32,13 +32,7 @@ export function CredentialTemplateRow({
     open: openDeleteDialog
   } = usePopupState({ variant: 'popover', popupId: 'credential-delete-popup' });
 
-  const isLargeScreen = useMediaQuery(theme.breakpoints.up('md'));
   const pageMenuAnchor = useRef();
-  const [pageMenuAnchorElement, setPageMenuAnchorElement] = useState<null | Element>(null);
-
-  function closeMenu() {
-    setPageMenuAnchorElement(null);
-  }
 
   return (
     <Box display='flex' justifyContent='space-between'>
@@ -47,64 +41,31 @@ export function CredentialTemplateRow({
         {template.name}
         <Box sx={{ ml: 2 }} gap={2} display='flex'>
           {template.credentialEvents.map((ev) => (
-            <Chip key={ev} label={credentialLabelMap[ev]} variant='outlined' size='small' />
+            <Chip key={ev} label={credentialLabelMap[ev]?.(getFeatureTitle)} variant='outlined' size='small' />
           ))}
         </Box>
       </Box>
       <Box ref={pageMenuAnchor} display='flex' alignSelf='stretch' alignItems='center'>
-        <div>
-          <Tooltip title='View comments, export content and more' arrow>
-            <IconButton
-              size={isLargeScreen ? 'small' : 'medium'}
-              onClick={() => {
-                setPageMenuAnchorElement(pageMenuAnchor.current || null);
-              }}
-            >
-              <MoreHorizIcon data-test='header--show-page-actions' color='secondary' />
-            </IconButton>
-          </Tooltip>
-        </div>
-        <Popover
-          anchorEl={pageMenuAnchorElement}
-          open={!!pageMenuAnchorElement}
-          onClose={closeMenu}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'left'
-          }}
-        >
-          <Box>
-            <div>
-              <ListItemButton
-                data-test='edit-credential-template'
-                disabled={!isAdmin}
-                onClick={() => {
-                  setPageMenuAnchorElement(null);
-                  onClickEdit(template);
-                }}
-              >
-                <EditOutlinedIcon
-                  fontSize='small'
-                  sx={{
-                    mr: 1
-                  }}
-                />
-                <ListItemText primary='Edit' />
-              </ListItemButton>
-            </div>
-            <div>
-              <ListItemButton data-test='delete-credential-template' disabled={!isAdmin} onClick={openDeleteDialog}>
-                <DeleteOutlineOutlinedIcon
-                  fontSize='small'
-                  sx={{
-                    mr: 1
-                  }}
-                />
-                <ListItemText primary='Delete' />
-              </ListItemButton>
-            </div>
-          </Box>
-        </Popover>
+        <ContextMenu iconColor='secondary' popupId='credential-context'>
+          <MenuItem
+            data-test='edit-credential-template'
+            disabled={!isAdmin}
+            onClick={() => {
+              onClickEdit(template);
+            }}
+          >
+            <ListItemIcon>
+              <EditOutlinedIcon />
+            </ListItemIcon>
+            <ListItemText primary='Edit' />
+          </MenuItem>
+          <MenuItem data-test='delete-credential-template' disabled={!isAdmin} onClick={openDeleteDialog}>
+            <ListItemIcon>
+              <DeleteOutlineOutlinedIcon />
+            </ListItemIcon>
+            <ListItemText primary='Delete' />
+          </MenuItem>
+        </ContextMenu>
       </Box>
       <ConfirmDeleteModal
         title='Delete credential template'
@@ -115,10 +76,4 @@ export function CredentialTemplateRow({
       />
     </Box>
   );
-
-  // if (isBasePageDocument || isBasePageDatabase || isForumPost) {
-  //   return (
-
-  //   );
-  //   );
 }

--- a/components/settings/credentials/components/ProposalCredentialPreview.tsx
+++ b/components/settings/credentials/components/ProposalCredentialPreview.tsx
@@ -3,9 +3,9 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-import { v4 as uuid } from 'uuid';
 
 import Link from 'components/common/Link';
+import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
 import { getEasConnector } from 'lib/credentials/connectors';
 import { attestationSchemaIds } from 'lib/credentials/schemas';
 
@@ -16,6 +16,7 @@ type Props = {
 };
 
 export function ProposalCredentialPreview({ credential }: Props) {
+  const { getFeatureTitle } = useSpaceFeatures();
   const proposalSchemaUrl = `${getEasConnector(10).attestationExplorerUrl}/schema/view/${
     attestationSchemaIds.proposal[10]
   }`;
@@ -58,7 +59,7 @@ export function ProposalCredentialPreview({ credential }: Props) {
           </Grid>
           <Grid item xs>
             <Typography variant='body2'>
-              <b>URL:</b> [Link to proposal]
+              <b>URL:</b> [Link to {getFeatureTitle('proposal')}]
             </Typography>
           </Grid>
         </Grid>

--- a/components/settings/credentials/components/ProposalCredentialPreview.tsx
+++ b/components/settings/credentials/components/ProposalCredentialPreview.tsx
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography';
 import Link from 'components/common/Link';
 import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
 import { getEasConnector } from 'lib/credentials/connectors';
+import { credentialLabelMap } from 'lib/credentials/constants';
 import { attestationSchemaIds } from 'lib/credentials/schemas';
 
 export type ProposalCredentialToPreview = Pick<CredentialTemplate, 'name' | 'description' | 'organization'>;
@@ -54,7 +55,7 @@ export function ProposalCredentialPreview({ credential }: Props) {
           </Grid>
           <Grid item xs>
             <Typography variant='body2'>
-              <b>Status:</b> Applied
+              <b>Status:</b> {credentialLabelMap.proposal_approved?.(getFeatureTitle)}
             </Typography>
           </Grid>
           <Grid item xs>

--- a/components/settings/space/components/SettingsItem.tsx
+++ b/components/settings/space/components/SettingsItem.tsx
@@ -31,8 +31,13 @@ export function SettingsItem({
       disableGutters
       secondaryAction={
         !!actions && (
-          <IconButton aria-label='Open identity options' disabled={disabled} {...bindTrigger(identityMenuState)}>
-            <MoreHoriz />
+          <IconButton
+            aria-label='Open identity options'
+            size='small'
+            disabled={disabled}
+            {...bindTrigger(identityMenuState)}
+          >
+            <MoreHoriz color='secondary' fontSize='small' />
           </IconButton>
         )
       }

--- a/hooks/useSpaceFeatures.ts
+++ b/hooks/useSpaceFeatures.ts
@@ -9,18 +9,17 @@ import { getFeatureTitle } from 'lib/features/getFeatureTitle';
 export const useSpaceFeatures = () => {
   const { space, isLoading } = useCurrentSpace();
 
+  const spaceFeatures = useMemo(() => (space?.features ?? []) as FeatureJson[], [space?.features]);
+
   const { features, mappedFeatures } = useMemo(() => {
-    return constructFeaturesRecord((space?.features ?? []) as FeatureJson[]);
-  }, [space?.features]);
+    return constructFeaturesRecord(spaceFeatures);
+  }, [spaceFeatures]);
 
   const _getFeatureTitle = useCallback(
     (featureTitle: FeatureTitleVariation) => {
-      return getFeatureTitle({
-        featureTitle,
-        mappedFeatures
-      });
+      return getFeatureTitle(featureTitle, spaceFeatures);
     },
-    [mappedFeatures]
+    [spaceFeatures]
   );
 
   return { features, mappedFeatures, isLoading, getFeatureTitle: _getFeatureTitle };

--- a/lib/credentials/constants.ts
+++ b/lib/credentials/constants.ts
@@ -1,6 +1,11 @@
 import type { CredentialEventType } from '@charmverse/core/prisma-client';
 
-export const credentialLabelMap: Record<CredentialEventType, string> = {
-  proposal_created: 'Published proposal',
-  proposal_approved: 'Proposal approved'
+import type { FeatureTitleVariation } from 'lib/features/getFeatureTitle';
+
+// Labels require a mapper to rename features based on the space's settings
+type LabelFn = (getFeatureTitle: (featureWord: FeatureTitleVariation) => string) => string;
+
+export const credentialLabelMap: Partial<Record<CredentialEventType, LabelFn>> = {
+  proposal_created: (map) => `Published ${map('proposal')}`,
+  proposal_approved: (map) => `${map('Proposal')} approved`
 };

--- a/lib/credentials/issueProposalCredentialsIfNecessary.ts
+++ b/lib/credentials/issueProposalCredentialsIfNecessary.ts
@@ -161,11 +161,11 @@ export async function issueProposalCredentialsIfNecessary({
     } else {
       try {
         for (const credentialTemplate of credentialsToGiveUser) {
-          const getLabel = credentialLabelMap[event];
-          if (!getLabel) {
+          const getStatusLabel = credentialLabelMap[event];
+          if (!getStatusLabel) {
             throw new Error(`No label mapper found for event: ${event}`);
           }
-          const statusLabel = getLabel((value) =>
+          const statusLabel = getStatusLabel((value) =>
             getFeatureTitle(value, proposalWithSpaceConfig.space.features as any[])
           );
           // Iterate through credentials one at a time so we can ensure they're properly created and tracked

--- a/lib/credentials/issueProposalCredentialsIfNecessary.ts
+++ b/lib/credentials/issueProposalCredentialsIfNecessary.ts
@@ -5,9 +5,11 @@ import { prisma } from '@charmverse/core/prisma-client';
 import { getCurrentEvaluation } from '@charmverse/core/proposals';
 import { optimism } from 'viem/chains';
 
+import { getFeatureTitle } from 'lib/features/getFeatureTitle';
 import { getPagePermalink } from 'lib/pages/getPagePermalink';
 
 import { signAndPublishCharmverseCredential } from './attest';
+import { credentialLabelMap } from './constants';
 
 const labels: Record<CredentialEventType, string> = {
   proposal_approved: 'Proposal Approved',
@@ -83,6 +85,7 @@ export async function issueProposalCredentialsIfNecessary({
       space: {
         select: {
           id: true,
+          features: true,
           credentialTemplates: {
             where: {
               credentialEvents: {
@@ -158,6 +161,13 @@ export async function issueProposalCredentialsIfNecessary({
     } else {
       try {
         for (const credentialTemplate of credentialsToGiveUser) {
+          const getLabel = credentialLabelMap[event];
+          if (!getLabel) {
+            throw new Error(`No label mapper found for event: ${event}`);
+          }
+          const statusLabel = getLabel((value) =>
+            getFeatureTitle(value, proposalWithSpaceConfig.space.features as any[])
+          );
           // Iterate through credentials one at a time so we can ensure they're properly created and tracked
           const publishedCredential = await signAndPublishCharmverseCredential({
             chainId: optimism.id,
@@ -168,8 +178,7 @@ export async function issueProposalCredentialsIfNecessary({
                 name: credentialTemplate.name,
                 description: credentialTemplate.description ?? '',
                 organization: credentialTemplate.organization,
-                // TODO - Add label mapping
-                status: labels[event],
+                status: statusLabel,
                 url: getPagePermalink({ pageId: proposalWithSpaceConfig.page.id })
               }
             }

--- a/lib/credentials/issueProposalCredentialsIfNecessary.ts
+++ b/lib/credentials/issueProposalCredentialsIfNecessary.ts
@@ -11,11 +11,6 @@ import { getPagePermalink } from 'lib/pages/getPagePermalink';
 import { signAndPublishCharmverseCredential } from './attest';
 import { credentialLabelMap } from './constants';
 
-const labels: Record<CredentialEventType, string> = {
-  proposal_approved: 'Proposal Approved',
-  proposal_created: 'Proposal Created'
-};
-
 const disablePublishedCredentials = process.env.DISABLE_PUBLISHED_CREDENTIALS === 'true';
 
 export async function issueProposalCredentialsIfNecessary({

--- a/lib/features/__tests__/getFeatureTitle.spec.ts
+++ b/lib/features/__tests__/getFeatureTitle.spec.ts
@@ -1,12 +1,5 @@
 import type { FeatureJson } from '../constants';
-import { constructFeaturesRecord } from '../constructFeaturesRecord';
-import type { FeatureTitleVariation } from '../getFeatureTitle';
-import { getFeatureTitle as _getFeatureTitle } from '../getFeatureTitle';
-
-function getFeatureTitle(featureTitle: FeatureTitleVariation, features?: FeatureJson[]) {
-  const { mappedFeatures } = constructFeaturesRecord(features || []);
-  return _getFeatureTitle({ featureTitle, mappedFeatures });
-}
+import { getFeatureTitle } from '../getFeatureTitle';
 
 describe('getFeatureTitle', () => {
   it('Maintains normal feature titles', () => {

--- a/lib/features/__tests__/getFeatureTitle.spec.ts
+++ b/lib/features/__tests__/getFeatureTitle.spec.ts
@@ -1,0 +1,31 @@
+import type { FeatureJson } from '../constants';
+import { constructFeaturesRecord } from '../constructFeaturesRecord';
+import type { FeatureTitleVariation } from '../getFeatureTitle';
+import { getFeatureTitle as _getFeatureTitle } from '../getFeatureTitle';
+
+function getFeatureTitle(featureTitle: FeatureTitleVariation, features?: FeatureJson[]) {
+  const { mappedFeatures } = constructFeaturesRecord(features || []);
+  return _getFeatureTitle({ featureTitle, mappedFeatures });
+}
+
+describe('getFeatureTitle', () => {
+  it('Maintains normal feature titles', () => {
+    expect(getFeatureTitle('proposal')).toBe('proposal');
+    expect(getFeatureTitle('Proposal')).toBe('Proposal');
+    expect(getFeatureTitle('proposals')).toBe('proposals');
+    expect(getFeatureTitle('Proposals')).toBe('Proposals');
+  });
+  it('Translates custom title for proposals', () => {
+    const customFeatures: FeatureJson[] = [
+      {
+        id: 'proposals',
+        title: 'Grants',
+        isHidden: false
+      }
+    ];
+    expect(getFeatureTitle('proposal', customFeatures)).toBe('grant');
+    expect(getFeatureTitle('Proposal', customFeatures)).toBe('Grant');
+    expect(getFeatureTitle('proposals', customFeatures)).toBe('grants');
+    expect(getFeatureTitle('Proposals', customFeatures)).toBe('Grants');
+  });
+});

--- a/lib/features/getFeatureTitle.ts
+++ b/lib/features/getFeatureTitle.ts
@@ -1,7 +1,8 @@
 import { capitalize } from 'lodash';
 
-import type { Feature, MappedFeature } from './constants';
+import type { FeatureJson, Feature } from './constants';
 import { STATIC_PAGES } from './constants';
+import { constructFeaturesRecord } from './constructFeaturesRecord';
 
 export type FeatureTitleVariation =
   | 'reward'
@@ -32,13 +33,8 @@ const featureTitleRecord: Record<FeatureTitleVariation, Feature> = {
   member_directory: 'member_directory'
 };
 
-export const getFeatureTitle = ({
-  featureTitle,
-  mappedFeatures
-}: {
-  featureTitle: FeatureTitleVariation;
-  mappedFeatures: Record<Feature, Pick<MappedFeature, 'title'>>;
-}) => {
+export const getFeatureTitle = (featureTitle: FeatureTitleVariation, features: FeatureJson[] = []) => {
+  const { mappedFeatures } = constructFeaturesRecord(features);
   const feature = featureTitleRecord[featureTitle];
   const featureCurrentTitle = mappedFeatures[feature]?.title;
   const staticPageFeature = STATIC_PAGES.find((page) => page.feature === feature)!;

--- a/lib/features/getFeatureTitle.ts
+++ b/lib/features/getFeatureTitle.ts
@@ -1,4 +1,6 @@
-import type { Feature, FeatureMap } from './constants';
+import { capitalize } from 'lodash';
+
+import type { Feature, MappedFeature } from './constants';
 import { STATIC_PAGES } from './constants';
 
 export type FeatureTitleVariation =
@@ -35,18 +37,25 @@ export const getFeatureTitle = ({
   mappedFeatures
 }: {
   featureTitle: FeatureTitleVariation;
-  mappedFeatures: FeatureMap;
+  mappedFeatures: Record<Feature, Pick<MappedFeature, 'title'>>;
 }) => {
-  const isCapitalized = featureTitle.charAt(0) === featureTitle.charAt(0).toUpperCase();
   const feature = featureTitleRecord[featureTitle];
-  const featureCurrentTitle = mappedFeatures[feature].title;
+  const featureCurrentTitle = mappedFeatures[feature]?.title;
   const staticPageFeature = STATIC_PAGES.find((page) => page.feature === feature)!;
+
+  let result: string = featureTitle;
   // Keep the current title without any modifications if its has been changed
-  if (featureCurrentTitle !== staticPageFeature.title) {
-    return isCapitalized
-      ? featureCurrentTitle.charAt(0).toUpperCase() + featureCurrentTitle.slice(1)
-      : featureCurrentTitle.toLowerCase();
+  if (featureCurrentTitle && featureCurrentTitle !== staticPageFeature.title) {
+    const isCapitalized = featureTitle.charAt(0) === featureTitle.charAt(0).toUpperCase();
+    const isPlural = featureTitle.charAt(featureTitle.length - 1) === 's';
+    result = featureCurrentTitle.toLocaleLowerCase();
+    if (isCapitalized) {
+      result = capitalize(featureCurrentTitle);
+    }
+    if (!isPlural && result.endsWith('s')) {
+      result = result.slice(0, -1);
+    }
   }
 
-  return featureTitle;
+  return result;
 };

--- a/lib/notifications/getNotificationMetadata.tsx
+++ b/lib/notifications/getNotificationMetadata.tsx
@@ -242,7 +242,6 @@ export function getNotificationMetadata({
   pageTitle: string;
 } {
   const href = getNotificationUrl(notification);
-  const { mappedFeatures } = constructFeaturesRecord(spaceFeatures);
 
   try {
     switch (notification.group) {
@@ -251,10 +250,7 @@ export function getNotificationMetadata({
           content: getRewardContent({
             notification: notification as BountyNotification,
             authorUsername: actorUsername,
-            rewardTitle: getFeatureTitle({
-              featureTitle: 'reward',
-              mappedFeatures
-            })
+            rewardTitle: getFeatureTitle('reward', spaceFeatures)
           }),
           href,
           pageTitle: notification.pageTitle


### PR DESCRIPTION
Fixes:
- add translation for "proposal" in credentials
- add translation when issuing credentials
- align the status labels we show in the UI as well as the backend
- add tests + correctly translate singular form of words, eg "grant" should be "grant" not "grants"
- refactor settings to use a common ContextMenu component


![image](https://github.com/charmverse/app.charmverse.io/assets/305398/0904f373-1535-4a5e-b346-110d489b097c)