### PR TITLE
fix duplicating proposal templates

### DIFF
--- a/components/proposals/ProposalPage/NewProposalPage.tsx
+++ b/components/proposals/ProposalPage/NewProposalPage.tsx
@@ -352,17 +352,9 @@ export function NewProposalPage({
     }
   }, [hasSource]);
 
-  // watch for changes in isTemplate
+  // watch for changes in isTemplate, which can change by using "Add proposal" from the sidebar
   useEffect(() => {
-    if (isTemplate) {
-      setFormInputs(
-        {
-          type: 'proposal_template',
-          proposalTemplateId: null
-        },
-        { fromUser: false }
-      );
-    } else {
+    if (!isTemplate) {
       setFormInputs(
         {
           type: 'proposal'


### PR DESCRIPTION
The bug was that we were clearing out the form input's proposal id, which is used to load the template. I think a more proper fix might be to not use formInput.proposalTemplateId to load the template. I am able to remove the code that I did since you cannot select 'template' when adding proposals from the sidebar.

TODO: add e2e