### PR TITLE
strip out custom domain when tracking page views

### DIFF
--- a/charmClient/hooks/track.ts
+++ b/charmClient/hooks/track.ts
@@ -27,6 +27,7 @@ export function useTrackPageView(page: Omit<PageEventMap['page_view'], 'spaceId'
       trackPageView({
         spaceId: currentSpace.id,
         spaceDomain: currentSpace.domain,
+        spaceCustomDomain: currentSpace.customDomain,
         ...page
       });
     }

--- a/components/[pageId]/EditorPage/EditorPage.tsx
+++ b/components/[pageId]/EditorPage/EditorPage.tsx
@@ -28,19 +28,20 @@ export function EditorPage({ pageId: pageIdOrPath }: { pageId: string }) {
     (page?.permissionFlags.edit_content === false && editMode !== 'suggesting') || editMode === 'viewing';
 
   useEffect(() => {
-    if (page) {
+    if (page && currentSpace) {
       trackPageView({
         type: page.type,
         pageId: page.id,
         spaceId: page.spaceId,
-        spaceDomain: currentSpace?.domain
+        spaceDomain: currentSpace.domain,
+        spaceCustomDomain: currentSpace.customDomain
       });
       setCurrentPageId(page.id);
     }
     return () => {
       resetPageProps();
     };
-  }, [page?.id]);
+  }, [page?.id, !!currentSpace]);
 
   // reset page id on unmount
   useEffect(() => {

--- a/components/[pageId]/SharedPage/SharedPage.tsx
+++ b/components/[pageId]/SharedPage/SharedPage.tsx
@@ -39,14 +39,15 @@ export function SharedPage({ publicPage }: Props) {
     }
   }, [publicPage, isLoadingRewards]);
 
-  async function onLoad(_publicPage: PublicPageResponse) {
+  async function onLoad(_publicPage: PublicPageResponse, spaceDomain: string, spaceCustomDomain: string | null) {
     const { page: rootPage, cards, boards, views } = _publicPage;
 
     trackPageView({
       type: rootPage.type,
       pageId: rootPage.id,
       spaceId: rootPage.spaceId,
-      spaceDomain: space?.domain
+      spaceDomain,
+      spaceCustomDomain
     });
 
     setPageTitle(rootPage.title);
@@ -65,14 +66,14 @@ export function SharedPage({ publicPage }: Props) {
   }
 
   useEffect(() => {
-    if (publicPage) {
-      onLoad(publicPage);
+    if (publicPage && space) {
+      onLoad(publicPage, space.domain, space.customDomain);
     }
 
     return () => {
       setCurrentPageId('');
     };
-  }, [publicPage?.page.id]);
+  }, [publicPage?.page.id, !!space]);
 
   const currentPage = publicPage?.page ?? pages?.[basePageId];
 

--- a/components/common/PageDialog/PageDialog.tsx
+++ b/components/common/PageDialog/PageDialog.tsx
@@ -16,6 +16,7 @@ import Dialog from 'components/common/DatabaseEditor/components/dialog';
 import type { PageDialogContext } from 'components/common/PageDialog/hooks/usePageDialog';
 import { useCharmEditor } from 'hooks/useCharmEditor';
 import { useCurrentPage } from 'hooks/useCurrentPage';
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { usePage } from 'hooks/usePage';
 import { usePages } from 'hooks/usePages';
 import debouncePromise from 'lib/utils/debouncePromise';
@@ -40,13 +41,13 @@ interface Props {
   showCard?: (cardId: string | null) => void;
   currentBoardId?: string; // the board we are looking at, to determine if we should show the parent chip
 }
-
 function PageDialogBase(props: Props) {
   const { hideToolsMenu = false, currentBoardId, pageId, readOnly, showCard, applicationContext } = props;
 
   const mounted = useRef(false);
   const popupState = usePopupState({ variant: 'popover', popupId: 'page-dialog' });
   const router = useRouter();
+  const { space } = useCurrentSpace();
   const { setCurrentPageId } = useCurrentPage();
   const { editMode, resetPageProps, setPageProps } = useCharmEditor();
 
@@ -83,10 +84,16 @@ function PageDialogBase(props: Props) {
   }, [!!contentType]);
 
   useEffect(() => {
-    if (page?.id) {
-      trackPageView({ spaceId: page.spaceId, pageId: page.id, type: page.type, spaceDomain: domain });
+    if (page?.id && space) {
+      trackPageView({
+        spaceId: page.spaceId,
+        pageId: page.id,
+        type: page.type,
+        spaceDomain: domain,
+        spaceCustomDomain: space.customDomain
+      });
     }
-  }, [page?.id]);
+  }, [page?.id, space?.customDomain]);
 
   function close() {
     popupState.close();

--- a/components/forum/components/PostDialog/PostDialog.tsx
+++ b/components/forum/components/PostDialog/PostDialog.tsx
@@ -110,11 +110,17 @@ export function PostDialog({ post, isLoading, spaceId, onClose, newPostCategory 
   }, []);
 
   useEffect(() => {
-    if (spaceId && post?.id) {
-      trackPageView({ spaceId, postId: post.id, type: 'post', spaceDomain: space?.domain });
+    if (spaceId && post?.id && space) {
+      trackPageView({
+        spaceId,
+        postId: post.id,
+        type: 'post',
+        spaceDomain: space.domain,
+        spaceCustomDomain: space.customDomain
+      });
       setFormInputs(post);
     }
-  }, [post?.id]);
+  }, [post?.id, !!space]);
 
   return (
     <>

--- a/lib/metrics/mixpanel/interfaces/PageEvent.ts
+++ b/lib/metrics/mixpanel/interfaces/PageEvent.ts
@@ -29,7 +29,9 @@ type ViewPageEvent = PageEvent & {
   postId?: string;
   meta?: { pathname: string };
   type: PageType | 'post' | StaticPageType;
+  // include these to remove from URL
   spaceDomain?: string;
+  spaceCustomDomain?: string | null;
 };
 
 export interface PageEventMap {

--- a/lib/session/__tests__/getDefaultPageForSpace.spec.ts
+++ b/lib/session/__tests__/getDefaultPageForSpace.spec.ts
@@ -132,7 +132,7 @@ describe('getDefaultPageForSpace()', () => {
     expect(url).toEqual(`/${space.domain}/${page.path}%20?id=123`);
   });
 
-  it('should not include subdomain when going to custom domain', async () => {
+  it('should not include subdomain when visiting custom domain', async () => {
     const customDomain = 'work.charmverse.fyi';
     const { space, user } = await generateUserAndSpace({
       spaceCustomDomain: customDomain


### PR DESCRIPTION
In theory we shouldn't need to strip out the custom domain from the path, but there is a bug when looking at databases where the custom domain gets added to the URL. This pathname then breaks if you go visit app.charmverse.io:


<img width="904" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/122d7f1e-7443-4e7f-819f-9c06b97367fa">
