### PR TITLE
fix flaky e2e test

### DIFF
--- a/__e2e__/proposals/joinSpaceViaProposals.spec.ts
+++ b/__e2e__/proposals/joinSpaceViaProposals.spec.ts
@@ -189,7 +189,7 @@ test('Try to create a proposal from a linked proposal template / user from outsi
   await documentPage.goToPage({ domain: space.domain, path: pageReferencingTemplate.path });
 
   // User won't have the proposal template showing
-  await documentPage.getLinkedPage('undefined').click();
+  await documentPage.getLinkedPage(template.id).click();
 
   await page.waitForURL(`${baseUrl}/join?domain=${space.domain}`);
 });

--- a/charmClient/hooks/pages.ts
+++ b/charmClient/hooks/pages.ts
@@ -1,7 +1,7 @@
 import type { PageMeta } from '@charmverse/core/pages';
 
 import type { ModifyChildPagesResponse } from 'lib/pages';
-import type { PageWithContent } from 'lib/pages/interfaces';
+import type { PageWithContent, PageMetaLite } from 'lib/pages/interfaces';
 
 import { useGET, useGETImmutable, usePUT } from './helpers';
 
@@ -11,6 +11,10 @@ export function useTrashPages() {
 
 export function useGetPage(pageId?: string | null) {
   return useGET<PageWithContent>(pageId ? `/api/pages/${pageId}` : null);
+}
+
+export function useGetPageMeta(pageId?: string | null) {
+  return useGET<PageMetaLite>(pageId ? `/api/pages/${pageId}` : null, { meta: true });
 }
 
 export function useInitialPagesForSpace(spaceId?: string) {

--- a/components/[pageId]/DocumentPage/components/PageParentChip.tsx
+++ b/components/[pageId]/DocumentPage/components/PageParentChip.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@mui/material';
 import { useMemo } from 'react';
 
-import { useGetPage } from 'charmClient/hooks/pages';
+import { useGetPageMeta } from 'charmClient/hooks/pages';
 import Link from 'components/common/Link';
 import { BreadcrumbPageTitle } from 'components/common/PageLayout/components/Header/components/PageTitleWithBreadcrumbs';
 import { useRewards } from 'components/rewards/hooks/useRewards';
@@ -27,7 +27,7 @@ export function PageParentChip({ pageId, parentId, insideModal }: Props) {
 
   const parentProposalId =
     (page?.type === 'bounty' && page.bountyId && getRewardById(page.bountyId)?.proposalId) || undefined;
-  const { data: parentProposal } = useGetPage(parentProposalId);
+  const { data: parentProposal } = useGetPageMeta(parentProposalId);
 
   const title = parentPage?.title || parentProposal?.title || 'Untitled';
   const path = parentPage?.path || parentProposal?.path || '/';

--- a/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
+++ b/components/common/BoardEditor/focalboard/src/components/centerPanel.tsx
@@ -18,6 +18,7 @@ import { connect } from 'react-redux';
 import useSWRMutation from 'swr/mutation';
 
 import charmClient from 'charmClient';
+import { useGetPageMeta } from 'charmClient/hooks/pages';
 import PageBanner, { randomBannerImage } from 'components/[pageId]/DocumentPage/components/PageBanner';
 import PageDeleteBanner from 'components/[pageId]/DocumentPage/components/PageDeleteBanner';
 import { PageWebhookBanner } from 'components/common/BoardEditor/components/PageWebhookBanner';
@@ -34,7 +35,6 @@ import { useApiPageKeys } from 'hooks/useApiPageKeys';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useLocalDbViewSettings } from 'hooks/useLocalDbViewSettings';
 import { useMembers } from 'hooks/useMembers';
-import { usePage } from 'hooks/usePage';
 import { usePages } from 'hooks/usePages';
 import type { Block } from 'lib/focalboard/block';
 import type { Board, BoardGroup, IPropertyOption, IPropertyTemplate } from 'lib/focalboard/board';
@@ -118,7 +118,7 @@ function CenterPanel(props: Props) {
     activeBoardId = activeView?.fields.sourceData?.boardId;
   }
 
-  const { page: activePage } = usePage({ pageIdOrPath: activeBoardId, spaceId: space?.id });
+  const { data: activePage } = useGetPageMeta(activeBoardId);
 
   const { keys } = useApiPageKeys(props.page?.id);
   const selectBoard = useMemo(makeSelectBoard, []);

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import type { EditorView } from 'prosemirror-view';
 
-import { useGetPage } from 'charmClient/hooks/pages';
+import { useGetPageMeta } from 'charmClient/hooks/pages';
 import type { NodeViewProps } from 'components/common/CharmEditor/components/@bangle.dev/core/node-view';
 import { useEditorViewContext } from 'components/common/CharmEditor/components/@bangle.dev/react/hooks';
 import Link from 'components/common/Link';
@@ -13,6 +13,7 @@ import { usePages } from 'hooks/usePages';
 import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
 import type { StaticPage } from 'lib/features/constants';
 import { STATIC_PAGES } from 'lib/features/constants';
+import type { PageMetaLite } from 'lib/pages/interfaces';
 
 import { enableDragAndDrop } from '../../../utils';
 import { pageNodeDropPluginKey } from '../../prosemirror/prosemirror-dropcursor/dropcursor';
@@ -70,7 +71,7 @@ export default function NestedPage({ isLinkedPage = false, node, getPos }: NodeV
   const pageFromPagesContext = pages[node.attrs.id];
 
   // retrieve the page directly if we are waiting for pages to load
-  const { data: sourcePage, isLoading: isPageLoading } = useGetPage(
+  const { data: sourcePage, isLoading: isPageLoading } = useGetPageMeta(
     !pageFromPagesContext && isDocumentPath && node.attrs.id
   );
 
@@ -90,7 +91,7 @@ export default function NestedPage({ isLinkedPage = false, node, getPos }: NodeV
     pageTitle = 'No access';
   }
 
-  const pageId = documentPage?.id || staticPage?.path || forumCategoryPage?.id;
+  const pageId = node.attrs.id || staticPage?.path || forumCategoryPage?.id;
   const pagePath = isProposalTemplate
     ? `/proposals/new?template=${node.attrs.id}`
     : documentPage
@@ -152,7 +153,7 @@ function LinkIcon({
   isCategoryPage
 }: {
   isLinkedPage: boolean;
-  documentPage?: PageMeta;
+  documentPage?: PageMetaLite;
   staticPage?: StaticPage;
   isCategoryPage: boolean;
 }) {

--- a/components/common/PageDialog/PageDialog.tsx
+++ b/components/common/PageDialog/PageDialog.tsx
@@ -8,6 +8,7 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useRef } from 'react';
 
+import { useGetPage } from 'charmClient/hooks/pages';
 import { trackPageView } from 'charmClient/hooks/track';
 import { DocumentPage } from 'components/[pageId]/DocumentPage/DocumentPage';
 import { DocumentPageProviders } from 'components/[pageId]/DocumentPage/DocumentPageProviders';
@@ -16,7 +17,6 @@ import { Button } from 'components/common/Button';
 import type { PageDialogContext } from 'components/common/PageDialog/hooks/usePageDialog';
 import { useCharmEditor } from 'hooks/useCharmEditor';
 import { useCurrentPage } from 'hooks/useCurrentPage';
-import { usePage } from 'hooks/usePage';
 import { usePages } from 'hooks/usePages';
 import debouncePromise from 'lib/utils/debouncePromise';
 
@@ -49,7 +49,7 @@ function PageDialogBase(props: Props) {
   const { editMode, resetPageProps, setPageProps } = useCharmEditor();
 
   const { updatePage } = usePages();
-  const { page } = usePage({ pageIdOrPath: pageId });
+  const { data: page } = useGetPage(pageId);
   const pagePermissions = page?.permissionFlags || new AvailablePagePermissions().full;
   const domain = router.query.domain as string;
   const fullPageUrl = page?.path

--- a/components/common/PageLayout/components/Header/components/PageTitleWithBreadcrumbs.tsx
+++ b/components/common/PageLayout/components/Header/components/PageTitleWithBreadcrumbs.tsx
@@ -5,7 +5,7 @@ import { Box, Typography, CircularProgress } from '@mui/material';
 import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
 
-import { useGetPage } from 'charmClient/hooks/pages';
+import { useGetPageMeta } from 'charmClient/hooks/pages';
 import { useGetApplication, useGetReward } from 'charmClient/hooks/rewards';
 import Link from 'components/common/Link';
 import { usePostByPath } from 'components/forum/hooks/usePostByPath';
@@ -167,7 +167,7 @@ function ReviewerNotesPageTitle({
   sectionName: string;
 }) {
   const [pageTitle] = usePageTitle();
-  const { data: proposalPage } = useGetPage(parentId);
+  const { data: proposalPage } = useGetPageMeta(parentId);
   return (
     <Box display='flex'>
       <BreadCrumb>

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/FreePagePermissions/FreeShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/FreePagePermissions/FreeShareToWeb.tsx
@@ -1,5 +1,5 @@
+import { useGetPage } from 'charmClient/hooks/pages';
 import { useGetProposalDetails } from 'charmClient/hooks/proposals';
-import { usePage } from 'hooks/usePage';
 
 import ShareToWeb from '../common/ShareToWeb';
 
@@ -8,8 +8,7 @@ type Props = {
 };
 
 export default function FreeShareToWeb({ pageId }: Props) {
-  const { page: currentPage } = usePage({ pageIdOrPath: pageId });
-
+  const { data: currentPage } = useGetPage(pageId);
   const { data: proposal } = useGetProposalDetails(currentPage?.proposalId);
 
   const shareAlertMessage =

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/PaidPagePermissions.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/PaidPagePermissions/PaidPagePermissions.tsx
@@ -9,11 +9,11 @@ import Stack from '@mui/material/Stack';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useEffect } from 'react';
 
+import { useGetPageMeta } from 'charmClient/hooks/pages';
 import { useCreatePermissions, useDeletePermissions } from 'charmClient/hooks/permissions';
 import Modal from 'components/common/Modal';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useMembers } from 'hooks/useMembers';
-import { usePage } from 'hooks/usePage';
 import { usePagePermissions } from 'hooks/usePagePermissions';
 import { canReceiveManualPermissionUpdates } from 'lib/pages';
 
@@ -62,7 +62,7 @@ interface Props {
 }
 
 export default function PaidPagePermissions({ pageId, pagePermissions, refreshPermissions }: Props) {
-  const { page } = usePage({ pageIdOrPath: pageId });
+  const { data: page } = useGetPageMeta(pageId);
   const { space } = useCurrentSpace();
   const { mutateMembers: refreshMembers } = useMembers();
   const { trigger: deletePermission } = useDeletePermissions();

--- a/components/common/PageLayout/components/Header/components/ShareButton/components/common/ShareToWeb.tsx
+++ b/components/common/PageLayout/components/Header/components/ShareButton/components/common/ShareToWeb.tsx
@@ -13,10 +13,10 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
+import { useGetPageMeta } from 'charmClient/hooks/pages';
 import { Button } from 'components/common/Button';
 import { UpgradeChip, UpgradeWrapper } from 'components/settings/subscription/UpgradeWrapper';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import { usePage } from 'hooks/usePage';
 import { getAbsolutePath } from 'lib/utils/browser';
 
 const StyledInput = styled(Input)`
@@ -68,7 +68,7 @@ export default function ShareToWeb({
 }: ShareToWebProps) {
   const [copied, setCopied] = useState<boolean>(false);
 
-  const { page } = usePage({ pageIdOrPath: pageId });
+  const { data: page } = useGetPageMeta(pageId);
 
   const { space } = useCurrentSpace();
   const router = useRouter();

--- a/components/rewards/components/RewardApplicationPage/RewardApplicationPage.tsx
+++ b/components/rewards/components/RewardApplicationPage/RewardApplicationPage.tsx
@@ -4,6 +4,7 @@ import { ArrowBack } from '@mui/icons-material';
 import { Box, Grid, Divider, FormLabel } from '@mui/material';
 import { useState } from 'react';
 
+import { useGetPage } from 'charmClient/hooks/pages';
 import { useGetReward, useGetRewardPermissions } from 'charmClient/hooks/rewards';
 import { PageEditorContainer } from 'components/[pageId]/DocumentPage/components/PageEditorContainer';
 import { PageTitleInput } from 'components/[pageId]/DocumentPage/components/PageTitleInput';
@@ -17,7 +18,6 @@ import { useNewWork } from 'components/rewards/hooks/useNewApplication';
 import { useCharmRouter } from 'hooks/useCharmRouter';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useMembers } from 'hooks/useMembers';
-import { usePage } from 'hooks/usePage';
 import { useSnackbar } from 'hooks/useSnackbar';
 import { useUser } from 'hooks/useUser';
 import type { PageContent } from 'lib/prosemirror/interfaces';
@@ -55,7 +55,7 @@ export function RewardApplicationPage({ applicationId, rewardId, closeDialog }: 
   const { data: reward, mutate: refreshReward } = useGetReward({ rewardId: application?.bountyId || rewardId || '' });
   const currentRewardId = rewardId || reward?.id;
 
-  const { page: rewardPageContent } = usePage({ pageIdOrPath: currentRewardId });
+  const { data: rewardPageContent } = useGetPage(currentRewardId);
 
   const { space } = useCurrentSpace();
 

--- a/lib/pages/interfaces.ts
+++ b/lib/pages/interfaces.ts
@@ -72,3 +72,6 @@ export interface PublicPageResponse {
   views: BoardView[];
   bounty: RewardWithUsersAndPageMeta | null;
 }
+
+// This type, for the most part, is used for showing links to pages in the UI
+export type PageMetaLite = Pick<Page, 'id' | 'title' | 'icon' | 'path' | 'type' | 'hasContent'>;

--- a/pages/api/pages/[id]/index.ts
+++ b/pages/api/pages/[id]/index.ts
@@ -8,7 +8,7 @@ import nc from 'next-connect';
 import { trackUserAction } from 'lib/metrics/mixpanel/trackUserAction';
 import { updateTrackPageProfile } from 'lib/metrics/mixpanel/updateTrackPageProfile';
 import { ActionNotPermittedError, NotFoundError, onError, onNoMatch, requireUser } from 'lib/middleware';
-import type { ModifyChildPagesResponse, PageWithContent } from 'lib/pages';
+import type { ModifyChildPagesResponse, PageWithContent, PageMetaLite } from 'lib/pages/interfaces';
 import { modifyChildPages } from 'lib/pages/modifyChildPages';
 import { generatePageQuery } from 'lib/pages/server/generatePageQuery';
 import { updatePage } from 'lib/pages/server/updatePage';
@@ -29,8 +29,13 @@ handler
   .put(updatePageHandler)
   .delete(deletePage);
 
-async function getPageRoute(req: NextApiRequest, res: NextApiResponse<PageWithContent>) {
-  const { id: pageIdOrPath, spaceId: spaceIdOrDomain } = req.query as { id: string; spaceId: string };
+async function getPageRoute(req: NextApiRequest, res: NextApiResponse<PageWithContent | PageMetaLite>) {
+  const {
+    id: pageIdOrPath,
+    spaceId: spaceIdOrDomain,
+    meta
+  } = req.query as { id: string; spaceId: string; meta?: string };
+  const returnOnlyMeta = meta && meta !== 'false';
   const userId = req.session?.user?.id;
   const searchQuery = generatePageQuery({
     pageIdOrPath,
@@ -72,6 +77,18 @@ async function getPageRoute(req: NextApiRequest, res: NextApiResponse<PageWithCo
   result.galleryImage = replaceS3Domain(result.galleryImage);
   result.headerImage = replaceS3Domain(result.headerImage);
   result.icon = replaceS3Domain(result.icon);
+
+  if (returnOnlyMeta) {
+    const pageMeta: PageMetaLite = {
+      id: result.id,
+      title: result.title,
+      hasContent: result.hasContent,
+      type: result.type,
+      icon: result.icon,
+      path: result.path
+    };
+    return res.status(200).json(pageMeta);
+  }
 
   return res.status(200).json(result);
 }


### PR DESCRIPTION
Fixes a failing e2e test. My recent update made it so that you can actually view proposal templates data even if you aren't in the space. What was happening is that the test id is "undefined" at first, until the proposal page meta loads. But I guess if the page loaded fast enough, then playwright would never see 'undefined'. 