### PR TITLE
allow grouping rewards by milestone

### DIFF
--- a/components/common/DatabaseEditor/components/ViewFilterControl.tsx
+++ b/components/common/DatabaseEditor/components/ViewFilterControl.tsx
@@ -1,4 +1,5 @@
-import { Popover } from '@mui/material';
+import { FilterList } from '@mui/icons-material';
+import { Popover, Tooltip } from '@mui/material';
 import { bindPopover, bindTrigger, usePopupState } from 'material-ui-popup-state/hooks';
 import { FormattedMessage } from 'react-intl';
 
@@ -6,6 +7,8 @@ import { Button } from 'components/common/Button';
 import { useViewFilter } from 'hooks/useViewFilter';
 import type { Board } from 'lib/databases/board';
 import type { BoardView } from 'lib/databases/boardView';
+
+import IconButton from '../widgets/buttons/iconButton';
 
 import FilterComponent from './viewHeader/filterComponent';
 
@@ -21,15 +24,12 @@ export function ViewFilterControl({ activeBoard, activeView }: Props) {
 
   return (
     <>
-      <Button
-        color={hasFilter ? 'primary' : 'secondary'}
-        variant='text'
-        size='small'
-        sx={{ minWidth: 0 }}
+      <IconButton
+        tooltip='Filter'
+        icon={<FilterList color={hasFilter ? 'primary' : 'secondary'} fontSize='small' />}
+        style={{ width: '32px' }}
         {...bindTrigger(viewFilterPopup)}
-      >
-        <FormattedMessage id='ViewHeader.filter' defaultMessage='Filter' />
-      </Button>
+      />
       <Popover
         {...bindPopover(viewFilterPopup)}
         anchorOrigin={{

--- a/components/common/DatabaseEditor/components/ViewSortControl.tsx
+++ b/components/common/DatabaseEditor/components/ViewSortControl.tsx
@@ -1,6 +1,7 @@
 import { Menu } from '@mui/material';
 import { bindMenu, bindTrigger, type PopupState } from 'material-ui-popup-state/hooks';
 import { usePopupState } from 'material-ui-popup-state/hooks';
+import { TbArrowsSort } from 'react-icons/tb';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from 'components/common/Button';
@@ -8,6 +9,8 @@ import { useViewSortOptions } from 'hooks/useViewSortOptions';
 import type { Board } from 'lib/databases/board';
 import type { BoardView } from 'lib/databases/boardView';
 import type { Card } from 'lib/databases/card';
+
+import IconButton from '../widgets/buttons/iconButton';
 
 import ViewHeaderSortMenu from './viewHeader/viewHeaderSortMenu';
 
@@ -39,7 +42,15 @@ export function SortMenuButton({ hasSort, menuItems }: { hasSort: boolean; menuI
 
   return (
     <>
-      <Button
+      <IconButton
+        tooltip='Sort'
+        icon={
+          <TbArrowsSort style={{ color: hasSort ? 'var(--primary-color)' : 'var(--secondary-text)', fontSize: 16 }} />
+        }
+        style={{ width: '32px' }}
+        {...bindTrigger(viewSortPopup)}
+      />
+      {/* <Button
         color={hasSort ? 'primary' : 'secondary'}
         variant='text'
         size='small'
@@ -47,7 +58,7 @@ export function SortMenuButton({ hasSort, menuItems }: { hasSort: boolean; menuI
         {...bindTrigger(viewSortPopup)}
       >
         <FormattedMessage id='ViewHeader.sort' defaultMessage='Sort' />
-      </Button>
+      </Button> */}
       <Menu
         {...bindMenu(viewSortPopup)}
         slotProps={{

--- a/components/common/DatabaseEditor/components/__snapshots__/centerPanel.spec.tsx.snap
+++ b/components/common/DatabaseEditor/components/__snapshots__/centerPanel.spec.tsx.snap
@@ -75,23 +75,28 @@ exports[`components/centerPanel return centerPanel and click on card to show car
             <div
               class="view-actions MuiBox-root css-37urdo"
             >
-              <button
-                class="Button IconButton css-w119tu"
-                style="width: 28px; height: 28px;"
-                type="button"
+              <span
+                class=""
+                data-mui-internal-clone-element="true"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-                  data-testid="AddIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 28px; height: 28px;"
+                  type="button"
                 >
-                  <path
-                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-                  />
-                </svg>
-              </button>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                    />
+                  </svg>
+                </button>
+              </span>
             </div>
             <div
               class="octo-spacer"
@@ -99,42 +104,10 @@ exports[`components/centerPanel return centerPanel and click on card to show car
             <div
               class="view-actions MuiBox-root css-0"
             >
-              <button
-                aria-haspopup="true"
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-16efx8q-MuiButtonBase-root-MuiButton-root"
-                tabindex="0"
-                type="button"
-              >
-                Filter
-              </button>
-              <button
-                aria-haspopup="true"
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-16efx8q-MuiButtonBase-root-MuiButton-root"
-                tabindex="0"
-                type="button"
-              >
-                Sort
-              </button>
-              <button
-                class="Button IconButton css-w119tu"
-                style="width: 32px;"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-                  data-testid="SearchIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
-                  />
-                </svg>
-              </button>
-              <div
-                class="MuiBox-root css-jw1lpn"
-                data-test="view-header-actions-menu"
+              <span
+                aria-label="Filter"
+                class=""
+                data-mui-internal-clone-element="true"
               >
                 <button
                   class="Button IconButton css-w119tu"
@@ -143,16 +116,103 @@ exports[`components/centerPanel return centerPanel and click on card to show car
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                    data-testid="MoreHorizOutlinedIcon"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeSmall css-887v1i-MuiSvgIcon-root"
+                    data-testid="FilterListIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
                     <path
-                      d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                      d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
                     />
                   </svg>
                 </button>
+              </span>
+              <span
+                aria-label="Sort"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 32px;"
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="font-size: 16px;"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                      stroke="none"
+                    />
+                    <path
+                      d="M3 9l4 -4l4 4m-4 -4v14"
+                    />
+                    <path
+                      d="M21 15l-4 4l-4 -4m4 4v-14"
+                    />
+                  </svg>
+                </button>
+              </span>
+              <span
+                aria-label="Search"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 32px;"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                    />
+                  </svg>
+                </button>
+              </span>
+              <div
+                class="MuiBox-root css-jw1lpn"
+                data-test="view-header-actions-menu"
+              >
+                <span
+                  aria-label="Edit view layout, grouping, and more..."
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  <button
+                    class="Button IconButton css-w119tu"
+                    style="width: 32px;"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                      data-testid="MoreHorizOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                      />
+                    </svg>
+                  </button>
+                </span>
               </div>
               <div
                 class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-disableElevation css-jgbgc3-MuiButtonGroup-root"
@@ -239,6 +299,32 @@ exports[`components/centerPanel return centerPanel and click on card to show car
                     data-testid="menu-wrapper"
                     role="button"
                   >
+                    <span
+                      class=""
+                      data-mui-internal-clone-element="true"
+                    >
+                      <button
+                        class="Button IconButton css-w119tu"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                          data-testid="MoreHorizIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                  </div>
+                  <span
+                    class=""
+                    data-mui-internal-clone-element="true"
+                  >
                     <button
                       class="Button IconButton css-w119tu"
                       type="button"
@@ -246,32 +332,16 @@ exports[`components/centerPanel return centerPanel and click on card to show car
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                        data-testid="MoreHorizIcon"
+                        data-testid="AddIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
                       >
                         <path
-                          d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
                         />
                       </svg>
                     </button>
-                  </div>
-                  <button
-                    class="Button IconButton css-w119tu"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-                      />
-                    </svg>
-                  </button>
+                  </span>
                 </div>
                 <div
                   class="octo-board-header-cell narrow"
@@ -786,23 +856,28 @@ exports[`components/centerPanel should match snapshot for Gallery 1`] = `
             <div
               class="view-actions MuiBox-root css-37urdo"
             >
-              <button
-                class="Button IconButton css-w119tu"
-                style="width: 28px; height: 28px;"
-                type="button"
+              <span
+                class=""
+                data-mui-internal-clone-element="true"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-                  data-testid="AddIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 28px; height: 28px;"
+                  type="button"
                 >
-                  <path
-                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-                  />
-                </svg>
-              </button>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                    />
+                  </svg>
+                </button>
+              </span>
             </div>
             <div
               class="octo-spacer"
@@ -810,42 +885,10 @@ exports[`components/centerPanel should match snapshot for Gallery 1`] = `
             <div
               class="view-actions MuiBox-root css-0"
             >
-              <button
-                aria-haspopup="true"
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-16efx8q-MuiButtonBase-root-MuiButton-root"
-                tabindex="0"
-                type="button"
-              >
-                Filter
-              </button>
-              <button
-                aria-haspopup="true"
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-16efx8q-MuiButtonBase-root-MuiButton-root"
-                tabindex="0"
-                type="button"
-              >
-                Sort
-              </button>
-              <button
-                class="Button IconButton css-w119tu"
-                style="width: 32px;"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-                  data-testid="SearchIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
-                  />
-                </svg>
-              </button>
-              <div
-                class="MuiBox-root css-jw1lpn"
-                data-test="view-header-actions-menu"
+              <span
+                aria-label="Filter"
+                class=""
+                data-mui-internal-clone-element="true"
               >
                 <button
                   class="Button IconButton css-w119tu"
@@ -854,16 +897,103 @@ exports[`components/centerPanel should match snapshot for Gallery 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                    data-testid="MoreHorizOutlinedIcon"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeSmall css-887v1i-MuiSvgIcon-root"
+                    data-testid="FilterListIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
                     <path
-                      d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                      d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
                     />
                   </svg>
                 </button>
+              </span>
+              <span
+                aria-label="Sort"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 32px;"
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="font-size: 16px;"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                      stroke="none"
+                    />
+                    <path
+                      d="M3 9l4 -4l4 4m-4 -4v14"
+                    />
+                    <path
+                      d="M21 15l-4 4l-4 -4m4 4v-14"
+                    />
+                  </svg>
+                </button>
+              </span>
+              <span
+                aria-label="Search"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 32px;"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                    />
+                  </svg>
+                </button>
+              </span>
+              <div
+                class="MuiBox-root css-jw1lpn"
+                data-test="view-header-actions-menu"
+              >
+                <span
+                  aria-label="Edit view layout, grouping, and more..."
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  <button
+                    class="Button IconButton css-w119tu"
+                    style="width: 32px;"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                      data-testid="MoreHorizOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                      />
+                    </svg>
+                  </button>
+                </span>
               </div>
               <div
                 class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-disableElevation css-jgbgc3-MuiButtonGroup-root"
@@ -1247,23 +1377,28 @@ exports[`components/centerPanel should match snapshot for Kanban 1`] = `
             <div
               class="view-actions MuiBox-root css-37urdo"
             >
-              <button
-                class="Button IconButton css-w119tu"
-                style="width: 28px; height: 28px;"
-                type="button"
+              <span
+                class=""
+                data-mui-internal-clone-element="true"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-                  data-testid="AddIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 28px; height: 28px;"
+                  type="button"
                 >
-                  <path
-                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-                  />
-                </svg>
-              </button>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                    />
+                  </svg>
+                </button>
+              </span>
             </div>
             <div
               class="octo-spacer"
@@ -1271,42 +1406,10 @@ exports[`components/centerPanel should match snapshot for Kanban 1`] = `
             <div
               class="view-actions MuiBox-root css-0"
             >
-              <button
-                aria-haspopup="true"
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-16efx8q-MuiButtonBase-root-MuiButton-root"
-                tabindex="0"
-                type="button"
-              >
-                Filter
-              </button>
-              <button
-                aria-haspopup="true"
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-16efx8q-MuiButtonBase-root-MuiButton-root"
-                tabindex="0"
-                type="button"
-              >
-                Sort
-              </button>
-              <button
-                class="Button IconButton css-w119tu"
-                style="width: 32px;"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-                  data-testid="SearchIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
-                  />
-                </svg>
-              </button>
-              <div
-                class="MuiBox-root css-jw1lpn"
-                data-test="view-header-actions-menu"
+              <span
+                aria-label="Filter"
+                class=""
+                data-mui-internal-clone-element="true"
               >
                 <button
                   class="Button IconButton css-w119tu"
@@ -1315,16 +1418,103 @@ exports[`components/centerPanel should match snapshot for Kanban 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                    data-testid="MoreHorizOutlinedIcon"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeSmall css-887v1i-MuiSvgIcon-root"
+                    data-testid="FilterListIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
                     <path
-                      d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                      d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
                     />
                   </svg>
                 </button>
+              </span>
+              <span
+                aria-label="Sort"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 32px;"
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="font-size: 16px;"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                      stroke="none"
+                    />
+                    <path
+                      d="M3 9l4 -4l4 4m-4 -4v14"
+                    />
+                    <path
+                      d="M21 15l-4 4l-4 -4m4 4v-14"
+                    />
+                  </svg>
+                </button>
+              </span>
+              <span
+                aria-label="Search"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 32px;"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                    />
+                  </svg>
+                </button>
+              </span>
+              <div
+                class="MuiBox-root css-jw1lpn"
+                data-test="view-header-actions-menu"
+              >
+                <span
+                  aria-label="Edit view layout, grouping, and more..."
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  <button
+                    class="Button IconButton css-w119tu"
+                    style="width: 32px;"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                      data-testid="MoreHorizOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                      />
+                    </svg>
+                  </button>
+                </span>
               </div>
               <div
                 class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-disableElevation css-jgbgc3-MuiButtonGroup-root"
@@ -1411,6 +1601,32 @@ exports[`components/centerPanel should match snapshot for Kanban 1`] = `
                     data-testid="menu-wrapper"
                     role="button"
                   >
+                    <span
+                      class=""
+                      data-mui-internal-clone-element="true"
+                    >
+                      <button
+                        class="Button IconButton css-w119tu"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                          data-testid="MoreHorizIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                  </div>
+                  <span
+                    class=""
+                    data-mui-internal-clone-element="true"
+                  >
                     <button
                       class="Button IconButton css-w119tu"
                       type="button"
@@ -1418,32 +1634,16 @@ exports[`components/centerPanel should match snapshot for Kanban 1`] = `
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                        data-testid="MoreHorizIcon"
+                        data-testid="AddIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
                       >
                         <path
-                          d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
                         />
                       </svg>
                     </button>
-                  </div>
-                  <button
-                    class="Button IconButton css-w119tu"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-                      />
-                    </svg>
-                  </button>
+                  </span>
                 </div>
                 <div
                   class="octo-board-header-cell narrow"
@@ -1958,23 +2158,28 @@ exports[`components/centerPanel should match snapshot for Table 1`] = `
             <div
               class="view-actions MuiBox-root css-37urdo"
             >
-              <button
-                class="Button IconButton css-w119tu"
-                style="width: 28px; height: 28px;"
-                type="button"
+              <span
+                class=""
+                data-mui-internal-clone-element="true"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-                  data-testid="AddIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 28px; height: 28px;"
+                  type="button"
                 >
-                  <path
-                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-                  />
-                </svg>
-              </button>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                    />
+                  </svg>
+                </button>
+              </span>
             </div>
             <div
               class="octo-spacer"
@@ -1982,42 +2187,10 @@ exports[`components/centerPanel should match snapshot for Table 1`] = `
             <div
               class="view-actions MuiBox-root css-0"
             >
-              <button
-                aria-haspopup="true"
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-16efx8q-MuiButtonBase-root-MuiButton-root"
-                tabindex="0"
-                type="button"
-              >
-                Filter
-              </button>
-              <button
-                aria-haspopup="true"
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-16efx8q-MuiButtonBase-root-MuiButton-root"
-                tabindex="0"
-                type="button"
-              >
-                Sort
-              </button>
-              <button
-                class="Button IconButton css-w119tu"
-                style="width: 32px;"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-                  data-testid="SearchIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
-                  />
-                </svg>
-              </button>
-              <div
-                class="MuiBox-root css-jw1lpn"
-                data-test="view-header-actions-menu"
+              <span
+                aria-label="Filter"
+                class=""
+                data-mui-internal-clone-element="true"
               >
                 <button
                   class="Button IconButton css-w119tu"
@@ -2026,16 +2199,103 @@ exports[`components/centerPanel should match snapshot for Table 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                    data-testid="MoreHorizOutlinedIcon"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeSmall css-887v1i-MuiSvgIcon-root"
+                    data-testid="FilterListIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
                     <path
-                      d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                      d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
                     />
                   </svg>
                 </button>
+              </span>
+              <span
+                aria-label="Sort"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 32px;"
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="font-size: 16px;"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                      stroke="none"
+                    />
+                    <path
+                      d="M3 9l4 -4l4 4m-4 -4v14"
+                    />
+                    <path
+                      d="M21 15l-4 4l-4 -4m4 4v-14"
+                    />
+                  </svg>
+                </button>
+              </span>
+              <span
+                aria-label="Search"
+                class=""
+                data-mui-internal-clone-element="true"
+              >
+                <button
+                  class="Button IconButton css-w119tu"
+                  style="width: 32px;"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                    />
+                  </svg>
+                </button>
+              </span>
+              <div
+                class="MuiBox-root css-jw1lpn"
+                data-test="view-header-actions-menu"
+              >
+                <span
+                  aria-label="Edit view layout, grouping, and more..."
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  <button
+                    class="Button IconButton css-w119tu"
+                    style="width: 32px;"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                      data-testid="MoreHorizOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                      />
+                    </svg>
+                  </button>
+                </span>
               </div>
               <div
                 class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-disableElevation css-jgbgc3-MuiButtonGroup-root"
@@ -2196,84 +2456,103 @@ exports[`components/centerPanel should match snapshot for Table 1`] = `
                   <div
                     class="octo-table-group"
                   >
-                    <div
-                      class="octo-group-header-cell expanded"
-                      draggable="true"
-                      style="opacity: 1;"
-                    >
+                    <div>
                       <div
-                        class="octo-table-cell"
-                        style="width: 100px;"
+                        class="octo-group-header-cell expanded"
+                        draggable="true"
+                        style="opacity: 1;"
                       >
+                        <div
+                          class="octo-table-cell"
+                          style="width: 100px;"
+                        >
+                          <span
+                            class=""
+                            data-mui-internal-clone-element="true"
+                          >
+                            <button
+                              class="Button IconButton css-w119tu"
+                              style="width: 24px; height: 24px; margin-right: 4px;"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-hvmj5c-MuiSvgIcon-root"
+                                data-testid="ArrowDropDownIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m7 10 5 5 5-5z"
+                                />
+                              </svg>
+                            </button>
+                          </span>
+                          <span
+                            aria-label="Items with an empty {propertyName} property will go here. This column cannot be removed."
+                            class="MuiTypography-root MuiTypography-subtitle1 css-159yneb-MuiTypography-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            No Property 1
+                          </span>
+                        </div>
                         <button
-                          class="Button IconButton hello-world css-w119tu"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                            data-testid="ArrowDropDownOutlinedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="m7 10 5 5 5-5z"
-                            />
-                          </svg>
+                          <span>
+                            2
+                          </span>
                         </button>
+                        <div
+                          aria-label="menuwrapper"
+                          class="MenuWrapper"
+                          data-testid="menu-wrapper"
+                          role="button"
+                        >
+                          <span
+                            class=""
+                            data-mui-internal-clone-element="true"
+                          >
+                            <button
+                              class="Button IconButton css-w119tu"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                                data-testid="MoreHorizIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                                />
+                              </svg>
+                            </button>
+                          </span>
+                        </div>
                         <span
-                          class="Label empty "
-                          title="Items with an empty Property 1 property will go here. This column cannot be removed."
+                          class=""
+                          data-mui-internal-clone-element="true"
                         >
-                          No Property 1
-                        </span>
-                      </div>
-                      <button
-                        type="button"
-                      >
-                        <span>
-                          2
-                        </span>
-                      </button>
-                      <div
-                        aria-label="menuwrapper"
-                        class="MenuWrapper"
-                        data-testid="menu-wrapper"
-                        role="button"
-                      >
-                        <button
-                          class="Button IconButton css-w119tu"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                            data-testid="MoreHorizIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <button
+                            class="Button IconButton css-w119tu"
+                            type="button"
                           >
-                            <path
-                              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                              data-testid="AddIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </div>
-                      <button
-                        class="Button IconButton css-w119tu"
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                          data-testid="AddIcon"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-                          />
-                        </svg>
-                      </button>
                     </div>
                     <div
                       class="TableRow octo-table-row"

--- a/components/common/DatabaseEditor/components/centerPanel.tsx
+++ b/components/common/DatabaseEditor/components/centerPanel.tsx
@@ -742,6 +742,7 @@ export function groupCardsByOptions(
   const groups: BoardGroup[] = [];
 
   // TODO: allow other type of properties besides select/multiSelect and proposalUrl
+  // Note: when adding a new field here, make sure it can be updated or editing is disabled in the onSave handler inside tableGroupHeaderRow.tsx
   if (groupByProperty?.type === 'proposalUrl') {
     // group cards based on the value of the proposalUrl property
     const valueMap: Record<string, Card[]> = {};
@@ -758,7 +759,9 @@ export function groupCardsByOptions(
 
     for (const [value, valueCards] of Object.entries(valueMap)) {
       const group: BoardGroup = {
-        option: { id: value, value: value || `No ${groupByProperty?.name}`, color: '' },
+        id: value || '',
+        // option: { id: 'proposalUrl', value: value || `No ${groupByProperty?.name}`, color: '' },
+        value: value || '',
         cards: valueCards
       };
       groups.push(group);
@@ -770,6 +773,7 @@ export function groupCardsByOptions(
         if (groupByProperty && option) {
           const filteredCards = cards.filter((o) => optionId === o.fields.properties[groupByProperty.id]);
           const group: BoardGroup = {
+            id: option.id,
             option,
             cards: filteredCards
           };
@@ -782,6 +786,7 @@ export function groupCardsByOptions(
           return !groupByOptionId || !(groupByProperty?.options ?? []).find((option) => option.id === groupByOptionId);
         });
         const group: BoardGroup = {
+          id: '',
           option: { id: '', value: `No ${groupByProperty?.name}`, color: '' },
           cards: emptyGroupCards
         };

--- a/components/common/DatabaseEditor/components/kanban/KanbanGroupColumn.tsx
+++ b/components/common/DatabaseEditor/components/kanban/KanbanGroupColumn.tsx
@@ -44,7 +44,7 @@ export function KanbanGroupColumn({
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const { data: cards, hasNextPage, showNextPage } = usePaginatedData(group.cards, { pageSize });
   return (
-    <KanbanColumn onDrop={(card: Card) => onDropToColumn(group.option, card)}>
+    <KanbanColumn onDrop={(card: Card) => onDropToColumn(group.option!, card)}>
       {cards.map((card) => (
         <KanbanCard
           card={card}
@@ -83,7 +83,7 @@ export function KanbanGroupColumn({
           color='secondary'
           sx={{ justifyContent: 'flex-start' }}
           onClick={() => {
-            addCard(group.option.id, true, {}, true);
+            addCard(group.id, true, {}, true);
           }}
           startIcon={<Add fontSize='small' />}
         >

--- a/components/common/DatabaseEditor/components/kanban/__snapshots__/kanban.spec.tsx.snap
+++ b/components/common/DatabaseEditor/components/kanban/__snapshots__/kanban.spec.tsx.snap
@@ -51,6 +51,32 @@ exports[`src/component/kanban/kanban return kanban and click on KanbanCalculatio
             data-testid="menu-wrapper"
             role="button"
           >
+            <span
+              class=""
+              data-mui-internal-clone-element="true"
+            >
+              <button
+                class="Button IconButton css-w119tu"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                  data-testid="MoreHorizIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
             <button
               class="Button IconButton css-w119tu"
               type="button"
@@ -58,32 +84,16 @@ exports[`src/component/kanban/kanban return kanban and click on KanbanCalculatio
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                data-testid="MoreHorizIcon"
+                data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
                 <path
-                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
                 />
               </svg>
             </button>
-          </div>
-          <button
-            class="Button IconButton css-w119tu"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-              data-testid="AddIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-              />
-            </svg>
-          </button>
+          </span>
         </div>
         <div
           class="octo-board-header-cell KanbanColumnHeader"
@@ -122,6 +132,32 @@ exports[`src/component/kanban/kanban return kanban and click on KanbanCalculatio
             data-testid="menu-wrapper"
             role="button"
           >
+            <span
+              class=""
+              data-mui-internal-clone-element="true"
+            >
+              <button
+                class="Button IconButton css-w119tu"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                  data-testid="MoreHorizIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
             <button
               class="Button IconButton css-w119tu"
               type="button"
@@ -129,32 +165,16 @@ exports[`src/component/kanban/kanban return kanban and click on KanbanCalculatio
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                data-testid="MoreHorizIcon"
+                data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
                 <path
-                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
                 />
               </svg>
             </button>
-          </div>
-          <button
-            class="Button IconButton css-w119tu"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-              data-testid="AddIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-              />
-            </svg>
-          </button>
+          </span>
         </div>
         <div
           class="octo-board-header-cell narrow"
@@ -467,6 +487,32 @@ exports[`src/component/kanban/kanban should match snapshot 1`] = `
             data-testid="menu-wrapper"
             role="button"
           >
+            <span
+              class=""
+              data-mui-internal-clone-element="true"
+            >
+              <button
+                class="Button IconButton css-w119tu"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                  data-testid="MoreHorizIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
             <button
               class="Button IconButton css-w119tu"
               type="button"
@@ -474,32 +520,16 @@ exports[`src/component/kanban/kanban should match snapshot 1`] = `
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                data-testid="MoreHorizIcon"
+                data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
                 <path
-                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
                 />
               </svg>
             </button>
-          </div>
-          <button
-            class="Button IconButton css-w119tu"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-              data-testid="AddIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-              />
-            </svg>
-          </button>
+          </span>
         </div>
         <div
           class="octo-board-header-cell KanbanColumnHeader"
@@ -538,6 +568,32 @@ exports[`src/component/kanban/kanban should match snapshot 1`] = `
             data-testid="menu-wrapper"
             role="button"
           >
+            <span
+              class=""
+              data-mui-internal-clone-element="true"
+            >
+              <button
+                class="Button IconButton css-w119tu"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                  data-testid="MoreHorizIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
             <button
               class="Button IconButton css-w119tu"
               type="button"
@@ -545,32 +601,16 @@ exports[`src/component/kanban/kanban should match snapshot 1`] = `
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                data-testid="MoreHorizIcon"
+                data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
                 <path
-                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
                 />
               </svg>
             </button>
-          </div>
-          <button
-            class="Button IconButton css-w119tu"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-              data-testid="AddIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-              />
-            </svg>
-          </button>
+          </span>
         </div>
         <div
           class="octo-board-header-cell narrow"

--- a/components/common/DatabaseEditor/components/kanban/__snapshots__/kanbanColumnHeader.spec.tsx.snap
+++ b/components/common/DatabaseEditor/components/kanban/__snapshots__/kanbanColumnHeader.spec.tsx.snap
@@ -43,6 +43,32 @@ exports[`src/components/kanban/kanbanColumnHeader return kanbanColumnHeader and 
         data-testid="menu-wrapper"
         role="button"
       >
+        <span
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          <button
+            class="Button IconButton css-w119tu"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+              data-testid="MoreHorizIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+              />
+            </svg>
+          </button>
+        </span>
+      </div>
+      <span
+        class=""
+        data-mui-internal-clone-element="true"
+      >
         <button
           class="Button IconButton css-w119tu"
           type="button"
@@ -50,32 +76,16 @@ exports[`src/components/kanban/kanbanColumnHeader return kanbanColumnHeader and 
           <svg
             aria-hidden="true"
             class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="MoreHorizIcon"
+            data-testid="AddIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
             <path
-              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
             />
           </svg>
         </button>
-      </div>
-      <button
-        class="Button IconButton css-w119tu"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-          data-testid="AddIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-          />
-        </svg>
-      </button>
+      </span>
     </div>
   </span>
 </div>
@@ -124,6 +134,32 @@ exports[`src/components/kanban/kanbanColumnHeader should match snapshot 1`] = `
         data-testid="menu-wrapper"
         role="button"
       >
+        <span
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          <button
+            class="Button IconButton css-w119tu"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+              data-testid="MoreHorizIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+              />
+            </svg>
+          </button>
+        </span>
+      </div>
+      <span
+        class=""
+        data-mui-internal-clone-element="true"
+      >
         <button
           class="Button IconButton css-w119tu"
           type="button"
@@ -131,32 +167,16 @@ exports[`src/components/kanban/kanbanColumnHeader should match snapshot 1`] = `
           <svg
             aria-hidden="true"
             class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="MoreHorizIcon"
+            data-testid="AddIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
             <path
-              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
             />
           </svg>
         </button>
-      </div>
-      <button
-        class="Button IconButton css-w119tu"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-          data-testid="AddIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-          />
-        </svg>
-      </button>
+      </span>
     </div>
   </span>
 </div>

--- a/components/common/DatabaseEditor/components/kanban/kanban.spec.tsx
+++ b/components/common/DatabaseEditor/components/kanban/kanban.spec.tsx
@@ -91,10 +91,12 @@ describe('src/component/kanban/kanban', () => {
 
   const visibleGroups: BoardGroup[] = [
     {
+      id: optionQ1.id,
       option: optionQ1,
       cards: [card1, card2]
     },
     {
+      id: optionQ2.id,
       option: optionQ2,
       cards: [card3]
     }
@@ -102,6 +104,7 @@ describe('src/component/kanban/kanban', () => {
 
   const hiddenGroups: BoardGroup[] = [
     {
+      id: optionQ3.id,
       option: optionQ3,
       cards: []
     }

--- a/components/common/DatabaseEditor/components/kanban/kanban.tsx
+++ b/components/common/DatabaseEditor/components/kanban/kanban.tsx
@@ -115,7 +115,7 @@ function Kanban(props: Props) {
   const orderAfterMoveToColumn = useCallback(
     (cardIds: string[], columnId?: string): string[] => {
       let cardOrder = activeView.fields.cardOrder.slice();
-      const columnGroup = visibleGroups.find((g) => g.option.id === columnId);
+      const columnGroup = visibleGroups.find((g) => g.id === columnId);
       const columnCards = columnGroup?.cards;
       if (!columnCards || columnCards.length === 0) {
         return cardOrder;
@@ -166,7 +166,7 @@ function Kanban(props: Props) {
       } else if (dstOption) {
         Utils.log(`ondrop. Header option: ${dstOption.value}, column: ${option?.value}`);
 
-        const visibleOptionIds = visibleGroups.map((o) => o.option.id);
+        const visibleOptionIds = visibleGroups.map((o) => o.id);
         const srcBlockX = visibleOptionIds.indexOf(option.id);
         const dstBlockX = visibleOptionIds.indexOf(dstOption.id);
 
@@ -331,7 +331,7 @@ function Kanban(props: Props) {
 
         {visibleGroups.map((group) => (
           <KanbanColumnHeader
-            key={group.option.id}
+            key={group.id}
             group={group}
             board={board}
             activeView={activeView}
@@ -341,9 +341,9 @@ function Kanban(props: Props) {
             readOnly={props.readOnly}
             propertyNameChanged={propertyNameChanged}
             onDropToColumn={onDropToColumn}
-            calculationMenuOpen={showCalculationsMenu.get(group.option.id) || false}
-            onCalculationMenuOpen={(_anchorEl) => toggleOptions(group.option.id, _anchorEl)}
-            onCalculationMenuClose={() => toggleOptions(group.option.id)}
+            calculationMenuOpen={showCalculationsMenu.get(group.id) || false}
+            onCalculationMenuOpen={(_anchorEl) => toggleOptions(group.id, _anchorEl)}
+            onCalculationMenuClose={() => toggleOptions(group.id)}
             anchorEl={anchorEl}
             readOnlyTitle={props.readOnlyTitle}
             disableAddingCards={props.disableAddingCards}
@@ -389,7 +389,7 @@ function Kanban(props: Props) {
               group={group}
               board={board}
               visiblePropertyTemplates={visiblePropertyTemplates}
-              key={group.option.id || 'empty'}
+              key={group.id || 'empty'}
               readOnly={props.readOnly}
               onDropToCard={props.disableDnd ? undefined : onDropToCard}
               selectedCardIds={props.selectedCardIds}
@@ -412,12 +412,12 @@ function Kanban(props: Props) {
             <div className='octo-board-column narrow'>
               {hiddenGroups.map((group) => (
                 <KanbanHiddenColumnItem
-                  key={group.option.id}
+                  key={group.id}
                   group={group}
                   activeView={activeView}
                   intl={props.intl}
                   readOnly={props.readOnly}
-                  onDrop={(card: Card) => onDropToColumn(group.option, card)}
+                  onDrop={(card: Card) => onDropToColumn(group.option!, card)}
                 />
               ))}
             </div>

--- a/components/common/DatabaseEditor/components/kanban/kanbanColumnHeader.spec.tsx
+++ b/components/common/DatabaseEditor/components/kanban/kanbanColumnHeader.spec.tsx
@@ -34,6 +34,7 @@ describe('src/components/kanban/kanbanColumnHeader', () => {
   };
 
   const group = {
+    id: option.id,
     option,
     cards: [card]
   };

--- a/components/common/DatabaseEditor/components/kanban/kanbanColumnHeader.tsx
+++ b/components/common/DatabaseEditor/components/kanban/kanbanColumnHeader.tsx
@@ -50,7 +50,7 @@ const defaultProperty: IPropertyTemplate = {
 
 export default function KanbanColumnHeader(props: Props): JSX.Element {
   const { board, activeView, intl, group, groupByProperty } = props;
-  const [groupTitle, setGroupTitle] = useState(group.option.value);
+  const [groupTitle, setGroupTitle] = useState(group.option?.value || group.value || '');
 
   const headerRef = useRef<HTMLDivElement>(null);
 
@@ -75,8 +75,8 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
   );
 
   useEffect(() => {
-    setGroupTitle(group.option.value);
-  }, [group.option.value]);
+    setGroupTitle(group.option?.value || group.value || '');
+  }, [group.option?.value, group.value]);
 
   drop(drag(headerRef));
   let className = 'octo-board-header-cell KanbanColumnHeader';
@@ -84,7 +84,7 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
     className += ' dragover';
   }
 
-  const groupCalculation = props.activeView.fields.kanbanCalculations[props.group.option.id];
+  const groupCalculation = props.activeView.fields.kanbanCalculations[props.group.id];
   const calculationValue = groupCalculation ? groupCalculation.calculation : defaultCalculation;
   const calculationProperty = groupCalculation
     ? props.board.fields.cardProperties.find((property) => property.id === groupCalculation.propertyId) ||
@@ -93,18 +93,18 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
 
   const formattedGroupTitle =
     groupByProperty?.type === 'proposalStatus'
-      ? EVALUATION_STATUS_LABELS[group.option.value as ProposalEvaluationStatus]
+      ? EVALUATION_STATUS_LABELS[group.option?.value as ProposalEvaluationStatus]
       : groupTitle;
 
   return (
     <div
-      key={group.option.id || 'empty'}
+      key={group.id || 'empty'}
       ref={headerRef}
       style={{ opacity: isDragging ? 0.5 : 1 }}
       className={className}
       draggable={!props.readOnly}
     >
-      {groupByProperty && !group.option.id && (
+      {groupByProperty && !group.id && (
         <Label
           title={intl.formatMessage(
             {
@@ -114,29 +114,23 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
             { property: groupByProperty.name }
           )}
         >
-          <FormattedMessage
-            id='BoardComponent.no-property'
-            defaultMessage='No {property}'
-            values={{
-              property: groupByProperty.name
-            }}
-          />
+          {group.value || group.option?.value || ''}
         </Label>
       )}
-      {group.option.id && (
-        <Label color={group.option.color}>
+      {group.option?.id && (
+        <Label color={group.option!.color}>
           <Editable
             value={formattedGroupTitle}
             placeholderText='New Select'
             onChange={setGroupTitle}
             onSave={() => {
               if (groupTitle.trim() === '') {
-                setGroupTitle(group.option.value);
+                setGroupTitle(group.option!.value);
               }
-              props.propertyNameChanged(group.option, groupTitle);
+              props.propertyNameChanged(group.option!, groupTitle);
             }}
             onCancel={() => {
-              setGroupTitle(group.option.value);
+              setGroupTitle(group.option!.value);
             }}
             readOnly={props.readOnly || props.readOnlyTitle}
             spellCheck={true}
@@ -161,7 +155,7 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
           const newCalculations = {
             ...props.activeView.fields.kanbanCalculations
           };
-          newCalculations[props.group.option.id] = {
+          newCalculations[props.group.id] = {
             calculation: data.calculation,
             propertyId: data.propertyId
           };
@@ -183,16 +177,16 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
                 id='hide-column-action'
                 icon={<VisibilityOffOutlinedIcon fontSize='small' />}
                 name={intl.formatMessage({ id: 'BoardComponent.hide', defaultMessage: 'Hide' })}
-                onClick={() => mutator.hideViewColumn(activeView, group.option.id || '')}
+                onClick={() => mutator.hideViewColumn(activeView, group.id || '')}
               />
-              {group.option.id && !props.readOnlyTitle && (
+              {group.option?.id && !props.readOnlyTitle && (
                 <>
                   {!proposalPropertyTypesList.includes((groupByProperty?.type || '') as any) && (
                     <Menu.Text
                       id='delete'
                       icon={<DeleteOutlineIcon fontSize='small' color='secondary' />}
                       name={intl.formatMessage({ id: 'BoardComponent.delete', defaultMessage: 'Delete' })}
-                      onClick={() => mutator.deletePropertyOption(board, groupByProperty!, group.option)}
+                      onClick={() => mutator.deletePropertyOption(board, groupByProperty!, group.option!)}
                     />
                   )}
 
@@ -202,7 +196,7 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
                       key={key}
                       id={key}
                       name={color}
-                      onClick={() => mutator.changePropertyOptionColor(board, groupByProperty!, group.option, key)}
+                      onClick={() => mutator.changePropertyOptionColor(board, groupByProperty!, group.option!, key)}
                     />
                   ))}
                 </>
@@ -213,7 +207,7 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
             <IconButton
               icon={<AddIcon fontSize='small' />}
               onClick={() => {
-                props.addCard(group.option.id, true);
+                props.addCard(group.option!.id, true);
               }}
             />
           )}

--- a/components/common/DatabaseEditor/components/kanban/kanbanHiddenColumnItem.spec.tsx
+++ b/components/common/DatabaseEditor/components/kanban/kanbanHiddenColumnItem.spec.tsx
@@ -31,6 +31,7 @@ describe('src/components/kanban/kanbanHiddenColumnItem', () => {
   beforeAll(() => {});
 
   const group = {
+    id: option.id,
     option,
     cards: [card]
   };

--- a/components/common/DatabaseEditor/components/kanban/kanbanHiddenColumnItem.tsx
+++ b/components/common/DatabaseEditor/components/kanban/kanbanHiddenColumnItem.tsx
@@ -42,17 +42,17 @@ export default function KanbanHiddenColumnItem(props: Props): JSX.Element {
   }
 
   return (
-    <div ref={drop} key={group.option.id || 'empty'} className={className}>
+    <div ref={drop} key={group.id || 'empty'} className={className}>
       <MenuWrapper disabled={props.readOnly}>
-        <Label key={group.option.id || 'empty'} color={group.option.color}>
-          {group.option.value}
+        <Label key={group.id || 'empty'} color={group.option?.color}>
+          {group.option?.value || group.value}
         </Label>
         <Menu>
           <Menu.Text
             id='show'
             icon={<VisibilityOutlinedIcon fontSize='small' />}
             name={intl.formatMessage({ id: 'BoardComponent.show', defaultMessage: 'Show' })}
-            onClick={() => mutator.unhideViewColumn(activeView, group.option.id)}
+            onClick={() => mutator.unhideViewColumn(activeView, group.id)}
           />
         </Menu>
       </MenuWrapper>

--- a/components/common/DatabaseEditor/components/table/__snapshots__/table.spec.tsx.snap
+++ b/components/common/DatabaseEditor/components/table/__snapshots__/table.spec.tsx.snap
@@ -3691,85 +3691,104 @@ exports[`components/table/Table should match snapshot with GroupBy 1`] = `
           <div
             class="octo-table-group"
           >
-            <div
-              class="octo-group-header-cell expanded"
-              draggable="true"
-              style="opacity: 1;"
-            >
+            <div>
               <div
-                class="octo-table-cell"
-                style="width: 100px;"
+                class="octo-group-header-cell expanded"
+                draggable="true"
+                style="opacity: 1;"
               >
+                <div
+                  class="octo-table-cell"
+                  style="width: 100px;"
+                >
+                  <span
+                    class=""
+                    data-mui-internal-clone-element="true"
+                  >
+                    <button
+                      class="Button IconButton css-w119tu"
+                      style="width: 24px; height: 24px; margin-right: 4px;"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-hvmj5c-MuiSvgIcon-root"
+                        data-testid="ArrowDropDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="m7 10 5 5 5-5z"
+                        />
+                      </svg>
+                    </button>
+                  </span>
+                  <span
+                    aria-label="Items with an empty {propertyName} property will go here. This column cannot be removed."
+                    class="MuiTypography-root MuiTypography-subtitle1 css-159yneb-MuiTypography-root"
+                    data-mui-internal-clone-element="true"
+                  >
+                    No Property 1
+                  </span>
+                </div>
                 <button
-                  class="Button IconButton hello-world css-w119tu"
+                  class="Button size--small"
                   type="button"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                    data-testid="ArrowDropDownOutlinedIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m7 10 5 5 5-5z"
-                    />
-                  </svg>
+                  <span>
+                    0
+                  </span>
                 </button>
+                <div
+                  aria-label="menuwrapper"
+                  class="MenuWrapper"
+                  data-testid="menu-wrapper"
+                  role="button"
+                >
+                  <span
+                    class=""
+                    data-mui-internal-clone-element="true"
+                  >
+                    <button
+                      class="Button IconButton css-w119tu"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                        data-testid="MoreHorizIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                        />
+                      </svg>
+                    </button>
+                  </span>
+                </div>
                 <span
-                  class="Label empty "
-                  title="Items with an empty Property 1 property will go here. This column cannot be removed."
+                  class=""
+                  data-mui-internal-clone-element="true"
                 >
-                  No Property 1
-                </span>
-              </div>
-              <button
-                class="Button size--small"
-                type="button"
-              >
-                <span>
-                  0
-                </span>
-              </button>
-              <div
-                aria-label="menuwrapper"
-                class="MenuWrapper"
-                data-testid="menu-wrapper"
-                role="button"
-              >
-                <button
-                  class="Button IconButton css-w119tu"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                    data-testid="MoreHorizIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
+                  <button
+                    class="Button IconButton css-w119tu"
+                    type="button"
                   >
-                    <path
-                      d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-                    />
-                  </svg>
-                </button>
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                      data-testid="AddIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                      />
+                    </svg>
+                  </button>
+                </span>
               </div>
-              <button
-                class="Button IconButton css-w119tu"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                  data-testid="AddIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-                  />
-                </svg>
-              </button>
             </div>
           </div>
         </div>

--- a/components/common/DatabaseEditor/components/table/__snapshots__/tableGroupHeaderRow.spec.tsx.snap
+++ b/components/common/DatabaseEditor/components/table/__snapshots__/tableGroupHeaderRow.spec.tsx.snap
@@ -5,52 +5,67 @@ exports[`should match snapshot on read only 1`] = `
   <span
     class="variable variable"
   >
-    <div
-      class="octo-group-header-cell expanded"
-      draggable="true"
-      style="opacity: 1;"
-    >
+    <div>
       <div
-        class="octo-table-cell"
-        style="width: 100px;"
+        class="octo-group-header-cell expanded"
+        draggable="true"
+        style="opacity: 1;"
       >
+        <div
+          class="octo-table-cell"
+          style="width: 100px;"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              style="width: 24px; height: 24px; margin-right: 4px;"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-hvmj5c-MuiSvgIcon-root"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m7 10 5 5 5-5z"
+                />
+              </svg>
+            </button>
+          </span>
+          <span
+            aria-label="Items with an empty {propertyName} property will go here. This column cannot be removed."
+            class="MuiTypography-root MuiTypography-subtitle1 css-159yneb-MuiTypography-root"
+            data-mui-internal-clone-element="true"
+          >
+            No undefined
+          </span>
+          <span
+            class="Label propColorTurquoise "
+          >
+            <input
+              class="Editable readonly undefined"
+              placeholder="New Select"
+              readonly=""
+              spellcheck="true"
+              title="value 1"
+              value="value 1"
+            />
+          </span>
+        </div>
         <button
-          class="Button IconButton hello-world css-w119tu"
+          class="Button size--small"
           type="button"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="ArrowDropDownOutlinedIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m7 10 5 5 5-5z"
-            />
-          </svg>
+          <span>
+            0
+          </span>
         </button>
-        <span
-          class="Label propColorTurquoise "
-        >
-          <input
-            class="Editable readonly undefined"
-            placeholder="New Select"
-            readonly=""
-            spellcheck="true"
-            title="value 1"
-            value="value 1"
-          />
-        </span>
       </div>
-      <button
-        class="Button size--small"
-        type="button"
-      >
-        <span>
-          0
-        </span>
-      </button>
     </div>
   </span>
 </div>
@@ -61,90 +76,115 @@ exports[`should match snapshot with Group 1`] = `
   <span
     class="variable variable"
   >
-    <div
-      class="octo-group-header-cell expanded"
-      draggable="true"
-      style="opacity: 1;"
-    >
+    <div>
       <div
-        class="octo-table-cell"
-        style="width: 100px;"
+        class="octo-group-header-cell expanded"
+        draggable="true"
+        style="opacity: 1;"
       >
+        <div
+          class="octo-table-cell"
+          style="width: 100px;"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              style="width: 24px; height: 24px; margin-right: 4px;"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-hvmj5c-MuiSvgIcon-root"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m7 10 5 5 5-5z"
+                />
+              </svg>
+            </button>
+          </span>
+          <span
+            aria-label="Items with an empty {propertyName} property will go here. This column cannot be removed."
+            class="MuiTypography-root MuiTypography-subtitle1 css-159yneb-MuiTypography-root"
+            data-mui-internal-clone-element="true"
+          >
+            No undefined
+          </span>
+          <span
+            class="Label propColorTurquoise "
+          >
+            <input
+              class="Editable undefined"
+              placeholder="New Select"
+              spellcheck="true"
+              title="value 1"
+              value="value 1"
+            />
+          </span>
+        </div>
         <button
-          class="Button IconButton hello-world css-w119tu"
+          class="Button size--small"
           type="button"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="ArrowDropDownOutlinedIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m7 10 5 5 5-5z"
-            />
-          </svg>
+          <span>
+            0
+          </span>
         </button>
+        <div
+          aria-label="menuwrapper"
+          class="MenuWrapper"
+          data-testid="menu-wrapper"
+          role="button"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                data-testid="MoreHorizIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
         <span
-          class="Label propColorTurquoise "
+          class=""
+          data-mui-internal-clone-element="true"
         >
-          <input
-            class="Editable undefined"
-            placeholder="New Select"
-            spellcheck="true"
-            title="value 1"
-            value="value 1"
-          />
-        </span>
-      </div>
-      <button
-        class="Button size--small"
-        type="button"
-      >
-        <span>
-          0
-        </span>
-      </button>
-      <div
-        aria-label="menuwrapper"
-        class="MenuWrapper"
-        data-testid="menu-wrapper"
-        role="button"
-      >
-        <button
-          class="Button IconButton css-w119tu"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="MoreHorizIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <button
+            class="Button IconButton css-w119tu"
+            type="button"
           >
-            <path
-              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+              data-testid="AddIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
-      <button
-        class="Button IconButton css-w119tu"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-          data-testid="AddIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-          />
-        </svg>
-      </button>
     </div>
   </span>
 </div>
@@ -155,90 +195,115 @@ exports[`should match snapshot, add new 1`] = `
   <span
     class="variable variable"
   >
-    <div
-      class="octo-group-header-cell expanded"
-      draggable="true"
-      style="opacity: 1;"
-    >
+    <div>
       <div
-        class="octo-table-cell"
-        style="width: 100px;"
+        class="octo-group-header-cell expanded"
+        draggable="true"
+        style="opacity: 1;"
       >
+        <div
+          class="octo-table-cell"
+          style="width: 100px;"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              style="width: 24px; height: 24px; margin-right: 4px;"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-hvmj5c-MuiSvgIcon-root"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m7 10 5 5 5-5z"
+                />
+              </svg>
+            </button>
+          </span>
+          <span
+            aria-label="Items with an empty {propertyName} property will go here. This column cannot be removed."
+            class="MuiTypography-root MuiTypography-subtitle1 css-159yneb-MuiTypography-root"
+            data-mui-internal-clone-element="true"
+          >
+            No undefined
+          </span>
+          <span
+            class="Label propColorTurquoise "
+          >
+            <input
+              class="Editable undefined"
+              placeholder="New Select"
+              spellcheck="true"
+              title="value 1"
+              value="value 1"
+            />
+          </span>
+        </div>
         <button
-          class="Button IconButton hello-world css-w119tu"
+          class="Button size--small"
           type="button"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="ArrowDropDownOutlinedIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m7 10 5 5 5-5z"
-            />
-          </svg>
+          <span>
+            0
+          </span>
         </button>
+        <div
+          aria-label="menuwrapper"
+          class="MenuWrapper"
+          data-testid="menu-wrapper"
+          role="button"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                data-testid="MoreHorizIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
         <span
-          class="Label propColorTurquoise "
+          class=""
+          data-mui-internal-clone-element="true"
         >
-          <input
-            class="Editable undefined"
-            placeholder="New Select"
-            spellcheck="true"
-            title="value 1"
-            value="value 1"
-          />
-        </span>
-      </div>
-      <button
-        class="Button size--small"
-        type="button"
-      >
-        <span>
-          0
-        </span>
-      </button>
-      <div
-        aria-label="menuwrapper"
-        class="MenuWrapper"
-        data-testid="menu-wrapper"
-        role="button"
-      >
-        <button
-          class="Button IconButton css-w119tu"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="MoreHorizIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <button
+            class="Button IconButton css-w119tu"
+            type="button"
           >
-            <path
-              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+              data-testid="AddIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
-      <button
-        class="Button IconButton css-w119tu"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-          data-testid="AddIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-          />
-        </svg>
-      </button>
     </div>
   </span>
 </div>
@@ -249,90 +314,115 @@ exports[`should match snapshot, edit title 1`] = `
   <span
     class="variable variable"
   >
-    <div
-      class="octo-group-header-cell expanded"
-      draggable="true"
-      style="opacity: 1;"
-    >
+    <div>
       <div
-        class="octo-table-cell"
-        style="width: 100px;"
+        class="octo-group-header-cell expanded"
+        draggable="true"
+        style="opacity: 1;"
       >
+        <div
+          class="octo-table-cell"
+          style="width: 100px;"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              style="width: 24px; height: 24px; margin-right: 4px;"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-hvmj5c-MuiSvgIcon-root"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m7 10 5 5 5-5z"
+                />
+              </svg>
+            </button>
+          </span>
+          <span
+            aria-label="Items with an empty {propertyName} property will go here. This column cannot be removed."
+            class="MuiTypography-root MuiTypography-subtitle1 css-159yneb-MuiTypography-root"
+            data-mui-internal-clone-element="true"
+          >
+            No undefined
+          </span>
+          <span
+            class="Label propColorTurquoise "
+          >
+            <input
+              class="Editable undefined"
+              placeholder="New Select"
+              spellcheck="true"
+              title="value 1"
+              value="value 1"
+            />
+          </span>
+        </div>
         <button
-          class="Button IconButton hello-world css-w119tu"
+          class="Button size--small"
           type="button"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="ArrowDropDownOutlinedIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m7 10 5 5 5-5z"
-            />
-          </svg>
+          <span>
+            0
+          </span>
         </button>
+        <div
+          aria-label="menuwrapper"
+          class="MenuWrapper"
+          data-testid="menu-wrapper"
+          role="button"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                data-testid="MoreHorizIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
         <span
-          class="Label propColorTurquoise "
+          class=""
+          data-mui-internal-clone-element="true"
         >
-          <input
-            class="Editable undefined"
-            placeholder="New Select"
-            spellcheck="true"
-            title="value 1"
-            value="value 1"
-          />
-        </span>
-      </div>
-      <button
-        class="Button size--small"
-        type="button"
-      >
-        <span>
-          0
-        </span>
-      </button>
-      <div
-        aria-label="menuwrapper"
-        class="MenuWrapper"
-        data-testid="menu-wrapper"
-        role="button"
-      >
-        <button
-          class="Button IconButton css-w119tu"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="MoreHorizIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <button
+            class="Button IconButton css-w119tu"
+            type="button"
           >
-            <path
-              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+              data-testid="AddIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
-      <button
-        class="Button IconButton css-w119tu"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-          data-testid="AddIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-          />
-        </svg>
-      </button>
     </div>
   </span>
 </div>
@@ -343,90 +433,115 @@ exports[`should match snapshot, hide group 1`] = `
   <span
     class="variable variable"
   >
-    <div
-      class="octo-group-header-cell"
-      draggable="true"
-      style="opacity: 1;"
-    >
+    <div>
       <div
-        class="octo-table-cell"
-        style="width: 100px;"
+        class="octo-group-header-cell expanded"
+        draggable="true"
+        style="opacity: 1;"
       >
+        <div
+          class="octo-table-cell"
+          style="width: 100px;"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              style="width: 24px; height: 24px; margin-right: 4px;"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-hvmj5c-MuiSvgIcon-root"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m7 10 5 5 5-5z"
+                />
+              </svg>
+            </button>
+          </span>
+          <span
+            aria-label="Items with an empty {propertyName} property will go here. This column cannot be removed."
+            class="MuiTypography-root MuiTypography-subtitle1 css-159yneb-MuiTypography-root"
+            data-mui-internal-clone-element="true"
+          >
+            No undefined
+          </span>
+          <span
+            class="Label propColorTurquoise "
+          >
+            <input
+              class="Editable undefined"
+              placeholder="New Select"
+              spellcheck="true"
+              title="value 1"
+              value="value 1"
+            />
+          </span>
+        </div>
         <button
-          class="Button IconButton hello-world css-w119tu"
+          class="Button size--small"
           type="button"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="ArrowDropDownOutlinedIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m7 10 5 5 5-5z"
-            />
-          </svg>
+          <span>
+            0
+          </span>
         </button>
+        <div
+          aria-label="menuwrapper"
+          class="MenuWrapper"
+          data-testid="menu-wrapper"
+          role="button"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                data-testid="MoreHorizIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
         <span
-          class="Label propColorTurquoise "
+          class=""
+          data-mui-internal-clone-element="true"
         >
-          <input
-            class="Editable undefined"
-            placeholder="New Select"
-            spellcheck="true"
-            title="value 1"
-            value="value 1"
-          />
-        </span>
-      </div>
-      <button
-        class="Button size--small"
-        type="button"
-      >
-        <span>
-          0
-        </span>
-      </button>
-      <div
-        aria-label="menuwrapper"
-        class="MenuWrapper"
-        data-testid="menu-wrapper"
-        role="button"
-      >
-        <button
-          class="Button IconButton css-w119tu"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="MoreHorizIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <button
+            class="Button IconButton css-w119tu"
+            type="button"
           >
-            <path
-              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+              data-testid="AddIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
-      <button
-        class="Button IconButton css-w119tu"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-          data-testid="AddIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-          />
-        </svg>
-      </button>
     </div>
   </span>
 </div>
@@ -437,85 +552,104 @@ exports[`should match snapshot, no groups 1`] = `
   <span
     class="variable variable"
   >
-    <div
-      class="octo-group-header-cell expanded"
-      draggable="true"
-      style="opacity: 1;"
-    >
+    <div>
       <div
-        class="octo-table-cell"
-        style="width: 100px;"
+        class="octo-group-header-cell expanded"
+        draggable="true"
+        style="opacity: 1;"
       >
+        <div
+          class="octo-table-cell"
+          style="width: 100px;"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              style="width: 24px; height: 24px; margin-right: 4px;"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-hvmj5c-MuiSvgIcon-root"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m7 10 5 5 5-5z"
+                />
+              </svg>
+            </button>
+          </span>
+          <span
+            aria-label="Items with an empty {propertyName} property will go here. This column cannot be removed."
+            class="MuiTypography-root MuiTypography-subtitle1 css-159yneb-MuiTypography-root"
+            data-mui-internal-clone-element="true"
+          >
+            No Property 1
+          </span>
+        </div>
         <button
-          class="Button IconButton hello-world css-w119tu"
+          class="Button size--small"
           type="button"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="ArrowDropDownOutlinedIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m7 10 5 5 5-5z"
-            />
-          </svg>
+          <span>
+            0
+          </span>
         </button>
+        <div
+          aria-label="menuwrapper"
+          class="MenuWrapper"
+          data-testid="menu-wrapper"
+          role="button"
+        >
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                data-testid="MoreHorizIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
         <span
-          class="Label empty "
-          title="Items with an empty Property 1 property will go here. This column cannot be removed."
+          class=""
+          data-mui-internal-clone-element="true"
         >
-          No Property 1
-        </span>
-      </div>
-      <button
-        class="Button size--small"
-        type="button"
-      >
-        <span>
-          0
-        </span>
-      </button>
-      <div
-        aria-label="menuwrapper"
-        class="MenuWrapper"
-        data-testid="menu-wrapper"
-        role="button"
-      >
-        <button
-          class="Button IconButton css-w119tu"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-            data-testid="MoreHorizIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <button
+            class="Button IconButton css-w119tu"
+            type="button"
           >
-            <path
-              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+              data-testid="AddIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
-      <button
-        class="Button IconButton css-w119tu"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-          data-testid="AddIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-          />
-        </svg>
-      </button>
     </div>
   </span>
 </div>

--- a/components/common/DatabaseEditor/components/table/table.scss
+++ b/components/common/DatabaseEditor/components/table/table.scss
@@ -54,10 +54,10 @@
 
       input {
         background: transparent;
-        width: 100%;
+        // width: 100%;
         text-transform: none;
-        font-weight: normal;
-        font-size: 16px;
+        // font-weight: normal;
+        // font-size: 16px;
         //     line-height: 20px;
         color: rgba(var(--center-channel-color-rgb), 1);
       }

--- a/components/common/DatabaseEditor/components/table/table.spec.tsx
+++ b/components/common/DatabaseEditor/components/table/table.spec.tsx
@@ -138,7 +138,7 @@ describe('components/table/Table', () => {
           cards={[]}
           board={board}
           activeView={{ ...view, fields: { ...view.fields, groupById: 'property1' } } as BoardView}
-          visibleGroups={[{ option: { id: '', value: 'test', color: '' }, cards: [] }]}
+          visibleGroups={[{ id: '', option: { id: '', value: 'test', color: '' }, cards: [] }]}
           groupByProperty={{
             id: '',
             name: 'Property 1',

--- a/components/common/DatabaseEditor/components/table/table.tsx
+++ b/components/common/DatabaseEditor/components/table/table.tsx
@@ -187,14 +187,18 @@ function Table(props: Props): JSX.Element {
   );
 
   const onDropToGroupHeader = useCallback(
-    async (option: IPropertyOption, dstOption?: IPropertyOption) => {
-      if (dstOption) {
-        Utils.log(`ondrop. Header target: ${dstOption.value}, source: ${option?.value}`);
+    async (group: BoardGroup, dstGroup?: BoardGroup) => {
+      if (dstGroup) {
+        Utils.log(
+          `ondrop. Header target: ${dstGroup.option?.value || dstGroup.value}, source: ${
+            group?.option?.value || group?.value
+          }`
+        );
 
         // Move option to new index
-        const visibleOptionIds = visibleGroups.map((o) => o.option.id);
-        const srcIndex = visibleOptionIds.indexOf(dstOption.id);
-        const destIndex = visibleOptionIds.indexOf(option.id);
+        const visibleOptionIds = visibleGroups.map((o) => o.id);
+        const srcIndex = visibleOptionIds.indexOf(dstGroup.id);
+        const destIndex = visibleOptionIds.indexOf(group.id);
 
         visibleOptionIds.splice(srcIndex, 0, visibleOptionIds.splice(destIndex, 1)[0]);
         Utils.log(`ondrop. updated visibleoptionids: ${visibleOptionIds}`);
@@ -341,7 +345,7 @@ function Table(props: Props): JSX.Element {
               visibleGroups.map((group) => {
                 return (
                   <TableGroup
-                    key={group.option.id}
+                    key={group.id}
                     board={board}
                     activeView={activeView}
                     groupByProperty={groupByProperty}

--- a/components/common/DatabaseEditor/components/table/table.tsx
+++ b/components/common/DatabaseEditor/components/table/table.tsx
@@ -364,6 +364,8 @@ function Table(props: Props): JSX.Element {
                     onDropToGroup={onDropToGroup}
                     readOnlyTitle={props.readOnlyTitle}
                     disableAddingCards={props.disableAddingCards}
+                    expandSubRowsOnLoad={expandSubRowsOnLoad}
+                    rowExpansionLocalStoragePrefix={rowExpansionLocalStoragePrefix}
                     subRowsEmptyValueContent={subRowsEmptyValueContent}
                     checkedIds={checkedIds}
                     setCheckedIds={setCheckedIds}

--- a/components/common/DatabaseEditor/components/table/tableGroup.tsx
+++ b/components/common/DatabaseEditor/components/table/tableGroup.tsx
@@ -24,7 +24,7 @@ type Props = {
   showCard: (cardId: string) => void;
   propertyNameChanged: (option: IPropertyOption, text: string) => Promise<void>;
   onCardClicked: (e: React.MouseEvent, card: Card) => void;
-  onDropToGroupHeader: (srcOption: IPropertyOption, dstOption?: IPropertyOption) => void;
+  onDropToGroupHeader: (srcOption: BoardGroup, dstOption?: BoardGroup) => void;
   onDropToCard: (srcCard: Card, dstCard: Card) => void;
   onDropToGroup: (srcCard: Card, groupID: string, dstCardID: string) => void;
   disableAddingCards?: boolean;
@@ -36,7 +36,7 @@ type Props = {
 
 const TableGroup = React.memo((props: Props): JSX.Element => {
   const { board, activeView, group, onDropToGroup, groupByProperty } = props;
-  const groupId = group.option.id;
+  const groupId = group.id;
 
   const [{ isOver }, drop] = useDrop<Card, any, { isOver: boolean }>(
     () => ({
@@ -59,7 +59,7 @@ const TableGroup = React.memo((props: Props): JSX.Element => {
   }
 
   return (
-    <div ref={drop} className={className} key={group.option.id}>
+    <div ref={drop} className={className} key={group.option?.id || group.value}>
       <TableGroupHeaderRow
         group={group}
         board={board}

--- a/components/common/DatabaseEditor/components/table/tableGroup.tsx
+++ b/components/common/DatabaseEditor/components/table/tableGroup.tsx
@@ -82,6 +82,9 @@ const TableGroup = React.memo((props: Props): JSX.Element => {
           activeView={activeView}
           columnRefs={props.columnRefs}
           cards={group.cards}
+          disableDragAndDrop={
+            groupByProperty && groupByProperty.type !== 'select' && groupByProperty.type !== 'multiSelect'
+          } // disables drag and drop
           selectedCardIds={props.selectedCardIds}
           readOnly={props.readOnly}
           cardIdToFocusOnRender={props.cardIdToFocusOnRender}

--- a/components/common/DatabaseEditor/components/table/tableGroup.tsx
+++ b/components/common/DatabaseEditor/components/table/tableGroup.tsx
@@ -29,6 +29,8 @@ type Props = {
   onDropToGroup: (srcCard: Card, groupID: string, dstCardID: string) => void;
   disableAddingCards?: boolean;
   readOnlyTitle?: boolean;
+  expandSubRowsOnLoad?: boolean;
+  rowExpansionLocalStoragePrefix?: string;
   subRowsEmptyValueContent?: ReactElement | string;
   checkedIds?: string[];
   setCheckedIds?: Dispatch<SetStateAction<string[]>>;
@@ -90,6 +92,8 @@ const TableGroup = React.memo((props: Props): JSX.Element => {
           onCardClicked={props.onCardClicked}
           onDrop={props.onDropToCard}
           readOnlyTitle={props.readOnlyTitle}
+          expandSubRowsOnLoad={props.expandSubRowsOnLoad}
+          rowExpansionLocalStoragePrefix={props.rowExpansionLocalStoragePrefix}
           subRowsEmptyValueContent={props.subRowsEmptyValueContent}
           checkedIds={props.checkedIds}
           setCheckedIds={props.setCheckedIds}

--- a/components/common/DatabaseEditor/components/table/tableGroupHeaderRow.spec.tsx
+++ b/components/common/DatabaseEditor/components/table/tableGroupHeaderRow.spec.tsx
@@ -15,6 +15,7 @@ const view2 = TestBlockFactory.createBoardView(board);
 view2.fields.sortOptions = [];
 
 const boardTreeNoGroup = {
+  id: '',
   option: {
     id: '',
     value: '',
@@ -24,6 +25,7 @@ const boardTreeNoGroup = {
 };
 
 const boardTreeGroup = {
+  id: '',
   option: {
     id: 'value1',
     value: 'value 1',
@@ -109,7 +111,7 @@ test('should match snapshot, hide group', async () => {
   );
 
   const { container } = render(component);
-  const triangle = container.querySelector('[data-testid="ArrowDropDownOutlinedIcon"]');
+  const triangle = container.querySelector('[data-testid="ArrowDropDownIcon"]');
   expect(triangle).not.toBeNull();
 
   act(() => {

--- a/components/common/DatabaseEditor/components/table/tableGroupHeaderRow.tsx
+++ b/components/common/DatabaseEditor/components/table/tableGroupHeaderRow.tsx
@@ -1,13 +1,17 @@
 /* eslint-disable max-lines */
 
+import { ArrowDropDown as CollapseIcon, ArrowRight as ExpandIcon } from '@mui/icons-material';
 import AddIcon from '@mui/icons-material/Add';
-import ArrowDropDownOutlinedIcon from '@mui/icons-material/ArrowDropDownOutlined';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined';
-import React, { useEffect, useState } from 'react';
+import { Tooltip, Typography } from '@mui/material';
+import type { MouseEvent } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
+import { useDisableClickPropagation } from 'hooks/useDisablePropagation';
+import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
 import type { Board, BoardGroup, IPropertyOption, IPropertyTemplate } from 'lib/databases/board';
 import { proposalPropertyTypesList } from 'lib/databases/board';
 import type { BoardView } from 'lib/databases/boardView';
@@ -33,36 +37,38 @@ type Props = {
   hideGroup: (groupByOptionId: string) => void;
   addCard: (groupByOptionId?: string) => Promise<void> | void;
   propertyNameChanged: (option: IPropertyOption, text: string) => Promise<void>;
-  onDrop: (srcOption: IPropertyOption, dstOption?: IPropertyOption) => void;
+  onDrop: (srcOption: BoardGroup, dstOption?: BoardGroup) => void;
   disableAddingCards?: boolean;
   readOnlyTitle?: boolean;
 };
-
-const TableGroupHeaderRow = React.memo((props: Props): JSX.Element => {
+const TableGroupHeaderRow = memo((props: Props): JSX.Element => {
   const { board, activeView, group, groupByProperty } = props;
-  const [groupTitle, setGroupTitle] = useState(group.option.value);
+  const [groupTitle, setGroupTitle] = useState(group.option?.value || group.value || '');
+  const { getFeatureTitle } = useSpaceFeatures();
 
-  const [isDragging, isOver, groupHeaderRef] = useSortable('groupHeader', group.option, !props.readOnly, props.onDrop);
+  const [isDragging, isOver, groupHeaderRef] = useSortable('groupHeader', group, !props.readOnly, props.onDrop);
   const intl = useIntl();
+  const disableMouseEvents = useDisableClickPropagation();
 
   const formattedGroupTitle =
     groupByProperty?.type === 'proposalEvaluationType'
-      ? PROPOSAL_STEP_LABELS[group.option.value as ProposalEvaluationStep]
+      ? PROPOSAL_STEP_LABELS[group.option!.value as ProposalEvaluationStep]
       : groupByProperty?.type === 'proposalStatus'
-      ? EVALUATION_STATUS_LABELS[group.option.value as ProposalEvaluationStatus]
+      ? EVALUATION_STATUS_LABELS[group.option!.value as ProposalEvaluationStatus]
       : groupTitle;
 
   const preventPropertyDeletion =
     props.groupByProperty && proposalPropertyTypesList.includes(props.groupByProperty.type as any);
 
   useEffect(() => {
-    setGroupTitle(group.option.value);
-  }, [group.option.value]);
+    setGroupTitle(group.option?.value || group.value || '');
+  }, [group.option?.value, group.value]);
   let className = 'octo-group-header-cell';
   if (isOver) {
     className += ' dragover';
   }
-  if (activeView.fields.collapsedOptionIds.indexOf(group.option.id || 'undefined') < 0) {
+  const isExpanded = activeView.fields.collapsedOptionIds.indexOf(group.id || 'undefined') < 0;
+  if (isExpanded) {
     className += ' expanded';
   }
 
@@ -70,100 +76,117 @@ const TableGroupHeaderRow = React.memo((props: Props): JSX.Element => {
     return Math.max(Constants.minColumnWidth, props.activeView.fields.columnWidths[templateId] || 0);
   };
 
+  const propertyName = groupByProperty?.name === 'Proposal' ? getFeatureTitle('Proposal') : groupByProperty?.name;
+
   return (
-    <div
-      key={`${group.option.id}header`}
-      ref={groupHeaderRef}
-      style={{ opacity: isDragging ? 0.5 : 1 }}
-      className={className}
-    >
-      <div className='octo-table-cell' style={{ width: columnWidth(Constants.titleColumnId) }}>
-        <IconButton
-          icon={<ArrowDropDownOutlinedIcon fontSize='small' />}
-          onClick={() => (props.readOnly ? {} : props.hideGroup(group.option.id || 'undefined'))}
-          className='hello-world'
-        />
-        {!group.option.id && (
-          <Label
-            title={`${intl.formatMessage(
-              {
-                id: 'BoardComponent.no-property-title',
-                defaultMessage: 'Items with an empty {property} property will go here. This column cannot be removed.'
-              },
-              { property: groupByProperty?.name }
-            )}`}
-          >
-            <FormattedMessage
-              id='BoardComponent.no-property'
-              defaultMessage='No {property}'
-              values={{
-                property: `${groupByProperty?.name}`
-              }}
-            />
-          </Label>
-        )}
-        {group.option.id && (
-          <Label color={group.option.color}>
-            <Editable
-              value={formattedGroupTitle}
-              placeholderText='New Select'
-              onChange={setGroupTitle}
-              onSave={() => {
-                if (groupTitle.trim() === '') {
-                  setGroupTitle(group.option.value);
-                }
-                props.propertyNameChanged(group.option, groupTitle);
-              }}
-              onCancel={() => {
-                setGroupTitle(group.option.value);
-              }}
-              readOnly={props.readOnly || !group.option.id || props.readOnlyTitle}
-              spellCheck={true}
-            />
-          </Label>
+    <div {...disableMouseEvents /* this should prevent selection but not sure why this doesnt do anything */}>
+      <div
+        key={`${group.id}header`}
+        ref={groupHeaderRef}
+        style={{ opacity: isDragging ? 0.5 : 1 }}
+        className={className}
+      >
+        <div className='octo-table-cell' style={{ width: columnWidth(Constants.titleColumnId) }}>
+          <IconButton
+            icon={isExpanded ? <CollapseIcon /> : <ExpandIcon />}
+            style={{ width: '24px', height: '24px', marginRight: '4px' }}
+            onClick={() => (props.readOnly ? {} : props.hideGroup(group.id || 'undefined'))}
+          />
+          {/** Empty  value */}
+          {!group.id && (
+            <Tooltip
+              title={intl.formatMessage(
+                {
+                  id: 'BoardComponent.no-property-title',
+                  defaultMessage:
+                    'Items with an empty {propertyName} property will go here. This column cannot be removed.'
+                },
+                { property: propertyName }
+              )}
+            >
+              <Typography component='span' variant='subtitle1'>
+                <FormattedMessage
+                  id='BoardComponent.no-property'
+                  defaultMessage='No {property}'
+                  values={{
+                    property: `${propertyName}`
+                  }}
+                />
+              </Typography>
+            </Tooltip>
+          )}
+          {/* Readonly values */}
+
+          {group.value && (
+            <Typography component='span' variant='subtitle1'>
+              {group.value}
+            </Typography>
+          )}
+          {/* For select/multi-select values */}
+          {group.option?.id && (
+            <Label color={group.option.color}>
+              <Editable
+                value={formattedGroupTitle}
+                placeholderText='New Select'
+                onChange={setGroupTitle}
+                onSave={() => {
+                  if (props.readOnly) return;
+                  if (groupTitle.trim() === '') {
+                    setGroupTitle(group.option!.value);
+                  }
+                  props.propertyNameChanged(group.option!, groupTitle);
+                }}
+                onCancel={() => {
+                  setGroupTitle(group.option!.value);
+                }}
+                readOnly={props.readOnly || !group.option.id || props.readOnlyTitle}
+                spellCheck={true}
+              />
+            </Label>
+          )}
+        </div>
+        <Button>{`${group.cards.length}`}</Button>
+        {!props.readOnly && (
+          <>
+            <MenuWrapper>
+              <IconButton icon={<MoreHorizIcon fontSize='small' />} />
+              <Menu>
+                <Menu.Text
+                  id='hide'
+                  icon={<VisibilityOffOutlinedIcon fontSize='small' />}
+                  name={intl.formatMessage({ id: 'BoardComponent.hide', defaultMessage: 'Hide' })}
+                  onClick={() => mutator.hideViewColumn(activeView, group?.id || '')}
+                />
+                {group.option?.id && (
+                  <>
+                    {!preventPropertyDeletion && (
+                      <Menu.Text
+                        id='delete'
+                        icon={<DeleteOutlineIcon fontSize='small' color='secondary' />}
+                        disabled={preventPropertyDeletion}
+                        name={intl.formatMessage({ id: 'BoardComponent.delete', defaultMessage: 'Delete' })}
+                        onClick={() => mutator.deletePropertyOption(board, groupByProperty!, group.option!)}
+                      />
+                    )}
+                    <Menu.Separator />
+                    {Object.entries(Constants.menuColors).map(([key, color]) => (
+                      <Menu.Color
+                        key={key}
+                        id={key}
+                        name={color}
+                        onClick={() => mutator.changePropertyOptionColor(board, groupByProperty!, group.option!, key)}
+                      />
+                    ))}
+                  </>
+                )}
+              </Menu>
+            </MenuWrapper>
+            {!props.disableAddingCards && (
+              <IconButton icon={<AddIcon fontSize='small' />} onClick={() => props.addCard(group.id)} />
+            )}
+          </>
         )}
       </div>
-      <Button>{`${group.cards.length}`}</Button>
-      {!props.readOnly && (
-        <>
-          <MenuWrapper>
-            <IconButton icon={<MoreHorizIcon fontSize='small' />} />
-            <Menu>
-              <Menu.Text
-                id='hide'
-                icon={<VisibilityOffOutlinedIcon fontSize='small' />}
-                name={intl.formatMessage({ id: 'BoardComponent.hide', defaultMessage: 'Hide' })}
-                onClick={() => mutator.hideViewColumn(activeView, group.option.id || '')}
-              />
-              {group.option.id && (
-                <>
-                  {!preventPropertyDeletion && (
-                    <Menu.Text
-                      id='delete'
-                      icon={<DeleteOutlineIcon fontSize='small' color='secondary' />}
-                      disabled={preventPropertyDeletion}
-                      name={intl.formatMessage({ id: 'BoardComponent.delete', defaultMessage: 'Delete' })}
-                      onClick={() => mutator.deletePropertyOption(board, groupByProperty!, group.option)}
-                    />
-                  )}
-                  <Menu.Separator />
-                  {Object.entries(Constants.menuColors).map(([key, color]) => (
-                    <Menu.Color
-                      key={key}
-                      id={key}
-                      name={color}
-                      onClick={() => mutator.changePropertyOptionColor(board, groupByProperty!, group.option, key)}
-                    />
-                  ))}
-                </>
-              )}
-            </Menu>
-          </MenuWrapper>
-          {!props.disableAddingCards && (
-            <IconButton icon={<AddIcon fontSize='small' />} onClick={() => props.addCard(group.option.id)} />
-          )}
-        </>
-      )}
     </div>
   );
 });

--- a/components/common/DatabaseEditor/components/table/tableRow.tsx
+++ b/components/common/DatabaseEditor/components/table/tableRow.tsx
@@ -179,7 +179,7 @@ function TableRow(props: Props) {
         return checkedIds;
       });
     }
-  }, [isSelected, selection]);
+  }, [isSelected, !!selection]);
 
   useEffect(() => {
     setTitle(pageTitle);

--- a/components/common/DatabaseEditor/components/table/tableRow.tsx
+++ b/components/common/DatabaseEditor/components/table/tableRow.tsx
@@ -65,6 +65,7 @@ type Props = {
   emptySubPagesPlaceholder?: ReactNode;
   isChecked?: boolean;
   setCheckedIds?: Dispatch<SetStateAction<string[]>>;
+  disableDragAndDrop?: boolean;
 };
 
 export const StyledCheckbox = styled(Checkbox, {
@@ -114,6 +115,7 @@ function TableRow(props: Props) {
     setIsExpanded,
     isExpanded,
     indentTitle,
+    disableDragAndDrop,
     isNested,
     subRowsEmptyValueContent,
     isChecked,
@@ -126,13 +128,13 @@ function TableRow(props: Props) {
   const titleRef = useRef<{ focus(selectAll?: boolean): void }>(null);
   const [title, setTitle] = useState('');
   const isGrouped = Boolean(activeView.fields.groupById);
-  const enabled = !isTouchScreen() && !props.readOnly;
+  const isDragAndDropEnabled = !isTouchScreen() && !props.readOnly && !props.disableDragAndDrop;
 
   const { drag, drop, preview, style } = useDragDrop({
     item: card,
     itemType: 'card',
     onDrop: props.onDrop,
-    enabled
+    enabled: isDragAndDropEnabled
   });
 
   const { selection } = useContext(SelectionContext);
@@ -232,7 +234,7 @@ function TableRow(props: Props) {
     >
       {!props.readOnly && (
         <Stack flexDirection='row' gap={1} alignItems='center'>
-          {!isNested && (
+          {!isNested && isDragAndDropEnabled && (
             <div
               className='icons row-actions'
               onClick={handleClick}

--- a/components/common/DatabaseEditor/components/table/tableRow.tsx
+++ b/components/common/DatabaseEditor/components/table/tableRow.tsx
@@ -193,8 +193,14 @@ function TableRow(props: Props) {
 
   if (isGrouped) {
     const groupID = activeView.fields.groupById || '';
-    const groupValue = (card.fields.properties[groupID] as string) || 'undefined';
-    if (activeView.fields.collapsedOptionIds.indexOf(groupValue) > -1) {
+    // look up property id if we grouped by column type (eg proposalUrl)
+    const groupTemplate = board.fields.cardProperties.find((prop) => prop.type === groupID);
+    const groupValue =
+      (groupTemplate ? card.fields.properties[groupTemplate.id] : (card.fields.properties[groupID] as string)) ||
+      'undefined';
+    const groupValueStr =
+      typeof groupValue === 'string' ? groupValue : Array.isArray(groupValue) ? groupValue[0] : null;
+    if (groupValueStr !== null && activeView.fields.collapsedOptionIds.indexOf(groupValueStr) > -1) {
       className += ' hidden';
     }
   }
@@ -404,7 +410,7 @@ function ExpandableTableRow({ subPages, ...props }: Props & { isNested?: boolean
                 indentTitle={30}
                 isNested
                 // Don't allow subrows to be selected
-                setCheckedIds={() => {}}
+                setCheckedIds={undefined}
                 subRowsEmptyValueContent={props.subRowsEmptyValueContent}
               />
             )))}

--- a/components/common/DatabaseEditor/components/table/tableRows.tsx
+++ b/components/common/DatabaseEditor/components/table/tableRows.tsx
@@ -64,7 +64,9 @@ function TableRows(props: Props): JSX.Element {
   );
 
   const setIsExpanded = ({ cardId, expanded }: { expanded: boolean; cardId: string }) => {
-    setCollapsedCardIds((prev) => (expanded ? prev?.filter((id) => id !== cardId) ?? [] : [...(prev ?? []), cardId]));
+    setCollapsedCardIds((prev) => {
+      return expanded ? prev?.filter((id) => id !== cardId) ?? [] : [...(prev ?? []), cardId];
+    });
   };
 
   const saveTitle = React.useCallback(async (saveType: string, cardId: string, title: string, oldTitle: string) => {

--- a/components/common/DatabaseEditor/components/table/tableRows.tsx
+++ b/components/common/DatabaseEditor/components/table/tableRows.tsx
@@ -35,6 +35,7 @@ type Props = {
   subRowsEmptyValueContent?: ReactElement | string;
   checkedIds?: string[];
   setCheckedIds?: Dispatch<SetStateAction<string[]>>;
+  disableDragAndDrop?: boolean;
 };
 
 function TableRows(props: Props): JSX.Element {
@@ -46,6 +47,7 @@ function TableRows(props: Props): JSX.Element {
     expandSubRowsOnLoad,
     subRowsEmptyValueContent,
     setCheckedIds,
+    disableDragAndDrop,
     checkedIds = []
   } = props;
   const hasSubPages = allCards.some((card) => card.subPages?.length);
@@ -124,6 +126,7 @@ function TableRows(props: Props): JSX.Element {
           setIsExpanded={setIsExpanded}
           setCheckedIds={setCheckedIds}
           isChecked={checkedIds.includes(card.id)}
+          disableDragAndDrop={disableDragAndDrop}
           emptySubPagesPlaceholder={
             card.reward ? (
               <Box

--- a/components/common/DatabaseEditor/components/viewHeader/ToggleViewSidebarButton.tsx
+++ b/components/common/DatabaseEditor/components/viewHeader/ToggleViewSidebarButton.tsx
@@ -11,7 +11,12 @@ type Props = {
 export function ToggleViewSidebarButton(props: Props) {
   return (
     <Box ml={0} mr={1} data-test='view-header-actions-menu'>
-      <IconButton icon={<MoreHorizOutlinedIcon fontSize='small' />} onClick={props.onClick} style={{ width: '32px' }} />
+      <IconButton
+        tooltip='Edit view layout, grouping, and more...'
+        icon={<MoreHorizOutlinedIcon fontSize='small' />}
+        onClick={props.onClick}
+        style={{ width: '32px' }}
+      />
     </Box>
   );
 }

--- a/components/common/DatabaseEditor/components/viewHeader/__snapshots__/viewHeader.spec.tsx.snap
+++ b/components/common/DatabaseEditor/components/viewHeader/__snapshots__/viewHeader.spec.tsx.snap
@@ -68,23 +68,28 @@ exports[`components/viewHeader/viewHeader return viewHeader 1`] = `
         <div
           class="view-actions MuiBox-root css-37urdo"
         >
-          <button
-            class="Button IconButton css-w119tu"
-            style="width: 28px; height: 28px;"
-            type="button"
+          <span
+            class=""
+            data-mui-internal-clone-element="true"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-              data-testid="AddIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <button
+              class="Button IconButton css-w119tu"
+              style="width: 28px; height: 28px;"
+              type="button"
             >
-              <path
-                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
-              />
-            </svg>
-          </button>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                data-testid="AddIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                />
+              </svg>
+            </button>
+          </span>
         </div>
         <div
           class="octo-spacer"
@@ -92,42 +97,10 @@ exports[`components/viewHeader/viewHeader return viewHeader 1`] = `
         <div
           class="view-actions MuiBox-root css-0"
         >
-          <button
-            aria-haspopup="true"
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-16efx8q-MuiButtonBase-root-MuiButton-root"
-            tabindex="0"
-            type="button"
-          >
-            Filter
-          </button>
-          <button
-            aria-haspopup="true"
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-16efx8q-MuiButtonBase-root-MuiButton-root"
-            tabindex="0"
-            type="button"
-          >
-            Sort
-          </button>
-          <button
-            class="Button IconButton css-w119tu"
-            style="width: 32px;"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-              data-testid="SearchIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
-              />
-            </svg>
-          </button>
-          <div
-            class="MuiBox-root css-jw1lpn"
-            data-test="view-header-actions-menu"
+          <span
+            aria-label="Filter"
+            class=""
+            data-mui-internal-clone-element="true"
           >
             <button
               class="Button IconButton css-w119tu"
@@ -136,16 +109,103 @@ exports[`components/viewHeader/viewHeader return viewHeader 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
-                data-testid="MoreHorizOutlinedIcon"
+                class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeSmall css-887v1i-MuiSvgIcon-root"
+                data-testid="FilterListIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
                 <path
-                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                  d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
                 />
               </svg>
             </button>
+          </span>
+          <span
+            aria-label="Sort"
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              style="width: 32px;"
+              type="button"
+            >
+              <svg
+                fill="none"
+                height="1em"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                style="font-size: 16px;"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                  stroke="none"
+                />
+                <path
+                  d="M3 9l4 -4l4 4m-4 -4v14"
+                />
+                <path
+                  d="M21 15l-4 4l-4 -4m4 4v-14"
+                />
+              </svg>
+            </button>
+          </span>
+          <span
+            aria-label="Search"
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Button IconButton css-w119tu"
+              style="width: 32px;"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                data-testid="SearchIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                />
+              </svg>
+            </button>
+          </span>
+          <div
+            class="MuiBox-root css-jw1lpn"
+            data-test="view-header-actions-menu"
+          >
+            <span
+              aria-label="Edit view layout, grouping, and more..."
+              class=""
+              data-mui-internal-clone-element="true"
+            >
+              <button
+                class="Button IconButton css-w119tu"
+                style="width: 32px;"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-qolhez-MuiSvgIcon-root"
+                  data-testid="MoreHorizOutlinedIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                  />
+                </svg>
+              </button>
+            </span>
           </div>
           <div
             class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-disableElevation css-jgbgc3-MuiButtonGroup-root"
@@ -258,23 +318,29 @@ exports[`components/viewHeader/viewHeader return viewHeader readonly 1`] = `
         <div
           class="view-actions MuiBox-root css-0"
         >
-          <button
-            class="Button IconButton css-w119tu"
-            style="width: 32px;"
-            type="button"
+          <span
+            aria-label="Search"
+            class=""
+            data-mui-internal-clone-element="true"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-              data-testid="SearchIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <button
+              class="Button IconButton css-w119tu"
+              style="width: 32px;"
+              type="button"
             >
-              <path
-                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
-              />
-            </svg>
-          </button>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+                data-testid="SearchIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                />
+              </svg>
+            </button>
+          </span>
         </div>
       </div>
     </div>

--- a/components/common/DatabaseEditor/components/viewHeader/__snapshots__/viewHeaderSearch.spec.tsx.snap
+++ b/components/common/DatabaseEditor/components/viewHeader/__snapshots__/viewHeaderSearch.spec.tsx.snap
@@ -19,23 +19,29 @@ exports[`components/viewHeader/ViewHeaderSearch return search menu 1`] = `
   <span
     class="variable variable"
   >
-    <button
-      class="Button IconButton css-w119tu"
-      style="width: 32px;"
-      type="button"
+    <span
+      aria-label="Search"
+      class=""
+      data-mui-internal-clone-element="true"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
-        data-testid="SearchIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
+      <button
+        class="Button IconButton css-w119tu"
+        style="width: 32px;"
+        type="button"
       >
-        <path
-          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
-        />
-      </svg>
-    </button>
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall css-fq32bd-MuiSvgIcon-root"
+          data-testid="SearchIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+          />
+        </svg>
+      </button>
+    </span>
   </span>
 </div>
 `;

--- a/components/common/DatabaseEditor/components/viewHeader/viewHeader.tsx
+++ b/components/common/DatabaseEditor/components/viewHeader/viewHeader.tsx
@@ -178,21 +178,16 @@ function ViewHeader(props: Props) {
             </>
           )}
 
-          {/* Search - disabled until we can access page data inside the redux selector */}
-
           <ViewHeaderSearch />
 
           {/* Link to view embedded table in full - check that at least one view is created */}
           {props.embeddedBoardPath && !!views.length && (
             <Link href={`/${router.query.domain}/${props.embeddedBoardPath}`}>
-              <Tooltip title='Open as full page' placement='top'>
-                <span>
-                  <IconButton
-                    icon={<OpenInFullIcon color='secondary' sx={{ fontSize: 14 }} />}
-                    style={{ width: '32px' }}
-                  />
-                </span>
-              </Tooltip>
+              <IconButton
+                tooltip='Open as full page'
+                icon={<OpenInFullIcon color='secondary' sx={{ fontSize: 14 }} />}
+                style={{ width: '32px' }}
+              />
             </Link>
           )}
 

--- a/components/common/DatabaseEditor/components/viewHeader/viewHeaderSearch.tsx
+++ b/components/common/DatabaseEditor/components/viewHeader/viewHeaderSearch.tsx
@@ -83,6 +83,7 @@ function ViewHeaderSearch(): JSX.Element {
   }
   return (
     <IconButton
+      tooltip='Search'
       style={{ width: '32px' }}
       onClick={() => setIsSearching(true)}
       icon={<SearchIcon color='secondary' fontSize='small' />}

--- a/components/common/DatabaseEditor/components/viewSidebar/viewGroupOptions.tsx
+++ b/components/common/DatabaseEditor/components/viewSidebar/viewGroupOptions.tsx
@@ -1,4 +1,4 @@
-import { Delete } from '@mui/icons-material';
+import { DeleteOutlined } from '@mui/icons-material';
 import CheckOutlinedIcon from '@mui/icons-material/CheckOutlined';
 import { Box, Divider, ListItem, ListItemIcon, ListItemText, MenuItem, Typography } from '@mui/material';
 
@@ -76,7 +76,7 @@ function GroupByOptions(props: LayoutOptionsProps) {
             }}
           >
             <ListItemIcon>
-              <Delete color='secondary' />
+              <DeleteOutlined color='secondary' />
             </ListItemIcon>
             <ListItemText color='secondary'>Remove grouping</ListItemText>
           </MenuItem>

--- a/components/common/DatabaseEditor/components/viewSidebar/viewGroupOptions.tsx
+++ b/components/common/DatabaseEditor/components/viewSidebar/viewGroupOptions.tsx
@@ -18,7 +18,13 @@ function GroupByOptions(props: LayoutOptionsProps) {
   const { groupByProperty, properties, view } = props;
   const showTableUngroup = view.fields.viewType === 'table' && view.fields.groupById;
 
-  const groupablePropertyTypes: PropertyType[] = ['select', 'proposalStatus', 'proposalEvaluationType', 'proposalStep'];
+  const groupablePropertyTypes: PropertyType[] = [
+    'select',
+    'proposalStatus',
+    'proposalEvaluationType',
+    'proposalStep',
+    'proposalUrl'
+  ];
 
   const filteredProperties = (properties ?? [])?.filter((o: IPropertyTemplate) =>
     groupablePropertyTypes.includes(o.type)

--- a/components/common/DatabaseEditor/widgets/buttons/iconButton.tsx
+++ b/components/common/DatabaseEditor/widgets/buttons/iconButton.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { Tooltip } from '@mui/material';
 import React from 'react';
 
 type Props = {
@@ -8,6 +9,7 @@ type Props = {
   className?: string;
   onMouseDown?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   style?: React.CSSProperties;
+  tooltip?: string;
 };
 
 const StyledButton = styled.button`
@@ -22,17 +24,21 @@ function IconButton(props: Props): JSX.Element {
     className += ` ${props.className}`;
   }
   return (
-    <StyledButton
-      type='button'
-      onClick={props.onClick}
-      onMouseDown={props.onMouseDown}
-      className={className}
-      title={props.title}
-      aria-label={props.title}
-      style={props.style}
-    >
-      {props.icon}
-    </StyledButton>
+    <Tooltip title={props.tooltip} enterDelay={100}>
+      <span>
+        <StyledButton
+          type='button'
+          onClick={props.onClick}
+          onMouseDown={props.onMouseDown}
+          className={className}
+          title={props.title}
+          aria-label={props.title}
+          style={props.style}
+        >
+          {props.icon}
+        </StyledButton>
+      </span>
+    </Tooltip>
   );
 }
 

--- a/components/rewards/RewardsPage.tsx
+++ b/components/rewards/RewardsPage.tsx
@@ -391,8 +391,8 @@ export function RewardsPage({ title }: { title: string }) {
                     activeView={activeView}
                     cards={cards}
                     groupByProperty={groupByProperty}
-                    visibleGroups={visibleGroups.filter((g) => !!g.option.id)}
-                    hiddenGroups={hiddenGroups.filter((g) => !!g.option.id)}
+                    visibleGroups={visibleGroups.filter((g) => !!g.id)}
+                    hiddenGroups={hiddenGroups.filter((g) => !!g.id)}
                     selectedCardIds={[]}
                     readOnly={!isAdmin}
                     addCard={async () => {}}

--- a/components/rewards/RewardsPage.tsx
+++ b/components/rewards/RewardsPage.tsx
@@ -356,7 +356,7 @@ export function RewardsPage({ title }: { title: string }) {
                     cards={cards}
                     groupByProperty={groupByProperty}
                     views={views}
-                    visibleGroups={[]}
+                    visibleGroups={visibleGroups}
                     selectedCardIds={[]}
                     readOnly={!isAdmin}
                     disableAddingCards
@@ -430,7 +430,6 @@ export function RewardsPage({ title }: { title: string }) {
                 hideLayoutOptions
                 hideLayoutSelectOptions={undefined}
                 hideSourceOptions
-                hideGroupOptions
                 groupByProperty={groupByProperty}
                 page={undefined}
                 pageId={undefined}

--- a/hooks/useAreaSelection.ts
+++ b/hooks/useAreaSelection.ts
@@ -195,8 +195,13 @@ export function useSelected(elementRef: RefObject<HTMLElement>, selection: DOMRe
       setIsSelected(false);
     } else {
       const a = elementRef.current.getBoundingClientRect();
-      const b = selection;
-      setIsSelected(!(a.y + a.height < b.y || a.y > b.y + b.height || a.x + a.width < b.x || a.x > b.x + b.width));
+      // element is hidden
+      if (a.height === 0 || a.width === 0) {
+        setIsSelected(false);
+      } else {
+        const b = selection;
+        setIsSelected(!(a.y + a.height < b.y || a.y > b.y + b.height || a.x + a.width < b.x || a.x > b.x + b.width));
+      }
     }
   }, [elementRef, selection]);
 

--- a/hooks/useDisablePropagation.ts
+++ b/hooks/useDisablePropagation.ts
@@ -1,0 +1,14 @@
+import type { MouseEvent } from 'react';
+import { useCallback } from 'react';
+
+export function useDisableClickPropagation() {
+  const stopPropagation = useCallback((e: MouseEvent) => {
+    e.stopPropagation();
+    return false;
+  }, []);
+  return {
+    onClick: stopPropagation,
+    onMouseDown: stopPropagation,
+    onMouseUp: stopPropagation
+  };
+}

--- a/lib/databases/board.ts
+++ b/lib/databases/board.ts
@@ -107,7 +107,9 @@ export type Board = UIBlockWithDetails & {
 };
 
 export type BoardGroup = {
-  option: IPropertyOption;
+  id: string;
+  option?: IPropertyOption;
+  value?: string;
   cards: Card[];
 };
 

--- a/lib/utils/react.ts
+++ b/lib/utils/react.ts
@@ -1,3 +1,5 @@
+import type { KeyboardEvent, ClipboardEvent, MouseEvent } from 'react';
+
 // pulled from react-merge-refs
 export function mergeRefs(refs: any) {
   return (value: any) => {

--- a/scripts/query.ts
+++ b/scripts/query.ts
@@ -5,21 +5,26 @@ import { prisma } from '@charmverse/core/prisma-client';
  */
 
 async function search() {
-  const bountyCards = await prisma.bounty.count({
+  const bountyCards = await prisma.proposal.findFirst({
     where: {
       page: {
-        type: "card"
-      },
-      space: {
-        domain: {
-          startsWith: "cvt-"
+        path: 'xandra-4799432385546818'
+      }
+    },
+    include: {
+      evaluations: {
+        include: {
+          permissions: true
         }
       }
     }
-  })
+  });
 
-  console.log(`Bounty cards: ${bountyCards}`);
+  console.log(
+    bountyCards?.evaluations.map(
+      (e) => e.title + e.permissions.filter((p) => p.operation === 'view').map((p) => p.systemRole)
+    )
+  );
 }
-
 
 search().then(() => console.log('Done'));

--- a/stories/Databases/Kanban.stories.tsx
+++ b/stories/Databases/Kanban.stories.tsx
@@ -150,8 +150,8 @@ export function DatabaseKanbanView() {
           onCardClicked={voidFunction}
           selectedCardIds={[]}
           visibleGroups={[
-            { cards: [card1], option: schema.select.options[0] },
-            { cards: [card2], option: schema.select.options[1] }
+            { id: card1.id, cards: [card1], option: schema.select.options[0] },
+            { id: card2.id, cards: [card2], option: schema.select.options[1] }
           ]}
         />
       </div>


### PR DESCRIPTION
we already supported grouping on regular db's, but not on rewards. i also had to allow you to sort by 'proposalUrl' field, since it only supported select/multi-select before. i'd like to add other types in the future
<img width="1021" alt="image" src="https://github.com/charmverse/app.charmverse.io/assets/305398/8bf5757d-3374-4fbd-80f7-23be790faa00">
