### PR TITLE
fix broken layout for iframe embeds inside of callout

### DIFF
--- a/components/common/CharmEditor/components/callout/components/Callout.tsx
+++ b/components/common/CharmEditor/components/callout/components/Callout.tsx
@@ -121,7 +121,10 @@ export default function Callout({
             />
           </Menu>
         </CalloutEmoji>
-        {children}
+        {/** Wrap children in a container  to prevent iframe embeds escaping the parent * */}
+        <Box flexGrow={1} sx={{ overflowX: 'hidden' }}>
+          {children}
+        </Box>
       </StyledCallout>
     </Box>
   );


### PR DESCRIPTION
Bug:

![image](https://github.com/charmverse/app.charmverse.io/assets/305398/9ec4b480-c73d-44e7-ad5c-6520090fb402)
