### PR TITLE
Fix sort databases

### DIFF
--- a/components/common/DatabaseEditor/components/table/tableHeader.tsx
+++ b/components/common/DatabaseEditor/components/table/tableHeader.tsx
@@ -185,22 +185,21 @@ function TableHeader(props: Props): JSX.Element {
             }}
           />
         </Stack>
-        {template.id !== Constants.titleColumnId && (
-          <>
-            <MenuItem
-              {...bindTriggerProps}
-              onClick={() => {
-                props.setSelectedPropertyId?.(template.id);
-              }}
-            >
-              <ListItemIcon>
-                <TuneIcon fontSize='small' />
-              </ListItemIcon>
-              <Typography variant='subtitle1'>Edit property</Typography>
-            </MenuItem>
-            <Divider />
-          </>
-        )}
+        {template.id !== Constants.titleColumnId && [
+          <MenuItem
+            key={1}
+            {...bindTriggerProps}
+            onClick={() => {
+              props.setSelectedPropertyId?.(template.id);
+            }}
+          >
+            <ListItemIcon>
+              <TuneIcon fontSize='small' />
+            </ListItemIcon>
+            <Typography variant='subtitle1'>Edit property</Typography>
+          </MenuItem>,
+          <Divider key={2} />
+        ]}
         <MenuItem
           onClick={() => {
             changeViewSortOptions([{ propertyId: templateId, reversed: false }]);

--- a/components/common/DatabaseEditor/store/cards.ts
+++ b/components/common/DatabaseEditor/store/cards.ts
@@ -150,10 +150,10 @@ export function sortCards(
   const sortOptions = localSort || globalSortOptions;
 
   if (sortOptions?.length < 1) {
-    return cards.sort((a, b) => manualOrder(activeView, a, b));
+    return [...cards].sort((a, b) => manualOrder(activeView, a, b));
   }
 
-  let sortedCards = cards;
+  let sortedCards = [...cards];
   for (const sortOption of sortOptions) {
     if (sortOption.propertyId === Constants.titleColumnId) {
       Utils.log('Sort by title');


### PR DESCRIPTION
React was not updating the component that was consuming the sorted cards.
The cards array was sorted and the original array was overwritten and that means no rerender.

Card:
https://app.charmverse.io/charmverse/sort-doesnt-work-on-databases-6821939509445178