### PR TITLE
clear out token settings when selecting reward type

### DIFF
--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -121,7 +121,11 @@ export function RewardPropertiesForm({
     }
 
     onChange({
-      rewardType
+      rewardType,
+      customReward: rewardType === 'custom' ? values.customReward : undefined,
+      rewardAmount: rewardType === 'token' ? values.rewardAmount : undefined,
+      rewardToken: rewardType === 'token' ? values.rewardToken : undefined,
+      chainId: rewardType === 'token' ? values.chainId : undefined
     });
   }
 


### PR DESCRIPTION
BUG: when going from "Custom" to "Token" reward type, it doesn't clear out customReward and we show the custom reward as a token:
<img width="553" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/f5567d4c-fc52-4211-bcb9-4b24f50037a7">
