### PR TITLE
Show clicked related pages in modal

### DIFF
--- a/components/[pageId]/DatabasePage/DatabasePage.tsx
+++ b/components/[pageId]/DatabasePage/DatabasePage.tsx
@@ -172,6 +172,7 @@ export function DatabasePage({ page, setPage, readOnly = false, pagePermissions 
             />
             {typeof shownCardId === 'string' && shownCardId.length !== 0 && (
               <PageDialog
+                showCard={showCard}
                 key={shownCardId}
                 pageId={shownCardId}
                 onClose={() => {

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -3,7 +3,7 @@ import type { Theme } from '@mui/material';
 import { Box, Tab, Tabs, useMediaQuery } from '@mui/material';
 import dynamic from 'next/dynamic';
 import type { EditorState } from 'prosemirror-state';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useResizeObserver } from 'usehooks-ts';
 
 import { useGetReward } from 'charmClient/hooks/rewards';
@@ -91,6 +91,7 @@ function DocumentPageComponent({
   const isAdmin = useIsAdmin();
   const pagePermissions = page.permissionFlags;
   const proposalId = page.proposalId;
+  const { updateURLQuery, navigateToSpacePath } = useCharmRouter();
 
   const { proposal, refreshProposal, onChangeEvaluation, onChangeWorkflow, onChangeRewardSettings } = useProposal({
     proposalId
@@ -164,6 +165,22 @@ function DocumentPageComponent({
   function onParticipantUpdate(participants: FrontendParticipant[]) {
     setPageProps({ participants });
   }
+
+  const showCard = useCallback(
+    async (cardId: string | null) => {
+      if (cardId === null) {
+        updateURLQuery({ cardId: null });
+        return;
+      }
+
+      if (insideModal) {
+        updateURLQuery({ viewId: router.query.viewId as string, cardId });
+      } else {
+        navigateToSpacePath(`/${cardId}`);
+      }
+    },
+    [router.query]
+  );
 
   function onConnectionEvent(event: ConnectionEvent) {
     if (event.type === 'error') {
@@ -361,6 +378,7 @@ function DocumentPageComponent({
                       syncWithPageId={page.syncWithPageId}
                       board={board}
                       card={card}
+                      showCard={showCard}
                       cards={cards}
                       activeView={activeBoardView}
                       views={boardViews}

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -67,6 +67,7 @@ export type DocumentPageProps = {
   setEditorState?: (state: EditorState) => void;
   sidebarView?: IPageSidebarContext['activeView'];
   setSidebarView?: IPageSidebarContext['setActiveView'];
+  showCard?: (cardId: string | null) => void;
 };
 
 function DocumentPageComponent({
@@ -76,7 +77,8 @@ function DocumentPageComponent({
   readOnly = false,
   setEditorState,
   sidebarView,
-  setSidebarView
+  setSidebarView,
+  showCard
 }: DocumentPageProps) {
   const { user } = useUser();
   const { router } = useCharmRouter();
@@ -166,20 +168,24 @@ function DocumentPageComponent({
     setPageProps({ participants });
   }
 
-  const showCard = useCallback(
+  const _showCard = useCallback(
     async (cardId: string | null) => {
-      if (cardId === null) {
-        updateURLQuery({ cardId: null });
-        return;
-      }
-
-      if (insideModal) {
-        updateURLQuery({ viewId: router.query.viewId as string, cardId });
+      if (showCard) {
+        showCard(cardId);
       } else {
-        navigateToSpacePath(`/${cardId}`);
+        if (cardId === null) {
+          updateURLQuery({ cardId: null });
+          return;
+        }
+
+        if (insideModal) {
+          updateURLQuery({ viewId: router.query.viewId as string, cardId });
+        } else {
+          navigateToSpacePath(`/${cardId}`);
+        }
       }
     },
-    [router.query]
+    [router.query, showCard]
   );
 
   function onConnectionEvent(event: ConnectionEvent) {
@@ -378,7 +384,7 @@ function DocumentPageComponent({
                       syncWithPageId={page.syncWithPageId}
                       board={board}
                       card={card}
-                      showCard={showCard}
+                      showCard={_showCard}
                       cards={cards}
                       activeView={activeBoardView}
                       views={boardViews}

--- a/components/common/BoardEditor/components/cardProperties/CardDetailProperty.tsx
+++ b/components/common/BoardEditor/components/cardProperties/CardDetailProperty.tsx
@@ -62,7 +62,7 @@ export function CardDetailProperty({
   mutator: Mutator;
   disableEditPropertyOption?: boolean;
   onDrop: (template: IPropertyTemplate, container: IPropertyTemplate) => void;
-  showCard?: (cardId: string | null) => void;
+  showCard: (cardId: string | null) => void;
 }) {
   const [isDragging, isOver, columnRef] = useSortable('column', property, !readOnly, onDrop);
   const changePropertyPopupState = usePopupState({ variant: 'popover', popupId: 'card-property' });

--- a/components/common/BoardEditor/components/cardProperties/CardDetailProperty.tsx
+++ b/components/common/BoardEditor/components/cardProperties/CardDetailProperty.tsx
@@ -62,7 +62,7 @@ export function CardDetailProperty({
   mutator: Mutator;
   disableEditPropertyOption?: boolean;
   onDrop: (template: IPropertyTemplate, container: IPropertyTemplate) => void;
-  showCard: (cardId: string | null) => void;
+  showCard?: (cardId: string | null) => void;
 }) {
   const [isDragging, isOver, columnRef] = useSortable('column', property, !readOnly, onDrop);
   const changePropertyPopupState = usePopupState({ variant: 'popover', popupId: 'card-property' });

--- a/components/common/BoardEditor/components/properties/PagesAutocomplete.tsx
+++ b/components/common/BoardEditor/components/properties/PagesAutocomplete.tsx
@@ -40,35 +40,37 @@ const StyledAutocomplete = styled(Autocomplete<PageListItem & { selected: boolea
 
 const renderDiv = (props: any & { children: ReactNode }) => <div>{props.children}</div>;
 
+const StyledStack = styled(Stack)`
+  flex-direction: row;
+  align-items: center;
+  overflow-x: hidden;
+  cursor: pointer;
+  gap: ${({ theme }) => theme.spacing(0.25)};
+`;
+
 export function RelationPageListItemsContainer({
   readOnly,
   pageListItems,
-  wrapColumn,
-  onRemove
+  onRemove,
+  onClick
 }: {
   readOnly?: boolean;
-  wrapColumn?: boolean;
   pageListItems: PageListItem[];
   onRemove?: (id: string) => void;
+  onClick?: (id: string) => void;
 }) {
   return (
     <>
       {pageListItems.map((pageListItem) => {
         return (
-          <Stack
-            key={pageListItem.id}
-            gap={0.5}
-            flexDirection='row'
-            alignItems='center'
-            sx={wrapColumn ? { overflowX: 'hidden' } : { overflowX: 'hidden' }}
-          >
+          <StyledStack key={pageListItem.id} onClick={() => onClick?.(pageListItem.id)}>
             <PageIcon icon={pageListItem.icon} isEditorEmpty={!pageListItem.hasContent} pageType={pageListItem.type} />
             <PageTitle hasContent={!pageListItem.title} sx={{ fontWeight: 'bold' }}>
               {pageListItem.title || 'Untitled'}
             </PageTitle>
 
             {!readOnly && onRemove && (
-              <IconButton size='small' onClick={() => onRemove(pageListItem.id)}>
+              <IconButton sx={{ ml: 1 }} size='small' onClick={() => onRemove(pageListItem.id)}>
                 <CloseIcon
                   sx={{
                     fontSize: 14
@@ -78,7 +80,7 @@ export function RelationPageListItemsContainer({
                 />
               </IconButton>
             )}
-          </Stack>
+          </StyledStack>
         );
       })}
     </>
@@ -152,14 +154,15 @@ function PagesAutocompleteBase({
       readOnly={readOnly}
       onClick={onClickToEdit}
     >
-      <Box display='inline-flex' flexWrap={wrapColumn ? 'wrap' : 'nowrap'} gap={0.5}>
+      <Box display='inline-flex' flexWrap={wrapColumn ? 'wrap' : 'nowrap'} gap={1}>
         {selectedPageListItems.length === 0 ? (
           showEmptyPlaceholder && <EmptyPlaceholder>{emptyPlaceholderContent}</EmptyPlaceholder>
         ) : (
           <RelationPageListItemsContainer
             readOnly={readOnly}
-            wrapColumn={wrapColumn}
             pageListItems={selectedPageListItems}
+            // only showCard if its in readOnly mode since we need to open the select field in non readOnly mode
+            onClick={readOnly ? showCard : undefined}
           />
         )}
       </Box>

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
@@ -40,7 +40,7 @@ type Props = {
   readOnlyProperties?: string[];
   disableEditPropertyOption?: boolean;
   boardType?: 'proposals' | 'rewards';
-  showCard: (cardId: string | null) => void;
+  showCard?: (cardId: string | null) => void;
 };
 
 function CardDetailProperties(props: Props) {

--- a/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/cardDetail/cardDetailProperties.tsx
@@ -40,6 +40,7 @@ type Props = {
   readOnlyProperties?: string[];
   disableEditPropertyOption?: boolean;
   boardType?: 'proposals' | 'rewards';
+  showCard: (cardId: string | null) => void;
 };
 
 function CardDetailProperties(props: Props) {
@@ -296,6 +297,7 @@ function CardDetailProperties(props: Props) {
             key={propertyTemplate.id}
             board={board}
             card={card}
+            showCard={props.showCard}
             deleteDisabledMessage={getDeleteDisabled(propertyTemplate)}
             onDelete={() => onPropertyDeleteSetAndOpenConfirmationDialog(propertyTemplate)}
             onTypeAndNameChanged={(newType: PropertyType, newName: string, relationData?: RelationPropertyData) => {

--- a/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
+++ b/components/common/CharmEditor/components/inlineDatabase/components/InlineDatabase.tsx
@@ -128,7 +128,13 @@ export function InlineDatabase({ containerWidth, readOnly: readOnlyOverride, nod
           />
         </InlineDatabaseContainer>
         {typeof shownCardId === 'string' && shownCardId.length !== 0 && (
-          <PageDialog key={shownCardId} pageId={shownCardId} onClose={() => setShownCardId(null)} readOnly={readOnly} />
+          <PageDialog
+            showCard={showCard}
+            key={shownCardId}
+            pageId={shownCardId}
+            onClose={() => setShownCardId(null)}
+            readOnly={readOnly}
+          />
         )}
       </DbViewSettingsProvider>
       <FocalBoardPortal />

--- a/components/common/PageDialog/PageDialog.tsx
+++ b/components/common/PageDialog/PageDialog.tsx
@@ -37,10 +37,11 @@ interface Props {
   readOnly?: boolean;
   hideToolsMenu?: boolean;
   applicationContext?: PageDialogContext;
+  showCard?: (cardId: string | null) => void;
 }
 
 function PageDialogBase(props: Props) {
-  const { hideToolsMenu = false, pageId, readOnly, applicationContext } = props;
+  const { hideToolsMenu = false, pageId, readOnly, showCard, applicationContext } = props;
 
   const mounted = useRef(false);
   const popupState = usePopupState({ variant: 'popover', popupId: 'page-dialog' });
@@ -174,7 +175,7 @@ function PageDialogBase(props: Props) {
       onClose={close}
     >
       {page && contentType === 'page' && (
-        <DocumentPage insideModal page={page} savePage={savePage} readOnly={readOnlyPage} />
+        <DocumentPage showCard={showCard} insideModal page={page} savePage={savePage} readOnly={readOnlyPage} />
       )}
       {contentType === 'application' && applicationContext && (
         <RewardApplicationPage

--- a/components/common/PageDialog/hooks/usePageDialog.tsx
+++ b/components/common/PageDialog/hooks/usePageDialog.tsx
@@ -1,7 +1,5 @@
 import type { ReactNode } from 'react';
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
-
-import { useCharmRouter } from 'hooks/useCharmRouter';
+import { createContext, useContext, useMemo, useState } from 'react';
 
 export interface PageDialogContext {
   bountyId?: string;


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

1. Clicking on related cards inside a modal should open the clicked card in the same modal
2. Show clicked related card in a modal/new page for public databases
