### PR TITLE
fix context for node views

### DIFF
--- a/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/ReactEditor.tsx
@@ -344,19 +344,20 @@ export const BangleEditor = React.forwardRef<CoreBangleEditor | undefined, Bangl
           <div contentEditable='false' className='charm-empty-footer' onMouseDown={onClickEditorBottom} />
         )}
       </div>
-      {nodeViews.map((nodeView) => {
-        return nodeView.containerDOM
-          ? reactDOM.createPortal(
-              <NodeViewWrapper
-                nodeViewUpdateStore={nodeViewUpdateStore}
-                nodeView={nodeView}
-                renderNodeViews={renderNodeViews!}
-              />,
-              nodeView.containerDOM,
-              objectUid.get(nodeView)
-            )
-          : null;
-      })}
+      {editor?.view &&
+        nodeViews.map((nodeView) => {
+          return nodeView.containerDOM
+            ? reactDOM.createPortal(
+                <NodeViewWrapper
+                  nodeViewUpdateStore={nodeViewUpdateStore}
+                  nodeView={nodeView}
+                  renderNodeViews={renderNodeViews!}
+                />,
+                nodeView.containerDOM,
+                objectUid.get(nodeView)
+              )
+            : null;
+        })}
     </EditorViewContext.Provider>
   );
 });


### PR DESCRIPTION
not sure why this only happens on one page i found: https://app.charmverse.io/op-grants/optimism-grants-council-8323028890716944. somehow the nodeViews get set before editor.view, and it throws an error that EditorViewContext is not set. we should clean it up in a refactor on charmeditor so we dont have to check for editor.view..