### PR TITLE
Strip the trailing period on DSN record names since providers usually do not expect it

### DIFF
--- a/components/settings/space/components/SetupCustomDomain.tsx
+++ b/components/settings/space/components/SetupCustomDomain.tsx
@@ -178,7 +178,9 @@ export function SetupCustomDomain({
                           <TableRow>
                             <TableCell>
                               <LabelWithCopy
-                                label={customDomainVerification?.certificateDetails?.dnsValidation?.name || ''}
+                                label={removeEndingPeriod(
+                                  customDomainVerification?.certificateDetails?.dnsValidation?.name || ''
+                                )}
                               />
                             </TableCell>
                             <TableCell>
@@ -234,4 +236,9 @@ export function SetupCustomDomain({
       </UpgradeWrapper>
     </Stack>
   );
+}
+
+// DNS setups usually do not expect the trailing period, so we remove it
+function removeEndingPeriod(domain: string) {
+  return domain.replace(/\.$/, '');
 }


### PR DESCRIPTION
### WHAT

Strip out the trailing period for the "Name" part of DNS records for validating custom domains. If you include a ".", then DNS registrars like Google will incorrectly apply the record with an additional period and it will not work as expected.

I'm just updating the frontend where users are copy/pasting in case these settings are used someplace else.

### WHY

Fix for https://github.com/charmverse/app.charmverse.io/issues/3888
