### PR TITLE
Revert change to hide block aligner for readonly

### DIFF
--- a/components/common/CharmEditor/components/BlockAligner.tsx
+++ b/components/common/CharmEditor/components/BlockAligner.tsx
@@ -71,8 +71,8 @@ const BlockAligner = forwardRef<HTMLDivElement, BlockAlignerProps>((props, ref) 
     onDelete();
   }
 
-  if (readOnly) {
-    const extraControls = props.extraControls?.filter((control) => control.showOnReadonly) ?? [];
+  if (readOnly && props.extraControls) {
+    const extraControls = props.extraControls.filter((control) => control.showOnReadonly);
     if (!extraControls.length) {
       return null;
     }


### PR DESCRIPTION
Some extra logic was added to hide if it's readOnly: https://github.com/charmverse/app.charmverse.io/commit/a9ca619bc7e525d21f7b131dd9fb097779678a31#diff-fcfabebfdfcdf3df1cd01702daa1cb76562c69c1877ad6df24664bf1afc1ac7fR74

But this hides File type components on public pages, and probably other components.

The BlockAligner element is too low-level IMO to have this type of logic.