### PR TITLE
Cleanup: only send meta data forward for proposal templates

### DIFF
--- a/__e2e__/po/document.po.ts
+++ b/__e2e__/po/document.po.ts
@@ -68,7 +68,7 @@ export class DocumentPage extends GlobalPage {
     this.deletePermanentlyButton = this.rootSelector.locator('data-test=banner--permanently-delete');
     this.restoreArchivedButton = this.rootSelector.locator('data-test=banner--restore-archived-page');
     this.trashModal = this.rootSelector.locator('data-test=trash-modal');
-    this.charmEditor = this.rootSelector.locator('data-test=page-charmeditor >> div[contenteditable]').first();
+    this.charmEditor = this.rootSelector.locator('data-test=page-charmeditor >> div[contenteditable]');
     this.proposalBanner = this.rootSelector.locator('data-test=proposal-banner');
     this.documentTitle = this.rootSelector.locator(`data-test=editor-page-title`);
     this.documentTitleInput = this.rootSelector.locator(`data-test=editor-page-title >> textarea`).first();

--- a/__e2e__/po/document.po.ts
+++ b/__e2e__/po/document.po.ts
@@ -68,7 +68,7 @@ export class DocumentPage extends GlobalPage {
     this.deletePermanentlyButton = this.rootSelector.locator('data-test=banner--permanently-delete');
     this.restoreArchivedButton = this.rootSelector.locator('data-test=banner--restore-archived-page');
     this.trashModal = this.rootSelector.locator('data-test=trash-modal');
-    this.charmEditor = this.rootSelector.locator('data-test=page-charmeditor >> .bangle-editor');
+    this.charmEditor = this.rootSelector.locator('data-test=page-charmeditor >> .bangle-editor').first();
     this.proposalBanner = this.rootSelector.locator('data-test=proposal-banner');
     this.documentTitle = this.rootSelector.locator(`data-test=editor-page-title`);
     this.documentTitleInput = this.rootSelector.locator(`data-test=editor-page-title >> textarea`).first();

--- a/__e2e__/po/document.po.ts
+++ b/__e2e__/po/document.po.ts
@@ -68,7 +68,7 @@ export class DocumentPage extends GlobalPage {
     this.deletePermanentlyButton = this.rootSelector.locator('data-test=banner--permanently-delete');
     this.restoreArchivedButton = this.rootSelector.locator('data-test=banner--restore-archived-page');
     this.trashModal = this.rootSelector.locator('data-test=trash-modal');
-    this.charmEditor = this.rootSelector.locator('data-test=page-charmeditor >> div[contenteditable]');
+    this.charmEditor = this.rootSelector.locator('data-test=page-charmeditor >> .bangle-editor');
     this.proposalBanner = this.rootSelector.locator('data-test=proposal-banner');
     this.documentTitle = this.rootSelector.locator(`data-test=editor-page-title`);
     this.documentTitleInput = this.rootSelector.locator(`data-test=editor-page-title >> textarea`).first();

--- a/__e2e__/proposals/freeFormProposalTemplate.spec.ts
+++ b/__e2e__/proposals/freeFormProposalTemplate.spec.ts
@@ -429,9 +429,8 @@ test.describe.serial('Create and use Proposal Template', async () => {
     expect(value).toEqual(role.name);
 
     await expect(proposalPage.editRubricCriteriaLabel).toBeDisabled();
-    await page.waitForFunction(async () => {
-      const content = (await proposalPage.charmEditor.allInnerTexts())[0];
-      return !content.trim();
+    await page.waitForFunction(() => {
+      return !!document.querySelector('.bangle-editor')?.textContent;
     });
     const content = (await proposalPage.charmEditor.allInnerTexts())[0];
 

--- a/__e2e__/proposals/freeFormProposalTemplate.spec.ts
+++ b/__e2e__/proposals/freeFormProposalTemplate.spec.ts
@@ -429,12 +429,8 @@ test.describe.serial('Create and use Proposal Template', async () => {
     expect(value).toEqual(role.name);
 
     await expect(proposalPage.editRubricCriteriaLabel).toBeDisabled();
-    await page.waitForFunction(() => {
-      return !!document.querySelector('[data-test=page-charmeditor] div[contenteditable]')?.textContent;
-    });
-    const content = (await proposalPage.charmEditor.allInnerTexts())[0];
 
-    expect(content.trim()).toEqual(templatePageContent.description);
+    expect(proposalPage.charmEditor).toHaveText(templatePageContent.description);
 
     await Promise.all([page.waitForResponse('**/api/proposals'), proposalPage.saveDraftButton.click()]);
 

--- a/__e2e__/proposals/freeFormProposalTemplate.spec.ts
+++ b/__e2e__/proposals/freeFormProposalTemplate.spec.ts
@@ -430,7 +430,7 @@ test.describe.serial('Create and use Proposal Template', async () => {
 
     await expect(proposalPage.editRubricCriteriaLabel).toBeDisabled();
     await page.waitForFunction(() => {
-      return !!document.querySelector('.bangle-editor')?.textContent;
+      return !!document.querySelector('[data-test=page-charmeditor] div[contenteditable]')?.textContent;
     });
     const content = (await proposalPage.charmEditor.allInnerTexts())[0];
 

--- a/__e2e__/proposals/freeFormProposalTemplate.spec.ts
+++ b/__e2e__/proposals/freeFormProposalTemplate.spec.ts
@@ -420,14 +420,16 @@ test.describe.serial('Create and use Proposal Template', async () => {
     await proposalPage.documentTitleInput.fill(userProposalConfig.title);
 
     // Check that configuration fields are readonly and user cannot edit proposal
-    const reviewerInput = (await proposalPage.getSelectedReviewers()).nth(1);
+    const reviewerInputs = await proposalPage.getSelectedReviewers();
+    await reviewerInputs.nth(1).waitFor();
+    const reviewerInput = reviewerInputs.nth(1);
 
     const value = (await reviewerInput.allInnerTexts())[0].trim();
 
     expect(value).toEqual(role.name);
 
     await expect(proposalPage.editRubricCriteriaLabel).toBeDisabled();
-
+    await proposalPage.charmEditor.waitFor();
     const content = (await proposalPage.charmEditor.allInnerTexts())[0];
 
     expect(content.trim()).toEqual(templatePageContent.description);

--- a/__e2e__/proposals/freeFormProposalTemplate.spec.ts
+++ b/__e2e__/proposals/freeFormProposalTemplate.spec.ts
@@ -430,7 +430,7 @@ test.describe.serial('Create and use Proposal Template', async () => {
 
     await expect(proposalPage.editRubricCriteriaLabel).toBeDisabled();
 
-    expect(proposalPage.charmEditor).toHaveText(templatePageContent.description);
+    expect(proposalPage.charmEditor).toHaveText(templatePageContent.description, { timeout: 3000 });
 
     await Promise.all([page.waitForResponse('**/api/proposals'), proposalPage.saveDraftButton.click()]);
 

--- a/__e2e__/proposals/freeFormProposalTemplate.spec.ts
+++ b/__e2e__/proposals/freeFormProposalTemplate.spec.ts
@@ -424,13 +424,11 @@ test.describe.serial('Create and use Proposal Template', async () => {
     await reviewerInputs.nth(1).waitFor();
     const reviewerInput = reviewerInputs.nth(1);
 
-    const value = (await reviewerInput.allInnerTexts())[0].trim();
-
-    expect(value).toEqual(role.name);
+    await expect(reviewerInput).toHaveText(role.name);
 
     await expect(proposalPage.editRubricCriteriaLabel).toBeDisabled();
 
-    expect(proposalPage.charmEditor).toHaveText(templatePageContent.description, { timeout: 3000 });
+    await expect(proposalPage.charmEditor).toHaveText(templatePageContent.description);
 
     await Promise.all([page.waitForResponse('**/api/proposals'), proposalPage.saveDraftButton.click()]);
 

--- a/__e2e__/proposals/freeFormProposalTemplate.spec.ts
+++ b/__e2e__/proposals/freeFormProposalTemplate.spec.ts
@@ -429,7 +429,10 @@ test.describe.serial('Create and use Proposal Template', async () => {
     expect(value).toEqual(role.name);
 
     await expect(proposalPage.editRubricCriteriaLabel).toBeDisabled();
-    await proposalPage.charmEditor.waitFor();
+    await page.waitForFunction(async () => {
+      const content = (await proposalPage.charmEditor.allInnerTexts())[0];
+      return !content.trim();
+    });
     const content = (await proposalPage.charmEditor.allInnerTexts())[0];
 
     expect(content.trim()).toEqual(templatePageContent.description);

--- a/charmClient/apis/proposalsApi.ts
+++ b/charmClient/apis/proposalsApi.ts
@@ -18,10 +18,6 @@ export class ProposalsApi {
     return http.GET<ProposalWithUsersAndRubric>(`/api/proposals/${proposalId}`);
   }
 
-  deleteProposalTemplate({ proposalTemplateId }: { proposalTemplateId: string }): Promise<PageWithPermissions> {
-    return http.DELETE(`/api/proposals/templates/${proposalTemplateId}`);
-  }
-
   updateProposalEvaluation({ proposalId, ...payload }: UpdateEvaluationRequest) {
     return http.PUT(`/api/proposals/${proposalId}/evaluation`, payload);
   }

--- a/charmClient/hooks/proposals.ts
+++ b/charmClient/hooks/proposals.ts
@@ -10,7 +10,7 @@ import type {
 import type { CreateProposalInput } from 'lib/proposal/createProposal';
 import type { ProposalWithUsersLite } from 'lib/proposal/getProposals';
 import type { RubricProposalsUserInfo } from 'lib/proposal/getProposalsEvaluatedByUser';
-import type { ProposalTemplate } from 'lib/proposal/getProposalTemplates';
+import type { ProposalTemplateMeta } from 'lib/proposal/getProposalTemplates';
 import type { GoBackToStepRequest } from 'lib/proposal/goBackToStep';
 import type { ProposalWithUsersAndRubric } from 'lib/proposal/interface';
 import type { ProposalRubricCriteriaAnswerWithTypedResponse } from 'lib/proposal/rubric/interfaces';
@@ -35,7 +35,7 @@ export function useGetProposalsBySpace({ spaceId }: Partial<ListProposalsRequest
 }
 
 export function useGetProposalTemplatesBySpace(spaceId: MaybeString) {
-  return useGET<ProposalTemplate[]>(spaceId ? `/api/spaces/${spaceId}/proposal-templates` : null);
+  return useGET<ProposalTemplateMeta[]>(spaceId ? `/api/spaces/${spaceId}/proposal-templates` : null);
 }
 
 export function useGetProposalIdsEvaluatedByUser(spaceId: MaybeString) {

--- a/charmClient/hooks/proposals.ts
+++ b/charmClient/hooks/proposals.ts
@@ -38,6 +38,10 @@ export function useGetProposalTemplatesBySpace(spaceId: MaybeString) {
   return useGET<ProposalTemplateMeta[]>(spaceId ? `/api/spaces/${spaceId}/proposal-templates` : null);
 }
 
+export function useGetProposalTemplate(pageId: MaybeString) {
+  return useGET<ProposalWithUsersAndRubric>(pageId ? `/api/proposals/templates/${pageId}` : null);
+}
+
 export function useGetProposalIdsEvaluatedByUser(spaceId: MaybeString) {
   return useGET<RubricProposalsUserInfo>(spaceId ? `/api/spaces/${spaceId}/proposals-evaluated-by-user` : null);
 }

--- a/components/[pageId]/DocumentPage/components/ProposalArchivedBanner.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalArchivedBanner.tsx
@@ -36,14 +36,7 @@ export function ProposalArchivedBanner({ proposalId, disabled }: { proposalId: s
       }
     >
       <Box display='flex' gap={1} alignItems='center' data-test='archived-page-banner'>
-        <div
-          style={{
-            color: 'white',
-            fontWeight: 600
-          }}
-        >
-          Archived
-        </div>
+        <div>Archived</div>
       </Box>
     </AlertBanner>
   );

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material';
 
-import { useUpdateProposal, useGetProposalDetails } from 'charmClient/hooks/proposals';
+import { useUpdateProposal, useGetProposalTemplate } from 'charmClient/hooks/proposals';
 import type { ProposalPropertiesInput } from 'components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase';
 import { ProposalPropertiesBase } from 'components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase';
 import { useIsAdmin } from 'hooks/useIsAdmin';
@@ -26,7 +26,7 @@ export function ProposalProperties({
 }: ProposalPropertiesProps) {
   const { trigger: updateProposal } = useUpdateProposal({ proposalId });
   const { showError } = useSnackbar();
-  const { data: sourceTemplate } = useGetProposalDetails(proposal?.page?.sourceTemplateId);
+  const { data: sourceTemplate } = useGetProposalTemplate(proposal?.page?.sourceTemplateId);
 
   const isAdmin = useIsAdmin();
 

--- a/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
+++ b/components/[pageId]/DocumentPage/components/ProposalProperties.tsx
@@ -1,7 +1,6 @@
 import { Box } from '@mui/material';
 
-import { useUpdateProposal } from 'charmClient/hooks/proposals';
-import { useProposalTemplateById } from 'components/proposals/hooks/useProposalTemplates';
+import { useUpdateProposal, useGetProposalDetails } from 'charmClient/hooks/proposals';
 import type { ProposalPropertiesInput } from 'components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase';
 import { ProposalPropertiesBase } from 'components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase';
 import { useIsAdmin } from 'hooks/useIsAdmin';
@@ -27,7 +26,7 @@ export function ProposalProperties({
 }: ProposalPropertiesProps) {
   const { trigger: updateProposal } = useUpdateProposal({ proposalId });
   const { showError } = useSnackbar();
-  const sourceTemplate = useProposalTemplateById(proposal?.page?.sourceTemplateId);
+  const { data: sourceTemplate } = useGetProposalDetails(proposal?.page?.sourceTemplateId);
 
   const isAdmin = useIsAdmin();
 

--- a/components/common/CharmEditor/components/linkedPage/components/LinkedPagesList.tsx
+++ b/components/common/CharmEditor/components/linkedPage/components/LinkedPagesList.tsx
@@ -94,12 +94,12 @@ function PagesListWithContext({
       icon: null
     }));
     const proposalPages: PageListItem[] = (proposalTemplates || []).map((template) => ({
-      id: template.page.id,
-      path: template.page.path || '',
+      id: template.pageId,
+      path: `/${template.pageId}`,
       hasContent: true,
-      originalTitle: template.page.title,
-      title: `Template > ${template.page.title}`,
-      type: template.page.type,
+      originalTitle: template.title,
+      title: `Template > ${template.title}`,
+      type: 'proposal_template',
       icon: null
     }));
 

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -94,6 +94,7 @@ export function NewProposalPage({
   const { activeView: sidebarView, setActiveView } = usePageSidebar();
   const { proposalTemplates } = useProposalTemplates();
   const [selectedProposalTemplateId, setSelectedProposalTemplateId] = useState<null | string>();
+  const [contentTemplateId, setContentTemplateId] = useState<null | string>(); // used to keep charm editor content up-to-date
   const [, setPageTitle] = usePageTitle();
   const { data: workflowOptions, isLoading: isLoadingWorkflows } = useGetProposalWorkflows(currentSpace?.id);
   const proposalPageType = isTemplate ? 'proposal_template' : 'proposal';
@@ -228,6 +229,7 @@ export function NewProposalPage({
       },
       { fromUser: false }
     );
+    setContentTemplateId(template.id);
     const workflow = workflowOptions?.find((w) => w.id === template.workflowId);
     if (workflow) {
       // pass in the template since the formState will not be updated in this instance of applyWorkflow
@@ -493,7 +495,7 @@ export function NewProposalPage({
                       onContentChange={applyProposalContent}
                       focusOnInit
                       isContentControlled
-                      key={`${formInputs.proposalTemplateId ?? formInputs.sourcePageId ?? formInputs.sourcePostId}`}
+                      key={`${contentTemplateId ?? formInputs.sourcePageId ?? formInputs.sourcePostId}`}
                     />
                   )}
                   {isStructured && formInputs.fields?.enableRewards && (

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -3,13 +3,14 @@ import type { PageType } from '@charmverse/core/prisma-client';
 import type { ProposalWorkflowTyped } from '@charmverse/core/proposals';
 import styled from '@emotion/styled';
 import type { Theme } from '@mui/material';
-import { Box, Divider, useMediaQuery, Stack, Typography } from '@mui/material';
+import { Box, Divider, useMediaQuery } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 import { useResizeObserver } from 'usehooks-ts';
 import { v4 as uuid } from 'uuid';
 
 import { useForumPost } from 'charmClient/hooks/forum';
 import { useGetPage } from 'charmClient/hooks/pages';
+import { useGetProposalDetails } from 'charmClient/hooks/proposals';
 import { useGetProposalWorkflows } from 'charmClient/hooks/spaces';
 import { DocumentColumnLayout, DocumentColumn } from 'components/[pageId]/DocumentPage/components/DocumentColumnLayout';
 import PageBanner from 'components/[pageId]/DocumentPage/components/PageBanner';
@@ -40,7 +41,8 @@ import { usePages } from 'hooks/usePages';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { usePreventReload } from 'hooks/usePreventReload';
 import { useUser } from 'hooks/useUser';
-import type { ProposalTemplate } from 'lib/proposal/getProposalTemplates';
+import type { ProposalTemplateMeta } from 'lib/proposal/getProposalTemplates';
+import type { ProposalWithUsersAndRubric } from 'lib/proposal/interface';
 import type { ProposalRubricCriteriaWithTypedParams } from 'lib/proposal/rubric/interfaces';
 import { emptyDocument } from 'lib/prosemirror/constants';
 import type { PageContent } from 'lib/prosemirror/interfaces';
@@ -106,14 +108,13 @@ export function NewProposalPage({
   } = useNewProposal({
     newProposal: { type: proposalPageType, proposalType }
   });
+  const { data: sourceTemplate } = useGetProposalDetails(formInputs.proposalTemplateId);
   const [submittedDraft, setSubmittedDraft] = useState<boolean>(false);
 
   const containerWidthRef = useRef<HTMLDivElement>(null);
   const { width: containerWidth = 0 } = useResizeObserver({ ref: containerWidthRef });
   const isSmallScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('lg'));
   const isAdmin = useIsAdmin();
-
-  const sourceTemplate = proposalTemplates?.find((template) => template.page.id === formInputs.proposalTemplateId);
 
   const isStructured = formInputs.proposalType === 'structured' || !!formInputs.formId;
   const pendingRewards = formInputs.fields?.pendingRewards || [];
@@ -157,7 +158,10 @@ export function NewProposalPage({
   usePreventReload(contentUpdated);
 
   const isTemplateRequired = Boolean(currentSpace?.requireProposalTemplate);
-  const templatePageOptions = (proposalTemplates || []).map((template) => template.page);
+  const templatePageOptions = (proposalTemplates || []).map((template) => ({
+    id: template.proposalId,
+    title: template.title
+  }));
   const { pages } = usePages();
 
   const proposalTemplatePage = formInputs.proposalTemplateId ? pages[formInputs.proposalTemplateId] : null;
@@ -183,49 +187,51 @@ export function NewProposalPage({
     document.querySelector(`.bangle-editor-core`)?.dispatchEvent(focusEvent);
   }
 
-  function applyTemplate(_templateId: string) {
-    const template = proposalTemplates?.find((t) => t.id === _templateId);
-    if (template) {
-      const formFields = template.form?.formFields ?? [];
-      const authors = Array.from(new Set([user!.id].concat(template.authors.map((author) => author.userId))));
-      setFormInputs(
-        {
-          authors,
-          content: template.page.content as PageContent,
-          contentText: template.page.contentText,
-          selectedCredentialTemplates: template.selectedCredentialTemplates ?? [],
-          proposalTemplateId: _templateId,
-          headerImage: template.page.headerImage,
-          icon: template.page.icon,
-          evaluations: template.evaluations,
-          fields:
-            {
-              ...template.fields,
-              pendingRewards: template.fields?.pendingRewards?.map((pendingReward) => ({
-                ...pendingReward,
-                reward: {
-                  ...pendingReward.reward,
-                  assignedSubmitters: authors
-                }
-              }))
-            } || {},
-          type: proposalPageType,
-          formId: template.formId ?? undefined,
-          formFields: isTemplate ? formFields.map((formField) => ({ ...formField, id: uuid() })) : formFields,
-          formAnswers: (template?.form?.formFields ?? [])
-            .filter((formField) => formField.type !== 'label')
-            .map((proposalFormField) => ({
-              fieldId: proposalFormField.id,
-              value: getInitialFormFieldValue(proposalFormField) as FieldAnswerInput['value']
+  function setTemplateId(_templateId: string) {
+    setFormInputs({
+      proposalTemplateId: _templateId
+    });
+  }
+  function applyTemplate(template: ProposalWithUsersAndRubric) {
+    const formFields = template.form?.formFields ?? [];
+    const authors = Array.from(new Set([user!.id].concat(template.authors.map((author) => author.userId))));
+    const page = template.page!;
+    setFormInputs(
+      {
+        authors,
+        content: page.content as PageContent,
+        contentText: page.contentText,
+        selectedCredentialTemplates: template.selectedCredentialTemplates ?? [],
+        headerImage: null,
+        icon: null,
+        evaluations: template.evaluations,
+        fields:
+          {
+            ...template.fields,
+            pendingRewards: template.fields?.pendingRewards?.map((pendingReward) => ({
+              ...pendingReward,
+              reward: {
+                ...pendingReward.reward,
+                assignedSubmitters: authors
+              }
             }))
-        },
-        { fromUser: false }
-      );
-      const workflow = workflowOptions?.find((w) => w.id === template.workflowId);
-      if (workflow) {
-        // pass in the template since the formState will not be updated in this instance of applyWorkflow
-        applyWorkflow(workflow, template);
-      }
+          } || {},
+        type: proposalPageType,
+        formId: template.formId ?? undefined,
+        formFields: isTemplate ? formFields.map((formField) => ({ ...formField, id: uuid() })) : formFields,
+        formAnswers: (template?.form?.formFields ?? [])
+          .filter((formField) => formField.type !== 'label')
+          .map((proposalFormField) => ({
+            fieldId: proposalFormField.id,
+            value: getInitialFormFieldValue(proposalFormField) as FieldAnswerInput['value']
+          }))
+      },
+      { fromUser: false }
+    );
+    const workflow = workflowOptions?.find((w) => w.id === template.workflowId);
+    if (workflow) {
+      // pass in the template since the formState will not be updated in this instance of applyWorkflow
+      applyWorkflow(workflow, template);
     }
   }
 
@@ -235,7 +241,7 @@ export function NewProposalPage({
     });
   }
 
-  function applyWorkflow(workflow: ProposalWorkflowTyped, template?: ProposalTemplate) {
+  function applyWorkflow(workflow: ProposalWorkflowTyped, template?: ProposalWithUsersAndRubric) {
     setFormInputs(
       {
         workflowId: workflow.id,
@@ -296,7 +302,7 @@ export function NewProposalPage({
     if (!isLoadingTemplates && !isLoadingWorkflows) {
       // populate with template if selected
       if (templateIdFromUrl) {
-        applyTemplate(templateIdFromUrl);
+        setTemplateId(templateIdFromUrl);
       }
       // populate workflow if not set and template is not selected
       else if (workflowOptions?.length) {
@@ -407,7 +413,7 @@ export function NewProposalPage({
                                       clearTemplate();
                                       // if user has not updated the content, then just overwrite everything
                                     } else if (formInputs.contentText?.length === 0) {
-                                      applyTemplate(page.id);
+                                      setTemplateId(page.id);
                                     } else {
                                       // set value to trigger a prompt
                                       setSelectedProposalTemplateId(page.id);
@@ -610,7 +616,7 @@ export function NewProposalPage({
           secondaryButtonText='Go back'
           question='Are you sure you want to overwrite your current content with the proposal template content?'
           onConfirm={() => {
-            applyTemplate(selectedProposalTemplateId!);
+            setTemplateId(selectedProposalTemplateId!);
             setSelectedProposalTemplateId(null);
           }}
         />

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -10,7 +10,7 @@ import { v4 as uuid } from 'uuid';
 
 import { useForumPost } from 'charmClient/hooks/forum';
 import { useGetPage } from 'charmClient/hooks/pages';
-import { useGetProposalDetails } from 'charmClient/hooks/proposals';
+import { useGetProposalTemplate } from 'charmClient/hooks/proposals';
 import { useGetProposalWorkflows } from 'charmClient/hooks/spaces';
 import { DocumentColumnLayout, DocumentColumn } from 'components/[pageId]/DocumentPage/components/DocumentColumnLayout';
 import PageBanner from 'components/[pageId]/DocumentPage/components/PageBanner';
@@ -92,7 +92,7 @@ export function NewProposalPage({
   const { user } = useUser();
   const [collapsedFieldIds, setCollapsedFieldIds] = useState<string[]>([]);
   const { activeView: sidebarView, setActiveView } = usePageSidebar();
-  const { proposalTemplates, isLoadingTemplates } = useProposalTemplates();
+  const { proposalTemplates } = useProposalTemplates();
   const [selectedProposalTemplateId, setSelectedProposalTemplateId] = useState<null | string>();
   const [, setPageTitle] = usePageTitle();
   const { data: workflowOptions, isLoading: isLoadingWorkflows } = useGetProposalWorkflows(currentSpace?.id);
@@ -108,7 +108,7 @@ export function NewProposalPage({
   } = useNewProposal({
     newProposal: { type: proposalPageType, proposalType }
   });
-  const { data: sourceTemplate } = useGetProposalDetails(formInputs.proposalTemplateId);
+  const { data: sourceTemplate } = useGetProposalTemplate(formInputs.proposalTemplateId);
   const [submittedDraft, setSubmittedDraft] = useState<boolean>(false);
 
   const containerWidthRef = useRef<HTMLDivElement>(null);
@@ -299,7 +299,7 @@ export function NewProposalPage({
   }, []);
 
   useEffect(() => {
-    if (!isLoadingTemplates && !isLoadingWorkflows) {
+    if (!isLoadingWorkflows) {
       // populate with template if selected
       if (templateIdFromUrl) {
         setTemplateId(templateIdFromUrl);
@@ -309,7 +309,7 @@ export function NewProposalPage({
         applyWorkflow(workflowOptions[0]);
       }
     }
-  }, [templateIdFromUrl, isLoadingTemplates, isLoadingWorkflows]);
+  }, [templateIdFromUrl, isLoadingWorkflows]);
 
   // Keep the formAnswers in sync with the formFields using a ref as charmEditor fields uses the initial field value
   const formAnswersRef = useRef(formInputs.formAnswers);
@@ -362,7 +362,7 @@ export function NewProposalPage({
         { fromUser: false }
       );
     }
-  }, [isTemplate]);
+  }, [isTemplate, setFormInputs]);
 
   useEffect(() => {
     if (sourceTemplate) {

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -364,6 +364,12 @@ export function NewProposalPage({
     }
   }, [isTemplate]);
 
+  useEffect(() => {
+    if (sourceTemplate) {
+      applyTemplate(sourceTemplate);
+    }
+  }, [sourceTemplate]);
+
   return (
     <Box display='flex' flexGrow={1} minHeight={0} /** add minHeight so that flexGrow expands to correct heigh */>
       <DocumentColumnLayout>

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/EvaluationStepSettingsModal.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/EvaluationStepSettingsModal.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material';
 
-import { useGetProposalDetails } from 'charmClient/hooks/proposals';
+import { useGetProposalTemplate } from 'charmClient/hooks/proposals';
 import { Button } from 'components/common/Button';
 import Modal from 'components/common/Modal';
 import { getEvaluationFormError } from 'lib/proposal/getProposalErrors';
@@ -21,7 +21,7 @@ export function EvaluationStepSettingsModal({
   saveEvaluation: (evaluation: ProposalEvaluationValues) => void;
   updateEvaluation: (evaluation: Partial<ProposalEvaluationValues>) => void;
 }) {
-  const { data: proposalTemplate } = useGetProposalDetails(templateId);
+  const { data: proposalTemplate } = useGetProposalTemplate(templateId);
   const evaluationInputError = evaluationInput && getEvaluationFormError(evaluationInput);
   // find matching template step, and allow editing if there were no reviewers set
   const matchingTemplateStep = proposalTemplate?.evaluations?.find((e) => e.title === evaluationInput.title);

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/EvaluationStepSettingsModal.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/EvaluationStepSettingsModal.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@mui/material';
 
+import { useGetProposalDetails } from 'charmClient/hooks/proposals';
 import { Button } from 'components/common/Button';
 import Modal from 'components/common/Modal';
-import { useProposalTemplateById } from 'components/proposals/hooks/useProposalTemplates';
 import { getEvaluationFormError } from 'lib/proposal/getProposalErrors';
 
 import type { ProposalEvaluationValues } from '../../Settings/components/EvaluationStepSettings';
@@ -21,7 +21,7 @@ export function EvaluationStepSettingsModal({
   saveEvaluation: (evaluation: ProposalEvaluationValues) => void;
   updateEvaluation: (evaluation: Partial<ProposalEvaluationValues>) => void;
 }) {
-  const proposalTemplate = useProposalTemplateById(templateId);
+  const { data: proposalTemplate } = useGetProposalDetails(templateId);
   const evaluationInputError = evaluationInput && getEvaluationFormError(evaluationInput);
   // find matching template step, and allow editing if there were no reviewers set
   const matchingTemplateStep = proposalTemplate?.evaluations?.find((e) => e.title === evaluationInput.title);

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Settings/EvaluationsSettings.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Settings/EvaluationsSettings.tsx
@@ -1,8 +1,8 @@
 import type { ProposalWorkflowTyped } from '@charmverse/core/proposals';
 import { Box, Chip, Collapse, Stack, Switch } from '@mui/material';
 
+import { useGetProposalDetails } from 'charmClient/hooks/proposals';
 import LoadingComponent from 'components/common/LoadingComponent';
-import { useProposalTemplateById } from 'components/proposals/hooks/useProposalTemplates';
 import type { ProposalEvaluationValues } from 'components/proposals/ProposalPage/components/ProposalEvaluations/components/Settings/components/EvaluationStepSettings';
 import type { ProposalPropertiesInput } from 'components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase';
 import { useIsAdmin } from 'hooks/useIsAdmin';
@@ -40,7 +40,7 @@ export function EvaluationsSettings({
   expanded: expandedContainer,
   isStructuredProposal
 }: Props) {
-  const proposalTemplate = useProposalTemplateById(templateId);
+  const { data: proposalTemplate } = useGetProposalDetails(templateId);
   const { mappedFeatures } = useSpaceFeatures();
   const isAdmin = useIsAdmin();
   return (

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Settings/EvaluationsSettings.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Settings/EvaluationsSettings.tsx
@@ -1,7 +1,7 @@
 import type { ProposalWorkflowTyped } from '@charmverse/core/proposals';
 import { Box, Chip, Collapse, Stack, Switch } from '@mui/material';
 
-import { useGetProposalDetails } from 'charmClient/hooks/proposals';
+import { useGetProposalTemplate } from 'charmClient/hooks/proposals';
 import LoadingComponent from 'components/common/LoadingComponent';
 import type { ProposalEvaluationValues } from 'components/proposals/ProposalPage/components/ProposalEvaluations/components/Settings/components/EvaluationStepSettings';
 import type { ProposalPropertiesInput } from 'components/proposals/ProposalPage/components/ProposalProperties/ProposalPropertiesBase';
@@ -40,7 +40,7 @@ export function EvaluationsSettings({
   expanded: expandedContainer,
   isStructuredProposal
 }: Props) {
-  const { data: proposalTemplate } = useGetProposalDetails(templateId);
+  const { data: proposalTemplate } = useGetProposalTemplate(templateId);
   const { mappedFeatures } = useSpaceFeatures();
   const isAdmin = useIsAdmin();
   return (

--- a/components/proposals/ProposalPage/components/TemplateSelect.tsx
+++ b/components/proposals/ProposalPage/components/TemplateSelect.tsx
@@ -1,19 +1,28 @@
-import type { PageMeta } from '@charmverse/core/pages';
-
 import { TagSelect } from 'components/common/BoardEditor/components/properties/TagSelect/TagSelect';
 import { fancyTrim } from 'lib/utilities/strings';
 
 const maxTitleLength = 35;
 
-type Props = {
-  disabled?: boolean;
-  displayType?: 'details';
-  options: PageMeta[];
-  value: { id: string } | null;
-  onChange: (value: PageMeta | null) => void;
+type TemplateOption = {
+  id: string;
+  title: string;
 };
 
-export function TemplateSelect({ disabled, displayType, options, value, onChange }: Props) {
+type Props<T> = {
+  disabled?: boolean;
+  displayType?: 'details';
+  options: T[];
+  value: { id: string } | null;
+  onChange: (value: T | null) => void;
+};
+
+export function TemplateSelect<T extends TemplateOption>({
+  disabled,
+  displayType,
+  options,
+  value,
+  onChange
+}: Props<T>) {
   const propertyOptions = options.map((option) => ({
     id: option.id,
     color: 'gray',

--- a/components/proposals/components/NewProposalButton.tsx
+++ b/components/proposals/components/NewProposalButton.tsx
@@ -54,10 +54,10 @@ export function NewProposalButton() {
   const canCreateProposal = spacePermissions?.createProposals;
 
   const proposalTemplatePages: TemplateItem[] = (proposalTemplates || []).map((proposal) => ({
-    id: proposal.page.id,
-    title: proposal.page.title,
-    proposalId: proposal.id,
-    isStructuredProposal: !!proposal.formId,
+    id: proposal.pageId,
+    title: proposal.title,
+    proposalId: proposal.proposalId,
+    isStructuredProposal: proposal.contentType === 'structured',
     archived: !!proposal.archived
   }));
 

--- a/components/proposals/hooks/useProposalTemplates.tsx
+++ b/components/proposals/hooks/useProposalTemplates.tsx
@@ -24,7 +24,7 @@ export function useProposalTemplates({ load = true }: { load?: boolean } = {}) {
     function handleDeleteEvent(value: WebSocketPayload<'pages_deleted'>) {
       mutate(
         (templates) => {
-          return templates?.filter((p) => !value.some((val) => val.id === p.id));
+          return templates?.filter((template) => !value.some((val) => val.id === template.pageId));
         },
         {
           revalidate: false
@@ -43,7 +43,7 @@ export function useProposalTemplates({ load = true }: { load?: boolean } = {}) {
         (list) => {
           if (!list) return list;
           return list.map((proposal) => {
-            if (payload.proposalIds.includes(proposal.id)) {
+            if (payload.proposalIds.includes(proposal.proposalId)) {
               return {
                 ...proposal,
                 archived: payload.archived
@@ -67,13 +67,6 @@ export function useProposalTemplates({ load = true }: { load?: boolean } = {}) {
 
   return {
     proposalTemplates: usableTemplates,
-    proposalTemplatePages: usableTemplates?.map((t) => t.page),
     isLoadingTemplates
   };
-}
-
-// TODO:  add an endpoint for a single template or return it along with the proposal??
-export function useProposalTemplateById(id: undefined | string | null) {
-  const { proposalTemplates } = useProposalTemplates({ load: !!id });
-  return proposalTemplates?.find((template) => template.page.id === id);
 }

--- a/lib/proposal/__tests__/getProposal.spec.ts
+++ b/lib/proposal/__tests__/getProposal.spec.ts
@@ -1,9 +1,4 @@
-import { prisma } from '@charmverse/core/prisma-client';
 import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
-import { v4 } from 'uuid';
-
-import type { FormFieldInput } from 'components/common/form/interfaces';
-import { createForm } from 'lib/form/createForm';
 
 import { getProposal } from '../getProposal';
 import type { ProposalWithUsersAndRubric } from '../interface';
@@ -31,51 +26,5 @@ describe('getProposal', () => {
         id: proposal.id
       })
     );
-  });
-
-  it('should return private form fields', async () => {
-    const { space, user: adminUser } = await testUtilsUser.generateUserAndSpace({
-      isAdmin: true,
-      spacePaidTier: 'community'
-    });
-    const fieldsInput: FormFieldInput[] = [
-      {
-        id: v4(),
-        type: 'short_text',
-        name: 'name',
-        description: 'description',
-        index: 0,
-        options: [],
-        private: true,
-        required: true
-      }
-    ];
-    const formId = await createForm(fieldsInput);
-
-    const template = await testUtilsProposals.generateProposal({
-      spaceId: space.id,
-      userId: adminUser.id,
-      pageType: 'proposal_template'
-    });
-    await prisma.proposal.update({
-      where: {
-        id: template.id
-      },
-      data: {
-        formId
-      }
-    });
-
-    const result = await getProposal({
-      id: template.id,
-      permissionsByStep: {
-        draft: {
-          view_private_fields: true
-        } as any
-      }
-    });
-
-    expect(result.form?.formFields).toHaveLength(1);
-    expect(result.form?.formFields![0]).toEqual(expect.objectContaining(fieldsInput[0]));
   });
 });

--- a/lib/proposal/__tests__/getProposal.spec.ts
+++ b/lib/proposal/__tests__/getProposal.spec.ts
@@ -1,4 +1,9 @@
+import { prisma } from '@charmverse/core/prisma-client';
 import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
+import { v4 } from 'uuid';
+
+import type { FormFieldInput } from 'components/common/form/interfaces';
+import { createForm } from 'lib/form/createForm';
 
 import { getProposal } from '../getProposal';
 import type { ProposalWithUsersAndRubric } from '../interface';
@@ -26,5 +31,51 @@ describe('getProposal', () => {
         id: proposal.id
       })
     );
+  });
+
+  it('should return private form fields', async () => {
+    const { space, user: adminUser } = await testUtilsUser.generateUserAndSpace({
+      isAdmin: true,
+      spacePaidTier: 'community'
+    });
+    const fieldsInput: FormFieldInput[] = [
+      {
+        id: v4(),
+        type: 'short_text',
+        name: 'name',
+        description: 'description',
+        index: 0,
+        options: [],
+        private: true,
+        required: true
+      }
+    ];
+    const formId = await createForm(fieldsInput);
+
+    const template = await testUtilsProposals.generateProposal({
+      spaceId: space.id,
+      userId: adminUser.id,
+      pageType: 'proposal_template'
+    });
+    await prisma.proposal.update({
+      where: {
+        id: template.id
+      },
+      data: {
+        formId
+      }
+    });
+
+    const result = await getProposal({
+      id: template.id,
+      permissionsByStep: {
+        draft: {
+          view_private_fields: true
+        } as any
+      }
+    });
+
+    expect(result.form?.formFields).toHaveLength(1);
+    expect(result.form?.formFields![0]).toEqual(expect.objectContaining(fieldsInput[0]));
   });
 });

--- a/lib/proposal/__tests__/getProposalTemplate.spec.ts
+++ b/lib/proposal/__tests__/getProposalTemplate.spec.ts
@@ -1,0 +1,73 @@
+import { prisma } from '@charmverse/core/prisma-client';
+import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
+import { v4 } from 'uuid';
+
+import type { FormFieldInput } from 'components/common/form/interfaces';
+import { createForm } from 'lib/form/createForm';
+
+import { getProposalTemplate } from '../getProposalTemplate';
+import type { ProposalWithUsersAndRubric } from '../interface';
+
+describe('getProposal', () => {
+  it('should return a proposal template', async () => {
+    const { space, user } = await testUtilsUser.generateUserAndSpace({
+      isAdmin: true,
+      spacePaidTier: 'community'
+    });
+
+    const proposal = await testUtilsProposals.generateProposal({
+      spaceId: space.id,
+      userId: user.id
+    });
+
+    const result = await getProposalTemplate({
+      pageId: proposal.page.id
+    });
+    expect(result).toMatchObject(
+      expect.objectContaining<Partial<ProposalWithUsersAndRubric>>({
+        id: proposal.id
+      })
+    );
+  });
+
+  it('should return private form fields', async () => {
+    const { space, user: adminUser } = await testUtilsUser.generateUserAndSpace({
+      isAdmin: true,
+      spacePaidTier: 'community'
+    });
+    const fieldsInput: FormFieldInput[] = [
+      {
+        id: v4(),
+        type: 'short_text',
+        name: 'name',
+        description: 'description',
+        index: 0,
+        options: [],
+        private: true,
+        required: true
+      }
+    ];
+    const formId = await createForm(fieldsInput);
+
+    const template = await testUtilsProposals.generateProposal({
+      spaceId: space.id,
+      userId: adminUser.id,
+      pageType: 'proposal_template'
+    });
+    await prisma.proposal.update({
+      where: {
+        id: template.id
+      },
+      data: {
+        formId
+      }
+    });
+
+    const result = await getProposalTemplate({
+      pageId: template.page.id
+    });
+
+    expect(result.form?.formFields).toHaveLength(1);
+    expect(result.form?.formFields![0]).toEqual(expect.objectContaining(fieldsInput[0]));
+  });
+});

--- a/lib/proposal/__tests__/getProposalTemplates.spec.ts
+++ b/lib/proposal/__tests__/getProposalTemplates.spec.ts
@@ -1,11 +1,6 @@
-import { prisma } from '@charmverse/core/prisma-client';
 import { testUtilsProposals, testUtilsUser } from '@charmverse/core/test';
-import { v4 } from 'uuid';
 
-import type { FormFieldInput } from 'components/common/form/interfaces';
-import { createForm } from 'lib/form/createForm';
-
-import type { ProposalTemplate } from '../getProposalTemplates';
+import type { ProposalTemplateMeta } from '../getProposalTemplates';
 import { getProposalTemplates } from '../getProposalTemplates';
 
 describe('getProposalTemplates', () => {
@@ -32,10 +27,9 @@ describe('getProposalTemplates', () => {
 
     expect(templates).toHaveLength(1);
     expect(templates[0]).toMatchObject(
-      expect.objectContaining<Partial<ProposalTemplate>>({
-        authors: expect.any(Array),
-        createdBy: adminUser.id,
-        id: expect.any(String)
+      expect.objectContaining<Partial<ProposalTemplateMeta>>({
+        pageId: expect.any(String),
+        title: expect.any(String)
       })
     );
   });
@@ -81,48 +75,5 @@ describe('getProposalTemplates', () => {
     });
 
     expect(templates).toHaveLength(0);
-  });
-
-  it('should return private form fields', async () => {
-    const { space, user: adminUser } = await testUtilsUser.generateUserAndSpace({
-      isAdmin: true,
-      spacePaidTier: 'community'
-    });
-    const fieldsInput: FormFieldInput[] = [
-      {
-        id: v4(),
-        type: 'short_text',
-        name: 'name',
-        description: 'description',
-        index: 0,
-        options: [],
-        private: true,
-        required: true
-      }
-    ];
-    const formId = await createForm(fieldsInput);
-
-    const template = await testUtilsProposals.generateProposal({
-      spaceId: space.id,
-      userId: adminUser.id,
-      pageType: 'proposal_template'
-    });
-    await prisma.proposal.update({
-      where: {
-        id: template.id
-      },
-      data: {
-        formId
-      }
-    });
-
-    const templates = await getProposalTemplates({
-      spaceId: space.id,
-      userId: adminUser.id
-    });
-
-    expect(templates).toHaveLength(1);
-    expect(templates[0].form?.formFields).toHaveLength(1);
-    expect(templates[0].form?.formFields![0]).toEqual(expect.objectContaining(fieldsInput[0]));
   });
 });

--- a/lib/proposal/getProposal.ts
+++ b/lib/proposal/getProposal.ts
@@ -40,8 +40,7 @@ export async function getProposal({
         }
       },
       authors: true,
-      page: { select: { id: true, sourceTemplateId: true, type: true } },
-      reviewers: true,
+      page: { select: { id: true, content: true, contentText: true, sourceTemplateId: true, type: true } },
       rewards: true,
       form: {
         include: {

--- a/lib/proposal/getProposalTemplate.ts
+++ b/lib/proposal/getProposalTemplate.ts
@@ -1,0 +1,68 @@
+import type { ProposalPermissionFlags } from '@charmverse/core/permissions';
+import { prisma } from '@charmverse/core/prisma-client';
+
+import type { permissionsApiClient } from 'lib/permissions/api/client';
+
+import type { ProposalWithUsersAndRubric } from './interface';
+import { mapDbProposalToProposal } from './mapDbProposalToProposal';
+
+const mockPermissions: ProposalPermissionFlags = {
+  evaluate: true,
+  comment: true,
+  edit: true,
+  delete: true,
+  view: false,
+  view_notes: false,
+  view_private_fields: true,
+  create_vote: false,
+  make_public: false,
+  archive: false,
+  unarchive: false,
+  move: false
+};
+
+export async function getProposalTemplate({ pageId }: { pageId: string }): Promise<ProposalWithUsersAndRubric> {
+  const proposal = await prisma.proposal.findFirstOrThrow({
+    where: {
+      page: {
+        id: pageId
+      }
+    },
+    include: {
+      evaluations: {
+        orderBy: {
+          index: 'asc'
+        },
+        include: {
+          permissions: true,
+          reviewers: true,
+          rubricCriteria: {
+            orderBy: {
+              index: 'asc'
+            }
+          },
+          rubricAnswers: true,
+          draftRubricAnswers: true,
+          vote: true
+        }
+      },
+      authors: true,
+      page: { select: { id: true, content: true, contentText: true, sourceTemplateId: true, type: true } },
+      rewards: true,
+      form: {
+        include: {
+          formFields: {
+            orderBy: {
+              index: 'asc'
+            }
+          }
+        }
+      }
+    }
+  });
+
+  return mapDbProposalToProposal({
+    proposal,
+    permissions: mockPermissions
+  });
+}

--- a/lib/proposal/getProposals.ts
+++ b/lib/proposal/getProposals.ts
@@ -77,6 +77,11 @@ export async function getProposals({ ids }: { ids: string[] }): Promise<Proposal
           }
         }
       }
+    },
+    orderBy: {
+      page: {
+        title: 'asc'
+      }
     }
   });
 

--- a/lib/proposal/getProposals.ts
+++ b/lib/proposal/getProposals.ts
@@ -78,6 +78,7 @@ export async function getProposals({ ids }: { ids: string[] }): Promise<Proposal
         }
       }
     },
+    // TODO: allow admins to sort by an index
     orderBy: {
       page: {
         title: 'asc'

--- a/lib/proposal/interface.ts
+++ b/lib/proposal/interface.ts
@@ -1,6 +1,7 @@
 import type { ProposalPermissionFlags } from '@charmverse/core/permissions';
 import type {
   FormField,
+  Page,
   Proposal,
   ProposalAuthor,
   ProposalReviewer,
@@ -66,7 +67,7 @@ export type ProposalWithUsersAndRubric = Omit<Proposal, 'fields'> & {
   rewardIds?: string[] | null;
   evaluations: PopulatedEvaluation[];
   fields: ProposalFields | null;
-  page?: { sourceTemplateId: string | null } | null;
+  page?: Partial<Pick<Page, 'sourceTemplateId' | 'content' | 'contentText' | 'type'>> | null;
   permissions: ProposalPermissionFlags;
   currentEvaluationId?: string;
   form: {

--- a/lib/proposal/mapDbProposalToProposal.ts
+++ b/lib/proposal/mapDbProposalToProposal.ts
@@ -1,6 +1,7 @@
 import type { ProposalPermissionFlags } from '@charmverse/core/permissions';
 import type {
   FormField,
+  Page,
   Proposal,
   ProposalAuthor,
   ProposalReviewer,
@@ -35,12 +36,13 @@ export function mapDbProposalToProposal({
         rubricCriteria: ProposalRubricCriteria[];
         draftRubricAnswers: ProposalRubricCriteriaAnswer[];
       })[];
+      page: Partial<Pick<Page, 'sourceTemplateId' | 'content' | 'contentText' | 'type'>> | null;
       rewards: { id: string }[];
     };
   permissions: ProposalPermissionFlags;
   permissionsByStep?: Record<string, ProposalPermissionFlags>;
 }): ProposalWithUsersAndRubric {
-  const { rewards, form, evaluations, fields, ...rest } = proposal;
+  const { rewards, form, evaluations, fields, page, ...rest } = proposal;
   const currentEvaluation = getCurrentEvaluation(proposal.evaluations);
   const formFields = getProposalFormFields(form?.formFields, !!permissions.view_private_fields);
   const mappedEvaluations = proposal.evaluations.map((evaluation) => {
@@ -54,9 +56,11 @@ export function mapDbProposalToProposal({
       isReviewer: !!stepPermissions?.evaluate
     } as unknown as PopulatedEvaluation;
   });
+  const pageFields = page?.type === 'proposal_template' ? page : { sourceTemplateId: page?.sourceTemplateId };
 
   const proposalWithUsers: ProposalWithUsersAndRubric = {
     ...rest,
+    page: pageFields,
     fields: fields as ProposalFields,
     evaluations: mappedEvaluations,
     permissions,

--- a/pages/api/proposals/templates/[id].ts
+++ b/pages/api/proposals/templates/[id].ts
@@ -2,53 +2,37 @@ import { prisma } from '@charmverse/core/prisma-client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
-import { onError, onNoMatch, requireUser } from 'lib/middleware';
+import { onError, onNoMatch, NotFoundError } from 'lib/middleware';
+import { getProposalTemplate } from 'lib/proposal/getProposalTemplate';
+import type { ProposalWithUsersAndRubric } from 'lib/proposal/interface';
 import { withSessionRoute } from 'lib/session/withSession';
 import { hasAccessToSpace } from 'lib/users/hasAccessToSpace';
-import { DataNotFoundError, InvalidInputError } from 'lib/utilities/errors';
+import { InvalidInputError } from 'lib/utilities/errors';
 
 const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
-handler.use(requireUser).delete(deleteProposalTemplateController);
+handler.get(getTemplateController);
 
-async function deleteProposalTemplateController(req: NextApiRequest, res: NextApiResponse) {
-  const userId = req.session.user.id;
+async function getTemplateController(req: NextApiRequest, res: NextApiResponse<ProposalWithUsersAndRubric>) {
+  const pageId = req.query.id as string;
+  const userId = req.session.user.id as string | undefined;
 
-  const templateId = req.query.id;
-
-  if (!templateId) {
-    throw new InvalidInputError('No proposalId provided');
+  if (!pageId) {
+    throw new InvalidInputError('Page ID is required');
   }
 
-  const proposal = await prisma.proposal.findUnique({
-    where: {
-      id: templateId as string
-    }
+  const proposal = await getProposalTemplate({ pageId });
+
+  const { isAdmin } = await hasAccessToSpace({
+    spaceId: proposal.spaceId,
+    userId
   });
 
-  if (!proposal) {
-    throw new DataNotFoundError(`No proposal template found with id ${templateId}`);
+  if (proposal.archived && !isAdmin) {
+    throw new NotFoundError();
   }
 
-  const { spaceId } = proposal;
-
-  const { error } = await hasAccessToSpace({
-    spaceId,
-    userId,
-    adminOnly: true
-  });
-
-  if (error) {
-    throw error;
-  }
-
-  await prisma.proposal.delete({
-    where: {
-      id: templateId as string
-    }
-  });
-
-  res.status(200).send({ success: true });
+  return res.status(200).json(proposal);
 }
 
 export default withSessionRoute(handler);

--- a/pages/api/spaces/[id]/proposal-templates.ts
+++ b/pages/api/spaces/[id]/proposal-templates.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
 import { onError, onNoMatch } from 'lib/middleware';
-import type { ProposalTemplate } from 'lib/proposal/getProposalTemplates';
+import type { ProposalTemplateMeta } from 'lib/proposal/getProposalTemplates';
 import { getProposalTemplates } from 'lib/proposal/getProposalTemplates';
 import { withSessionRoute } from 'lib/session/withSession';
 
@@ -10,7 +10,7 @@ const handler = nc<NextApiRequest, NextApiResponse>({ onError, onNoMatch });
 
 handler.get(getProposalTemplatesController);
 
-async function getProposalTemplatesController(req: NextApiRequest, res: NextApiResponse<ProposalTemplate[]>) {
+async function getProposalTemplatesController(req: NextApiRequest, res: NextApiResponse<ProposalTemplateMeta[]>) {
   const userId = req.session.user?.id;
   const spaceId = req.query.id as string;
 

--- a/stories/lib/mockData.ts
+++ b/stories/lib/mockData.ts
@@ -1,5 +1,5 @@
 import type { Member, MemberPropertyWithPermissions, PropertyValueWithDetails } from 'lib/members/interfaces';
-import type { ProposalTemplate } from 'lib/proposal/getProposalTemplates';
+import type { ProposalTemplateMeta } from 'lib/proposal/getProposalTemplates';
 import type { LoggedInUser } from 'models/User';
 import { createMemberProperty, createMemberPropertyValue } from 'testing/mocks/memberProperty';
 import { createMockSpace } from 'testing/mocks/space';
@@ -95,4 +95,4 @@ export const spaceRoles: ListSpaceRolesResponse[] = [
   { id: '2', name: 'Grant Reviewer', spacePermissions: [], source: null }
 ];
 
-export const proposalTemplates: ProposalTemplate[] = [];
+export const proposalTemplates: ProposalTemplateMeta[] = [];


### PR DESCRIPTION
Given that we get all the forms and evaluation information currently, we're grabbing an enormous amount of data for spaces like OP that have 10-15 proposal templates (1 MB in size!)