### PR TITLE
disable flaky e2e test

### DIFF
--- a/__e2e__/charmEditor/rangeDeleteBlocks.spec.ts
+++ b/__e2e__/charmEditor/rangeDeleteBlocks.spec.ts
@@ -26,7 +26,7 @@ const confirmDiffFrameReceived = (page: Page) => {
   });
 };
 
-test('Select and delete all blocks in a document', async ({ documentPage }) => {
+test.fixme('Select and delete all blocks in a document', async ({ documentPage }) => {
   const { space, user, page } = await generateUserAndSpace({
     isAdmin: true,
     pageContent: _.doc(_.p('Paragraph 1'), _.p(''), _.p('Paragraph 2')).toJSON()


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

https://github.com/charmverse/app.charmverse.io/actions/runs/8604066895/job/23577665135

Another alternative could be to not use e2e for this, but instead extract the logic we're using in the RowActions UI so it can be unit-tested
