### PR TITLE
Fix user select property

### DIFF
--- a/components/common/form/InputSearchMember.tsx
+++ b/components/common/form/InputSearchMember.tsx
@@ -147,36 +147,25 @@ export function InputSearchMemberMultiple({
   ...props
 }: IInputSearchMemberMultipleProps) {
   const { members, membersRecord } = useMembers();
-  const defaultMembers = (defaultValue ?? []).map((userId) => membersRecord[userId]).filter(Boolean);
-  const [value, setValue] = useState<Member[]>(defaultMembers);
+  const selectedMembers = (defaultValue ?? []).map((userId) => membersRecord[userId]).filter(Boolean);
 
   function emitValue(users: Member[], reason: AutocompleteChangeReason) {
     onChange(
       users.map((user) => (user.id.startsWith('email') ? user.username : user.id)),
       reason
     );
-    setValue(users);
   }
-
-  useEffect(() => {
-    if (defaultValue && value.length === 0) {
-      const _defaultMembers = (defaultValue ?? []).map((userId) => membersRecord[userId]).filter(Boolean);
-      if (_defaultMembers.length > 0) {
-        setValue(_defaultMembers);
-      }
-    }
-  }, [defaultValue, membersRecord]);
 
   return (
     <InputSearchMemberBase
       filterSelectedOptions
       multiple={multiple}
-      value={value}
+      value={selectedMembers}
       disableCloseOnSelect={disableCloseOnSelect}
       onChange={(e, _value, reason) => emitValue(_value as Member[], reason)}
       isOptionEqualToValue={(option, val) => option.id === val.id}
       {...props}
-      placeholder={defaultValue?.length || value.length ? undefined : props.placeholder ?? 'Select members'}
+      placeholder={defaultValue?.length ? undefined : props.placeholder ?? 'Select members'}
       options={members.filter((member) => !member.isBot)}
     />
   );

--- a/components/common/form/InputSearchMember.tsx
+++ b/components/common/form/InputSearchMember.tsx
@@ -3,7 +3,7 @@ import EmailIcon from '@mui/icons-material/Email';
 import type { AutocompleteChangeReason, AutocompleteProps } from '@mui/material';
 import { Autocomplete, TextField } from '@mui/material';
 import type { ReactNode } from 'react';
-import { createRef, useEffect, useState } from 'react';
+import { createRef, useMemo } from 'react';
 import { v4 } from 'uuid';
 
 import UserDisplay from 'components/common/UserDisplay';
@@ -147,7 +147,10 @@ export function InputSearchMemberMultiple({
   ...props
 }: IInputSearchMemberMultipleProps) {
   const { members, membersRecord } = useMembers();
-  const selectedMembers = (defaultValue ?? []).map((userId) => membersRecord[userId]).filter(Boolean);
+  const selectedMembers = useMemo(
+    () => (defaultValue ?? []).map((userId) => membersRecord[userId]).filter(Boolean),
+    [defaultValue, membersRecord]
+  );
 
   function emitValue(users: Member[], reason: AutocompleteChangeReason) {
     onChange(


### PR DESCRIPTION
Card:
https://app.charmverse.io/charmverse/when-adding-a-person-to-a-card-property-it-doesnt-actually-remove-the-original-person-1513873279848057


## WHY
The `value` state was not synced with the `defaultValue` state. Only after the user closes the dropdown the component was rerendered and the value was shown correctly.

## FIX
Remove the `value` state, since we have the `defaultValue` which should be the same thing.