### PR TITLE
rename FormFieldsInput to more clear FormFielAnswers

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -503,15 +503,14 @@ function DocumentPageComponent({
           )}
         </PageEditorContainer>
       </Box>
-      {page.type === 'proposal' ||
-        (page.type === 'proposal_template' && proposal?.status === 'draft' && (
-          <ProposalStickyFooter
-            page={page}
-            proposal={proposal}
-            isStructuredProposal={isStructuredProposal}
-            refreshProposal={refreshProposal}
-          />
-        ))}
+      {page.type === 'proposal' && proposal?.status === 'draft' && (
+        <ProposalStickyFooter
+          page={page}
+          proposal={proposal}
+          isStructuredProposal={isStructuredProposal}
+          refreshProposal={refreshProposal}
+        />
+      )}
     </Box>
   );
 }

--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -19,7 +19,7 @@ import type { ConnectionEvent } from 'components/common/CharmEditor/components/f
 import { focusEventName } from 'components/common/CharmEditor/constants';
 import { FormFieldsEditor } from 'components/common/form/FormFieldsEditor';
 import { ProposalEvaluations } from 'components/proposals/ProposalPage/components/ProposalEvaluations/ProposalEvaluations';
-import { ProposalFormFieldsInput } from 'components/proposals/ProposalPage/components/ProposalFormFieldsInput';
+import { ProposalFormFieldAnswers } from 'components/proposals/ProposalPage/components/ProposalFormFieldAnswers';
 import { ProposalRewardsTable } from 'components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewardsTable';
 import { ProposalStickyFooter } from 'components/proposals/ProposalPage/components/ProposalStickyFooter/ProposalStickyFooter';
 import { NewInlineReward } from 'components/rewards/components/NewInlineReward';
@@ -403,7 +403,7 @@ function DocumentPageComponent({
                     formFields={proposal.form?.formFields ?? []}
                   />
                 ) : (
-                  <ProposalFormFieldsInput
+                  <ProposalFormFieldAnswers
                     pageId={page.id}
                     enableComments={proposal.permissions.comment}
                     proposalId={proposal.id}
@@ -503,14 +503,15 @@ function DocumentPageComponent({
           )}
         </PageEditorContainer>
       </Box>
-      {page.type === 'proposal' && proposal?.status === 'draft' && (
-        <ProposalStickyFooter
-          page={page}
-          proposal={proposal}
-          isStructuredProposal={isStructuredProposal}
-          refreshProposal={refreshProposal}
-        />
-      )}
+      {page.type === 'proposal' ||
+        (page.type === 'proposal_template' && proposal?.status === 'draft' && (
+          <ProposalStickyFooter
+            page={page}
+            proposal={proposal}
+            isStructuredProposal={isStructuredProposal}
+            refreshProposal={refreshProposal}
+          />
+        ))}
     </Box>
   );
 }

--- a/components/common/form/FormFieldAnswers.tsx
+++ b/components/common/form/FormFieldAnswers.tsx
@@ -20,12 +20,12 @@ import { FormFieldAnswerComment } from './FormFieldAnswerComment';
 import { useFormFields } from './hooks/useFormFields';
 import type { FormFieldValue } from './interfaces';
 
-const FormFieldsInputContainer = styled(Stack)`
+const FormFieldAnswersContainer = styled(Stack)`
   gap: ${(props) => props.theme.spacing(1)};
   flex-direction: column;
 `;
 
-type FormFieldsInputProps = {
+type FormFieldAnswersProps = {
   formFields: (Pick<FormField, 'type' | 'name' | 'required' | 'id' | 'description' | 'private'> & {
     value?: FormFieldValue;
     options?: SelectOptionType[];
@@ -48,17 +48,17 @@ type FormFieldsInputProps = {
   threads?: Record<string, ThreadWithComments | undefined>;
 };
 
-export function ControlledFormFieldsInput(props: Omit<FormFieldsInputProps, 'onSave'>) {
-  return <FormFieldsInputBase {...props} />;
+export function ControlledFormFieldAnswers(props: Omit<FormFieldAnswersProps, 'onSave'>) {
+  return <FormFieldAnswersBase {...props} />;
 }
 
-export function FormFieldsInput(props: Omit<FormFieldsInputProps, 'control' | 'errors' | 'onFormChange'>) {
+export function FormFieldAnswers(props: Omit<FormFieldAnswersProps, 'control' | 'errors' | 'onFormChange'>) {
   const { control, errors, onFormChange, values } = useFormFields({
     fields: props.formFields
   });
 
   return (
-    <FormFieldsInputBase {...props} control={control} errors={errors} onFormChange={onFormChange} values={values} />
+    <FormFieldAnswersBase {...props} control={control} errors={errors} onFormChange={onFormChange} values={values} />
   );
 }
 
@@ -70,7 +70,7 @@ const StyledStack = styled(Stack)`
   position: relative;
 `;
 
-function FormFieldsInputBase({
+function FormFieldAnswersBase({
   onSave,
   formFields,
   values,
@@ -81,7 +81,7 @@ function FormFieldsInputBase({
   onFormChange,
   pageId,
   threads = {}
-}: FormFieldsInputProps & {
+}: FormFieldAnswersProps & {
   threads?: Record<string, ThreadWithComments | undefined>;
 }) {
   const { user } = useUser();
@@ -143,7 +143,7 @@ function FormFieldsInputBase({
   }, [debouncedValues]);
 
   return (
-    <FormFieldsInputContainer>
+    <FormFieldAnswersContainer>
       {formFields.map((formField) => {
         const fieldAnswerThreads =
           (formField.formFieldAnswer ? fieldAnswerIdThreadRecord[formField.formFieldAnswer.id] : []) ?? [];
@@ -216,6 +216,6 @@ function FormFieldsInputBase({
           </StyledStack>
         );
       })}
-    </FormFieldsInputContainer>
+    </FormFieldAnswersContainer>
   );
 }

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -27,8 +27,8 @@ import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
 import { focusEventName } from 'components/common/CharmEditor/constants';
+import { ControlledFormFieldAnswers } from 'components/common/form/FormFieldAnswers';
 import { ControlledFormFieldsEditor } from 'components/common/form/FormFieldsEditor';
-import { ControlledFormFieldsInput } from 'components/common/form/FormFieldsInput';
 import { getInitialFormFieldValue, useFormFields } from 'components/common/form/hooks/useFormFields';
 import type { FieldAnswerInput, FormFieldInput } from 'components/common/form/interfaces';
 import ConfirmDeleteModal from 'components/common/Modal/ConfirmDeleteModal';
@@ -470,7 +470,7 @@ export function NewProposalPage({
                         }}
                       />
                     ) : (
-                      <ControlledFormFieldsInput
+                      <ControlledFormFieldAnswers
                         control={proposalFormFieldControl}
                         enableComments={false}
                         errors={proposalFormFieldErrors}

--- a/components/proposals/ProposalPage/components/ProposalFormFieldAnswers.tsx
+++ b/components/proposals/ProposalPage/components/ProposalFormFieldAnswers.tsx
@@ -2,12 +2,12 @@ import type { FormField } from '@charmverse/core/prisma-client';
 
 import { useGetProposalFormFieldAnswers, useUpdateProposalFormFieldAnswers } from 'charmClient/hooks/proposals';
 import type { SelectOptionType } from 'components/common/form/fields/Select/interfaces';
-import { FormFieldsInput } from 'components/common/form/FormFieldsInput';
+import { FormFieldAnswers } from 'components/common/form/FormFieldAnswers';
 import type { FormFieldValue } from 'components/common/form/interfaces';
 import type { ThreadWithComments } from 'lib/threads/interfaces';
 import { isTruthy } from 'lib/utils/types';
 
-export function ProposalFormFieldsInput({
+export function ProposalFormFieldAnswers({
   proposalId,
   formFields,
   enableComments,
@@ -43,7 +43,7 @@ export function ProposalFormFieldsInput({
   }
 
   return (
-    <FormFieldsInput
+    <FormFieldAnswers
       enableComments={enableComments}
       onSave={onSave}
       pageId={pageId}

--- a/stories/FormFields/FormFields.stories.tsx
+++ b/stories/FormFields/FormFields.stories.tsx
@@ -7,8 +7,8 @@ import { v4 } from 'uuid';
 
 import { formFieldTypes } from 'components/common/form/constants';
 import type { SelectOptionType } from 'components/common/form/fields/Select/interfaces';
+import { FormFieldAnswers as CustomFormFieldAnswers } from 'components/common/form/FormFieldAnswers';
 import { ControlledFormFieldsEditor } from 'components/common/form/FormFieldsEditor';
-import { FormFieldsInput as CustomFormFieldsInput } from 'components/common/form/FormFieldsInput';
 import type { FormFieldInput, FormFieldValue } from 'components/common/form/interfaces';
 import { createDocumentWithText } from 'lib/prosemirror/constants';
 
@@ -65,7 +65,7 @@ export function FormFieldsEditor() {
 export function FormFieldsInputs() {
   return (
     <GlobalContext>
-      <CustomFormFieldsInput
+      <CustomFormFieldAnswers
         enableComments={true}
         formFields={formFieldTypes.map((formFieldType, index) => {
           const label = capitalize(formFieldType.replaceAll(/_/g, ' '));
@@ -88,7 +88,7 @@ export function FormFieldsInputs() {
 export function FormFieldsInputsDisplay() {
   return (
     <GlobalContext>
-      <CustomFormFieldsInput
+      <CustomFormFieldAnswers
         enableComments={true}
         disabled
         formFields={formFieldTypes.map((formFieldType, index) => {


### PR DESCRIPTION
Before, we had "FormFieldsInput" and "FormFieldsEditor" and they sound too similar, since you are "inputting" form fields inside the editor too