### PR TITLE
consider None as reward type in UI components

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/RubricAnswersForm.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/RubricAnswersForm.tsx
@@ -148,7 +148,6 @@ export function RubricAnswersForm({
     defaultValues: {
       answers: showDraftAnswers ? mapAnswersToFormValues(draftAnswers) : mapAnswersToFormValues(answers)
     }
-    // resolver: yupResolver(schema(hasCustomReward))
   });
 
   const { fields } = useFieldArray({ control, name: 'answers' });

--- a/components/rewards/components/RewardApplicationPage/RewardApplicationPage.tsx
+++ b/components/rewards/components/RewardApplicationPage/RewardApplicationPage.tsx
@@ -21,6 +21,7 @@ import { usePage } from 'hooks/usePage';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { useUser } from 'hooks/useUser';
 import type { PageContent } from 'lib/prosemirror/interfaces';
+import { getRewardType } from 'lib/rewards/getRewardType';
 
 import { ApplicationComments } from './components/ApplicationComments';
 import { ApplicationInput } from './components/RewardApplicationInput';
@@ -105,6 +106,7 @@ export function RewardApplicationPage({ applicationId, rewardId, closeDialog }: 
     return null;
   }
 
+  const rewardType = getRewardType(reward);
   const submitter = members.find((m) => m.id === application?.createdBy);
 
   const readonlySubmission =
@@ -177,7 +179,7 @@ export function RewardApplicationPage({ applicationId, rewardId, closeDialog }: 
                         rewardPermissions={rewardPermissions}
                         refreshApplication={refreshApplication}
                         reviewApplication={reviewApplication}
-                        hasCustomReward={!!reward.customReward}
+                        rewardType={rewardType}
                       />
                     </Box>
                   )}
@@ -223,7 +225,7 @@ export function RewardApplicationPage({ applicationId, rewardId, closeDialog }: 
                       }
                       bountyId={currentRewardId}
                       permissions={applicationRewardPermissions}
-                      hasCustomReward={!!reward.customReward}
+                      rewardType={rewardType}
                       isSaving={isSaving}
                     />
                   )}

--- a/components/rewards/components/RewardApplicationPage/components/RewardReviewerActions.tsx
+++ b/components/rewards/components/RewardApplicationPage/components/RewardReviewerActions.tsx
@@ -11,7 +11,7 @@ import { useSnackbar } from 'hooks/useSnackbar';
 import { getSafeApiClient } from 'lib/gnosis/safe/getSafeApiClient';
 import { getGnosisTransactionUrl } from 'lib/gnosis/utils';
 import type { BountyPermissionFlags } from 'lib/permissions/bounties';
-import type { ApplicationWithTransactions, RewardWithUsers } from 'lib/rewards/interfaces';
+import type { ApplicationWithTransactions, RewardWithUsers, RewardType } from 'lib/rewards/interfaces';
 import type { ReviewDecision } from 'lib/rewards/reviewApplication';
 
 import { AcceptOrRejectButtons } from './AcceptOrRejectButtons';
@@ -23,7 +23,7 @@ type Props = {
   application: ApplicationWithTransactions;
   refreshApplication: () => void;
   reviewApplication: (input: { decision: ReviewDecision }) => Promise<void>;
-  hasCustomReward: boolean;
+  rewardType: RewardType;
   hasApplicationSlots: boolean;
 };
 export function RewardReviewerActions({
@@ -32,7 +32,7 @@ export function RewardReviewerActions({
   refreshApplication,
   rewardPermissions,
   reviewApplication,
-  hasCustomReward,
+  rewardType,
   hasApplicationSlots
 }: Props) {
   const { showMessage } = useSnackbar();
@@ -97,7 +97,7 @@ export function RewardReviewerActions({
           hasApplicationSlots={hasApplicationSlots}
         />
       )}
-      {application.status === 'complete' && !hasCustomReward && rewardPermissions?.review && (
+      {application.status === 'complete' && rewardType === 'token' && rewardPermissions?.review && (
         <RewardPaymentButton
           amount={String(reward.rewardAmount)}
           chainIdToUse={reward.chainId as number}
@@ -111,7 +111,7 @@ export function RewardReviewerActions({
         />
       )}
 
-      {application.status === 'complete' && hasCustomReward && rewardPermissions?.review && (
+      {application.status === 'complete' && rewardType === 'custom' && rewardPermissions?.review && (
         <Button onClick={open}>Mark as paid</Button>
       )}
 

--- a/components/rewards/components/RewardApplicationPage/components/RewardSubmissionInput.tsx
+++ b/components/rewards/components/RewardApplicationPage/components/RewardSubmissionInput.tsx
@@ -17,27 +17,29 @@ import { useUser } from 'hooks/useUser';
 import type { BountyPermissionFlags } from 'lib/permissions/bounties';
 import { checkIsContentEmpty } from 'lib/prosemirror/checkIsContentEmpty';
 import type { PageContent } from 'lib/prosemirror/interfaces';
+import type { RewardType } from 'lib/rewards/interfaces';
 import type { WorkUpsertData } from 'lib/rewards/work';
 import { isValidChainAddress } from 'lib/tokens/validation';
 import type { SystemError } from 'lib/utilities/errors';
 
 import { RewardApplicationStatusChip, applicationStatuses } from '../../RewardApplicationStatusChip';
 
-const schema = (customReward?: boolean) => {
+const schema = (rewardType: RewardType) => {
   return yup.object({
     submission: yup.string().required(),
     submissionNodes: yup.mixed<string>().required(),
-    walletAddress: customReward
-      ? yup.string()
-      : yup
-          .string()
-          .required()
-          .test('verifyContractFormat', 'Invalid wallet address', (address) => {
-            if (address.endsWith('eth')) {
-              return true;
-            }
-            return isValidChainAddress(address);
-          }),
+    walletAddress:
+      rewardType === 'token'
+        ? yup
+            .string()
+            .required()
+            .test('verifyContractFormat', 'Invalid wallet address', (address) => {
+              if (address.endsWith('eth')) {
+                return true;
+              }
+              return isValidChainAddress(address);
+            })
+        : yup.string(),
     rewardInfo: yup.string()
   });
 };
@@ -56,7 +58,7 @@ interface Props {
   permissions?: BountyPermissionFlags;
   expandedOnLoad?: boolean;
   alwaysExpanded?: boolean;
-  hasCustomReward: boolean;
+  rewardType: RewardType;
   refreshSubmission: VoidFunction;
   currentUserIsAuthor: boolean;
   isSaving?: boolean;
@@ -67,7 +69,7 @@ export function RewardSubmissionInput({
   readOnly = false,
   submission,
   onSubmit: onSubmitProp,
-  hasCustomReward,
+  rewardType,
   currentUserIsAuthor,
   isSaving
 }: Props) {
@@ -87,7 +89,7 @@ export function RewardSubmissionInput({
       submissionNodes: submission?.submissionNodes as any as string,
       walletAddress: submission?.walletAddress ?? user?.wallets[0]?.address ?? ''
     },
-    resolver: yupResolver(schema(hasCustomReward))
+    resolver: yupResolver(schema(rewardType))
   });
 
   const formValues = getValues();
@@ -147,7 +149,7 @@ export function RewardSubmissionInput({
             />
           </Grid>
 
-          {(currentUserIsAuthor || permissions?.review) && !hasCustomReward && (
+          {(currentUserIsAuthor || permissions?.review) && rewardType === 'token' && (
             <Grid item>
               <InputLabel>Address/ENS to receive reward</InputLabel>
               <TextField
@@ -161,7 +163,7 @@ export function RewardSubmissionInput({
             </Grid>
           )}
 
-          {(currentUserIsAuthor || permissions?.review) && hasCustomReward && (
+          {(currentUserIsAuthor || permissions?.review) && rewardType === 'custom' && (
             <Grid item>
               <InputLabel>Information for custom reward</InputLabel>
               <TextField

--- a/lib/rewards/getRewardType.ts
+++ b/lib/rewards/getRewardType.ts
@@ -1,0 +1,14 @@
+import type { Bounty } from '@charmverse/core/prisma';
+
+import type { RewardType } from './interfaces';
+
+// TODO: this should be stored on the reward table
+export function getRewardType(
+  reward: Pick<Bounty, 'chainId' | 'customReward' | 'rewardToken' | 'rewardAmount'>
+): RewardType {
+  return reward.customReward
+    ? 'custom'
+    : reward.chainId && reward.rewardToken && reward.rewardAmount
+    ? 'token'
+    : 'none';
+}

--- a/lib/rewards/interfaces.ts
+++ b/lib/rewards/interfaces.ts
@@ -10,6 +10,8 @@ export type ApplicationMeta = Pick<
 
 export type RewardStatus = BountyStatus;
 
+export type RewardType = 'token' | 'custom' | 'none';
+
 export type Reward = Bounty;
 
 export type RewardWithUsers = Bounty & {


### PR DESCRIPTION
Updated logic to consider 3 different reward types: When a reward type is "none", then `hasCustomReward` was false, but we were assuming it would be token.