### PR TITLE
disable integration settings for non-admins

### DIFF
--- a/components/settings/integrations/components/Boto/BotoSettings.tsx
+++ b/components/settings/integrations/components/Boto/BotoSettings.tsx
@@ -15,10 +15,10 @@ export function BotoSettings({ isAdmin }: { isAdmin: boolean }) {
     <IntegrationContainer
       title='Boto'
       subheader='Send events to Discord or Telegram'
-      isConnected={false}
       expanded={expanded}
       setExpanded={setExpanded}
-      disableConnectTooltip={!isAdmin ? 'Only admins can configure this' : undefined}
+      isAdmin={isAdmin}
+      isConnected={false}
     >
       <Stack gap={2}>
         <Typography variant='body2'>

--- a/components/settings/integrations/components/CollabLand/CollabLandSettings.tsx
+++ b/components/settings/integrations/components/CollabLand/CollabLandSettings.tsx
@@ -40,12 +40,12 @@ export function CollabLandSettings({ isAdmin }: { isAdmin: boolean }) {
 
   return (
     <IntegrationContainer
-      isConnected={isConnected}
-      expanded={expanded}
-      setExpanded={setExpanded}
       title='Collab.Land'
       subheader='Sync members and roles with Discord'
-      disableConnectTooltip={!isAdmin ? 'Collab.Land is not connected yet. Only admins can configure this' : undefined}
+      expanded={expanded}
+      setExpanded={setExpanded}
+      isAdmin={isAdmin}
+      isConnected={isConnected}
     >
       {isConnected ? (
         <Stack gap={2}>

--- a/components/settings/integrations/components/Github/GithubSettings.tsx
+++ b/components/settings/integrations/components/Github/GithubSettings.tsx
@@ -28,11 +28,12 @@ export function GithubSettings({
 
   return (
     <IntegrationContainer
-      isConnected={!!githubApplicationData}
-      expanded={expanded}
-      setExpanded={setExpanded}
       title='Github'
       subheader={`Link issues to ${getFeatureTitle('rewards')}`}
+      expanded={expanded}
+      setExpanded={setExpanded}
+      isAdmin={isAdmin}
+      isConnected={!!githubApplicationData}
     >
       <Stack gap={2}>
         {isLoadingGithubApplicationData || isConnectingWithGithubApp ? (

--- a/components/settings/integrations/components/IntegrationContainer.tsx
+++ b/components/settings/integrations/components/IntegrationContainer.tsx
@@ -12,25 +12,26 @@ const StyledCard = styled(Card)`
 `;
 
 export function IntegrationContainer({
+  title,
+  subheader,
   expanded,
   setExpanded,
-  title,
+  isAdmin,
   isConnected,
-  subheader,
   onCancel,
-  disableConnectTooltip,
   children
 }: {
-  expanded: boolean;
-  setExpanded: (expanded: boolean) => void;
-  onCancel?: () => void;
   title: string;
   subheader: string;
+  expanded: boolean;
+  setExpanded: (expanded: boolean) => void;
+  isAdmin: boolean;
   isConnected: boolean;
-  disableConnectTooltip?: string;
+  onCancel?: () => void;
   children: ReactNode;
 }) {
   function clickAction() {
+    if (!isAdmin) return;
     setExpanded(!expanded);
   }
 
@@ -50,8 +51,8 @@ export function IntegrationContainer({
           </Typography>
         }
         subheader={<Typography variant='caption'>{subheader}</Typography>}
-        sx={{ cursor: !expanded ? 'pointer' : undefined, p: 2 }}
-        onClick={!expanded ? clickAction : undefined}
+        sx={{ cursor: !expanded && isAdmin ? 'pointer' : undefined, p: 2 }}
+        onClick={!expanded && isAdmin ? clickAction : undefined}
         action={
           !isConnected ? (
             expanded ? (
@@ -63,8 +64,8 @@ export function IntegrationContainer({
                 sx={{ width: 100 }}
                 color='primary'
                 data-test='connect-button'
-                disabled={!!disableConnectTooltip}
-                disabledTooltip={disableConnectTooltip}
+                disabled={!isAdmin}
+                disabledTooltip='Admin role required'
                 onClick={clickAction}
               >
                 Connect
@@ -74,6 +75,8 @@ export function IntegrationContainer({
             <Button
               startIcon={<CheckCircleOutlineOutlined />}
               color='secondary'
+              disabled={!isAdmin}
+              disabledTooltip='Admin role required'
               variant='outlined'
               sx={{ width: 130 }}
               onClick={clickAction}

--- a/components/settings/integrations/components/KYC/KYCSettings.tsx
+++ b/components/settings/integrations/components/KYC/KYCSettings.tsx
@@ -132,12 +132,13 @@ export function KYCSettings({ space, isAdmin }: { space: Space; isAdmin: boolean
 
   return (
     <IntegrationContainer
-      isConnected={!!space.kycOption}
-      expanded={expanded}
-      setExpanded={setExpanded}
-      onCancel={resetValues}
       title='KYC'
       subheader='Verify the identity of your members'
+      expanded={expanded}
+      setExpanded={setExpanded}
+      isAdmin={isAdmin}
+      isConnected={!!space.kycOption}
+      onCancel={resetValues}
     >
       <form onSubmit={handleSubmit(onSubmit)}>
         <Stack gap={2}>

--- a/components/settings/integrations/components/Snapshot/SnapshotSettings.tsx
+++ b/components/settings/integrations/components/Snapshot/SnapshotSettings.tsx
@@ -81,13 +81,13 @@ export function SnapshotSettings({ isAdmin, space }: { isAdmin: boolean; space: 
 
   return (
     <IntegrationContainer
-      expanded={expanded}
-      setExpanded={setExpanded}
-      onCancel={() => reset({ snapshotDomain: space.snapshotDomain || '' })}
-      isConnected={isConnected}
-      disableConnectTooltip={!isAdmin ? 'Only an admin can change Snapshot domain' : undefined}
       title='Snapshot.org'
       subheader='Publish votes to Snapshot'
+      expanded={expanded}
+      setExpanded={setExpanded}
+      isAdmin={isAdmin}
+      isConnected={isConnected}
+      onCancel={() => reset({ snapshotDomain: space.snapshotDomain || '' })}
     >
       <Stack gap={2}>
         <div>


### PR DESCRIPTION
Simplify and standardize the Integration settings for non-admins. They just don't get to expand the views, but they can see what has been connected. In the future we might add a summary