### PR TITLE
silence errors about response size

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,11 @@ const config = {
     ignoreBuildErrors: true,
     tsconfigPath: 'tsconfig.next.json'
   },
+  api: {
+    // silence errors about response size
+    // https://nextjs.org/docs/messages/api-routes-response-size-limit
+    responseLimit: false
+  },
   compiler: {
     styledComponents: true
   },


### PR DESCRIPTION
4MB is a lot, but these errors just create noise in our logs right now. I think its originally geared towards serveless endpoints anyway