### PR TITLE
require rubric criteria to always have a title

### DIFF
--- a/lib/proposals/__tests__/getProposalErrors.spec.ts
+++ b/lib/proposals/__tests__/getProposalErrors.spec.ts
@@ -4,34 +4,56 @@ import { createMockProposal } from 'testing/mocks/proposal';
 import { getProposalErrors } from '../getProposalErrors';
 
 describe('getProposalErrors', () => {
-  it(`Should false for a title with whitespace only`, async () => {
-    const { proposal, page } = getProposalMock({ title: ' ' });
-    const input = getFunctionInput({
-      page,
-      proposal
+  it(`Should return true for the default state`, async () => {
+    const proposal = createMockProposal({
+      workflowId: 'test'
     });
+    const input = getFunctionInput({ proposal });
+    const errors = getProposalErrors(input);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it(`Should return false for a title with whitespace only`, async () => {
+    const proposal = createMockProposal();
+    const page = createMockPage({
+      title: ' '
+    });
+    const input = getFunctionInput({ proposal, page });
     const errors = getProposalErrors(input);
 
     expect(errors).toContain('Title is required');
   });
-});
 
-function getProposalMock(options: { title?: string }) {
-  const proposal = createMockProposal();
-  const page = createMockPage({
-    title: options.title
+  it(`Should return false when rubric criteria is missing a title`, async () => {
+    const proposal = createMockProposal({
+      evaluations: [
+        {
+          type: 'rubric',
+          title: 'Test',
+          reviewers: [{ userId: 'someone' }] as any[],
+          rubricCriteria: [{ title: '' }] as any[]
+        }
+      ],
+      workflowId: 'test'
+    });
+    const input = getFunctionInput({
+      proposal
+    });
+    const errors = getProposalErrors(input);
+
+    expect(errors).toContain('Rubric criteria is missing a label in the "Test" step');
   });
-  return { proposal, page };
-}
+});
 
 type GetProposalErrorsInput = Parameters<typeof getProposalErrors>[0];
 
 function getFunctionInput({
   proposal,
-  ...options
+  page = createMockPage({ title: 'dummy title' })
 }: {
   proposal: ReturnType<typeof createMockProposal>;
-  page: ReturnType<typeof createMockPage>;
+  page?: ReturnType<typeof createMockPage>;
 }): GetProposalErrorsInput {
   return {
     isDraft: false,
@@ -45,6 +67,6 @@ function getFunctionInput({
         voteSettings: evaluation.voteSettings as any
       }))
     },
-    ...options
+    page
   };
 }

--- a/lib/proposals/getProposalErrors.ts
+++ b/lib/proposals/getProposalErrors.ts
@@ -58,7 +58,6 @@ export function getProposalErrors({
   } else if (proposalType === 'free_form' && page.type === 'proposal_template' && checkIsContentEmpty(page.content)) {
     errors.push('Content is required for free-form proposals');
   }
-
   // get the first validation error from the evaluations
   errors.push(...proposal.evaluations.map(getEvaluationFormError).filter(isTruthy));
 
@@ -76,6 +75,8 @@ export function getEvaluationFormError(evaluation: ProposalEvaluationInput): str
         ? `Reviewers are required for the "${evaluation.title}" step`
         : evaluation.rubricCriteria.length === 0
         ? `At least one rubric criteria is required for the "${evaluation.title}" step`
+        : evaluation.rubricCriteria.some((c) => !c.title?.trim())
+        ? `Rubric criteria is missing a label in the "${evaluation.title}" step`
         : false;
     case 'pass_fail':
       return evaluation.reviewers.length === 0 ? `Reviewers are required for the "${evaluation.title}" step` : false;


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

I noticed while creating a proposal with Descision Matrix workflow, i could publish it without adding a title for the first criteria
