### PR TITLE
Fix displaying EAS credentials from charmverse and add script for deploying schemas

### DIFF
--- a/lib/credentials/connectors.ts
+++ b/lib/credentials/connectors.ts
@@ -3,7 +3,7 @@ import { arbitrum, base, optimism, optimismSepolia, sepolia } from 'viem/chains'
 
 import type { ExternalCredentialChain } from './external/schemas';
 
-export const easSchemaMainnetChains = [optimism] as const;
+export const easSchemaMainnetChains = [optimism, arbitrum] as const;
 export const easSchemaTestnetChains = [sepolia, optimismSepolia] as const;
 
 export type EasSchemaChain =

--- a/lib/credentials/external/getOnchainCredentials.ts
+++ b/lib/credentials/external/getOnchainCredentials.ts
@@ -32,7 +32,7 @@ const graphQlClients: Record<ExternalCredentialChain | EasSchemaChain, ApolloCli
   }),
   [sepolia.id]: new ApolloClientWithRedisCache({
     cacheKeyPrefix: 'optimism-easscan',
-    uri: 'https://optimism-sepolia.easscan.org/graphql',
+    uri: 'https://sepolia.easscan.org/graphql',
     persistForSeconds: defaultEASCacheDuration,
     skipRedisCache: !isProdEnv
   }),
@@ -97,7 +97,7 @@ function getTrackedOnChainCredentials<Chain extends ExternalCredentialChain | Ea
   wallets,
   schemas
 }: {
-  schemas: Record<Chain, { schemaId: string; issuers: string[] }[]>;
+  schemas: Record<Chain, { schemaId: string; issuers?: string[] }[]>;
   chainId: Chain;
   wallets: string[];
 }): Promise<EASAttestationFromApi[]> {
@@ -108,9 +108,7 @@ function getTrackedOnChainCredentials<Chain extends ExternalCredentialChain | Ea
       schemaId: {
         equals: _schema.schemaId
       },
-      attester: {
-        in: _schema.issuers
-      },
+      attester: _schema.issuers ? { in: _schema.issuers } : undefined,
       recipient: { in: recipient }
     }))
   };

--- a/lib/credentials/external/schemas.ts
+++ b/lib/credentials/external/schemas.ts
@@ -11,10 +11,11 @@ export type ExternalCredentialChain = (typeof externalCredentialChains)[number];
 /**
  * Utility for configuration relating to the schema
  * @fields specific fields of the attestation we want to show the user
+ * @issuers list of issuers that we should filter for
  */
 export type TrackedSchemaParams = {
   schemaId: string;
-  issuers: string[];
+  issuers?: string[];
   title: string;
   organization: string;
   iconUrl: string;
@@ -54,11 +55,8 @@ const optimismRetroPgfContributionSchema: TrackedSchemaParams = {
   ]
 };
 
-const charmverseWalletAddress = '0x8Bc704386DCE0C4f004194684AdC44Edf6e85f07';
-
 const optimismCharmverseProposalSchema: TrackedSchemaParams = {
   schemaId: proposalCredentialSchemaId,
-  issuers: [charmverseWalletAddress],
   title: 'Proposal',
   organization: 'CharmVerse',
   iconUrl: charmverseLogo,
@@ -67,7 +65,6 @@ const optimismCharmverseProposalSchema: TrackedSchemaParams = {
 
 const optimismCharmverseRewardSchema: TrackedSchemaParams = {
   schemaId: rewardCredentialSchemaId,
-  issuers: [charmverseWalletAddress],
   title: 'Reward',
   organization: 'CharmVerse',
   iconUrl: charmverseLogo,
@@ -118,6 +115,7 @@ export const trackedSchemas: Record<ExternalCredentialChain, TrackedSchemaParams
 };
 
 export const trackedCharmverseSchemas: Record<EasSchemaChain, TrackedSchemaParams[]> = {
+  [arbitrum.id]: [optimismCharmverseProposalSchema, optimismCharmverseRewardSchema],
   [optimismSepolia.id]: [optimismCharmverseProposalSchema, optimismCharmverseRewardSchema],
   [optimism.id]: [optimismCharmverseProposalSchema, optimismCharmverseRewardSchema],
   [sepolia.id]: [optimismCharmverseProposalSchema, optimismCharmverseRewardSchema]

--- a/lib/credentials/schemas/deploySchema.ts
+++ b/lib/credentials/schemas/deploySchema.ts
@@ -1,0 +1,53 @@
+import { log } from '@charmverse/core/log';
+import { SchemaRegistry, getSchemaUID } from '@ethereum-attestation-service/eas-sdk';
+import { arbitrum, optimismSepolia } from 'viem/chains';
+
+import { prettyPrint } from 'lib/utils/strings';
+
+import type { EasSchemaChain } from '../connectors';
+import { getEasConnector, getOnChainSchemaUrl } from '../connectors';
+import { getCharmverseSigner } from '../getCharmverseSigner';
+
+import { allSchemaDefinitions } from './index';
+
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+async function deploySchema({ schema, chainId }: { schema: string; chainId: EasSchemaChain }) {
+  const connector = getEasConnector(chainId);
+
+  const schemaRegistry = new SchemaRegistry(connector.schemaRegistryContract);
+
+  const signer = getCharmverseSigner({ chainId });
+
+  const signerAddress = await signer.getAddress();
+
+  if (signerAddress !== '0x8Bc704386DCE0C4f004194684AdC44Edf6e85f07') {
+    throw new Error('Schema must be deployed with CharmVerse Credentials Wallet');
+  }
+
+  schemaRegistry.connect(signer);
+
+  const nonce = (await signer.provider?.getTransactionCount(signerAddress)) ?? 0;
+
+  const populatedTx = await schemaRegistry.contract.populateTransaction.register(schema, NULL_ADDRESS, true, {
+    nonce: nonce + 1
+  });
+
+  await (await signer.sendTransaction(populatedTx)).wait();
+
+  // SchemaUID is deterministic
+  const schemaUid = getSchemaUID(schema, NULL_ADDRESS, true);
+
+  const schemaUrl = getOnChainSchemaUrl({ chainId, schemaId: schemaUid });
+
+  log.info(`Schema ${schema} deployed at ${schemaUrl}`);
+}
+
+async function deployAllSchemas({ chainId }: { chainId: EasSchemaChain }) {
+  for (const schemaDefinition of allSchemaDefinitions) {
+    log.info(`Deploying schema ${prettyPrint(schemaDefinition)}...`);
+    await deploySchema({ schema: schemaDefinition, chainId });
+  }
+}
+
+deployAllSchemas({ chainId: arbitrum.id }).then(log.info);

--- a/lib/credentials/schemas/index.ts
+++ b/lib/credentials/schemas/index.ts
@@ -2,9 +2,11 @@
 import type { AttestationType } from '@charmverse/core/prisma';
 
 import type { ProposalCredential } from './proposal';
-import { encodeProposalCredential, proposalCredentialSchemaId } from './proposal';
+import { encodeProposalCredential, proposalCredentialSchemaId, proposalCredentialSchemaDefinition } from './proposal';
 import type { RewardCredential } from './reward';
-import { encodeRewardCredential, rewardCredentialSchemaId } from './reward';
+import { encodeRewardCredential, rewardCredentialSchemaId, rewardCredentialSchemaDefinition } from './reward';
+
+export const allSchemaDefinitions = [proposalCredentialSchemaDefinition, rewardCredentialSchemaDefinition];
 
 export const credentialLabels: Record<AttestationType, string> = {
   proposal: 'Proposal',


### PR DESCRIPTION
### WHAT

- Fixed a bug where we were filtering onchain credentials for CharmVerse schemas
- Added script for deploying to new chains

⚠️ Pending issue: Deploy fails on Arbitrum due to estimating gas
-- Option 1: Rerun the transaction with 1k USD in the wallet
-- Option 2: Fix the gas calculation

### WHY

<!-- why was this necessary? -->
