### PR TITLE
filter out markdown files based on view filter

### DIFF
--- a/lib/focalboard/generateCsv.ts
+++ b/lib/focalboard/generateCsv.ts
@@ -207,7 +207,7 @@ export async function loadAndGenerateCsv({
   };
 }
 
-export function generateCSV(
+function generateCSV(
   board: Pick<Board, 'fields'>,
   view: BoardView,
   cards: Card[],

--- a/lib/focalboard/generateCsv.ts
+++ b/lib/focalboard/generateCsv.ts
@@ -203,7 +203,7 @@ export async function loadAndGenerateCsv({
 
   return {
     csvData: csvData.csvContent,
-    childPageIds: accessibleCardIds
+    childPageIds: csvData.rowIds
   };
 }
 
@@ -215,7 +215,7 @@ export function generateCSV(
   context: PropertyContext,
   relationPropertiesCardsRecord: PageListItemsRecord
 ) {
-  const rows = generateTableArray(board, cards, view, formatters, context, relationPropertiesCardsRecord);
+  const { rows, rowIds } = generateTableArray(board, cards, view, formatters, context, relationPropertiesCardsRecord);
   let csvContent = '';
 
   rows.forEach((row) => {
@@ -232,7 +232,8 @@ export function generateCSV(
 
   return {
     filename,
-    csvContent
+    csvContent,
+    rowIds
   };
 }
 
@@ -240,14 +241,14 @@ function encodeText(text: string): string {
   return text.replace(/"/g, '""');
 }
 
-export function generateTableArray(
+function generateTableArray(
   board: Pick<Board, 'fields'>,
   cards: Card[],
   viewToExport: BoardView,
   formatters: Formatters,
   context: PropertyContext,
   relationPropertiesCardsRecord: PageListItemsRecord
-): string[][] {
+): { rows: string[][]; rowIds: string[] } {
   const rows: string[][] = [];
   const cardProperties = board.fields.cardProperties as IPropertyTemplate[];
 
@@ -287,7 +288,7 @@ export function generateTableArray(
     rows.push(rowColumns);
   });
 
-  return rows;
+  return { rows, rowIds: filteredCards.map(({ id }) => id) };
 }
 
 export function getCSVColumns({

--- a/pages/api/pages/[id]/export-database.ts
+++ b/pages/api/pages/[id]/export-database.ts
@@ -25,7 +25,7 @@ async function requestZip(req: NextApiRequest, res: NextApiResponse) {
     try {
       filter = JSON.parse(customFilter) as FilterGroup;
     } catch (err) {
-      //
+      log.warn('Could not parse filter when exporting database', { error: err, filter: customFilter });
     }
   }
 


### PR DESCRIPTION
When exporting CSV, the rows are filtered by the active view, but the markdown was only filtered by pages that are accessible to you.