### PR TITLE
remove extra bullet styles from bangle.dev

### DIFF
--- a/theme/@bangle.dev/styles.scss
+++ b/theme/@bangle.dev/styles.scss
@@ -222,33 +222,33 @@ img.ProseMirror-separator {
 }
 
 // nested list styles
-ul li {
-  ul li {
-    list-style-type: circle;
+// ul li {
+//   ul li {
+//     list-style-type: circle;
 
-    ul li {
-      list-style-type: square;
+//     ul li {
+//       list-style-type: square;
 
-      ul li {
-        list-style-type: disc;
-      }
-    }
-  }
-}
+//       ul li {
+//         list-style-type: disc;
+//       }
+//     }
+//   }
+// }
 
-ol li {
-  ol li {
-    list-style-type: lower-alpha;
+// ol li {
+//   ol li {
+//     list-style-type: lower-alpha;
 
-    ol li {
-      list-style-type: lower-roman;
+//     ol li {
+//       list-style-type: lower-roman;
 
-      ol li {
-        list-style-type: circle;
-      }
-    }
-  }
-}
+//       ol li {
+//         list-style-type: circle;
+//       }
+//     }
+//   }
+// }
 
 .bangle-editor li > span {
   display: block;


### PR DESCRIPTION
I noticed an extra set of bullet icons appearing in the left margin on someone's page. It's the first time i noticed it, but we don't need these styles anyway. the correct styles are defined in czi-list.scss and czi-indent.scss

Bullets still look fine in storybook:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/7a504810-956b-4878-9561-d0d89088ba98)

