### PR TITLE
use correct tenant urls and user ids for Summon API

### DIFF
--- a/__integration-tests__/server/pages/api/v1/spaces/[spaceId]/members/index.spec.ts
+++ b/__integration-tests__/server/pages/api/v1/spaces/[spaceId]/members/index.spec.ts
@@ -50,14 +50,14 @@ describe('POST /api/v1/spaces/{spaceId}/members', () => {
 
   it('should respond 200 with user profile and create user if no charmverse user with the provided email or wallet address exist', async () => {
     const wallet = randomETHWalletAddress().toLowerCase();
-    const xpsEngineId = v4();
+    const xpsUserId = v4();
     const tenantId = v4();
     const { listen, router } = createServer();
 
-    router.get('/scan/inventory/:xpsEngineId', (ctx) => {
+    router.get('/v1/xps/scan/inventory/:xpsUserId', (ctx) => {
       ctx.body = {
         data: {
-          user: xpsEngineId,
+          user: xpsUserId,
           tenantId,
           meta: {
             rank: 1
@@ -70,10 +70,10 @@ describe('POST /api/v1/spaces/{spaceId}/members', () => {
 
     const response = await request(baseUrl)
       .post(`/api/v1/spaces/${space.id}/members`)
-      .query({ summonApiUrl: `http://localhost:${(server.address() as AddressInfo).port}` })
+      .query({ summonTestUrl: `http://localhost:${(server.address() as AddressInfo).port}` })
       .set('Authorization', superApiKey.token)
       .send({
-        summonUserId: xpsEngineId,
+        summonUserId: xpsUserId,
         wallet
       });
 
@@ -105,6 +105,7 @@ describe('POST /api/v1/spaces/{spaceId}/members', () => {
       wallet
     });
     expect(spaceRole).toBeTruthy();
+    expect(spaceRole.xpsUserId).toBe(xpsUserId);
     expect(spaceRoleToRole).toBeTruthy();
 
     // Cleanup.

--- a/charmClient/apis/publicProfileApi.ts
+++ b/charmClient/apis/publicProfileApi.ts
@@ -9,8 +9,8 @@ export class PublicProfileApi {
     return http.GET<EnsProfile | null>(`/api/public/profile/${userId}/ens`);
   }
 
-  getSummonProfile(userId: string) {
-    return http.GET<SummonUserProfile | null>(`/api/public/profile/${userId}/summon`);
+  getSummonProfile(userId: string, spaceId: string) {
+    return http.GET<SummonUserProfile | null>(`/api/public/profile/${userId}/summon`, { spaceId });
   }
 
   getLensProfile(userId: string) {

--- a/components/members/components/MemberProfile/components/ProfileWidgets/ProfileWidgets.tsx
+++ b/components/members/components/MemberProfile/components/ProfileWidgets/ProfileWidgets.tsx
@@ -42,8 +42,9 @@ export function ProfileWidgets({
     charmClient.publicProfile.getEnsProfile(userId)
   );
 
-  const { data: summonProfile, isLoading: isLoadingSummonProfile } = useSWR(`public/profile/${userId}/summon`, () =>
-    charmClient.publicProfile.getSummonProfile(userId)
+  const { data: summonProfile, isLoading: isLoadingSummonProfile } = useSWR(
+    space && `public/profile/${userId}/summon`,
+    () => charmClient.publicProfile.getSummonProfile(userId, space!.id)
   );
 
   const { isFetchingNfts, isFetchingPoaps, mutateNfts, nfts, nftsError, poaps, poapsError } = useMemberCollections({

--- a/lib/blockchain/provider/alchemy/client.ts
+++ b/lib/blockchain/provider/alchemy/client.ts
@@ -82,7 +82,6 @@ export async function getNFTs({
   walletId: string;
 }): Promise<NFTData[]> {
   const url = `${getAlchemyBaseUrl(chainId, 'nft')}/getNFTs`;
-  const filterSpam = chainId === 1 || chainId === 137;
 
   const responses = await paginatedCall(
     (params) => {

--- a/lib/profile/__tests__/getSummonProfile.spec.ts
+++ b/lib/profile/__tests__/getSummonProfile.spec.ts
@@ -2,11 +2,13 @@ import { prisma } from '@charmverse/core/prisma-client';
 import fetchMock from 'fetch-mock-jest';
 import { v4 } from 'uuid';
 
-import { DEFAULT_TENANT_ID, DEFAULT_URL } from 'lib/summon/constants';
+import { PRODUCTION_URLS } from 'lib/summon/constants';
 import { randomETHWalletAddress } from 'lib/utilities/blockchain';
 import { generateUserAndSpace, generateSpaceUser } from 'testing/setupDatabase';
 
 import { getSummonProfile } from '../getSummonProfile';
+
+const [DEFAULT_TENANT_ID, SUMMON_BASE_URL] = Object.entries(PRODUCTION_URLS)[0];
 
 const mockSandbox = fetchMock.sandbox();
 
@@ -17,15 +19,13 @@ jest.mock('undici', () => {
 let spaceId: string;
 
 beforeAll(async () => {
-  const { space, user } = await generateUserAndSpace({ xpsEngineId: DEFAULT_TENANT_ID });
+  const { space } = await generateUserAndSpace({ xpsEngineId: DEFAULT_TENANT_ID });
   spaceId = space.id;
 });
 
 afterAll(() => {
   fetchMock.restore();
 });
-
-const SUMMON_BASE_URL = DEFAULT_URL;
 
 const summonIdentityErrorResponse = {
   data: {

--- a/lib/profile/__tests__/getSummonProfile.spec.ts
+++ b/lib/profile/__tests__/getSummonProfile.spec.ts
@@ -2,13 +2,13 @@ import { prisma } from '@charmverse/core/prisma-client';
 import fetchMock from 'fetch-mock-jest';
 import { v4 } from 'uuid';
 
-import { PRODUCTION_URLS } from 'lib/summon/constants';
+import { TENANT_URLS } from 'lib/summon/constants';
 import { randomETHWalletAddress } from 'lib/utilities/blockchain';
 import { generateUserAndSpace, generateSpaceUser } from 'testing/setupDatabase';
 
 import { getSummonProfile } from '../getSummonProfile';
 
-const [DEFAULT_TENANT_ID, SUMMON_BASE_URL] = Object.entries(PRODUCTION_URLS)[0];
+const [DEFAULT_TENANT_ID, SUMMON_BASE_URL] = Object.entries(TENANT_URLS)[0];
 
 const mockSandbox = fetchMock.sandbox();
 

--- a/lib/profile/__tests__/getSummonProfile.spec.ts
+++ b/lib/profile/__tests__/getSummonProfile.spec.ts
@@ -2,9 +2,9 @@ import { prisma } from '@charmverse/core/prisma-client';
 import fetchMock from 'fetch-mock-jest';
 import { v4 } from 'uuid';
 
-import { SUMMON_BASE_URL } from 'lib/summon/api';
+import { DEFAULT_TENANT_ID, DEFAULT_URL } from 'lib/summon/constants';
 import { randomETHWalletAddress } from 'lib/utilities/blockchain';
-import { generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+import { generateUserAndSpace, generateSpaceUser } from 'testing/setupDatabase';
 
 import { getSummonProfile } from '../getSummonProfile';
 
@@ -14,9 +14,18 @@ jest.mock('undici', () => {
   return { fetch: (...args: any[]) => mockSandbox(...args) };
 });
 
+let spaceId: string;
+
+beforeAll(async () => {
+  const { space, user } = await generateUserAndSpace({ xpsEngineId: DEFAULT_TENANT_ID });
+  spaceId = space.id;
+});
+
 afterAll(() => {
   fetchMock.restore();
 });
+
+const SUMMON_BASE_URL = DEFAULT_URL;
 
 const summonIdentityErrorResponse = {
   data: {
@@ -28,14 +37,14 @@ const summonIdentityErrorResponse = {
 
 describe('getSummonProfile', () => {
   it(`Should return null if not user exist`, async () => {
-    const summonProfile = await getSummonProfile({ userId: v4() });
+    const summonProfile = await getSummonProfile({ userId: v4(), spaceId });
     expect(summonProfile).toBeNull();
   });
 
   it(`Should return null if user doesn't have any summon account connected with wallet address, email or discord account`, async () => {
     const walletAddress = randomETHWalletAddress().toLowerCase();
     const emailAddress = `test-${v4()}@gmail.com`;
-    const { user } = await generateUserAndSpaceWithApiToken({ walletAddress });
+    const { user } = await generateUserAndSpace({ walletAddress });
 
     await prisma.googleAccount.create({
       data: {
@@ -58,30 +67,33 @@ describe('getSummonProfile', () => {
     });
 
     mockSandbox
-      .get(`${SUMMON_BASE_URL}/scan/identity?walletAddress=${walletAddress}`, summonIdentityErrorResponse)
+      .get(`${SUMMON_BASE_URL}/v1/xps/scan/identity?walletAddress=${walletAddress}`, summonIdentityErrorResponse)
       .get(
-        `${SUMMON_BASE_URL}/scan/identity?discordHandle=${encodeURIComponent(`${discordUsername}`)}`,
+        `${SUMMON_BASE_URL}/v1/xps/scan/identity?discordHandle=${encodeURIComponent(`${discordUsername}`)}`,
         summonIdentityErrorResponse
       )
-      .get(`${SUMMON_BASE_URL}/scan/identity?email=${encodeURIComponent(emailAddress)}`, summonIdentityErrorResponse);
+      .get(
+        `${SUMMON_BASE_URL}/v1/xps/scan/identity?email=${encodeURIComponent(emailAddress)}`,
+        summonIdentityErrorResponse
+      );
 
-    const summonProfile = await getSummonProfile({ userId: user.id });
+    const summonProfile = await getSummonProfile({ userId: user.id, spaceId });
 
     expect(summonProfile).toBeNull();
   });
 
   it(`Should return summon profile attached with user's wallet address`, async () => {
-    const walletAddress = randomETHWalletAddress().toLowerCase();
-    const { user } = await generateUserAndSpaceWithApiToken({ walletAddress });
+    const user = await generateSpaceUser({ spaceId });
+    const walletAddress = user.wallets[0].address;
     mockSandbox
-      .get(`${SUMMON_BASE_URL}/scan/identity?walletAddress=${walletAddress}`, {
+      .get(`${SUMMON_BASE_URL}/v1/xps/scan/identity?walletAddress=${walletAddress}`, {
         data: {
           userId: user.id
         },
         message: '',
         status: 0
       })
-      .get(`${SUMMON_BASE_URL}/scan/inventory/${user.id}`, {
+      .get(`${SUMMON_BASE_URL}/v1/xps/scan/inventory/${user.id}`, {
         data: {
           user: user.id
         },
@@ -89,7 +101,7 @@ describe('getSummonProfile', () => {
         status: 0
       });
 
-    const summonProfile = await getSummonProfile({ userId: user.id });
+    const summonProfile = await getSummonProfile({ userId: user.id, spaceId });
 
     expect(summonProfile).toStrictEqual({
       id: user.id,
@@ -100,9 +112,9 @@ describe('getSummonProfile', () => {
 
   it(`Should return summon profile attached with user's discord handle`, async () => {
     const discordUsername = `test123`;
-    const walletAddress = randomETHWalletAddress().toLowerCase();
+    const user = await generateSpaceUser({ spaceId });
+    const walletAddress = user.wallets[0].address;
 
-    const { user } = await generateUserAndSpaceWithApiToken({ walletAddress });
     await prisma.discordUser.create({
       data: {
         account: {
@@ -114,15 +126,15 @@ describe('getSummonProfile', () => {
     });
 
     mockSandbox
-      .get(`${SUMMON_BASE_URL}/scan/identity?walletAddress=${walletAddress}`, summonIdentityErrorResponse)
-      .get(`${SUMMON_BASE_URL}/scan/identity?discordHandle=${encodeURIComponent(`${discordUsername}`)}`, {
+      .get(`${SUMMON_BASE_URL}/v1/xps/scan/identity?walletAddress=${walletAddress}`, summonIdentityErrorResponse)
+      .get(`${SUMMON_BASE_URL}/v1/xps/scan/identity?discordHandle=${encodeURIComponent(`${discordUsername}`)}`, {
         data: {
           userId: user.id
         },
         message: '',
         status: 0
       })
-      .get(`${SUMMON_BASE_URL}/scan/inventory/${user.id}`, {
+      .get(`${SUMMON_BASE_URL}/v1/xps/scan/inventory/${user.id}`, {
         data: {
           user: user.id
         },
@@ -130,7 +142,7 @@ describe('getSummonProfile', () => {
         status: 0
       });
 
-    const summonProfile = await getSummonProfile({ userId: user.id });
+    const summonProfile = await getSummonProfile({ userId: user.id, spaceId });
 
     expect(summonProfile).toStrictEqual({
       id: user.id,
@@ -143,8 +155,8 @@ describe('getSummonProfile', () => {
     const discordUsername = `test`;
     const discordDiscriminator = v4();
     const emailAddress = `test-${v4()}@gmail.com`;
-    const walletAddress = randomETHWalletAddress().toLowerCase();
-    const { user } = await generateUserAndSpaceWithApiToken({ walletAddress });
+    const user = await generateSpaceUser({ spaceId });
+    const walletAddress = user.wallets[0].address;
 
     await prisma.googleAccount.create({
       data: {
@@ -167,21 +179,21 @@ describe('getSummonProfile', () => {
     });
 
     mockSandbox
-      .get(`${SUMMON_BASE_URL}/scan/identity?walletAddress=${walletAddress}`, summonIdentityErrorResponse)
+      .get(`${SUMMON_BASE_URL}/v1/xps/scan/identity?walletAddress=${walletAddress}`, summonIdentityErrorResponse)
       .get(
-        `${SUMMON_BASE_URL}/scan/identity?discordHandle=${encodeURIComponent(
+        `${SUMMON_BASE_URL}/v1/xps/scan/identity?discordHandle=${encodeURIComponent(
           `${discordUsername}#${discordDiscriminator}`
         )}`,
         summonIdentityErrorResponse
       )
-      .get(`${SUMMON_BASE_URL}/scan/identity?email=${encodeURIComponent(emailAddress)}`, {
+      .get(`${SUMMON_BASE_URL}/v1/xps/scan/identity?email=${encodeURIComponent(emailAddress)}`, {
         data: {
           userId: user.id
         },
         message: '',
         status: 0
       })
-      .get(`${SUMMON_BASE_URL}/scan/inventory/${user.id}`, {
+      .get(`${SUMMON_BASE_URL}/v1/xps/scan/inventory/${user.id}`, {
         data: {
           user: user.id
         },
@@ -189,7 +201,7 @@ describe('getSummonProfile', () => {
         status: 0
       });
 
-    const summonProfile = await getSummonProfile({ userId: user.id });
+    const summonProfile = await getSummonProfile({ userId: user.id, spaceId });
 
     expect(summonProfile).toStrictEqual({
       id: user.id,

--- a/lib/profile/getSummonProfile.ts
+++ b/lib/profile/getSummonProfile.ts
@@ -2,7 +2,7 @@ import { log } from '@charmverse/core/log';
 import { prisma } from '@charmverse/core/prisma-client';
 
 import * as api from 'lib/summon/api';
-import { PRODUCTION_URLS } from 'lib/summon/constants';
+import { TENANT_URLS } from 'lib/summon/constants';
 import type { SummonUserProfile } from 'lib/summon/interfaces';
 
 export async function getSummonProfile({
@@ -56,7 +56,7 @@ export async function getSummonProfile({
     log.debug('Space is not connected to Summon', { spaceId });
     return null;
   }
-  const summonApiUrl = summonTestUrl || PRODUCTION_URLS[spaceRole.space.xpsEngineId];
+  const summonApiUrl = summonTestUrl || TENANT_URLS[spaceRole.space.xpsEngineId];
 
   const discordUserAccount = user.discordUser?.account as { username: string } | null;
   const userEmail = user.googleAccounts[0]?.email;

--- a/lib/profile/getSummonProfile.ts
+++ b/lib/profile/getSummonProfile.ts
@@ -1,13 +1,15 @@
+import { log } from '@charmverse/core/log';
 import { prisma } from '@charmverse/core/prisma-client';
 
 import * as api from 'lib/summon/api';
+import { PRODUCTION_URLS } from 'lib/summon/constants';
 import type { SummonUserProfile } from 'lib/summon/interfaces';
 
 export async function getSummonProfile({
   userId,
-  summonApiUrl = api.SUMMON_BASE_URL
+  spaceId
 }: {
-  summonApiUrl?: string;
+  spaceId: string;
   userId: string;
 }): Promise<null | SummonUserProfile> {
   const user = await prisma.user.findUnique({
@@ -15,7 +17,6 @@ export async function getSummonProfile({
       id: userId
     },
     select: {
-      xpsEngineId: true,
       wallets: {
         select: {
           address: true
@@ -33,27 +34,52 @@ export async function getSummonProfile({
   if (!user) {
     return null;
   }
+  const spaceRole = await prisma.spaceRole.findUnique({
+    where: {
+      spaceUser: {
+        userId,
+        spaceId
+      }
+    },
+    include: {
+      space: {
+        select: {
+          xpsEngineId: true
+        }
+      }
+    }
+  });
+
+  if (!spaceRole || !spaceRole.space.xpsEngineId) {
+    log.debug('Space is not connected to Summon', { spaceId });
+    return null;
+  }
+  const summonApiUrl = PRODUCTION_URLS[spaceRole.space.xpsEngineId];
 
   const discordUserAccount = user.discordUser?.account as { username: string } | null;
   const userEmail = user.googleAccounts[0]?.email;
   const walletAddresses = user.wallets.map((wallet) => wallet.address);
 
-  const xpsEngineId =
-    user.xpsEngineId ??
-    (await api.findUserXpsEngineId({
+  let xpsUserId = spaceRole?.xpsUserId;
+  if (!xpsUserId) {
+    const _xpsUserId = await api.findUserXpsEngineId({
       discordUserAccount,
       userEmail,
       walletAddresses,
       summonApiUrl
-    }));
+    });
+    if (_xpsUserId) {
+      xpsUserId = _xpsUserId;
+    }
+  }
 
   // Summon has a bug where it returns the wrong user profile when none exist
-  if (!xpsEngineId || xpsEngineId === '366899703492640833') {
+  if (!xpsUserId || xpsUserId === '366899703492640833') {
     return null;
   }
 
   return api.getUserSummonProfile({
-    xpsEngineId,
+    xpsUserId,
     summonApiUrl
   });
 }

--- a/lib/profile/getSummonProfile.ts
+++ b/lib/profile/getSummonProfile.ts
@@ -7,10 +7,12 @@ import type { SummonUserProfile } from 'lib/summon/interfaces';
 
 export async function getSummonProfile({
   userId,
-  spaceId
+  spaceId,
+  summonTestUrl
 }: {
   spaceId: string;
   userId: string;
+  summonTestUrl?: string;
 }): Promise<null | SummonUserProfile> {
   const user = await prisma.user.findUnique({
     where: {
@@ -54,7 +56,7 @@ export async function getSummonProfile({
     log.debug('Space is not connected to Summon', { spaceId });
     return null;
   }
-  const summonApiUrl = PRODUCTION_URLS[spaceRole.space.xpsEngineId];
+  const summonApiUrl = summonTestUrl || PRODUCTION_URLS[spaceRole.space.xpsEngineId];
 
   const discordUserAccount = user.discordUser?.account as { username: string } | null;
   const userEmail = user.googleAccounts[0]?.email;

--- a/lib/profile/getSummonProfile.ts
+++ b/lib/profile/getSummonProfile.ts
@@ -64,15 +64,12 @@ export async function getSummonProfile({
 
   let xpsUserId = spaceRole?.xpsUserId;
   if (!xpsUserId) {
-    const _xpsUserId = await api.findUserXpsEngineId({
+    xpsUserId = await api.findUserXpsEngineId({
       discordUserAccount,
       userEmail,
       walletAddresses,
       summonApiUrl
     });
-    if (_xpsUserId) {
-      xpsUserId = _xpsUserId;
-    }
   }
 
   // Summon has a bug where it returns the wrong user profile when none exist

--- a/lib/summon/addUserToSpace.ts
+++ b/lib/summon/addUserToSpace.ts
@@ -7,10 +7,10 @@ import { checkUserSpaceBanStatus } from 'lib/members/checkUserSpaceBanStatus';
 type Props = {
   spaceId: string;
   userId: string;
-  userXpsEngineId?: string;
+  xpsUserId?: string;
 };
 
-export async function addUserToSpace({ spaceId, userId, userXpsEngineId }: Props): Promise<Space | null> {
+export async function addUserToSpace({ spaceId, userId, xpsUserId }: Props): Promise<Space | null> {
   const space = await prisma.space.findFirstOrThrow({ where: { id: spaceId } });
 
   const spaceMembership = await prisma.spaceRole.findFirst({
@@ -42,17 +42,8 @@ export async function addUserToSpace({ spaceId, userId, userXpsEngineId }: Props
           connect: {
             id: userId
           }
-        }
-      }
-    });
-  }
-  if (userXpsEngineId) {
-    await prisma.user.update({
-      where: {
-        id: userId
-      },
-      data: {
-        xpsEngineId: userXpsEngineId
+        },
+        xpsUserId
       }
     });
   }

--- a/lib/summon/api.ts
+++ b/lib/summon/api.ts
@@ -1,14 +1,11 @@
 import * as http from '@charmverse/core/http';
 
+import { API_TOKEN } from './constants';
 import type { SummonAchievement, SummonUserInventory, SummonUserProfile } from './interfaces';
 
-const apiToken = process.env.XPS_API_TOKEN as string | undefined;
-
 const headers = {
-  Authorization: apiToken ? `Bearer ${apiToken}` : null
+  Authorization: API_TOKEN ? `Bearer ${API_TOKEN}` : null
 };
-
-export const SUMMON_BASE_URL = 'https://g7p.io/v1/xps';
 
 type ApiResponse<T> = {
   data: T;
@@ -28,9 +25,9 @@ export async function findUserByIdentity(
     discordHandle?: string;
     githubUsername?: string;
   },
-  summonApiUrl: string = SUMMON_BASE_URL
+  summonApiUrl: string
 ): Promise<string | null> {
-  const result = await http.GET<ApiResponse<{ userId: string }>>(`${summonApiUrl}/scan/identity`, query, {
+  const result = await http.GET<ApiResponse<{ userId: string }>>(`${summonApiUrl}/v1/xps/scan/identity`, query, {
     headers
   });
   // Note that an empty Apiresponse looks very similar to positive result: {
@@ -43,9 +40,9 @@ export async function findUserByIdentity(
 
 // ### Read user information about achievements by userId
 // `/v1/xps/scan/inventory/{userId}`
-export async function getUserInventory({ summonApiUrl, xpsEngineId }: { xpsEngineId: string; summonApiUrl: string }) {
+export async function getUserInventory({ summonApiUrl, xpsUserId }: { xpsUserId: string; summonApiUrl: string }) {
   const { data } = await http.GET<ApiResponse<SummonUserInventory | null>>(
-    `${summonApiUrl}/scan/inventory/${xpsEngineId}`,
+    `${summonApiUrl}/v1/xps/scan/inventory/${xpsUserId}`,
     {},
     { headers }
   );
@@ -53,7 +50,7 @@ export async function getUserInventory({ summonApiUrl, xpsEngineId }: { xpsEngin
 }
 
 export async function getUserSummonProfile(props: {
-  xpsEngineId: string;
+  xpsUserId: string;
   summonApiUrl: string;
 }): Promise<SummonUserProfile | null> {
   const inventory = await getUserInventory(props);
@@ -79,7 +76,7 @@ export async function getAchievementById({
 }) {
   try {
     const { data } = await http.GET<ApiResponse<SummonAchievement | null>>(
-      `${summonApiUrl}/achievement/${achievementId}`,
+      `${summonApiUrl}/v1/xps/achievement/${achievementId}`,
       {},
       { headers }
     );

--- a/lib/summon/constants.ts
+++ b/lib/summon/constants.ts
@@ -1,7 +1,7 @@
 export const API_TOKEN = process.env.XPS_API_TOKEN as string | undefined;
 
 // These URLs could potentially be saved in the DB. But for now, we'll keep them here in case Summon changes their design
-export const PRODUCTION_URLS: Record<string, string> = {
+export const TENANT_URLS: Record<string, string> = {
   // game7
   '355730745719783510': 'https://g7p.io',
   // ethdenver
@@ -11,7 +11,7 @@ export const PRODUCTION_URLS: Record<string, string> = {
 };
 
 // Just in case we need them...
-const STAGING_URLS: Record<string, string> = {
+const TENANT_STAGING_URLS: Record<string, string> = {
   // game7
   '355947552633258069': 'https://staging-g7-api.summon.xyz',
   // ethdenver

--- a/lib/summon/constants.ts
+++ b/lib/summon/constants.ts
@@ -1,0 +1,22 @@
+export const API_TOKEN = process.env.XPS_API_TOKEN as string | undefined;
+
+export const DEFAULT_TENANT_ID = '355730745719783510';
+export const DEFAULT_URL = '355730745719783510';
+
+export const PRODUCTION_URLS: Record<string, string> = {
+  // game7
+  [DEFAULT_TENANT_ID]: DEFAULT_URL,
+  // ethdenver
+  '355932655192113238': 'https://ethd-api.summon.xyz',
+  // zksync
+  '355932655192113587': 'https://zksync-api.summon.xyz'
+};
+
+export const STAGING_URLS: Record<string, string> = {
+  // game7
+  '355947552633258069': 'https://staging-g7-api.summon.xyz',
+  // ethdenver
+  '355932655193224698': 'https://staging-ethd-api.summon.xyz',
+  // zksync
+  '355932655194335702': 'https://staging-zksync-api.summon.xyz'
+};

--- a/lib/summon/constants.ts
+++ b/lib/summon/constants.ts
@@ -1,18 +1,17 @@
 export const API_TOKEN = process.env.XPS_API_TOKEN as string | undefined;
 
-export const DEFAULT_TENANT_ID = '355730745719783510';
-export const DEFAULT_URL = '355730745719783510';
-
+// These URLs could potentially be saved in the DB. But for now, we'll keep them here in case Summon changes their design
 export const PRODUCTION_URLS: Record<string, string> = {
   // game7
-  [DEFAULT_TENANT_ID]: DEFAULT_URL,
+  '355730745719783510': 'https://g7p.io',
   // ethdenver
   '355932655192113238': 'https://ethd-api.summon.xyz',
   // zksync
   '355932655192113587': 'https://zksync-api.summon.xyz'
 };
 
-export const STAGING_URLS: Record<string, string> = {
+// Just in case we need them...
+const STAGING_URLS: Record<string, string> = {
   // game7
   '355947552633258069': 'https://staging-g7-api.summon.xyz',
   // ethdenver

--- a/lib/summon/syncSummonSpaceRoles.ts
+++ b/lib/summon/syncSummonSpaceRoles.ts
@@ -119,7 +119,7 @@ export async function syncSummonSpaceRoles({
         if (!spaceRole.xpsUserId) {
           await prisma.spaceRole.update({
             where: {
-              id: spaceRole.user.id
+              id: spaceRole.id
             },
             data: {
               xpsUserId: summonProfile.id

--- a/lib/summon/syncSummonSpaceRoles.ts
+++ b/lib/summon/syncSummonSpaceRoles.ts
@@ -45,9 +45,9 @@ export async function syncSummonSpaceRoles({
     select: {
       id: true,
       spaceId: true,
+      xpsUserId: true,
       user: {
         select: {
-          xpsEngineId: true,
           id: true,
           discordUser: {
             select: {
@@ -112,13 +112,13 @@ export async function syncSummonSpaceRoles({
       const summonProfile = await getSummonProfile({ userId: spaceRole.user.id, spaceId: spaceRole.spaceId });
       const userRank = summonProfile ? Math.floor(summonProfile.meta.rank) : null;
       if (summonProfile && userRank) {
-        if (!spaceRole.user.xpsEngineId) {
-          await prisma.user.update({
+        if (!spaceRole.xpsUserId) {
+          await prisma.spaceRole.update({
             where: {
               id: spaceRole.user.id
             },
             data: {
-              xpsEngineId: summonProfile.id
+              xpsUserId: summonProfile.id
             }
           });
         }

--- a/lib/summon/syncSummonSpaceRoles.ts
+++ b/lib/summon/syncSummonSpaceRoles.ts
@@ -8,9 +8,9 @@ import { getSummonRoleLabel } from './getSummonRoleLabel';
 export async function syncSummonSpaceRoles({
   spaceId,
   userId,
-  summonApiUrl
+  summonTestUrl
 }: {
-  summonApiUrl?: string;
+  summonTestUrl?: string;
   userId?: string;
   spaceId: string;
 }) {
@@ -109,7 +109,11 @@ export async function syncSummonSpaceRoles({
 
   for (const spaceRole of spaceRoles) {
     try {
-      const summonProfile = await getSummonProfile({ userId: spaceRole.user.id, spaceId: spaceRole.spaceId });
+      const summonProfile = await getSummonProfile({
+        userId: spaceRole.user.id,
+        spaceId: spaceRole.spaceId,
+        summonTestUrl
+      });
       const userRank = summonProfile ? Math.floor(summonProfile.meta.rank) : null;
       if (summonProfile && userRank) {
         if (!spaceRole.xpsUserId) {

--- a/lib/summon/syncSummonSpaceRoles.ts
+++ b/lib/summon/syncSummonSpaceRoles.ts
@@ -44,6 +44,7 @@ export async function syncSummonSpaceRoles({
     },
     select: {
       id: true,
+      spaceId: true,
       user: {
         select: {
           xpsEngineId: true,
@@ -108,7 +109,7 @@ export async function syncSummonSpaceRoles({
 
   for (const spaceRole of spaceRoles) {
     try {
-      const summonProfile = await getSummonProfile({ userId: spaceRole.user.id, summonApiUrl });
+      const summonProfile = await getSummonProfile({ userId: spaceRole.user.id, spaceId: spaceRole.spaceId });
       const userRank = summonProfile ? Math.floor(summonProfile.meta.rank) : null;
       if (summonProfile && userRank) {
         if (!spaceRole.user.xpsEngineId) {

--- a/lib/summon/verifyMembership.ts
+++ b/lib/summon/verifyMembership.ts
@@ -4,7 +4,7 @@ import { prisma } from '@charmverse/core/prisma-client';
 import type { DiscordAccount } from 'lib/discord/client/getDiscordAccount';
 
 import { findUserByIdentity, getUserSummonProfile } from './api';
-import { PRODUCTION_URLS } from './constants';
+import { TENANT_URLS } from './constants';
 
 export type VerificationResponse =
   | {
@@ -37,7 +37,7 @@ export async function verifyMembership({
       log.debug('Space does not have a Summon tenant ID', { spaceId });
       return { isVerified: false, reason: 'Space does not have a Summon tenant ID' };
     }
-    const summonApiUrl = PRODUCTION_URLS[space.xpsEngineId];
+    const summonApiUrl = TENANT_URLS[space.xpsEngineId];
     if (!summonApiUrl) {
       log.debug('Space does not have a Summon URL', { spaceId });
       return { isVerified: false, reason: 'Space does not have a Summon URL' };

--- a/lib/summon/verifyMembership.ts
+++ b/lib/summon/verifyMembership.ts
@@ -3,7 +3,8 @@ import { prisma } from '@charmverse/core/prisma-client';
 
 import type { DiscordAccount } from 'lib/discord/client/getDiscordAccount';
 
-import { SUMMON_BASE_URL, findUserByIdentity, getUserSummonProfile } from './api';
+import { findUserByIdentity, getUserSummonProfile } from './api';
+import { PRODUCTION_URLS } from './constants';
 
 export type VerificationResponse =
   | {
@@ -36,6 +37,12 @@ export async function verifyMembership({
       log.debug('Space does not have a Summon tenant ID', { spaceId });
       return { isVerified: false, reason: 'Space does not have a Summon tenant ID' };
     }
+    const summonApiUrl = PRODUCTION_URLS[space.xpsEngineId];
+    if (!summonApiUrl) {
+      log.debug('Space does not have a Summon URL', { spaceId });
+      return { isVerified: false, reason: 'Space does not have a Summon URL' };
+    }
+
     const user = await prisma.user.findUniqueOrThrow({
       where: {
         id: userId
@@ -46,23 +53,31 @@ export async function verifyMembership({
         wallets: true
       }
     });
-    let summonUserId = user.xpsEngineId;
-    if (!summonUserId) {
+    const spaceRole = await prisma.spaceRole.findUnique({
+      where: {
+        spaceUser: {
+          userId,
+          spaceId
+        }
+      }
+    });
+    let xpsUserId = spaceRole?.xpsUserId;
+    if (!xpsUserId) {
       const discordAccount = user.discordUser?.account as unknown as DiscordAccount;
-      summonUserId = await findUserByIdentity(
+      xpsUserId = await findUserByIdentity(
         {
           // walletAddress: '0x91d76d31080ca88339a4e506affb4ded4b192bcb',
           walletAddress: user.wallets[0]?.address,
           email: user.googleAccounts[0]?.email,
           discordHandle: discordAccount?.username
         },
-        SUMMON_BASE_URL
+        summonApiUrl
       );
       // check another user isnt already using this Summon account
-      if (summonUserId) {
-        const existing = await prisma.user.findUnique({
+      if (xpsUserId) {
+        const existing = await prisma.spaceRole.findUnique({
           where: {
-            xpsEngineId: summonUserId
+            xpsUserId
           }
         });
         if (existing) {
@@ -70,12 +85,12 @@ export async function verifyMembership({
         }
       }
     }
-    if (!summonUserId) {
+    if (!xpsUserId) {
       return { isVerified: false, reason: 'User does not have a Summon ID' };
     }
     const summonUserInfo = await getUserSummonProfile({
-      xpsEngineId: summonUserId,
-      summonApiUrl: SUMMON_BASE_URL
+      xpsUserId,
+      summonApiUrl
     });
     if (!summonUserInfo) {
       return { isVerified: false, reason: 'User does not have a Summon account' };

--- a/pages/api/public/profile/[userId]/summon.ts
+++ b/pages/api/public/profile/[userId]/summon.ts
@@ -1,4 +1,4 @@
-import { InvalidInputError } from '@charmverse/core/dist/cjs/errors';
+import { InvalidInputError } from '@charmverse/core/errors';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 

--- a/pages/api/public/profile/[userId]/summon.ts
+++ b/pages/api/public/profile/[userId]/summon.ts
@@ -1,3 +1,4 @@
+import { InvalidInputError } from '@charmverse/core/dist/cjs/errors';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
@@ -11,8 +12,12 @@ handler.get(getSummonProfileController);
 
 async function getSummonProfileController(req: NextApiRequest, res: NextApiResponse<SummonUserProfile | null>) {
   const userId = req.query.userId as string;
+  const spaceId = req.query.spaceId as string;
+  if (!spaceId) {
+    throw new InvalidInputError('spaceId is required');
+  }
 
-  const summonProfile = await getSummonProfile({ userId });
+  const summonProfile = await getSummonProfile({ userId, spaceId });
 
   res.status(200).json(summonProfile);
 }

--- a/pages/api/summon/join-space.ts
+++ b/pages/api/summon/join-space.ts
@@ -32,7 +32,7 @@ async function joinSpaceEndpoint(req: NextApiRequest, res: NextApiResponse) {
     throw new InvalidInputError('You are not a member of this space');
   }
 
-  await addUserToSpace({ spaceId, userId, userXpsEngineId: result.summonUserId });
+  await addUserToSpace({ spaceId, userId, xpsUserId: result.summonUserId });
 
   trackUserAction('join_a_workspace', {
     spaceId,

--- a/pages/api/v1/spaces/[spaceId]/members/index.ts
+++ b/pages/api/v1/spaces/[spaceId]/members/index.ts
@@ -9,7 +9,6 @@ import type { UserProfile } from 'lib/public-api/interfaces';
 import { searchUserProfile } from 'lib/public-api/searchUserProfile';
 import { withSessionRoute } from 'lib/session/withSession';
 import { addUserToSpace } from 'lib/summon/addUserToSpace';
-import { PRODUCTION_URLS, DEFAULT_URL } from 'lib/summon/constants';
 import { syncSummonSpaceRoles } from 'lib/summon/syncSummonSpaceRoles';
 import { createUserFromWallet } from 'lib/users/createUser';
 

--- a/pages/api/v1/spaces/[spaceId]/members/index.ts
+++ b/pages/api/v1/spaces/[spaceId]/members/index.ts
@@ -9,7 +9,7 @@ import type { UserProfile } from 'lib/public-api/interfaces';
 import { searchUserProfile } from 'lib/public-api/searchUserProfile';
 import { withSessionRoute } from 'lib/session/withSession';
 import { addUserToSpace } from 'lib/summon/addUserToSpace';
-import { SUMMON_BASE_URL } from 'lib/summon/api';
+import { DEFAULT_TENANT_ID, DEFAULT_URL } from 'lib/summon/constants';
 import { syncSummonSpaceRoles } from 'lib/summon/syncSummonSpaceRoles';
 import { createUserFromWallet } from 'lib/users/createUser';
 
@@ -62,7 +62,9 @@ async function createSpaceMember(req: NextApiRequest, res: NextApiResponse<UserP
   const spaceId = req.query.spaceId as string;
   const payload = req.body as CreateSpaceMemberRequestBody;
   const spaceIds = req.spaceIdRange;
-  const summonApiUrl = (isTestEnv ? req.query.summonApiUrl ?? SUMMON_BASE_URL : SUMMON_BASE_URL) as string;
+  const summonTenantId = req.query.summonTenantId;
+  const summonApiUrl = (isTestEnv ? req.query.summonApiUrl ?? DEFAULT_URL : DEFAULT_URL) as string;
+  // For now, allow Api url to override
   if (!spaceIds || !spaceIds.length) {
     throw new UnauthorisedActionError("API key doesn't have access to any spaces");
   }

--- a/scripts/query.ts
+++ b/scripts/query.ts
@@ -1,23 +1,17 @@
 import { prisma } from '@charmverse/core/prisma-client';
-
+import { uniq } from 'lodash';
 /**
  * Use this script to perform database searches.
  */
 
 async function search() {
-  const acc = await prisma.page.findMany({
+  const acc = await prisma.user.findMany({
     where: {
-      type: 'bounty_template'
-    },
-    select: { createdAt: true, space: true, bounty: { include: { permissions: true } } }
+      xpsEngineId: {
+        not: null
+      }
+    }
   });
-
-  console.log('Acc', acc.length);
-  console.log('Acc', acc.filter((a) => !a.bounty?.permissions.some((p) => p.permissionLevel === 'reviewer')).length);
-  console.log(
-    'Acc',
-    acc.filter((a) => !a.bounty?.permissions.some((p) => p.permissionLevel === 'reviewer')).map((a) => a.createdAt)
-  );
 }
 
 search().then(() => console.log('Done'));

--- a/testing/mocks/user.ts
+++ b/testing/mocks/user.ts
@@ -24,7 +24,6 @@ export function createMockUser(user?: Partial<LoggedInUser>): LoggedInUser {
     username: deterministicRandomName(id),
     path: uuid(),
     spacesOrder: [],
-    xpsEngineId: null,
     wallets: [
       {
         ensname: null,
@@ -37,5 +36,5 @@ export function createMockUser(user?: Partial<LoggedInUser>): LoggedInUser {
     googleAccounts: [],
     verifiedEmails: [],
     ...user
-  };
+  } as LoggedInUser;
 }

--- a/testing/setupDatabase.ts
+++ b/testing/setupDatabase.ts
@@ -64,7 +64,7 @@ export async function generateSpaceUser({
       username: 'Username',
       wallets: {
         create: {
-          address: randomETHWalletAddress()
+          address: randomETHWalletAddress().toLowerCase()
         }
       },
       spaceRoles: {


### PR DESCRIPTION
We shouldn't need a migration, at least right away. The cron sync job should retrieve and update spaceRoles automatically. I'll make another PR to remove xpsEngineId on user table later