### PR TITLE
Skip document authors if comment access groups is not empty

### DIFF
--- a/lib/notifications/documents/createDocumentNotifications.ts
+++ b/lib/notifications/documents/createDocumentNotifications.ts
@@ -214,7 +214,8 @@ export async function createDocumentNotifications(webhookData: {
         }
       });
 
-      const notificationTargetUserIds = data.document.authors.map((author) => author.id);
+      const notificationTargetUserIds =
+        threadAccessGroups.length === 0 ? data.document.authors.map((author) => author.id) : [];
 
       // Get all the users that have access to the thread
       for (const threadAccessGroup of threadAccessGroups) {
@@ -251,11 +252,6 @@ export async function createDocumentNotifications(webhookData: {
         ids.push(id);
         notificationSentUserIds.add(previousInlineComment.userId);
       }
-
-      const permissionsClient = await getPermissionsClient({
-        resourceId: webhookData.spaceId,
-        resourceIdType: 'space'
-      });
 
       for (const userId of new Set(notificationTargetUserIds)) {
         if (


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

[Card](https://app.charmverse.io/charmverse/author-should-not-receive-notification-for-a-comment-if-it-was-assigned-to-someone-else-6073920785219709)
