### PR TITLE
Add conditional ceramic deploy tag for staging

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -13,8 +13,8 @@ concurrency:
 jobs:
   deploy:
     if: |
-      (github.event.action == 'labeled' && contains(github.event.label.name, 'deploy')) ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'deploy'))
+      (github.event.action == 'labeled' && (github.event.label.name == ':rocket: deploy' || github.event.label.name == 'deploy-ceramic')) ||
+      (github.event.action != 'labeled' && (contains(github.event.pull_request.labels.*.name, ':rocket: deploy') || contains(github.event.pull_request.labels.*.name, 'deploy-ceramic')))
     runs-on: ubuntu-latest
     # prevent workflows running in parallel
     concurrency: deploy-pr-app-${{ github.head_ref }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   deploy:
     if: |
-      (github.event.action == 'labeled' && github.event.label.name == ':rocket: deploy') ||
+      (github.event.action == 'labeled' && (github.event.label.name == ':rocket: deploy' || github.event.label.name == 'deploy-ceramic')) ||
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, ':rocket: deploy'))
     runs-on: ubuntu-latest
     # prevent workflows running in parallel

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -166,7 +166,11 @@ jobs:
           rm -rf .ebextensions && mv .ebextensions_ceramic .ebextensions
           cat files_to_zip.txt | zip --symlinks -r@ deploy_ceramic.zip
 
+      
       - name: Deploy ceramic to Beanstalk
+        if: |
+        (github.event.action == 'labeled' && github.event.label.name == 'deploy-ceramic') ||
+        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'deploy-ceramic'))
         uses: einaregilsson/beanstalk-deploy@v21
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -13,8 +13,8 @@ concurrency:
 jobs:
   deploy:
     if: |
-      (github.event.action == 'labeled' && (github.event.label.name == ':rocket: deploy' || github.event.label.name == 'deploy-ceramic')) ||
-      (github.event.action != 'labeled' && (contains(github.event.pull_request.labels.*.name, ':rocket: deploy') || contains(github.event.pull_request.labels.*.name, 'deploy-ceramic')))
+      (github.event.action == 'labeled' && contains(github.event.label.name, 'deploy')) ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'deploy'))
     runs-on: ubuntu-latest
     # prevent workflows running in parallel
     concurrency: deploy-pr-app-${{ github.head_ref }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -168,9 +168,9 @@ jobs:
 
       
       - name: Deploy ceramic to Beanstalk
-        if: |
-        (github.event.action == 'labeled' && github.event.label.name == 'deploy-ceramic') ||
-        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'deploy-ceramic'))
+        if: >
+          (github.event.action == 'labeled' && github.event.label.name == 'deploy-ceramic') ||
+          (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'deploy-ceramic'))
         uses: einaregilsson/beanstalk-deploy@v21
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -14,7 +14,7 @@ jobs:
   deploy:
     if: |
       (github.event.action == 'labeled' && (github.event.label.name == ':rocket: deploy' || github.event.label.name == 'deploy-ceramic')) ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, ':rocket: deploy'))
+      (github.event.action != 'labeled' && (contains(github.event.pull_request.labels.*.name, ':rocket: deploy') || contains(github.event.pull_request.labels.*.name, 'deploy-ceramic')))
     runs-on: ubuntu-latest
     # prevent workflows running in parallel
     concurrency: deploy-pr-app-${{ github.head_ref }}

--- a/.github/workflows/destroy_staging.yml
+++ b/.github/workflows/destroy_staging.yml
@@ -10,8 +10,8 @@ concurrency:
 jobs:
   clean-up:
     if: |
-      (github.event.action == 'unlabeled' && github.event.label.name == ':rocket: deploy') ||
-      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, ':rocket: deploy'))
+      (github.event.action == 'unlabeled' && contains(github.event.label.name, 'deploy')) ||
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy'))
     runs-on: ubuntu-latest
     # wait until all deploys are complete to destroy the env
     concurrency: deploy-pr-app-${{ github.head_ref }}

--- a/.github/workflows/destroy_staging.yml
+++ b/.github/workflows/destroy_staging.yml
@@ -10,8 +10,8 @@ concurrency:
 jobs:
   clean-up:
     if: |
-      (github.event.action == 'unlabeled' && contains(github.event.label.name, 'deploy')) ||
-      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy'))
+      (github.event.action == 'unlabeled' && (github.event.label.name == ':rocket: deploy' || github.event.label.name == 'deploy-ceramic')) ||
+      (github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, ':rocket: deploy') || contains(github.event.pull_request.labels.*.name, 'deploy-ceramic')))
     runs-on: ubuntu-latest
     # wait until all deploys are complete to destroy the env
     concurrency: deploy-pr-app-${{ github.head_ref }}


### PR DESCRIPTION
### WHAT

When working on ceramic fixes, it's difficult to debug staging as concurrent pushes to staging by other developers block the deploy

This ensures ceramic staging only deploys if the tag is provided

### WHY

<!-- why was this necessary? -->
