### PR TITLE
improve document performance

### DIFF
--- a/components/[pageId]/DocumentPage/hooks/usePageSidebar.tsx
+++ b/components/[pageId]/DocumentPage/hooks/usePageSidebar.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { createContext, useContext, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 
 import { useCurrentPage } from 'hooks/useCurrentPage';
 
@@ -16,22 +16,24 @@ export const PageSidebarContext = createContext<IPageSidebarContext | null>(null
 
 export function PageSidebarProvider({ children }: { children: ReactNode }) {
   const [activeView, setActiveView] = useState<IPageSidebarContext['activeView']>(null);
-  const { currentPageId } = useCurrentPage();
 
-  function _setActiveView(view: PageSidebarView | null | ((view: PageSidebarView | null) => PageSidebarView | null)) {
-    // handle case when a callback is used as the new value
-    if (typeof view === 'function') {
-      return setActiveView((prevView) => {
-        return view(prevView);
-      });
-    } else {
-      return setActiveView(view);
-    }
-  }
+  const _setActiveView = useCallback(
+    (view: PageSidebarView | null | ((view: PageSidebarView | null) => PageSidebarView | null)) => {
+      // handle case when a callback is used as the new value
+      if (typeof view === 'function') {
+        return setActiveView((prevView) => {
+          return view(prevView);
+        });
+      } else {
+        return setActiveView(view);
+      }
+    },
+    [setActiveView]
+  );
 
-  function closeSidebar() {
+  const closeSidebar = useCallback(() => {
     _setActiveView(null);
-  }
+  }, [_setActiveView]);
 
   const value = useMemo<IPageSidebarContext>(
     () => ({
@@ -39,7 +41,7 @@ export function PageSidebarProvider({ children }: { children: ReactNode }) {
       setActiveView: _setActiveView,
       closeSidebar
     }),
-    [activeView, currentPageId, _setActiveView]
+    [activeView, _setActiveView, closeSidebar]
   );
 
   return <PageSidebarContext.Provider value={value}>{children}</PageSidebarContext.Provider>;

--- a/components/common/CharmEditor/components/@bangle.dev/react/NodeViewWrapper.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/NodeViewWrapper.tsx
@@ -14,7 +14,7 @@ interface StateType {
   nodeViewProps: NodeViewProps;
 }
 
-export class NodeViewWrapper extends React.Component<PropsType, StateType> {
+class NodeViewWrapperClass extends React.Component<PropsType, StateType> {
   update: () => void;
 
   attachToContentDOM: (reactElement: HTMLDivElement) => void;
@@ -85,3 +85,5 @@ export class NodeViewWrapper extends React.Component<PropsType, StateType> {
     return element;
   }
 }
+
+export const NodeViewWrapper = React.memo(NodeViewWrapperClass);

--- a/components/common/CharmEditor/components/@bangle.dev/react/node-view-helpers.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/node-view-helpers.tsx
@@ -46,11 +46,11 @@ export function useNodeViews(ref: RefObject<HTMLElement>) {
         if (!destroyed) {
           // make sure that updates run sequentially for prosemiror, or we get infinite recursion of node views being created and destroyed.
           // See also: https://github.com/ueberdosis/tiptap/pull/2985
-          // flushSync(() => {
-          // use callback variant of setState to
-          // always get freshest nodeViews.
-          setNodeViews((_nodeViews) => cb(_nodeViews));
-          // });
+          flushSync(() => {
+            // use callback variant of setState to
+            // always get freshest nodeViews.
+            setNodeViews((_nodeViews) => cb(_nodeViews));
+          });
         }
       })
     );

--- a/components/common/CharmEditor/components/@bangle.dev/react/node-view-helpers.tsx
+++ b/components/common/CharmEditor/components/@bangle.dev/react/node-view-helpers.tsx
@@ -1,9 +1,11 @@
+import { objectUid } from '@bangle.dev/utils';
+import { log } from '@charmverse/core/log';
 import { useEffect, useState } from 'react';
 import type { RefObject } from 'react';
 import { flushSync } from 'react-dom';
 
-import { saveRenderHandlers } from 'components/common/CharmEditor/components/@bangle.dev/core/node-view';
-import type { NodeView, RenderHandlers } from 'components/common/CharmEditor/components/@bangle.dev/core/node-view';
+import type { NodeView, RenderHandlers } from '../core/node-view';
+import { saveRenderHandlers } from '../core/node-view';
 
 export const nodeViewUpdateStore = new WeakMap();
 
@@ -12,11 +14,11 @@ type UpdateNodeViewsFunction = (updater: NodeViewsUpdater) => void;
 
 export const nodeViewRenderHandlers = (updateNodeViews: UpdateNodeViewsFunction): RenderHandlers => ({
   create: (nodeView, _nodeViewProps) => {
-    // log.debug('create', objectUid.get(nodeView), new Error().stack);
+    log.debug('create node', objectUid.get(nodeView)); // , new Error().stack);
     updateNodeViews((nodeViews) => [...nodeViews, nodeView]);
   },
   update: (nodeView, _nodeViewProps) => {
-    // log.debug('update', objectUid.get(nodeView));
+    log.debug('update node', objectUid.get(nodeView));
     const updateCallback = nodeViewUpdateStore.get(nodeView);
     // If updateCallback is undefined (which can happen if react took long to mount),
     // we are still okay, as the latest nodeViewProps will be accessed whenever it mounts.
@@ -44,11 +46,11 @@ export function useNodeViews(ref: RefObject<HTMLElement>) {
         if (!destroyed) {
           // make sure that updates run sequentially for prosemiror, or we get infinite recursion of node views being created and destroyed.
           // See also: https://github.com/ueberdosis/tiptap/pull/2985
-          flushSync(() => {
-            // use callback variant of setState to
-            // always get freshest nodeViews.
-            setNodeViews((_nodeViews) => cb(_nodeViews));
-          });
+          // flushSync(() => {
+          // use callback variant of setState to
+          // always get freshest nodeViews.
+          setNodeViews((_nodeViews) => cb(_nodeViews));
+          // });
         }
       })
     );

--- a/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
+++ b/components/common/CharmEditor/components/nestedPage/components/NestedPage.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import type { EditorView } from 'prosemirror-view';
+import { memo } from 'react';
 
 import Link from 'components/common/Link';
 import { NoAccessPageIcon, PageIcon } from 'components/common/PageIcon';
@@ -56,7 +57,7 @@ function resetPageNodeDropPluginState(view: EditorView) {
   }
 }
 
-export function NestedPage({ isLinkedPage = false, node, getPos }: NodeViewProps & { isLinkedPage?: boolean }) {
+function NestedPageComponent({ isLinkedPage = false, node, getPos }: NodeViewProps & { isLinkedPage?: boolean }) {
   const view = useEditorViewContext();
   const { getFeatureTitle, mappedFeatures } = useSpaceFeatures();
   const { categories } = useForumCategories();
@@ -135,6 +136,8 @@ export function NestedPage({ isLinkedPage = false, node, getPos }: NodeViewProps
     </StyledLink>
   );
 }
+
+export const NestedPage = memo(NestedPageComponent);
 
 function LinkIcon({
   isLinkedPage,


### PR DESCRIPTION
Another reason to move away from Bangle.dev @Devorein : it is written for React 16. Ever since React 18 implemented async updates, I had to hack it myself adding flushSync. This makes rendering the page very slow as we call that for each node view. I think this other lib might be a better approach, and it just exposes some hook sthat we can mostly replace the ones from Bangle.dev. Instead of rendering each node view one at a time, it renders them all at once I think: https://github.com/nytimes/react-prosemirror/tree/main