### PR TITLE
Fix error on filter

### DIFF
--- a/lib/databases/cardFilter.ts
+++ b/lib/databases/cardFilter.ts
@@ -67,9 +67,8 @@ class CardFilter {
     let value = card.fields.properties[filter.propertyId] as CardPropertyValue | undefined;
 
     if (filter.propertyId === Constants.titleColumnId) {
-      value = card.title.toLowerCase();
-    }
-    if (!value) {
+      value = card.title?.toLowerCase() ?? '';
+    } else if (!value) {
       switch (filterProperty?.type) {
         case 'updatedBy': {
           value = card.updatedBy;


### PR DESCRIPTION
### WHAT

If card title was empty in the filter, it threw an error

### WHY

<!-- why was this necessary? -->
