### PR TITLE
use a different port for permissions in test mode by default

### DIFF
--- a/.env.test.local.example
+++ b/.env.test.local.example
@@ -9,7 +9,7 @@ SERVERLESS_PORT=3020
 # necessary so that the serverless app can be tested locally
 MAILGUN_DOMAIN=mg.charmverse.com
 MAILGUN_KEY=test-key
-PERMISSIONS_API_URL=http://127.0.0.1:3001
+PERMISSIONS_API_URL=http://127.0.0.1:3337
 REACT_APP_WEBSOCKETS_HOST=http://127.0.0.1:3336
 RECOVERY_CODE_SECRET_KEY=b1dd67559b5b17ff62d5956ddf5248
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -148,9 +148,9 @@ jobs:
           echo "network ${{ job.services.postgres.network }}"
           docker run -d --name permissions-api  \
                      -h permissions-api \
-                     -p "3001:3001"     \
+                     -p "3337:3337"     \
                      -e HOST=0.0.0.0    \
-                     -e PORT=3001       \
+                     -e PORT=3337       \
                      -v $PWD/nodes_modules/@charmverse/core:/apps/node_modules/@charmverse/core \
                      --network "${{ job.services.postgres.network }}"  \
                      -e DATABASE_URL=postgres://postgres:postgres@postgres:5432/charmversetest  \
@@ -158,7 +158,7 @@ jobs:
                      node --experimental-specifier-resolution=node ./dist/main.js
 
           sleep_loop_ct=0
-          until curl localhost:3001/api/health || [[ $sleep_loop_ct > 30 ]]; do
+          until curl localhost:3337/api/health || [[ $sleep_loop_ct > 30 ]]; do
             docker ps
             docker logs permissions-api
             docker inspect permissions-api
@@ -238,9 +238,9 @@ jobs:
           echo "network ${{ job.services.postgres.network }}"
           docker run -d --name permissions-api  \
                       -h permissions-api \
-                      -p "3001:3001"     \
+                      -p "3337:3337"     \
                       -e HOST=0.0.0.0    \
-                      -e PORT=3001       \
+                      -e PORT=3337       \
                       -v $PWD/nodes_modules/@charmverse/core:/apps/node_modules/@charmverse/core \
                       --network "${{ job.services.postgres.network }}"  \
                       -e DATABASE_URL=postgres://postgres:postgres@postgres:5432/charmversetest  \
@@ -248,7 +248,7 @@ jobs:
                       node --experimental-specifier-resolution=node ./dist/main.js
 
           sleep_loop_ct=0
-          until curl localhost:3001/api/health || [[ $sleep_loop_ct > 30 ]]; do
+          until curl localhost:3337/api/health || [[ $sleep_loop_ct > 30 ]]; do
             docker ps
             docker logs permissions-api
             docker inspect permissions-api

--- a/.github/workflows/test_new_core_pkg.yml
+++ b/.github/workflows/test_new_core_pkg.yml
@@ -96,9 +96,9 @@ jobs:
           echo "network ${{ job.services.postgres.network }}"
           docker run -d --name permissions-api  \
                      -h permissions-api \
-                     -p "3001:3001"     \
+                     -p "3337:3337"     \
                      -e HOST=0.0.0.0    \
-                     -e PORT=3001       \
+                     -e PORT=3337       \
                      -v $PWD/nodes_modules/@charmverse/core:/apps/node_modules/@charmverse/core \
                      --network "${{ job.services.postgres.network }}"  \
                      -e DATABASE_URL=postgres://postgres:postgres@postgres:5432/charmversetest  \
@@ -109,7 +109,7 @@ jobs:
             docker ps
             docker logs permissions-api
             docker inspect permissions-api
-            curl localhost:3001/api/health && {
+            curl localhost:3337/api/health && {
               echo "permission api container is up..."
               break
             }


### PR DESCRIPTION
You can already do this with env files by setting PERMISSIONS_API_URL in webapp and PORT in the permissions folder, but it's not the default.

This way you can run a dev and test versions of permissions at once. I'm changing the port in CI too just for consistency