### PR TITLE
protect track api if event is not a string

### DIFF
--- a/pages/api/events/index.ts
+++ b/pages/api/events/index.ts
@@ -34,14 +34,11 @@ async function trackHandler(req: NextApiRequest, res: NextApiResponse<{ success:
     eventPayload.isAnonymous = true;
   }
 
-  // backwards compatibility - can delete after December 14
-  const _eventName = eventName ?? req.query.event;
-
-  if (!userId || !_eventName) {
+  if (!userId) {
     throw new InvalidInputError('Invalid track data');
   }
 
-  trackUserAction(_eventName, { ...eventPayload, userId });
+  trackUserAction(eventName, { ...eventPayload, userId });
 
   try {
     await recordDatabaseEvent({

--- a/pages/api/events/index.ts
+++ b/pages/api/events/index.ts
@@ -18,6 +18,10 @@ async function trackHandler(req: NextApiRequest, res: NextApiResponse<{ success:
 
   const { event: eventName, ...eventPayload } = request;
 
+  if (typeof eventName !== 'string') {
+    throw new InvalidInputError(`Invalid eventName: ${eventName}`);
+  }
+
   if (!req.session.anonymousUserId) {
     req.session.anonymousUserId = uuid();
     await req.session.save();


### PR DESCRIPTION
Fix for error i saw. i'm not sure whats going on w/the input, we dont use "$eq" in the frontend:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/2eff0730-b651-4ac9-acaf-bb3db9393e18)
