### PR TITLE
Ensure created date has value on new proposals

### DIFF
--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -50,6 +50,7 @@ export function ProposalProperties({
       : [];
 
   const proposalFormInputs: ProposalPropertiesInput = {
+    createdAt: proposalPage.createdAt.toString(),
     archived: proposal?.archived ?? false,
     authors: proposal?.authors.map((author) => author.userId) ?? [],
     evaluations: proposal?.evaluations ?? [],

--- a/components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase.tsx
@@ -17,6 +17,7 @@ import type { PageContent } from 'lib/prosemirror/interfaces';
 import type { ProposalEvaluationValues } from '../ProposalEvaluations/components/Settings/components/EvaluationStepSettings';
 
 export type ProposalPropertiesInput = {
+  createdAt: string; // this is necessary for Created Time custom property
   content?: PageContent | null;
   contentText?: string; // required to know if we can overwrite content when selecting a template
   authors: string[];

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/CustomPropertiesAdapter.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/CustomPropertiesAdapter.tsx
@@ -9,7 +9,7 @@ import { usePropertiesMutator } from '../hooks/usePropertiesMutator';
 import { useProposalsBoardAdapter } from '../hooks/useProposalsBoardAdapter';
 
 type Props = {
-  proposal: { fields: ProposalFields | null; id?: string };
+  proposal: { createdAt: string; fields: ProposalFields | null; id?: string };
   onChange?: (properties: ProposalFields['properties']) => void;
   readOnly?: boolean;
   readOnlyProperties?: string[];

--- a/components/proposals/ProposalPage/components/ProposalProperties/hooks/useProposalsBoardAdapter.ts
+++ b/components/proposals/ProposalPage/components/ProposalProperties/hooks/useProposalsBoardAdapter.ts
@@ -234,8 +234,8 @@ function mapProposalToCardPage({
     type: 'card' as BlockTypes,
     updatedBy: proposalPage?.updatedBy || '',
     createdBy: proposalPage?.createdBy || '',
-    createdAt: proposalPage?.createdAt ? new Date(proposalPage?.createdAt).getTime() : 0,
-    updatedAt: proposalPage?.updatedAt ? new Date(proposalPage?.updatedAt).getTime() : 0,
+    createdAt: proposalPage?.createdAt ? new Date(proposalPage?.createdAt).getTime() : Date.now(),
+    updatedAt: proposalPage?.updatedAt ? new Date(proposalPage?.updatedAt).getTime() : Date.now(),
     deletedAt: null,
     fields: { properties: {}, ...proposalFields, contentOrder: [] }
   };

--- a/components/proposals/ProposalPage/hooks/useNewProposal.tsx
+++ b/components/proposals/ProposalPage/hooks/useNewProposal.tsx
@@ -95,6 +95,7 @@ function emptyState({
   ...inputs
 }: Partial<ProposalPageAndPropertiesInput> & { userId?: string } = {}): ProposalPageAndPropertiesInput {
   return {
+    createdAt: new Date().toISOString(),
     proposalType: 'free_form',
     content: null,
     contentText: '',

--- a/components/proposals/hooks/useProposalsBoard.tsx
+++ b/components/proposals/hooks/useProposalsBoard.tsx
@@ -25,20 +25,7 @@ export type ProposalsBoardContextType = {
   setBoardProposal: (boardProposal: BoardProposal | null) => void;
 };
 
-export const ProposalsBoardContext = createContext<Readonly<ProposalsBoardContextType>>({
-  board: {} as Board,
-  boardCustomProperties: {} as Board,
-  card: {} as Card,
-  cards: [],
-  cardPages: [],
-  activeView: {} as BoardView,
-  views: [],
-  proposalPage: undefined,
-  isLoading: true,
-  refreshProposals: () => {},
-  boardProposal: null,
-  setBoardProposal: () => {}
-});
+export const ProposalsBoardContext = createContext<Readonly<ProposalsBoardContextType | null>>(null);
 
 export function ProposalsBoardProvider({ children }: { children: ReactNode }) {
   const boardContext = useProposalsBoardAdapter();
@@ -46,4 +33,10 @@ export function ProposalsBoardProvider({ children }: { children: ReactNode }) {
   return <ProposalsBoardContext.Provider value={boardContext}>{children}</ProposalsBoardContext.Provider>;
 }
 
-export const useProposalsBoard = () => useContext(ProposalsBoardContext);
+export const useProposalsBoard = () => {
+  const context = useContext(ProposalsBoardContext);
+  if (!context) {
+    throw new Error('useProposalsBoard must be used within a ProposalsBoardProvider');
+  }
+  return context;
+};

--- a/lib/proposal/interface.ts
+++ b/lib/proposal/interface.ts
@@ -52,11 +52,24 @@ export type ProposalFields = {
   enableRewards?: boolean; // used by form templates to enable rewards for new proposals
 };
 
-export type ProposalWithUsersLite = Omit<Proposal, 'fields'> & {
+export type ProposalWithUsersLite = Omit<
+  Proposal,
+  | 'fields'
+  | 'archived'
+  | 'reviewedBy'
+  | 'formId'
+  | 'reviewedAt'
+  | 'publishToLens'
+  | 'lensPostLink'
+  | 'selectedCredentialTemplates'
+  | 'workflowId'
+> & {
+  archived?: boolean;
   authors: ProposalAuthor[];
   fields: ProposalFields | null;
+  formId?: string;
   reviewers: ProposalReviewer[];
-  rewardIds?: string[] | null;
+  rewardIds: string[];
   currentEvaluationId?: string;
   permissions?: ProposalPermissionFlags;
   evaluations: {

--- a/lib/proposal/mapDbProposalToProposal.ts
+++ b/lib/proposal/mapDbProposalToProposal.ts
@@ -101,8 +101,13 @@ export function mapDbProposalToProposalLite({
   const currentEvaluation = getCurrentEvaluation(proposal.evaluations);
   const fields = (rest.fields as ProposalFields) ?? null;
 
-  const proposalWithUsers = {
-    ...rest,
+  const proposalWithUsers: ProposalWithUsersLite = {
+    id: rest.id,
+    createdBy: rest.createdBy,
+    authors: proposal.authors,
+    archived: proposal.archived || undefined,
+    formId: rest.formId || undefined,
+    spaceId: rest.spaceId,
     evaluations: sortBy(proposal.evaluations, 'index').map((e) => ({
       title: e.title,
       index: e.index,
@@ -120,7 +125,7 @@ export function mapDbProposalToProposalLite({
     currentEvaluationId: proposal.status !== 'draft' && proposal.evaluations.length ? currentEvaluation?.id : undefined,
     status: proposal.status,
     reviewers: (proposal.status !== 'draft' && currentEvaluation?.reviewers) || [],
-    rewardIds: rewards.map((r) => r.id) || null,
+    rewardIds: rewards.map((r) => r.id),
     fields
   };
 


### PR DESCRIPTION
**WHY**
Currently in prod, it just shows the unix epoch

**WHAT**
The 'createdAt' prop previously depended on a page existing in usePages(). The below screenshot is the correct version. 

<img width="716" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/eb99d68e-8c6e-4f9a-ab6f-52662a791a0f">

Working on this  made me feel that it could be much simpler if we split out the states from useProposalsBoardAdapter(). For instance, the `card` export is only needed on individual pages -- and it felt hacky to have to pass in 'createdAt' for new proposals. And if we split out the board block, we would not need to retrieve all proposals and blocks on a single page.