### PR TITLE
fix views not appearing in the sidebar

### DIFF
--- a/components/common/DatabaseEditor/store/views.ts
+++ b/components/common/DatabaseEditor/store/views.ts
@@ -90,7 +90,7 @@ export const makeSelectSortedViews = () =>
     (state: RootState, boardId: string) => state.boards.boards[boardId],
     getViews,
     (boardId, board, views) => {
-      const viewIds = board?.fields.viewIds.length ? board?.fields.viewIds : Object.keys(views);
+      const viewIds = board?.fields.viewIds?.length ? board?.fields.viewIds : Object.keys(views);
       return Object.values(views)
         .filter((v) => v.parentId === boardId)
         .sort((a, b) => (viewIds.indexOf(a.id) > viewIds.indexOf(b.id) ? 1 : -1))

--- a/components/common/DatabaseEditor/store/views.ts
+++ b/components/common/DatabaseEditor/store/views.ts
@@ -86,12 +86,13 @@ export const getViews = (state: RootState): { [key: string]: BoardView } => stat
 // export a factory to be memoized, so multiple instances can be used at once
 export const makeSelectSortedViews = () =>
   createSelector(
+    (state: RootState, boardId: string) => boardId,
     (state: RootState, boardId: string) => state.boards.boards[boardId],
     getViews,
-    (board, views) => {
-      const viewIds = board?.fields.viewIds ? board?.fields.viewIds : Object.keys(views);
+    (boardId, board, views) => {
+      const viewIds = board?.fields.viewIds.length ? board?.fields.viewIds : Object.keys(views);
       return Object.values(views)
-        .filter((v) => v.parentId === board?.id)
+        .filter((v) => v.parentId === boardId)
         .sort((a, b) => (viewIds.indexOf(a.id) > viewIds.indexOf(b.id) ? 1 : -1))
         .map((v) => createBoardView(v));
     }


### PR DESCRIPTION
Two issues I fixed:
- it seems that we usually ignore board.fields.viewIds if it is empty. I think this field is empty until you choose to sort the views
- if the board block isn't loaded, we were not showing the views

So, this WAS working sometimes, for example if you had done something to load the database board block and had also sorted its views at some point in time.