### PR TITLE
Fix card reordering

### DIFF
--- a/components/common/DatabaseEditor/components/centerPanel.tsx
+++ b/components/common/DatabaseEditor/components/centerPanel.tsx
@@ -205,13 +205,13 @@ function CenterPanel(props: Props) {
     () =>
       activeView
         ? getVisibleAndHiddenGroups(
-            _cards,
+            sortedCards,
             activeView.fields.visibleOptionIds,
             activeView.fields.hiddenOptionIds,
             groupByProperty
           )
         : { visible: [], hidden: [] },
-    [_cards, activeView, groupByProperty]
+    [sortedCards, activeView, groupByProperty]
   );
 
   const backgroundRef = React.createRef<HTMLDivElement>();

--- a/components/common/DatabaseEditor/components/kanban/kanban.tsx
+++ b/components/common/DatabaseEditor/components/kanban/kanban.tsx
@@ -78,7 +78,7 @@ type Props = {
 };
 
 function Kanban(props: Props) {
-  const { board, activeView, cards, groupByProperty, visibleGroups, hiddenGroups } = props;
+  const { board, activeView, cards, groupByProperty, visibleGroups, hiddenGroups, selectedCardIds } = props;
   const popupState = usePopupState({ variant: 'popper', popupId: 'new-group' });
   const propertyValues = groupByProperty?.options || [];
   Utils.log(`${propertyValues.length} propertyValues`);
@@ -132,7 +132,6 @@ function Kanban(props: Props) {
 
   const onDropToColumn = useCallback(
     async (option: IPropertyOption, card?: Card, dstOption?: IPropertyOption) => {
-      const { selectedCardIds } = props;
       const optionId = option ? option.id : undefined;
 
       let draggedCardIds = selectedCardIds;
@@ -191,7 +190,7 @@ function Kanban(props: Props) {
         );
       }
     },
-    [cards, visibleGroups, activeView, groupByProperty, props.selectedCardIds]
+    [cards, visibleGroups, activeView, groupByProperty, selectedCardIds]
   );
 
   const onDropToCard = useCallback(
@@ -218,7 +217,6 @@ function Kanban(props: Props) {
       }
 
       Utils.log(`onDropToCard: ${dstCard.title}`);
-      const { selectedCardIds } = props;
       const optionId = groupByProperty ? dstCard.fields.properties[groupByProperty.id] : null;
 
       const draggedCardIds = Array.from(new Set(selectedCardIds).add(srcCard.id));
@@ -290,7 +288,7 @@ function Kanban(props: Props) {
         );
       });
     },
-    [cards, activeView, groupByProperty, props.selectedCardIds]
+    [cards, activeView, groupByProperty, selectedCardIds]
   );
 
   const [showCalculationsMenu, setShowCalculationsMenu] = useState<Map<string, boolean>>(new Map<string, boolean>());


### PR DESCRIPTION
Issue:
- Drag and drop in the same column is not working properly. The cardOrder is updated, but the cards positioning inside the group is not updated because it is not taking into consideration the cardOrder.

More info:
- before it was working because we were overriding the cards object when sorting. The cards should not be mutated, it should get the cardOrder array and sort it by that.
- this was the PR that fixed sorting but broke the cards order
https://github.com/charmverse/app.charmverse.io/pull/4059/files

Solution:
- Send sortedCards to the group