### PR TITLE
Fix forms values

### DIFF
--- a/components/common/form/hooks/useFormFields.ts
+++ b/components/common/form/hooks/useFormFields.ts
@@ -162,7 +162,7 @@ export function useFormFields({
     )
   });
 
-  const values = watch() as Record<string, FormFieldValue>;
+  const values = watch();
 
   function onFormChange(updatedFields: { id: string; value: FormFieldValue }[]) {
     updatedFields.forEach((updatedField) => {

--- a/components/members/hooks/useRequiredMemberProperties.ts
+++ b/components/members/hooks/useRequiredMemberProperties.ts
@@ -141,21 +141,19 @@ export function useRequiredMemberPropertiesForm({ userId }: { userId: string }) 
       }));
   }, [memberProperties]);
 
-  const { getValues, control, errors, isDirty, isSubmitting, isValid, onFormChange, onSubmit } = useFormFields({
+  const { values, control, errors, isDirty, isSubmitting, isValid, onFormChange, onSubmit } = useFormFields({
     fields: nonDefaultMemberProperties,
-    onSubmit: async (values) => {
+    onSubmit: async (_values) => {
       if (space) {
         await updateSpaceValues(
           space.id,
-          Object.entries(values).map(([memberPropertyId, value]) => ({ memberPropertyId, value }))
+          Object.entries(_values).map(([memberPropertyId, value]) => ({ memberPropertyId, value }))
         );
         refreshPropertyValues();
         mutateMembers();
       }
     }
   });
-
-  const values = getValues();
 
   return {
     values,
@@ -186,7 +184,8 @@ export function useRequiredUserDetailsForm({ userId }: { userId: string }) {
     setValue,
     handleSubmit,
     getValues,
-    reset
+    reset,
+    watch
   } = useForm({
     mode: 'onChange',
     defaultValues: {
@@ -226,7 +225,7 @@ export function useRequiredUserDetailsForm({ userId }: { userId: string }) {
     });
   }
 
-  const values = getValues();
+  const values = watch();
 
   function onSubmit() {
     if (isDirty && isValid) {

--- a/components/rewards/components/RewardApplicationPage/components/RewardSubmissionInput.tsx
+++ b/components/rewards/components/RewardApplicationPage/components/RewardSubmissionInput.tsx
@@ -79,7 +79,7 @@ export function RewardSubmissionInput({
     register,
     handleSubmit,
     setValue,
-    getValues,
+    watch,
     formState: { errors, isValid }
   } = useForm<FormValues>({
     mode: 'onChange',
@@ -91,7 +91,7 @@ export function RewardSubmissionInput({
     resolver: yupResolver(schema(rewardType))
   });
 
-  const formValues = getValues();
+  const submissionNodes = watch('submissionNodes');
 
   async function onSubmit(values: FormValues) {
     const hasSaved = await onSubmitProp({
@@ -186,7 +186,7 @@ export function RewardSubmissionInput({
                 disabled={
                   (!isValid && submission?.status === 'inProgress') ||
                   !isEditorTouched ||
-                  checkIsContentEmpty(formValues.submissionNodes as unknown as PageContent)
+                  checkIsContentEmpty(submissionNodes as unknown as PageContent)
                 }
                 data-test='submit-submission-button'
                 type='submit'

--- a/components/settings/profile/components/SocialInputs.tsx
+++ b/components/settings/profile/components/SocialInputs.tsx
@@ -7,7 +7,7 @@ import type { Social } from 'lib/members/interfaces';
 
 type SocialInputsProps = {
   social?: Social;
-  onChange: (social: Social) => Promise<void>;
+  onChange: (social: Social) => void;
   readOnly?: boolean;
   errors?: FieldErrors<Record<keyof Social, string | null>>;
   required?: Record<keyof Social, boolean>;

--- a/components/settings/profile/components/UserDescription.tsx
+++ b/components/settings/profile/components/UserDescription.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
+import { useEffect } from 'react';
 import type { FieldError } from 'react-hook-form';
 import * as yup from 'yup';
 
@@ -13,7 +14,7 @@ export type FormValues = yup.InferType<typeof schema>;
 
 type UserDescriptionProps = {
   description: string | null | undefined;
-  onChange: (description: string) => Promise<void>;
+  onChange: (description: string) => void;
   readOnly?: boolean;
   required?: boolean;
   error?: FieldError;
@@ -33,11 +34,9 @@ function UserDescription(props: UserDescriptionProps) {
         helperText={error?.message}
         placeholder='Tell the world a bit more about yourself ...'
         multiline
+        inputProps={{ maxLength: 500 }}
         minRows={2}
-        onChange={async (event) => {
-          const val = event.target.value;
-          await onChange(val.length > 500 ? val.substring(0, 500) : val);
-        }}
+        onChange={async (event) => onChange(event.target.value)}
       />
       <Box justifyContent='end' display='flex'>
         {description?.length ?? 0}/500

--- a/components/settings/profile/components/UserDetailsForm.tsx
+++ b/components/settings/profile/components/UserDetailsForm.tsx
@@ -72,17 +72,16 @@ export function UserDetailsForm({ errors, userDetails, user, onChange, sx = {} }
   const identityModalState = usePopupState({ variant: 'popover', popupId: 'identity-modal' });
 
   const { updateProfileAvatar, isSaving: isSavingAvatar } = useUpdateProfileAvatar();
-  const { saveUser } = useUserDetails();
 
-  const setDescription = async (description: string) => {
+  const setDescription = (description: string) => {
     onChange({ description });
   };
 
-  const setTimezone = async (timezone: string | null = null) => {
+  const setTimezone = (timezone: string | null = null) => {
     onChange({ timezone });
   };
 
-  const setSocial = async (social: Social) => {
+  const setSocial = (social: Social) => {
     onChange({ social });
   };
 

--- a/components/settings/projects/components/ProjectForm.tsx
+++ b/components/settings/projects/components/ProjectForm.tsx
@@ -168,8 +168,8 @@ export function ProposalProjectFormAnswers({
 }
 
 export function SettingsProjectFormAnswers({ isTeamLead }: { isTeamLead: boolean }) {
-  const { getValues, setValue, control } = useFormContext<ProjectAndMembersPayload>();
-  const projectValues = getValues();
+  const { watch, setValue, control } = useFormContext<ProjectAndMembersPayload>();
+  const projectValues = watch();
   const { user } = useUser();
   const extraProjectMembers = projectValues.projectMembers.slice(1);
   const fieldConfig = createDefaultProjectAndMembersFieldConfig();


### PR DESCRIPTION
Card:
https://app.charmverse.io/charmverse/edit-member-profile-cursor-jumps-to-end-of-text-everytime-you-make-an-edit-5293657149451723

Info:
- components were rerendering because of getValues() and cursor was jumping.
- as a best practice we should use watch() in a component and getValues() only inside functions when we need to get once the values.
- I changed it in all the places I saw it happening.