### PR TITLE
fix rendering of invalid strings in card properties

### DIFF
--- a/components/common/DatabaseEditor/components/propertyValueElement.tsx
+++ b/components/common/DatabaseEditor/components/propertyValueElement.tsx
@@ -710,9 +710,10 @@ function PropertyValueElement(props: Props) {
       </div>
     );
   } else if (propertyValueElement === null) {
+    const displayValueStr = typeof displayValue === 'string' ? displayValue : '';
     propertyValueElement = (
       <div className={clsx('octo-propertyvalue', { readonly: readOnly })}>
-        {displayValue || (showEmptyPlaceholder && <EmptyPlaceholder>{emptyDisplayValue}</EmptyPlaceholder>)}
+        {displayValueStr || (showEmptyPlaceholder && <EmptyPlaceholder>{emptyDisplayValue}</EmptyPlaceholder>)}
       </div>
     );
   }

--- a/components/common/DatabaseEditor/components/propertyValueElement.tsx
+++ b/components/common/DatabaseEditor/components/propertyValueElement.tsx
@@ -1,3 +1,4 @@
+import { log } from '@charmverse/core/log';
 import type { ApplicationStatus, ProposalSystemRole } from '@charmverse/core/prisma';
 import PersonIcon from '@mui/icons-material/Person';
 import { Box, Link, Stack } from '@mui/material';
@@ -711,6 +712,9 @@ function PropertyValueElement(props: Props) {
     );
   } else if (propertyValueElement === null) {
     const displayValueStr = typeof displayValue === 'string' ? displayValue : '';
+    if (typeof displayValue !== 'string') {
+      log.error('displayValue for card property is not a string', { displayValue, template: props.propertyTemplate });
+    }
     propertyValueElement = (
       <div className={clsx('octo-propertyvalue', { readonly: readOnly })}>
         {displayValueStr || (showEmptyPlaceholder && <EmptyPlaceholder>{emptyDisplayValue}</EmptyPlaceholder>)}

--- a/lib/databases/createCardsFromProposals.ts
+++ b/lib/databases/createCardsFromProposals.ts
@@ -23,8 +23,8 @@ import type { BoardViewFields } from './boardView';
 import type { CardPropertyValue } from './card';
 import { extractDatabaseProposalProperties } from './extractDatabaseProposalProperties';
 import { generateResyncedProposalEvaluationForCard } from './generateResyncedProposalEvaluationForCard';
+import { getCardPropertiesFromAnswers } from './getCardPropertiesFromAnswers';
 import { setDatabaseProposalProperties } from './setDatabaseProposalProperties';
-import { updateCardFormFieldPropertiesValue } from './updateCardFormFieldPropertiesValue';
 
 export async function createCardsFromProposals({
   boardId,
@@ -284,7 +284,7 @@ export async function createCardsFromProposals({
       userId
     });
     const accessPrivateFields = permissions.view_private_fields;
-    const formFieldProperties = updateCardFormFieldPropertiesValue({
+    const formFieldProperties = getCardPropertiesFromAnswers({
       accessPrivateFields,
       cardProperties: boardBlockCardProperties,
       formFields,

--- a/lib/databases/getCardPropertiesFromAnswers.ts
+++ b/lib/databases/getCardPropertiesFromAnswers.ts
@@ -5,10 +5,9 @@ import type { PageContent } from 'lib/prosemirror/interfaces';
 import type { BoardPropertyValue } from 'lib/public-api/interfaces';
 
 import type { IPropertyTemplate } from './board';
+import { excludedFieldTypes } from './setDatabaseProposalProperties';
 
-const excludedFieldTypes = ['project_profile', 'label'];
-
-export function updateCardFormFieldPropertiesValue({
+export function getCardPropertiesFromAnswers({
   accessPrivateFields,
   formFields,
   cardProperties,

--- a/lib/databases/setDatabaseProposalProperties.ts
+++ b/lib/databases/setDatabaseProposalProperties.ts
@@ -15,6 +15,8 @@ import {
 import { InvalidStateError } from 'lib/middleware/errors';
 import type { PageContent } from 'lib/prosemirror/interfaces';
 
+export const excludedFieldTypes = ['project_profile', 'label'];
+
 export async function setDatabaseProposalProperties({
   boardId,
   cardProperties
@@ -136,8 +138,9 @@ function getBoardProperties({
   currentCardProperties: IPropertyTemplate[];
   formFields?: FormField[];
 }) {
-  const boardProperties = [...currentCardProperties];
-
+  // TODO: we shouldn't have to filter out the excluded field types here after week of April 3, 2024.
+  // We should probably hav ea whitelist of form field answers that we support
+  const boardProperties = [...currentCardProperties].filter((prop) => !excludedFieldTypes.includes(prop.type));
   const statusProp = generateUpdatedProposalStatusProperty({ boardProperties });
   const proposalUrlProp = generateUpdatedProposalUrlProperty({ boardProperties });
   const proposalEvaluationTypeProp = generateUpdatedProposalEvaluationTypeProperty({ boardProperties });
@@ -240,12 +243,11 @@ function getBoardProperties({
         break;
       }
       default: {
-        if (formField.type !== 'label') {
+        if (!excludedFieldTypes.includes(formField.type)) {
           boardPropertyType = formField.type as IPropertyTemplate['type'];
         }
       }
     }
-
     if (boardPropertyType) {
       const boardProperty = {
         name: formField.name,
@@ -268,7 +270,6 @@ function getBoardProperties({
       }
     }
   });
-
   return boardProperties;
 }
 

--- a/lib/databases/updateCardFormFieldPropertiesValue.ts
+++ b/lib/databases/updateCardFormFieldPropertiesValue.ts
@@ -6,6 +6,8 @@ import type { BoardPropertyValue } from 'lib/public-api/interfaces';
 
 import type { IPropertyTemplate } from './board';
 
+const excludedFieldTypes = ['project_profile', 'label'];
+
 export function updateCardFormFieldPropertiesValue({
   accessPrivateFields,
   formFields,
@@ -26,7 +28,8 @@ export function updateCardFormFieldPropertiesValue({
   for (const formField of filteredFormFields) {
     const cardProperty = cardProperties.find((p) => p.formFieldId === formField.id);
     const answerValue = formField.answers.find((ans) => ans.proposalId === proposalId)?.value as FormFieldValue;
-    if (formField.type !== 'label' && cardProperty) {
+    // exclude some field types
+    if (!excludedFieldTypes.includes(formField.type) && cardProperty) {
       if (formField.type === 'long_text') {
         properties[cardProperty.id] =
           (

--- a/lib/databases/updateCardsFromProposals.ts
+++ b/lib/databases/updateCardsFromProposals.ts
@@ -30,8 +30,8 @@ import type { BoardViewFields } from './boardView';
 import type { CardFields, CardPropertyValue } from './card';
 import { DEFAULT_BOARD_BLOCK_ID } from './customBlocks/constants';
 import { generateResyncedProposalEvaluationForCard } from './generateResyncedProposalEvaluationForCard';
+import { getCardPropertiesFromAnswers } from './getCardPropertiesFromAnswers';
 import { setDatabaseProposalProperties } from './setDatabaseProposalProperties';
-import { updateCardFormFieldPropertiesValue } from './updateCardFormFieldPropertiesValue';
 
 const pageSelectObject = {
   id: true,
@@ -598,7 +598,7 @@ export async function updateCardsFromProposals({
 
           const proposalFormFields = formFields.filter((f) => f.formId === pageWithProposal.proposal?.formId);
 
-          const formFieldProperties = updateCardFormFieldPropertiesValue({
+          const formFieldProperties = getCardPropertiesFromAnswers({
             accessPrivateFields,
             cardProperties: boardBlockCardProperties,
             formFields: proposalFormFields,


### PR DESCRIPTION
Two bugs:
- we were creating card properties for project profile form types, even tho we havent added support yet
- the value was an object { projectId: string }, but the default card property element assumes its a string. caused the page to blow up.

I am not sure whether it's possible to have the board automatically review properties that are no longer valid?