### PR TITLE
only author can Move Back from first workflow step

### DIFF
--- a/components/settings/proposals/components/EvaluationDialog.tsx
+++ b/components/settings/proposals/components/EvaluationDialog.tsx
@@ -50,10 +50,12 @@ type FormValues = yup.InferType<typeof schema>;
 
 export function EvaluationDialog({
   evaluation,
+  isFirstEvaluation,
   onClose,
   onSave
 }: {
   evaluation: EvaluationTemplateFormItem | null;
+  isFirstEvaluation: boolean;
   onClose: VoidFunction;
   onSave: (evaluation: WorkflowEvaluationJson) => void;
 }) {
@@ -180,7 +182,13 @@ export function EvaluationDialog({
             </div>
             <FieldLabel>Permissions</FieldLabel>
             <Stack flex={1} className='CardDetail content'>
-              {evaluation && <EvaluationPermissions evaluation={formValues} onChange={updatePermissions} />}
+              {evaluation && (
+                <EvaluationPermissions
+                  evaluation={formValues}
+                  isFirstEvaluation={isFirstEvaluation}
+                  onChange={updatePermissions}
+                />
+              )}
             </Stack>
           </>
         )}

--- a/components/settings/proposals/components/EvaluationPermissions.tsx
+++ b/components/settings/proposals/components/EvaluationPermissions.tsx
@@ -180,13 +180,15 @@ export function EvaluationPermissions<T extends EvaluationTemplateFormItem | Wor
         <Box key={operation} className='octo-propertyrow'>
           <PropertyLabel readOnly>{operation === 'move' ? 'Move Backward' : capitalize(operation)}</PropertyLabel>
           {isFirstEvaluation && operation === 'move' ? (
-            <UserAndRoleSelect
-              readOnly
-              wrapColumn
-              value={[{ group: 'system_role', id: ProposalSystemRole.author }]}
-              systemRoles={[authorSystemRole]}
-              onChange={() => {}}
-            />
+            <Tooltip title='Only authors can move back to Draft'>
+              <UserAndRoleSelect
+                readOnly
+                wrapColumn
+                value={[{ group: 'system_role', id: ProposalSystemRole.author }]}
+                systemRoles={[authorSystemRole]}
+                onChange={() => {}}
+              />
+            </Tooltip>
           ) : (
             <UserAndRoleSelect
               readOnly={readOnly}

--- a/components/settings/proposals/components/EvaluationPermissions.tsx
+++ b/components/settings/proposals/components/EvaluationPermissions.tsx
@@ -129,10 +129,12 @@ export function EvaluationPermissionsRow({
 
 export function EvaluationPermissions<T extends EvaluationTemplateFormItem | WorkflowEvaluationJson>({
   evaluation,
+  isFirstEvaluation,
   onChange,
   readOnly
 }: {
   evaluation: T;
+  isFirstEvaluation: boolean; // use a default Move permission for the first evaluation in a workflow
   onChange: (evaluation: T) => void;
   readOnly?: boolean;
 }) {
@@ -170,22 +172,32 @@ export function EvaluationPermissions<T extends EvaluationTemplateFormItem | Wor
       {proposalOperations.map((operation) => (
         <Box key={operation} className='octo-propertyrow'>
           <PropertyLabel readOnly>{operation === 'move' ? 'Move Backward' : capitalize(operation)}</PropertyLabel>
-          <UserAndRoleSelect
-            readOnly={readOnly}
-            variant='outlined'
-            wrapColumn
-            // required values cannot be removed
-            isRequiredValue={(option) => {
-              if (operation === 'view') {
-                return option.id === ProposalSystemRole.author || option.id === ProposalSystemRole.current_reviewer;
-              }
-              return false;
-            }}
-            value={valuesByOperation[operation] || []}
-            systemRoles={extraEvaluationRoles}
-            inputPlaceholder={permissionOperationPlaceholders[operation]}
-            onChange={async (options) => updatePermissionOperation(operation, options)}
-          />
+          {isFirstEvaluation && operation === 'move' ? (
+            <UserAndRoleSelect
+              readOnly
+              wrapColumn
+              value={[{ group: 'system_role', id: ProposalSystemRole.author }]}
+              systemRoles={[authorSystemRole]}
+              onChange={() => {}}
+            />
+          ) : (
+            <UserAndRoleSelect
+              readOnly={readOnly}
+              variant='outlined'
+              wrapColumn
+              // required values cannot be removed
+              isRequiredValue={(option) => {
+                if (operation === 'view') {
+                  return option.id === ProposalSystemRole.author || option.id === ProposalSystemRole.current_reviewer;
+                }
+                return false;
+              }}
+              value={valuesByOperation[operation] || []}
+              systemRoles={extraEvaluationRoles}
+              inputPlaceholder={permissionOperationPlaceholders[operation]}
+              onChange={async (options) => updatePermissionOperation(operation, options)}
+            />
+          )}
         </Box>
       ))}
 

--- a/components/settings/proposals/components/EvaluationPermissions.tsx
+++ b/components/settings/proposals/components/EvaluationPermissions.tsx
@@ -181,13 +181,15 @@ export function EvaluationPermissions<T extends EvaluationTemplateFormItem | Wor
           <PropertyLabel readOnly>{operation === 'move' ? 'Move Backward' : capitalize(operation)}</PropertyLabel>
           {isFirstEvaluation && operation === 'move' ? (
             <Tooltip title='Only authors can move back to Draft'>
-              <UserAndRoleSelect
-                readOnly
-                wrapColumn
-                value={[{ group: 'system_role', id: ProposalSystemRole.author }]}
-                systemRoles={[authorSystemRole]}
-                onChange={() => {}}
-              />
+              <span>
+                <UserAndRoleSelect
+                  readOnly
+                  wrapColumn
+                  value={[{ group: 'system_role', id: ProposalSystemRole.author }]}
+                  systemRoles={[authorSystemRole]}
+                  onChange={() => {}}
+                />
+              </span>
             </Tooltip>
           ) : (
             <UserAndRoleSelect

--- a/components/settings/proposals/components/EvaluationPermissions.tsx
+++ b/components/settings/proposals/components/EvaluationPermissions.tsx
@@ -96,11 +96,13 @@ export function EvaluationPermissionsRow({
   onDuplicate,
   onRename,
   onChange,
-  readOnly
+  readOnly,
+  isFirstEvaluation
 }: {
   evaluation: WorkflowEvaluationJson;
   onChange: (evaluation: WorkflowEvaluationJson) => void;
   readOnly: boolean;
+  isFirstEvaluation: boolean;
 } & ContextMenuProps) {
   return (
     <Card variant='outlined' key={evaluation.id} sx={{ mb: 1 }}>
@@ -120,7 +122,12 @@ export function EvaluationPermissionsRow({
         </Box>
 
         <Stack flex={1} className='CardDetail content'>
-          <EvaluationPermissions evaluation={evaluation} onChange={onChange} readOnly={readOnly} />
+          <EvaluationPermissions
+            isFirstEvaluation={isFirstEvaluation}
+            evaluation={evaluation}
+            onChange={onChange}
+            readOnly={readOnly}
+          />
         </Stack>
       </Box>
     </Card>

--- a/components/settings/proposals/components/ProposalWorkflow.tsx
+++ b/components/settings/proposals/components/ProposalWorkflow.tsx
@@ -209,7 +209,7 @@ export function ProposalWorkflowItem({
           {({ value }) => (
             <Box pt={2}>
               {value === 'Steps' &&
-                workflow.evaluations.map((evaluation) => (
+                workflow.evaluations.map((evaluation, index) => (
                   <EvaluationRow
                     key={evaluation.id}
                     evaluation={evaluation}

--- a/components/settings/proposals/components/ProposalWorkflow.tsx
+++ b/components/settings/proposals/components/ProposalWorkflow.tsx
@@ -221,9 +221,10 @@ export function ProposalWorkflowItem({
                   />
                 ))}
               {value === 'Permissions' &&
-                workflow.evaluations.map((evaluation) => (
+                workflow.evaluations.map((evaluation, index) => (
                   <EvaluationPermissionsRow
                     key={evaluation.id}
+                    isFirstEvaluation={index === 0}
                     evaluation={evaluation}
                     onDelete={deleteEvaluationStep}
                     onDuplicate={duplicateEvaluationStep}
@@ -257,7 +258,12 @@ export function ProposalWorkflowItem({
           )}
         </MultiTabs>
 
-        <EvaluationDialog evaluation={activeEvaluation} onClose={closeEvaluationStep} onSave={updateEvaluationStep} />
+        <EvaluationDialog
+          isFirstEvaluation={workflow.evaluations[0]?.id === activeEvaluation?.id}
+          evaluation={activeEvaluation}
+          onClose={closeEvaluationStep}
+          onSave={updateEvaluationStep}
+        />
       </AccordionDetails>
     </Accordion>
   );


### PR DESCRIPTION
This way we can use 'move' permission to go back to draft state

<img width="884" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/4e2bf85d-4490-4926-a6d7-af0487737144">