### PR TITLE
Add cloudwatch alarm for ceramic

### DIFF
--- a/.ebextensions_ceramic/06_cloudwatch_alarm.config
+++ b/.ebextensions_ceramic/06_cloudwatch_alarm.config
@@ -1,0 +1,21 @@
+# Adding alarm for degraded state
+Resources:
+  EnvHealthAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: "A CloudWatch Alarm that triggers when an Elastic Beanstalk Environment is unhealthy."
+      Namespace: "AWS/ElasticBeanstalk"
+      MetricName: "EnvironmentHealth"
+      Dimensions:
+        - Name: EnvironmentName
+          Value: { "Ref" : "AWSEBEnvironmentName" } 
+      Statistic: "Average"
+      Period: "300"
+      EvaluationPeriods: "2"
+      Threshold: "19"            # a value between 15 and 20. 15 is warning, 20 is degraded
+      ComparisonOperator: "GreaterThanOrEqualToThreshold"
+      AlarmActions:
+        - "arn:aws:sns:us-east-1:310849459438:Production-Alerts"
+      OKActions:
+        - "arn:aws:sns:us-east-1:310849459438:Production-Alerts"
+      TreatMissingData: "notBreaching"


### PR DESCRIPTION
### WHAT

Infrastructure as Code alarm for the ceramic graphql env

### WHY

<!-- why was this necessary? -->
