### PR TITLE
fix printing for PDFs

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -565,7 +565,7 @@ function DocumentPageComponent({
                   )}
 
                 {(page.type === 'proposal' || page.type === 'card' || page.type === 'card_synced') && (
-                  <Box>
+                  <Box className='dont-print-me'>
                     {/* add negative margin to offset height of .charm-empty-footer */}
                     <PageComments page={page} canComment={pagePermissions.comment} />
                   </Box>

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewards.tsx
@@ -190,7 +190,7 @@ export function ProposalRewards({
           })}
 
           {canCreatePendingRewards && (
-            <Box>
+            <Box className='dont-print-me'>
               <AttachRewardButton createNewReward={createNewReward} variant={variant} />
             </Box>
           )}

--- a/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewardsTable.tsx
+++ b/components/proposals/ProposalPage/components/ProposalProperties/components/ProposalRewards/ProposalRewardsTable.tsx
@@ -152,7 +152,7 @@ export function ProposalRewardsTable({
               <Box my={1}>
                 <Typography variant='h5'>{getFeatureTitle('Rewards')}</Typography>
               </Box>
-              <Box my={1}>
+              <Box my={1} className='dont-print-me'>
                 {canCreatePendingRewards && !loadingData && (
                   <AttachRewardButton createNewReward={createNewReward} variant={variant} />
                 )}

--- a/theme/print.scss
+++ b/theme/print.scss
@@ -43,11 +43,6 @@
     break-before: auto;
     break-inside: avoid;
 
-    &::before {
-      display: block;
-      break-before: auto;
-      break-inside: avoid;
-    }
   }
 
   body.dark-mode * {


### PR DESCRIPTION
I removed a rule (::before) which I think was used for the old bullet list styles, not sure what else it was used for. This seemed to be messing with the layout with our new bullets at least