### PR TITLE
Fix Hats Protocol Ankr error on polygon

### DIFF
--- a/lib/blockchain/provider/ankr/client.ts
+++ b/lib/blockchain/provider/ankr/client.ts
@@ -74,7 +74,7 @@ export async function getNFT({ address, tokenId, chainId }: GetNFTInput): Promis
     log.warn('Ankr API Key is missing to retrive NFT');
     return null;
   }
-  if (supportedChainIds.includes(chainId)) {
+  if (chainId === 5000) {
     return getTokenInfoOnMantle({ address, chainId, tokenId });
   }
   const provider = new AnkrProvider(advancedAPIEndpoint);
@@ -83,7 +83,7 @@ export async function getNFT({ address, tokenId, chainId }: GetNFTInput): Promis
   await rateLimiter();
   const nft = await provider.getNFTMetadata({
     blockchain: blockchain as AnkrBlockchain,
-    tokenId: toInt(tokenId).toString(),
+    tokenId: BigInt(tokenId).toString(),
     contractAddress: address,
     forceFetch: false
   });

--- a/lib/blockchain/updateTokenGateDetails.ts
+++ b/lib/blockchain/updateTokenGateDetails.ts
@@ -30,7 +30,7 @@ async function getAccessControlMetaData(condition: AccessControlCondition) {
     case 'Hats':
     case 'ERC721':
     case 'ERC1155': {
-      const tokenId = condition.tokenIds.at(0) || '1';
+      const tokenId = BigInt(condition.tokenIds.at(0) || '1').toString();
       const nft = await getNFT({
         address: condition.contractAddress,
         tokenId,


### PR DESCRIPTION
After moving fron Ankr to Alchemy, Hats Protocol token gate was erroring because tokenId was too big and it couldn't be a number