### PR TITLE
filter should not include empty values

### DIFF
--- a/lib/databases/cardFilter.ts
+++ b/lib/databases/cardFilter.ts
@@ -107,6 +107,7 @@ class CardFilter {
       if (filterPropertyDataType === 'text') {
         const condition = filter.condition as (typeof TextDataTypeConditions)[number];
         const sourceValue = valueArray[0]?.toLowerCase() ?? '';
+
         switch (condition) {
           case 'contains': {
             if (sourceValue.includes(filterValue)) {
@@ -121,16 +122,16 @@ class CardFilter {
             return false;
           }
           case 'ends_with': {
-            return sourceValue.length === 0 ? true : sourceValue.endsWith(filterValue);
+            return sourceValue.endsWith(filterValue);
           }
           case 'starts_with': {
-            return sourceValue.length === 0 ? true : sourceValue.startsWith(filterValue);
+            return sourceValue.startsWith(filterValue);
           }
           case 'is': {
-            return sourceValue.length === 0 ? true : sourceValue === filterValue;
+            return sourceValue === filterValue;
           }
           case 'is_not': {
-            return sourceValue.length === 0 ? true : sourceValue !== filterValue;
+            return sourceValue !== filterValue;
           }
           case 'is_empty': {
             return sourceValue === '';
@@ -161,19 +162,19 @@ class CardFilter {
         const sourceValue = valueArray[0]?.toLowerCase() ?? '';
         switch (condition) {
           case 'equal': {
-            return sourceValue.length === 0 ? false : Number(sourceValue) === Number(filterValue);
+            return Number(sourceValue) === Number(filterValue);
           }
           case 'greater_than': {
-            return sourceValue.length === 0 ? false : Number(sourceValue) > Number(filterValue);
+            return Number(sourceValue) > Number(filterValue);
           }
           case 'less_than': {
-            return sourceValue.length === 0 ? false : Number(sourceValue) < Number(filterValue);
+            return Number(sourceValue) < Number(filterValue);
           }
           case 'less_than_equal': {
-            return sourceValue.length === 0 ? false : Number(sourceValue) <= Number(filterValue);
+            return Number(sourceValue) <= Number(filterValue);
           }
           case 'greater_than_equal': {
-            return sourceValue.length === 0 ? false : Number(sourceValue) >= Number(filterValue);
+            return Number(sourceValue) >= Number(filterValue);
           }
           case 'is_empty': {
             return sourceValue === '';
@@ -229,7 +230,7 @@ class CardFilter {
         const sourceValue = valueArray[0]?.toLowerCase() ?? '';
         switch (condition) {
           case 'is': {
-            return sourceValue.length !== 0 && filterValue === sourceValue;
+            return filterValue === sourceValue;
           }
           case 'is_not': {
             return sourceValue.length === 0 ? true : filterValue !== sourceValue;


### PR DESCRIPTION
This code was added in a large refactor a year ago: https://github.com/charmverse/app.charmverse.io/commit/13ae5d2ba81e668edf6d4f495b62711077ee99d8. It seems unintuitive to include values that are empty when I'm looking for "is" or "starts with". This also doesn't match Notion UX