### PR TITLE
better handling of api errors

### DIFF
--- a/lib/credentials/apolloClientWithRedisCache.ts
+++ b/lib/credentials/apolloClientWithRedisCache.ts
@@ -87,6 +87,7 @@ export class ApolloClientWithRedisCache extends ApolloClient<any> {
     const refreshedData = await super.query(options);
 
     this.setCache(cacheKey, refreshedData);
+
     return refreshedData;
   }
 }

--- a/lib/credentials/getGitcoinCredentialsByWallets.ts
+++ b/lib/credentials/getGitcoinCredentialsByWallets.ts
@@ -35,7 +35,11 @@ type ScoreItem = {
 
 const cachedTime = 60 * 60 * 1000; // 1 hour
 
-export async function getGitcoinPassportScore(wallet: string) {
+export async function getGitcoinPassportScore(wallet: string): Promise<ScoreItem | null> {
+  if (!process.env.GITCOIN_API_KEY) {
+    log.debug('Ignore gitcoin request, no api key provided');
+    return null;
+  }
   const registryScore = await http
     .GET<ScoreItem>(`${GITCOIN_SCORER_BASE_URL}/registry/score/${GITCOIN_SCORER_ID}/${wallet}`, undefined, {
       credentials: 'omit',
@@ -66,8 +70,9 @@ export async function getGitcoinPassportScore(wallet: string) {
         headers: GITCOIN_API_HEADERS
       }
     )
-    .catch(() => {
+    .catch((error) => {
       log.error('Error submitting wallet for passport score', {
+        error,
         wallet
       });
       return null;

--- a/lib/credentials/queriesAndMutations.ts
+++ b/lib/credentials/queriesAndMutations.ts
@@ -158,7 +158,11 @@ export async function getCharmverseOffchainCredentialsByWallets({
       // For now, let's refetch each time and rely on http endpoint-level caching
       // https://www.apollographql.com/docs/react/data/queries/#supported-fetch-policies
     })
-    .then(({ data }) => data.charmverseCredentialIndex.edges.map((e: any) => getParsedCredential(e.node)));
+    .then((response) =>
+      response
+        ? response.data.charmverseCredentialIndex.edges.map((e: any) => getParsedCredential(e.node))
+        : Promise.reject(new Error('Unknown error'))
+    );
 
   const credentialIds = charmverseCredentials.map((c) => c.id);
 
@@ -280,7 +284,11 @@ export async function getExternalCredentialsByWallets({
       // For now, let's refetch each time and rely on http endpoint-level caching
       // https://www.apollographql.com/docs/react/data/queries/#supported-fetch-policies
     })
-    .then(({ data }) => data.charmverseCredentialIndex.edges.map((e: any) => getParsedCredential(e.node)));
+    .then((response) =>
+      response
+        ? response.data.charmverseCredentialIndex.edges.map((e: any) => getParsedCredential(e.node))
+        : Promise.reject(new Error('Unknown error'))
+    );
 
   return externalCredentials.map((credential) => ({
     ...credential,


### PR DESCRIPTION
When ceramic fails, we just get an empty value for response. Not sure if there's a way to get better errors, or how to check if we can use it or not. This is my dev env