### PR TITLE
show formfields even if no answer was found

### DIFF
--- a/components/[pageId]/SharedPage/SharedPage.tsx
+++ b/components/[pageId]/SharedPage/SharedPage.tsx
@@ -87,7 +87,7 @@ export function SharedPage({ publicPage }: Props) {
   return currentPage.type.match(/board/) ? (
     <DatabasePage page={currentPage} setPage={() => null} readOnly />
   ) : (
-    <Box sx={{ overflowY: 'auto' }}>
+    <Box display='flex' flexGrow={1} minHeight={0} /** add minHeight so that flexGrow expands to correct heigh */>
       <DocumentPageWithSidebars page={publicPage.page} savePage={() => null} readOnly />
     </Box>
   );

--- a/components/common/form/FormFieldAnswers.tsx
+++ b/components/common/form/FormFieldAnswers.tsx
@@ -48,20 +48,6 @@ type FormFieldAnswersProps = {
   threads?: Record<string, ThreadWithComments | undefined>;
 };
 
-export function ControlledFormFieldAnswers(props: Omit<FormFieldAnswersProps, 'onSave'>) {
-  return <FormFieldAnswersBase {...props} />;
-}
-
-export function FormFieldAnswers(props: Omit<FormFieldAnswersProps, 'control' | 'errors' | 'onFormChange'>) {
-  const { control, errors, onFormChange, values } = useFormFields({
-    fields: props.formFields
-  });
-
-  return (
-    <FormFieldAnswersBase {...props} control={control} errors={errors} onFormChange={onFormChange} values={values} />
-  );
-}
-
 const StyledStack = styled(Stack)`
   ${hoverIconsStyle()};
   flex-direction: row;
@@ -70,7 +56,7 @@ const StyledStack = styled(Stack)`
   position: relative;
 `;
 
-function FormFieldAnswersBase({
+export function FormFieldAnswers({
   onSave,
   formFields,
   values,

--- a/components/common/form/FormFieldAnswers.tsx
+++ b/components/common/form/FormFieldAnswers.tsx
@@ -26,7 +26,7 @@ const FormFieldAnswersContainer = styled(Stack)`
 `;
 
 type FormFieldAnswersProps = {
-  formFields: (Pick<FormField, 'type' | 'name' | 'required' | 'id' | 'description' | 'private'> & {
+  formFields?: (Pick<FormField, 'type' | 'name' | 'required' | 'id' | 'description' | 'private'> & {
     value?: FormFieldValue;
     options?: SelectOptionType[];
     formFieldAnswer?: FormFieldAnswer | null;
@@ -130,7 +130,7 @@ export function FormFieldAnswers({
 
   return (
     <FormFieldAnswersContainer>
-      {formFields.map((formField) => {
+      {formFields?.map((formField) => {
         const fieldAnswerThreads =
           (formField.formFieldAnswer ? fieldAnswerIdThreadRecord[formField.formFieldAnswer.id] : []) ?? [];
         return (

--- a/components/common/form/FormFieldsEditor.tsx
+++ b/components/common/form/FormFieldsEditor.tsx
@@ -10,7 +10,6 @@ import { emptyDocument } from 'lib/prosemirror/constants';
 
 import { Button } from '../Button';
 
-import { checkFormFieldErrors } from './checkFormFieldErrors';
 import type { SelectOptionType } from './fields/Select/interfaces';
 import { FormField } from './FormField';
 import type { FormFieldInput } from './interfaces';
@@ -29,19 +28,14 @@ export function FormFieldsEditor({
   const { trigger } = useUpdateProposalFormFields({ proposalId });
   const { showError } = useSnackbar();
   const debouncedUpdate = useMemo(() => {
-    return debounce(trigger, 500);
+    return debounce(trigger, 200);
   }, [trigger]);
 
   async function updateFormFields(_formFields: FormFieldInput[]) {
     if (readOnly) {
       return;
     }
-    const errors = checkFormFieldErrors(_formFields);
     setFormFields(_formFields);
-    if (errors) {
-      showError(errors);
-      return;
-    }
     try {
       await debouncedUpdate({ formFields: _formFields });
     } catch (error) {

--- a/components/common/form/FormFieldsEditor.tsx
+++ b/components/common/form/FormFieldsEditor.tsx
@@ -39,6 +39,7 @@ export function FormFieldsEditor({
     const errors = checkFormFieldErrors(_formFields);
     setFormFields(_formFields);
     if (errors) {
+      showError(errors);
       return;
     }
     try {

--- a/components/common/form/checkFormFieldErrors.ts
+++ b/components/common/form/checkFormFieldErrors.ts
@@ -11,7 +11,7 @@ export function checkFormFieldErrors(formFields: FormFieldInput[]): string | und
         (formField.type === 'select' || formField.type === 'multiselect') && (formField.options ?? []).length === 0
     )
   ) {
-    return 'Select fields must have atleast one option';
+    return 'Select fields must have at least one option';
   }
   return undefined;
 }

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -27,7 +27,7 @@ import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
 import { focusEventName } from 'components/common/CharmEditor/constants';
-import { ControlledFormFieldAnswers } from 'components/common/form/FormFieldAnswers';
+import { FormFieldAnswers } from 'components/common/form/FormFieldAnswers';
 import { ControlledFormFieldsEditor } from 'components/common/form/FormFieldsEditor';
 import { getInitialFormFieldValue, useFormFields } from 'components/common/form/hooks/useFormFields';
 import type { FieldAnswerInput, FormFieldInput } from 'components/common/form/interfaces';
@@ -470,7 +470,7 @@ export function NewProposalPage({
                         }}
                       />
                     ) : (
-                      <ControlledFormFieldAnswers
+                      <FormFieldAnswers
                         control={proposalFormFieldControl}
                         enableComments={false}
                         errors={proposalFormFieldErrors}

--- a/components/proposals/ProposalPage/components/ProposalFormFieldAnswers.tsx
+++ b/components/proposals/ProposalPage/components/ProposalFormFieldAnswers.tsx
@@ -5,6 +5,7 @@ import type { SelectOptionType } from 'components/common/form/fields/Select/inte
 import { FormFieldAnswers } from 'components/common/form/FormFieldAnswers';
 import { useFormFields } from 'components/common/form/hooks/useFormFields';
 import type { FormFieldValue } from 'components/common/form/interfaces';
+import LoadingComponent from 'components/common/LoadingComponent';
 import type { ThreadWithComments } from 'lib/threads/interfaces';
 import { isTruthy } from 'lib/utils/types';
 
@@ -20,7 +21,7 @@ export function ProposalFormFieldAnswers({
   readOnly?: boolean;
   enableComments: boolean;
   proposalId: string;
-  formFields: FormField[];
+  formFields?: FormField[];
   pageId: string;
   threads: Record<string, ThreadWithComments | undefined>;
   isDraft?: boolean;
@@ -28,19 +29,21 @@ export function ProposalFormFieldAnswers({
   const { data: proposalFormFieldAnswers = [], isLoading } = useGetProposalFormFieldAnswers({ proposalId });
   const { trigger } = useUpdateProposalFormFieldAnswers({ proposalId });
 
-  const fields = formFields
-    .map((formField) => {
-      const proposalFormFieldAnswer = proposalFormFieldAnswers.find(
-        (_proposalFormFieldAnswer) => _proposalFormFieldAnswer.fieldId === formField.id
-      );
-      return {
-        ...formField,
-        formFieldAnswer: proposalFormFieldAnswer,
-        value: proposalFormFieldAnswer?.value as FormFieldValue,
-        options: (formField.options ?? []) as SelectOptionType[]
-      };
-    })
-    .filter(isTruthy);
+  const fields =
+    !isLoading && formFields
+      ? formFields.map((formField) => {
+          const proposalFormFieldAnswer = proposalFormFieldAnswers.find(
+            (_proposalFormFieldAnswer) => _proposalFormFieldAnswer.fieldId === formField.id
+          );
+          return {
+            ...formField,
+            formFieldAnswer: proposalFormFieldAnswer,
+            value: proposalFormFieldAnswer?.value as FormFieldValue,
+            options: (formField.options ?? []) as SelectOptionType[]
+          };
+        })
+      : undefined;
+
   const { control, errors, onFormChange, values } = useFormFields({ fields });
 
   const onSave = async (answers: { id: string; value: FormFieldValue }[]) => {
@@ -56,7 +59,7 @@ export function ProposalFormFieldAnswers({
   };
 
   if (isLoading) {
-    return null;
+    return <LoadingComponent minHeight={600} />;
   }
 
   return (

--- a/components/proposals/ProposalPage/components/ProposalFormFieldAnswers.tsx
+++ b/components/proposals/ProposalPage/components/ProposalFormFieldAnswers.tsx
@@ -3,6 +3,7 @@ import type { FormField } from '@charmverse/core/prisma-client';
 import { useGetProposalFormFieldAnswers, useUpdateProposalFormFieldAnswers } from 'charmClient/hooks/proposals';
 import type { SelectOptionType } from 'components/common/form/fields/Select/interfaces';
 import { FormFieldAnswers } from 'components/common/form/FormFieldAnswers';
+import { useFormFields } from 'components/common/form/hooks/useFormFields';
 import type { FormFieldValue } from 'components/common/form/interfaces';
 import type { ThreadWithComments } from 'lib/threads/interfaces';
 import { isTruthy } from 'lib/utils/types';
@@ -26,6 +27,22 @@ export function ProposalFormFieldAnswers({
 }) {
   const { data: proposalFormFieldAnswers = [], isLoading } = useGetProposalFormFieldAnswers({ proposalId });
   const { trigger } = useUpdateProposalFormFieldAnswers({ proposalId });
+
+  const fields = formFields
+    .map((formField) => {
+      const proposalFormFieldAnswer = proposalFormFieldAnswers.find(
+        (_proposalFormFieldAnswer) => _proposalFormFieldAnswer.fieldId === formField.id
+      );
+      return {
+        ...formField,
+        formFieldAnswer: proposalFormFieldAnswer,
+        value: proposalFormFieldAnswer?.value as FormFieldValue,
+        options: (formField.options ?? []) as SelectOptionType[]
+      };
+    })
+    .filter(isTruthy);
+  const { control, errors, onFormChange, values } = useFormFields({ fields });
+
   const onSave = async (answers: { id: string; value: FormFieldValue }[]) => {
     await trigger({
       answers: answers.map((answer) => {
@@ -45,27 +62,16 @@ export function ProposalFormFieldAnswers({
   return (
     <FormFieldAnswers
       enableComments={enableComments}
+      formFields={fields}
       onSave={onSave}
       pageId={pageId}
       disabled={readOnly}
       threads={threads}
       isDraft={isDraft}
-      formFields={formFields
-        .map((formField) => {
-          const proposalFormFieldAnswer = proposalFormFieldAnswers.find(
-            (_proposalFormFieldAnswer) => _proposalFormFieldAnswer.fieldId === formField.id
-          );
-          if (!proposalFormFieldAnswer && formField.type !== 'label') {
-            return null;
-          }
-          return {
-            ...formField,
-            formFieldAnswer: proposalFormFieldAnswer,
-            value: proposalFormFieldAnswer?.value as FormFieldValue,
-            options: (formField.options ?? []) as SelectOptionType[]
-          };
-        })
-        .filter(isTruthy)}
+      control={control}
+      errors={errors}
+      onFormChange={onFormChange}
+      values={values}
     />
   );
 }

--- a/components/proposals/ProposalPage/components/ProposalFormFieldAnswers.tsx
+++ b/components/proposals/ProposalPage/components/ProposalFormFieldAnswers.tsx
@@ -59,7 +59,7 @@ export function ProposalFormFieldAnswers({
   };
 
   if (isLoading) {
-    return <LoadingComponent minHeight={600} />;
+    return <LoadingComponent />;
   }
 
   return (

--- a/lib/proposals/form/__tests__/upsertProposalFormFields.spec.ts
+++ b/lib/proposals/form/__tests__/upsertProposalFormFields.spec.ts
@@ -131,26 +131,6 @@ describe('upsertProposalFormFields', () => {
     );
   });
 
-  it('should throw an error if no proposalId is provided', async () => {
-    await expect(
-      upsertProposalFormFields({
-        proposalId: undefined as any,
-        formFields: [
-          {
-            id: v4(),
-            type: 'long_text',
-            name: 'long name',
-            description: 'another description',
-            index: 1,
-            options: [],
-            private: true,
-            required: true
-          }
-        ]
-      })
-    ).rejects.toBeInstanceOf(InvalidInputError);
-  });
-
   it('should throw an error if no form fields were provided', async () => {
     await expect(
       upsertProposalFormFields({

--- a/lib/proposals/getProposalErrors.ts
+++ b/lib/proposals/getProposalErrors.ts
@@ -1,4 +1,4 @@
-import { checkFormFieldErrors } from 'components/common/form/checkFormFieldErrors';
+import type { FormFieldInput } from 'components/common/form/interfaces';
 import { validateAnswers } from 'lib/forms/validateAnswers';
 import { checkIsContentEmpty } from 'lib/prosemirror/checkIsContentEmpty';
 import { isTruthy } from 'lib/utils/types';
@@ -92,4 +92,20 @@ export function getEvaluationFormError(evaluation: ProposalEvaluationInput): str
     default:
       return false;
   }
+}
+
+export function checkFormFieldErrors(formFields: FormFieldInput[]): string | undefined {
+  if (formFields.length === 0) {
+    return 'Form fields are required for structured proposals';
+  } else if (formFields.some((formField) => !formField.name)) {
+    return 'Form fields must have a name';
+  } else if (
+    formFields.some(
+      (formField) =>
+        (formField.type === 'select' || formField.type === 'multiselect') && (formField.options ?? []).length === 0
+    )
+  ) {
+    return 'Select fields must have at least one option';
+  }
+  return undefined;
 }

--- a/pages/api/proposals/[id]/form/index.ts
+++ b/pages/api/proposals/[id]/form/index.ts
@@ -1,3 +1,4 @@
+import { InvalidInputError } from '@charmverse/core/errors';
 import type { FormField } from '@charmverse/core/prisma-client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
@@ -15,6 +16,9 @@ handler.use(requireUser).put(upsertProposalFormController);
 async function upsertProposalFormController(req: NextApiRequest, res: NextApiResponse<FormField[]>) {
   const proposalId = req.query.id as string;
   const userId = req.session.user.id;
+  if (!proposalId) {
+    throw new InvalidInputError(`No proposal found with id: ${proposalId}`);
+  }
 
   const permissions = await permissionsApiClient.proposals.computeProposalPermissions({
     resourceId: proposalId,

--- a/stories/FormFields/FormFields.stories.tsx
+++ b/stories/FormFields/FormFields.stories.tsx
@@ -9,6 +9,7 @@ import { formFieldTypes } from 'components/common/form/constants';
 import type { SelectOptionType } from 'components/common/form/fields/Select/interfaces';
 import { FormFieldAnswers as CustomFormFieldAnswers } from 'components/common/form/FormFieldAnswers';
 import { ControlledFormFieldsEditor } from 'components/common/form/FormFieldsEditor';
+import { useFormFields } from 'components/common/form/hooks/useFormFields';
 import type { FormFieldInput, FormFieldValue } from 'components/common/form/interfaces';
 import { createDocumentWithText } from 'lib/prosemirror/constants';
 
@@ -63,106 +64,103 @@ export function FormFieldsEditor() {
 }
 
 export function FormFieldsInputs() {
+  const fields = formFieldTypes.map((formFieldType, index) => {
+    const label = capitalize(formFieldType.replaceAll(/_/g, ' '));
+    return {
+      description: createDocumentWithText(`This is a description for ${label.toLocaleLowerCase()}`),
+      name: `${label} title`,
+      options: formFieldType.match(/select|multiselect/) ? options : [],
+      private: index % 2 !== 0,
+      required: index % 2 !== 0,
+      type: formFieldType,
+      id: v4(),
+      value: ''
+    };
+  });
+  const props = useFormFields({ fields });
   return (
     <GlobalContext>
-      <CustomFormFieldAnswers
-        enableComments={true}
-        formFields={formFieldTypes.map((formFieldType, index) => {
-          const label = capitalize(formFieldType.replaceAll(/_/g, ' '));
-          return {
-            description: createDocumentWithText(`This is a description for ${label.toLocaleLowerCase()}`),
-            name: `${label} title`,
-            options: formFieldType.match(/select|multiselect/) ? options : [],
-            private: index % 2 !== 0,
-            required: index % 2 !== 0,
-            type: formFieldType,
-            id: v4(),
-            value: ''
-          };
-        })}
-      />
+      <CustomFormFieldAnswers {...props} enableComments={true} formFields={fields} />
     </GlobalContext>
   );
 }
 
 export function FormFieldsInputsDisplay() {
+  const fields = formFieldTypes.map((formFieldType, index) => {
+    const label = capitalize(formFieldType.replaceAll(/_/g, ' '));
+    let value: FormFieldValue = '';
+    switch (formFieldType) {
+      case 'phone': {
+        value = '+1 123 456 7890';
+        break;
+      }
+      case 'label': {
+        value = 'Label';
+        break;
+      }
+      case 'long_text': {
+        value = {
+          content: createDocumentWithText("This is a long text field's value"),
+          contentText: "This is a long text field's value"
+        };
+        break;
+      }
+      case 'wallet': {
+        value = '0x36d3515d5818f672168a595f68bae614ee6b91ee';
+        break;
+      }
+      case 'date': {
+        value = new Date('2021-10-10').toString();
+        break;
+      }
+      case 'email': {
+        value = 'johndoe@gmail.com';
+        break;
+      }
+      case 'multiselect': {
+        value = options.map((option) => option.id);
+        break;
+      }
+      case 'number': {
+        value = '123';
+        break;
+      }
+      case 'select': {
+        value = options[0].id;
+        break;
+      }
+      case 'short_text': {
+        value = 'This is a short text field value';
+        break;
+      }
+      case 'url': {
+        value = 'https://google.com';
+        break;
+      }
+      case 'person': {
+        value = [members[0].id];
+        break;
+      }
+      default: {
+        value = '';
+        break;
+      }
+    }
+    return {
+      description: createDocumentWithText(`This is a description for ${label.toLocaleLowerCase()}`),
+      name: `${label} title`,
+      options: formFieldType.match(/select|multiselect/) ? options : [],
+      private: index % 2 !== 0,
+      required: index % 2 === 0,
+      type: formFieldType,
+      id: v4(),
+      value
+    };
+  });
+  const props = useFormFields({ fields });
   return (
     <GlobalContext>
-      <CustomFormFieldAnswers
-        enableComments={true}
-        disabled
-        formFields={formFieldTypes.map((formFieldType, index) => {
-          const label = capitalize(formFieldType.replaceAll(/_/g, ' '));
-          let value: FormFieldValue = '';
-          switch (formFieldType) {
-            case 'phone': {
-              value = '+1 123 456 7890';
-              break;
-            }
-            case 'label': {
-              value = 'Label';
-              break;
-            }
-            case 'long_text': {
-              value = {
-                content: createDocumentWithText("This is a long text field's value"),
-                contentText: "This is a long text field's value"
-              };
-              break;
-            }
-            case 'wallet': {
-              value = '0x36d3515d5818f672168a595f68bae614ee6b91ee';
-              break;
-            }
-            case 'date': {
-              value = new Date('2021-10-10').toString();
-              break;
-            }
-            case 'email': {
-              value = 'johndoe@gmail.com';
-              break;
-            }
-            case 'multiselect': {
-              value = options.map((option) => option.id);
-              break;
-            }
-            case 'number': {
-              value = '123';
-              break;
-            }
-            case 'select': {
-              value = options[0].id;
-              break;
-            }
-            case 'short_text': {
-              value = 'This is a short text field value';
-              break;
-            }
-            case 'url': {
-              value = 'https://google.com';
-              break;
-            }
-            case 'person': {
-              value = [members[0].id];
-              break;
-            }
-            default: {
-              value = '';
-              break;
-            }
-          }
-          return {
-            description: createDocumentWithText(`This is a description for ${label.toLocaleLowerCase()}`),
-            name: `${label} title`,
-            options: formFieldType.match(/select|multiselect/) ? options : [],
-            private: index % 2 !== 0,
-            required: index % 2 === 0,
-            type: formFieldType,
-            id: v4(),
-            value
-          };
-        })}
-      />
+      <CustomFormFieldAnswers {...props} enableComments={true} disabled formFields={fields} />
     </GlobalContext>
   );
 }


### PR DESCRIPTION
- we were literally just filtering out form fields with no answers, assuming that meant they are 'private' *
- fixed layout for public version of documentpage with sidebars (the scrollbars were wrong in SharedPage.tsx)
- removed some very light, unecessary wrappers for FormFieldAnswers. It is now always "controlled". Previously, these wrappers had a bit more logic but we slowly removed it
- made it so we can call useFormFields and pass in fields after-the-fact. the form was depending on fields being defined from the git-go

* One thing we could do in the future is hide fields if they are private and you are not the viewer. I dont like how it was currently guessing in the frontend,. so its a larger change
