### PR TITLE
Filter notifications to be accessible for a user

### DIFF
--- a/lib/notifications/cards/getCardNotifications.ts
+++ b/lib/notifications/cards/getCardNotifications.ts
@@ -9,7 +9,19 @@ import { notificationMetadataSelectStatement, queryCondition } from '../utils';
 
 export async function getCardNotifications({ id, userId }: QueryCondition): Promise<CardNotification[]> {
   const cardNotifications = await prisma.cardNotification.findMany({
-    where: queryCondition({ id, userId }),
+    where: {
+      ...queryCondition({ id, userId }),
+      card: {
+        deletedAt: null,
+        space: {
+          spaceRoles: {
+            some: {
+              userId
+            }
+          }
+        }
+      }
+    },
     select: {
       id: true,
       type: true,

--- a/lib/notifications/documents/getDocumentNotifications.ts
+++ b/lib/notifications/documents/getDocumentNotifications.ts
@@ -9,7 +9,19 @@ import { notificationMetadataSelectStatement, queryCondition } from '../utils';
 
 export async function getDocumentNotifications({ id, userId }: QueryCondition): Promise<DocumentNotification[]> {
   const documentNotifications = await prisma.documentNotification.findMany({
-    where: queryCondition({ id, userId }),
+    where: {
+      ...queryCondition({ id, userId }),
+      page: {
+        deletedAt: null,
+        space: {
+          spaceRoles: {
+            some: {
+              userId
+            }
+          }
+        }
+      }
+    },
     select: {
       id: true,
       type: true,

--- a/lib/notifications/forum/getForumNotifications.ts
+++ b/lib/notifications/forum/getForumNotifications.ts
@@ -6,7 +6,19 @@ import { notificationMetadataSelectStatement, queryCondition } from '../utils';
 
 export async function getPostNotifications({ id, userId }: QueryCondition): Promise<PostNotification[]> {
   const postNotifications = await prisma.postNotification.findMany({
-    where: queryCondition({ id, userId }),
+    where: {
+      ...queryCondition({ id, userId }),
+      post: {
+        deletedAt: null,
+        space: {
+          spaceRoles: {
+            some: {
+              userId
+            }
+          }
+        }
+      }
+    },
     select: {
       id: true,
       type: true,

--- a/lib/notifications/mailer/sendNotificationEmail.ts
+++ b/lib/notifications/mailer/sendNotificationEmail.ts
@@ -31,7 +31,7 @@ export async function sendNotificationEmail({ id, type }: NotificationEmailInput
         select: notificationSelectFields
       });
       if (user.email && user.emailNotifications) {
-        const notifications = await getCardNotifications({ id });
+        const notifications = await getCardNotifications({ id, userId: user.id });
         if (notifications.length) {
           await sendEmail({
             notification: notifications[0],
@@ -55,7 +55,7 @@ export async function sendNotificationEmail({ id, type }: NotificationEmailInput
         select: notificationSelectFields
       });
       if (user.email && user.emailNotifications) {
-        const notifications = await getPostNotifications({ id });
+        const notifications = await getPostNotifications({ id, userId: user.id });
         if (notifications.length) {
           await sendEmail({
             notification: notifications[0],
@@ -79,7 +79,7 @@ export async function sendNotificationEmail({ id, type }: NotificationEmailInput
         select: notificationSelectFields
       });
       if (user.email && user.emailNotifications) {
-        const notifications = await getDocumentNotifications({ id });
+        const notifications = await getDocumentNotifications({ id, userId: user.id });
         if (notifications.length) {
           await sendEmail({
             notification: notifications[0],
@@ -103,7 +103,7 @@ export async function sendNotificationEmail({ id, type }: NotificationEmailInput
         select: notificationSelectFields
       });
       if (user.email && user.emailNotifications) {
-        const notifications = await getPollNotifications({ id });
+        const notifications = await getPollNotifications({ id, userId: user.id });
         if (notifications.length) {
           await sendEmail({
             notification: notifications[0],
@@ -127,7 +127,7 @@ export async function sendNotificationEmail({ id, type }: NotificationEmailInput
         select: notificationSelectFields
       });
       if (user.email && user.emailNotifications) {
-        const notifications = await getProposalNotifications({ id });
+        const notifications = await getProposalNotifications({ id, userId: user.id });
         if (notifications.length) {
           await sendEmail({
             notification: notifications[0],
@@ -151,7 +151,7 @@ export async function sendNotificationEmail({ id, type }: NotificationEmailInput
         select: notificationSelectFields
       });
       if (user.email && user.emailNotifications) {
-        const notifications = await getBountyNotifications({ id });
+        const notifications = await getBountyNotifications({ id, userId: user.id });
         if (notifications.length) {
           await sendEmail({
             notification: notifications[0],

--- a/lib/notifications/proposals/getProposalNotifications.ts
+++ b/lib/notifications/proposals/getProposalNotifications.ts
@@ -8,7 +8,21 @@ import { notificationMetadataSelectStatement, queryCondition } from '../utils';
 
 export async function getProposalNotifications({ id, userId }: QueryCondition): Promise<ProposalNotification[]> {
   const proposalNotifications = await prisma.proposalNotification.findMany({
-    where: queryCondition({ id, userId }),
+    where: {
+      ...queryCondition({ id, userId }),
+      proposal: {
+        space: {
+          spaceRoles: {
+            some: {
+              userId
+            }
+          }
+        },
+        page: {
+          deletedAt: null
+        }
+      }
+    },
     select: {
       id: true,
       type: true,

--- a/lib/notifications/rewards/getRewardNotifications.ts
+++ b/lib/notifications/rewards/getRewardNotifications.ts
@@ -7,7 +7,21 @@ import { notificationMetadataSelectStatement, queryCondition } from '../utils';
 
 export async function getBountyNotifications({ id, userId }: QueryCondition): Promise<BountyNotification[]> {
   const bountyNotifications = await prisma.bountyNotification.findMany({
-    where: queryCondition({ id, userId }),
+    where: {
+      ...queryCondition({ id, userId }),
+      bounty: {
+        space: {
+          spaceRoles: {
+            some: {
+              userId
+            }
+          }
+        },
+        page: {
+          deletedAt: null
+        }
+      }
+    },
     select: {
       id: true,
       type: true,


### PR DESCRIPTION
Issue:
- Users see Updates for pages that are deleted, don't exist anymore or they don't have access to the space anymore.

Fix:
- filter notifications that have a page or post relation, deletedAt is null and the user has a spaceRole