### PR TITLE
fix updating block so that we do not save reward properties

### DIFF
--- a/__integration-tests__/server/pages/api/spaces/rewards/blocks.spec.ts
+++ b/__integration-tests__/server/pages/api/spaces/rewards/blocks.spec.ts
@@ -2,14 +2,10 @@ import type { Space } from '@charmverse/core/prisma';
 import { prisma } from '@charmverse/core/prisma-client';
 import request from 'supertest';
 
-import type { LoggedInUser } from 'models';
 import { baseUrl, loginUser } from 'testing/mockApiCall';
 import { mockRewardBlocks } from 'testing/mocks/rewards';
-import { generateUserAndSpace, generateBounty } from 'testing/setupDatabase';
+import { generateUserAndSpace } from 'testing/setupDatabase';
 
-let nonAdminUser: LoggedInUser;
-let nonAdminUserCookie: string;
-let adminUserCookie: string;
 let space: Space;
 let rewardBlocks: ReturnType<typeof mockRewardBlocks>;
 
@@ -22,13 +18,11 @@ beforeAll(async () => {
   await prisma.rewardBlock.createMany({
     data: rewardBlocks
   });
-
-  nonAdminUserCookie = await loginUser(user.id);
 });
 
 describe('GET /api/spaces/[id]/rewards/blocks', () => {
   it('should return reward blocks for the space', async () => {
-    const result = (await request(baseUrl).get(`/api/spaces/${space.id}/rewards/blocks`).expect(200)).body as Space;
+    const result = (await request(baseUrl).get(`/api/spaces/${space.id}/rewards/blocks`).expect(200)).body;
 
     expect(result).toEqual(
       expect.arrayContaining(rewardBlocks.map(({ id, type }) => expect.objectContaining({ id, type })))
@@ -38,7 +32,7 @@ describe('GET /api/spaces/[id]/rewards/blocks', () => {
   it('should return only "board" type block for the space', async () => {
     const result = (
       await request(baseUrl).get(`/api/spaces/${space.id}/rewards/blocks`).query({ type: 'board' }).expect(200)
-    ).body as Space;
+    ).body;
 
     expect(result).toMatchObject([expect.objectContaining({ type: 'board' })]);
   });

--- a/__integration-tests__/server/pages/api/spaces/rewards/blocks.spec.ts
+++ b/__integration-tests__/server/pages/api/spaces/rewards/blocks.spec.ts
@@ -1,0 +1,45 @@
+import type { Space } from '@charmverse/core/prisma';
+import { prisma } from '@charmverse/core/prisma-client';
+import request from 'supertest';
+
+import type { LoggedInUser } from 'models';
+import { baseUrl, loginUser } from 'testing/mockApiCall';
+import { mockRewardBlocks } from 'testing/mocks/rewards';
+import { generateUserAndSpace, generateBounty } from 'testing/setupDatabase';
+
+let nonAdminUser: LoggedInUser;
+let nonAdminUserCookie: string;
+let adminUserCookie: string;
+let space: Space;
+let rewardBlocks: ReturnType<typeof mockRewardBlocks>;
+
+beforeAll(async () => {
+  const { space: generatedSpace, user } = await generateUserAndSpace();
+
+  space = generatedSpace;
+  rewardBlocks = mockRewardBlocks({ spaceId: space.id, createdBy: user.id });
+
+  await prisma.rewardBlock.createMany({
+    data: rewardBlocks
+  });
+
+  nonAdminUserCookie = await loginUser(user.id);
+});
+
+describe('GET /api/spaces/[id]/rewards/blocks', () => {
+  it('should return reward blocks for the space', async () => {
+    const result = (await request(baseUrl).get(`/api/spaces/${space.id}/rewards/blocks`).expect(200)).body as Space;
+
+    expect(result).toEqual(
+      expect.arrayContaining(rewardBlocks.map(({ id, type }) => expect.objectContaining({ id, type })))
+    );
+  });
+
+  it('should return only "board" type block for the space', async () => {
+    const result = (
+      await request(baseUrl).get(`/api/spaces/${space.id}/rewards/blocks`).query({ type: 'board' }).expect(200)
+    ).body as Space;
+
+    expect(result).toMatchObject([expect.objectContaining({ type: 'board' })]);
+  });
+});

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewardsTable.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewardsTable.tsx
@@ -228,7 +228,7 @@ export function ProposalRewardsTable({
           ) : cardPages.length ? (
             <Box className='container-container'>
               <Stack>
-                <Box width='100%'>
+                <Box width='100%' mb={1}>
                   <Table
                     boardType='rewards'
                     hideCalculations

--- a/lib/rewards/blocks/getBlocks.ts
+++ b/lib/rewards/blocks/getBlocks.ts
@@ -1,17 +1,21 @@
 import { prisma } from '@charmverse/core/prisma-client';
 
+import type { BlockTypes } from 'lib/focalboard/block';
 import type { RewardBlockWithTypedFields } from 'lib/rewards/blocks/interfaces';
 
 export async function getBlocks({
   spaceId,
+  type,
   ids
 }: {
   spaceId: string;
+  type?: BlockTypes;
   ids?: string[];
 }): Promise<RewardBlockWithTypedFields[]> {
   const blocks = await prisma.rewardBlock.findMany({
     where: {
       spaceId,
+      type,
       id:
         Array.isArray(ids) && ids.length
           ? {

--- a/lib/utilities/types.ts
+++ b/lib/utilities/types.ts
@@ -25,8 +25,8 @@ export type OptionalNullable<T> = T extends any[]
   ? OptionalNullable<T[number]>[]
   : T extends object
   ? {
-      [K in keyof PickNullable<T>]?: OptionalNullable<T[K]>;
+      [K in keyof PickNullable<T>]?: Exclude<T[K], null>;
     } & {
-      [K in keyof PickNotNullable<T>]: OptionalNullable<T[K]>;
+      [K in keyof PickNotNullable<T>]: T[K];
     }
   : T;

--- a/pages/api/spaces/[id]/rewards/blocks/index.ts
+++ b/pages/api/spaces/[id]/rewards/blocks/index.ts
@@ -1,9 +1,8 @@
-import { hasAccessToSpace } from '@charmverse/core/permissions';
 import { prisma } from '@charmverse/core/prisma-client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
-import { ActionNotPermittedError, onError, onNoMatch, requireSpaceMembership } from 'lib/middleware';
+import { onError, onNoMatch, requireSpaceMembership } from 'lib/middleware';
 import { deleteBlocks } from 'lib/rewards/blocks/deleteBlocks';
 import { getBlocks } from 'lib/rewards/blocks/getBlocks';
 import type { RewardBlockUpdateInput, RewardBlockWithTypedFields } from 'lib/rewards/blocks/interfaces';
@@ -22,19 +21,11 @@ handler
 async function getRewardBlocksHandler(req: NextApiRequest, res: NextApiResponse<RewardBlockWithTypedFields[]>) {
   const spaceId = req.query.id as string;
   const blockId = req.query.blockId as string;
-
-  const space = await prisma.space.findUniqueOrThrow({
-    where: {
-      id: spaceId
-    },
-    select: {
-      publicBountyBoard: true,
-      publicProposals: true
-    }
-  });
+  const type = req.query.type as 'board' | 'card' | 'view' | undefined;
 
   const rewardBlocks = await getBlocks({
     spaceId,
+    type,
     ids: blockId ? [blockId] : undefined
   });
 

--- a/testing/mocks/rewards.ts
+++ b/testing/mocks/rewards.ts
@@ -1,0 +1,85 @@
+import type { RewardBlock, Prisma } from '@charmverse/core/prisma';
+
+import type { OptionalNullable } from 'lib/utilities/types';
+
+export function mockRewardBlocks({
+  spaceId,
+  createdBy
+}: {
+  spaceId: string;
+  createdBy: string;
+}): Prisma.RewardBlockCreateManyInput[] {
+  return [
+    {
+      id: '__defaultBoard',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      title: '',
+      parentId: '',
+      rootId: spaceId,
+      spaceId,
+      type: 'board',
+      schema: 1,
+      createdBy,
+      updatedBy: createdBy,
+      fields: {
+        icon: '',
+        viewIds: [],
+        isTemplate: false,
+        description: '',
+        headerImage: null,
+        cardProperties: [],
+        showDescription: false,
+        columnCalculations: []
+      }
+    },
+    {
+      id: '__defaultView',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      title: '',
+      parentId: '__defaultBoard',
+      rootId: spaceId,
+      spaceId,
+      type: 'view',
+      schema: 1,
+      createdBy,
+      updatedBy: createdBy,
+      fields: {
+        filter: { filters: [], operation: 'and' },
+        viewType: 'table',
+        cardOrder: [],
+        openPageIn: 'center_peek',
+        sortOptions: [{ reversed: false, propertyId: '__title' }],
+        columnWidths: {
+          __limit: 150,
+          __title: 400,
+          __available: 150,
+          __reviewers: 150,
+          __applicants: 200,
+          __rewardChain: 150,
+          __rewardAmount: 150,
+          __rewardStatus: 150,
+          __rewardCustomValue: 150
+        },
+        hiddenOptionIds: [],
+        columnWrappedIds: ['__title'],
+        visibleOptionIds: [],
+        defaultTemplateId: '',
+        collapsedOptionIds: [],
+        columnCalculations: {},
+        kanbanCalculations: {},
+        visiblePropertyIds: [
+          '__rewardStatus',
+          '__rewardAmount',
+          '__rewardChain',
+          '__rewardCustomValue',
+          '__applicants',
+          '__reviewers',
+          '__available',
+          '__limit'
+        ]
+      }
+    }
+  ];
+}

--- a/testing/mocks/space.ts
+++ b/testing/mocks/space.ts
@@ -1,4 +1,4 @@
-import type { Space } from '@charmverse/core/prisma-client';
+import type { Space } from '@charmverse/core/prisma';
 import { v4 as uuid } from 'uuid';
 
 import { STATIC_PAGES } from 'lib/features/constants';


### PR DESCRIPTION
I was grabbing the cardProperties from the fully-configured board which we export when updating the data. Apparently, we should not be storing the reward properties - they get added each time the board is loaded in the DB by getDefaultBoard.

I'm also just wondering if there could be a need to save reward card properties or not? And should we/do we use this approach for proposal-as-a-source? (I think every time we add a field we have to do a migration right now)