### PR TITLE
fix space settings not refreshing

### DIFF
--- a/hooks/useSpaces.tsx
+++ b/hooks/useSpaces.tsx
@@ -51,21 +51,24 @@ export function SpacesProvider({ children }: { children: ReactNode }) {
     }
   }, [user?.id, isUserLoaded]);
 
-  const createNewSpace = useCallback(async (newSpace: Pick<CreateSpaceProps, 'spaceTemplate' | 'spaceData'>) => {
-    setIsCreatingSpace(true);
+  const createNewSpace = useCallback(
+    async (newSpace: Pick<CreateSpaceProps, 'spaceTemplate' | 'spaceData'>) => {
+      setIsCreatingSpace(true);
 
-    try {
-      const space = await charmClient.spaces.createSpace(newSpace);
-      setSpaces((s) => [...s, space]);
-      // refresh user permissions
-      await refreshUser();
-      setIsCreatingSpace(false);
-      return space;
-    } catch (e) {
-      setIsCreatingSpace(false);
-      throw e;
-    }
-  }, []);
+      try {
+        const space = await charmClient.spaces.createSpace(newSpace);
+        setSpaces((s) => [...s, space]);
+        // refresh user permissions
+        await refreshUser();
+        setIsCreatingSpace(false);
+        return space;
+      } catch (e) {
+        setIsCreatingSpace(false);
+        throw e;
+      }
+    },
+    [setIsCreatingSpace, setSpaces]
+  );
 
   const setSpace = useCallback(
     (_space: Space) => {
@@ -75,9 +78,10 @@ export function SpacesProvider({ children }: { children: ReactNode }) {
     [spaces, setSpaces]
   );
 
-  const memberSpaces = !user
-    ? []
-    : spaces.filter((s) => !!user?.spaceRoles.find((sr) => sr.spaceId === s.id && !sr.isGuest));
+  const memberSpaces = useMemo(
+    () => (!user ? [] : spaces.filter((s) => !!user?.spaceRoles.find((sr) => sr.spaceId === s.id && !sr.isGuest))),
+    [user, spaces]
+  );
 
   const value = useMemo(
     () =>
@@ -90,7 +94,7 @@ export function SpacesProvider({ children }: { children: ReactNode }) {
         createNewSpace,
         isCreatingSpace
       } as IContext),
-    [spaces, isLoaded, isCreatingSpace]
+    [spaces, memberSpaces, isLoaded, setSpace, createNewSpace, isCreatingSpace]
   );
 
   return <SpacesContext.Provider value={value}>{children}</SpacesContext.Provider>;


### PR DESCRIPTION
To reproduce, try creating a new space and then visit Settings. The settings wouldn't appear because 'memberSpaces' had not been updated in the component. TUrned out we had useMemo'd the value in SpacesProvider and it wasn't updating when the user roles were changed.

And we would hide the space settigns if the space was not listed inside 'memberSpaces'