### PR TITLE
dont load charm editor until field answers are loaded

### DIFF
--- a/components/common/form/FormFieldAnswers.tsx
+++ b/components/common/form/FormFieldAnswers.tsx
@@ -56,7 +56,23 @@ const StyledStack = styled(Stack)`
   position: relative;
 `;
 
-export function FormFieldAnswers({
+export function FormFieldAnswers(props: Omit<FormFieldAnswersProps, 'control' | 'errors' | 'onFormChange'>) {
+  const { control, errors, onFormChange, values } = useFormFields({
+    fields: props.formFields
+  });
+
+  return (
+    <FormFieldAnswersControlled
+      {...props}
+      control={control}
+      errors={errors}
+      onFormChange={onFormChange}
+      values={values}
+    />
+  );
+}
+
+export function FormFieldAnswersControlled({
   onSave,
   formFields,
   values,

--- a/components/common/form/fields/CharmEditorInputField.tsx
+++ b/components/common/form/fields/CharmEditorInputField.tsx
@@ -9,7 +9,6 @@ type Props = ControlFieldProps & FieldProps & { multiline?: boolean; rows?: numb
 
 export function CharmEditorInputField({ placeholder, error, ...inputProps }: Props) {
   const theme = useTheme();
-
   return (
     <FieldWrapper inputEndAdornmentAlignItems='flex-start' {...inputProps}>
       <CharmEditor

--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -27,7 +27,7 @@ import { Button } from 'components/common/Button';
 import { CharmEditor } from 'components/common/CharmEditor';
 import type { ICharmEditorOutput } from 'components/common/CharmEditor/CharmEditor';
 import { focusEventName } from 'components/common/CharmEditor/constants';
-import { FormFieldAnswers } from 'components/common/form/FormFieldAnswers';
+import { FormFieldAnswersControlled } from 'components/common/form/FormFieldAnswers';
 import { ControlledFormFieldsEditor } from 'components/common/form/FormFieldsEditor';
 import { getInitialFormFieldValue, useFormFields } from 'components/common/form/hooks/useFormFields';
 import type { FieldAnswerInput, FormFieldInput } from 'components/common/form/interfaces';
@@ -470,7 +470,7 @@ export function NewProposalPage({
                         }}
                       />
                     ) : (
-                      <FormFieldAnswers
+                      <FormFieldAnswersControlled
                         control={proposalFormFieldControl}
                         enableComments={false}
                         errors={proposalFormFieldErrors}


### PR DESCRIPTION
The "controlled" CharmEditor doesn't actually update if the content prop changes. So i introduced a race condition in my last update where the fields would be empty