### PR TITLE
Refactored proposal evaluation appeal reviews model

### DIFF
--- a/__integration-tests__/server/pages/api/proposals/evaluations/[id]/appeal/reset-review.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/evaluations/[id]/appeal/reset-review.spec.ts
@@ -141,11 +141,10 @@ describe('POST /api/proposals/evaluations/[id]/appeal/reset-review - Reset revie
       .set('Cookie', userCookie);
     expect(response.statusCode).toBe(200);
 
-    const review = await prisma.proposalEvaluationReview.findFirst({
+    const review = await prisma.proposalEvaluationAppealReview.findFirst({
       where: {
         evaluationId,
-        reviewerId: admin.id,
-        appeal: true
+        reviewerId: admin.id
       }
     });
 

--- a/__integration-tests__/server/pages/api/proposals/evaluations/[id]/appeal/submit-result.spec.ts
+++ b/__integration-tests__/server/pages/api/proposals/evaluations/[id]/appeal/submit-result.spec.ts
@@ -129,12 +129,11 @@ describe('PUT /api/proposals/evaluations/[id]/appeal/submit-result - Submit appe
   });
 
   it('should throw error if the appeal evaluations is equal to the required reviews', async () => {
-    await prisma.proposalEvaluationReview.create({
+    await prisma.proposalEvaluationAppealReview.create({
       data: {
         evaluationId,
         reviewerId: admin.id,
-        result: 'pass',
-        appeal: true
+        result: 'pass'
       }
     });
 
@@ -146,11 +145,10 @@ describe('PUT /api/proposals/evaluations/[id]/appeal/submit-result - Submit appe
     expect(response.statusCode).toBe(401);
     expect(response.body.message).toBe('This evaluation appeal has already been reviewed.');
 
-    await prisma.proposalEvaluationReview.deleteMany({
+    await prisma.proposalEvaluationAppealReview.deleteMany({
       where: {
         evaluationId,
-        reviewerId: admin.id,
-        appeal: true
+        reviewerId: admin.id
       }
     });
   });
@@ -195,12 +193,11 @@ describe('PUT /api/proposals/evaluations/[id]/appeal/submit-result - Submit appe
       }
     });
 
-    await prisma.proposalEvaluationReview.create({
+    await prisma.proposalEvaluationAppealReview.create({
       data: {
         evaluationId,
         reviewerId: admin.id,
-        result: 'pass',
-        appeal: true
+        result: 'pass'
       }
     });
 
@@ -212,11 +209,10 @@ describe('PUT /api/proposals/evaluations/[id]/appeal/submit-result - Submit appe
     expect(response.statusCode).toBe(401);
     expect(response.body.message).toBe('You have already reviewed this appeal.');
 
-    await prisma.proposalEvaluationReview.deleteMany({
+    await prisma.proposalEvaluationAppealReview.deleteMany({
       where: {
         evaluationId,
-        reviewerId: admin.id,
-        appeal: true
+        reviewerId: admin.id
       }
     });
 

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/PassFailEvaluationContainer.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/PassFailEvaluationContainer.tsx
@@ -44,6 +44,7 @@ type Props = {
     | 'appealedBy'
     | 'declinedAt'
     | 'isAppealReviewer'
+    | 'appealReviews'
   >;
   refreshProposal?: VoidFunction;
   confirmationMessage?: string;
@@ -154,7 +155,7 @@ export function PassFailEvaluationContainer({
       id: (reviewer.roleId ?? reviewer.userId ?? reviewer.systemRole) as string
     })),
     isSubmittingReview: isSubmittingEvaluationReview,
-    evaluationReviews: evaluation.reviews?.filter((review) => !review.appeal),
+    evaluationReviews: evaluation.reviews,
     requiredReviews: evaluation.requiredReviews,
     evaluationResult: evaluation.appealedAt ? 'fail' : evaluation.result,
     declineReasonOptions: evaluation.declineReasonOptions,
@@ -182,13 +183,14 @@ export function PassFailEvaluationContainer({
                 <PassFailEvaluation
                   {...passFailProps}
                   isAppealProcess
+                  onResetEvaluationReview={onResetEvaluationAppealReview}
                   isReviewer={evaluation.isAppealReviewer}
                   onSubmitEvaluationReview={onSubmitEvaluationAppealReview}
                   isSubmittingReview={isSubmittingEvaluationAppealReview}
                   isResettingEvaluationReview={isResettingEvaluationAppealReview}
                   completedAt={evaluation.result !== null ? evaluation.completedAt : undefined}
                   evaluationResult={evaluation.result}
-                  evaluationReviews={evaluation.reviews?.filter((review) => Boolean(review.appeal))}
+                  evaluationReviews={evaluation.appealReviews}
                   requiredReviews={evaluation.appealRequiredReviews ?? 1}
                 />
               </Stack>

--- a/components/settings/proposals/components/EvaluationDialog.tsx
+++ b/components/settings/proposals/components/EvaluationDialog.tsx
@@ -207,7 +207,6 @@ function EvaluationAppealSettings({
 }) {
   const { appealable, appealRequiredReviews, finalStep } = formValues;
   const { getFeatureTitle } = useSpaceFeatures();
-  const proposalLabel = getFeatureTitle('Proposal');
   return (
     <Stack gap={1}>
       <Box>
@@ -231,8 +230,7 @@ function EvaluationAppealSettings({
         <FieldLabel>Appeal</FieldLabel>
         <Stack flexDirection='row' justifyContent='space-between' alignItems='center'>
           <Typography color='textSecondary' variant='body2'>
-            {proposalLabel} authors can appeal the reviewer's decision. The appeal result is final, and passes or fails
-            the {proposalLabel.toLowerCase()}.
+            Authors can appeal the decision. The results of the appeal are final.
           </Typography>
           <Switch
             checked={!!appealable}

--- a/lib/proposals/__tests__/goBackToStep.spec.ts
+++ b/lib/proposals/__tests__/goBackToStep.spec.ts
@@ -123,7 +123,8 @@ describe('goBackToStep()', () => {
         id: proposal.evaluations[1].id
       },
       include: {
-        proposalEvaluationReviews: true
+        proposalEvaluationReviews: true,
+        proposalEvaluationAppealReviews: true
       }
     });
 
@@ -144,13 +145,20 @@ describe('goBackToStep()', () => {
       declineReasons: []
     });
 
-    const proposalEvaluationReviews = await prisma.proposalEvaluationReview.findMany({
+    const proposalEvaluationReviews = await prisma.proposalEvaluationReview.count({
       where: {
         evaluationId: proposal.evaluations[1].id
       }
     });
 
-    expect(proposalEvaluationReviews.length).toBe(2);
+    const proposalEvaluationAppealReviews = await prisma.proposalEvaluationAppealReview.count({
+      where: {
+        evaluationId: proposal.evaluations[1].id
+      }
+    });
+
+    expect(proposalEvaluationReviews).toBe(1);
+    expect(proposalEvaluationAppealReviews).toBe(1);
 
     await goBackToStep({
       proposalId: proposal.id,
@@ -180,12 +188,18 @@ describe('goBackToStep()', () => {
       })
     );
 
-    const updatedProposalEvaluationReviews = await prisma.proposalEvaluationReview.findMany({
+    const updatedProposalEvaluationReviews = await prisma.proposalEvaluationReview.count({
       where: {
         evaluationId: proposal.evaluations[1].id
       }
     });
-    expect(updatedProposalEvaluationReviews.length).toBe(0);
+    const updatedProposalEvaluationAppealReviews = await prisma.proposalEvaluationAppealReview.count({
+      where: {
+        evaluationId: proposal.evaluations[1].id
+      }
+    });
+    expect(updatedProposalEvaluationReviews).toBe(0);
+    expect(updatedProposalEvaluationAppealReviews).toBe(0);
   });
 
   it('Should delete previous evaluation reviews when moving back to draft state', async () => {

--- a/lib/proposals/__tests__/goBackToStep.spec.ts
+++ b/lib/proposals/__tests__/goBackToStep.spec.ts
@@ -123,8 +123,8 @@ describe('goBackToStep()', () => {
         id: proposal.evaluations[1].id
       },
       include: {
-        proposalEvaluationReviews: true,
-        proposalEvaluationAppealReviews: true
+        reviews: true,
+        appealReviews: true
       }
     });
 
@@ -226,7 +226,7 @@ describe('goBackToStep()', () => {
         id: proposal.evaluations[0].id
       },
       include: {
-        proposalEvaluationReviews: true
+        reviews: true
       }
     });
 

--- a/lib/proposals/__tests__/submitEvaluationAppealResult.spec.ts
+++ b/lib/proposals/__tests__/submitEvaluationAppealResult.spec.ts
@@ -39,8 +39,8 @@ describe('submitEvaluationAppealResult()', () => {
         proposalId
       },
       include: {
-        proposalEvaluationReviews: true,
-        proposalEvaluationAppealReviews: true
+        reviews: true,
+        appealReviews: true
       }
     });
 

--- a/lib/proposals/__tests__/submitEvaluationAppealResult.spec.ts
+++ b/lib/proposals/__tests__/submitEvaluationAppealResult.spec.ts
@@ -39,7 +39,8 @@ describe('submitEvaluationAppealResult()', () => {
         proposalId
       },
       include: {
-        proposalEvaluationReviews: true
+        proposalEvaluationReviews: true,
+        proposalEvaluationAppealReviews: true
       }
     });
 
@@ -69,10 +70,9 @@ describe('submitEvaluationAppealResult()', () => {
       spaceId: space.id
     });
 
-    const proposalEvaluationReview = await prisma.proposalEvaluationReview.findFirst({
+    const proposalEvaluationAppealReview = await prisma.proposalEvaluationAppealReview.findFirst({
       where: {
         evaluationId: evaluation.id,
-        appeal: true,
         result: 'pass'
       }
     });
@@ -85,6 +85,6 @@ describe('submitEvaluationAppealResult()', () => {
 
     expect(evaluationAfterAppeal.result).toBe('pass');
     expect(evaluationAfterAppeal.decidedBy).toBe(user.id);
-    expect(proposalEvaluationReview).toBeTruthy();
+    expect(proposalEvaluationAppealReview).toBeTruthy();
   });
 });

--- a/lib/proposals/__tests__/submitEvaluationResult.spec.ts
+++ b/lib/proposals/__tests__/submitEvaluationResult.spec.ts
@@ -34,7 +34,7 @@ describe('submitEvaluationResult()', () => {
         proposalId
       },
       include: {
-        proposalEvaluationReviews: true
+        reviews: true
       }
     });
 
@@ -101,7 +101,7 @@ describe('submitEvaluationResult()', () => {
         proposalId
       },
       include: {
-        proposalEvaluationReviews: true
+        reviews: true
       }
     });
 
@@ -120,7 +120,7 @@ describe('submitEvaluationResult()', () => {
         id: evaluation.id
       },
       include: {
-        proposalEvaluationReviews: true
+        reviews: true
       }
     });
 
@@ -139,7 +139,7 @@ describe('submitEvaluationResult()', () => {
         id: evaluation.id
       },
       include: {
-        proposalEvaluationReviews: true
+        reviews: true
       }
     });
 
@@ -217,7 +217,7 @@ describe('submitEvaluationResult()', () => {
         proposalId
       },
       include: {
-        proposalEvaluationReviews: true
+        reviews: true
       }
     });
 
@@ -236,7 +236,7 @@ describe('submitEvaluationResult()', () => {
         id: evaluation.id
       },
       include: {
-        proposalEvaluationReviews: true
+        reviews: true
       }
     });
 
@@ -255,7 +255,7 @@ describe('submitEvaluationResult()', () => {
         id: evaluation.id
       },
       include: {
-        proposalEvaluationReviews: true
+        reviews: true
       }
     });
 

--- a/lib/proposals/getProposal.ts
+++ b/lib/proposals/getProposal.ts
@@ -99,8 +99,17 @@ export async function getProposal({
     }
   });
 
+  const proposalEvaluationAppealReviews = await prisma.proposalEvaluationAppealReview.findMany({
+    where: {
+      evaluationId: {
+        in: evaluationIds
+      }
+    }
+  });
+
   return mapDbProposalToProposal({
     proposalEvaluationReviews,
+    proposalEvaluationAppealReviews,
     workflow: workflow
       ? {
           evaluations: workflow.evaluations as WorkflowEvaluationJson[]

--- a/lib/proposals/goBackToStep.ts
+++ b/lib/proposals/goBackToStep.ts
@@ -89,6 +89,13 @@ export async function goBackToStep({
         }
       }
     }),
+    prisma.proposalEvaluationAppealReview.deleteMany({
+      where: {
+        evaluationId: {
+          in: evaluationIds
+        }
+      }
+    }),
     prisma.proposalEvaluation.updateMany({
       where: {
         id: {

--- a/lib/proposals/interfaces.ts
+++ b/lib/proposals/interfaces.ts
@@ -11,7 +11,8 @@ import type {
   ProposalEvaluationType,
   Vote,
   ProposalEvaluationReview,
-  ProposalAppealReviewer
+  ProposalAppealReviewer,
+  ProposalEvaluationAppealReview
 } from '@charmverse/core/prisma';
 import type { WorkflowEvaluationJson } from '@charmverse/core/proposals';
 
@@ -73,6 +74,7 @@ export type PopulatedEvaluation = Omit<ProposalEvaluation, 'voteSettings' | 'act
   appealRequiredReviews?: number | null;
   declineReasonOptions: string[];
   reviews?: ProposalEvaluationReview[];
+  appealReviews?: ProposalEvaluationAppealReview[];
   actionLabels?: WorkflowEvaluationJson['actionLabels'];
   type: ConcealableEvaluationType;
 };

--- a/lib/proposals/mapDbProposalToProposal.ts
+++ b/lib/proposals/mapDbProposalToProposal.ts
@@ -11,6 +11,7 @@ import type {
 import type {
   ProposalAppealReviewer,
   ProposalEvaluation,
+  ProposalEvaluationAppealReview,
   ProposalEvaluationReview
 } from '@charmverse/core/prisma-client';
 import type { WorkflowEvaluationJson } from '@charmverse/core/proposals';
@@ -37,12 +38,14 @@ export function mapDbProposalToProposal({
   permissions,
   permissionsByStep,
   proposalEvaluationReviews,
-  workflow
+  workflow,
+  proposalEvaluationAppealReviews
 }: {
   workflow: {
     evaluations: WorkflowEvaluationJson[];
   } | null;
   proposalEvaluationReviews?: ProposalEvaluationReview[];
+  proposalEvaluationAppealReviews?: ProposalEvaluationAppealReview[];
   proposal: Proposal &
     FormFieldsIncludeType & {
       authors: ProposalAuthor[];
@@ -83,6 +86,7 @@ export function mapDbProposalToProposal({
       (e) => e.title === evaluation.title && e.type === evaluation.type
     );
     const reviews = proposalEvaluationReviews?.filter((review) => review.evaluationId === evaluation.id);
+    const appealReviews = proposalEvaluationAppealReviews?.filter((review) => review.evaluationId === evaluation.id);
     const stepPermissions = permissionsByStep?.[evaluation.id];
     if (!stepPermissions?.evaluate) {
       evaluation.draftRubricAnswers = [];
@@ -92,6 +96,7 @@ export function mapDbProposalToProposal({
       ...evaluation,
       appealReviewers: evaluation.appealReviewers || [],
       reviews,
+      appealReviews,
       declineReasonOptions: workflowEvaluation?.declineReasons ?? [],
       isReviewer: !!stepPermissions?.evaluate,
       isAppealReviewer: !!stepPermissions?.evaluate_appeal

--- a/lib/proposals/submitEvaluationAppealResult.ts
+++ b/lib/proposals/submitEvaluationAppealResult.ts
@@ -78,7 +78,7 @@ export async function submitEvaluationAppealResult({
   evaluation: {
     id: string;
     appealRequiredReviews: number | null;
-    proposalEvaluationAppealReviews: {
+    appealReviews: {
       result: ProposalEvaluationResult;
     }[];
   };
@@ -95,14 +95,14 @@ export async function submitEvaluationAppealResult({
     }
   });
 
-  if (evaluation.proposalEvaluationAppealReviews.length + 1 >= requiredAppealReviews) {
+  if (evaluation.appealReviews.length + 1 >= requiredAppealReviews) {
     await updateEvaluationResult({
       decidedBy,
       proposalId,
       evaluationId,
       result,
       spaceId,
-      existingEvaluationReviews: evaluation.proposalEvaluationAppealReviews
+      existingEvaluationReviews: evaluation.appealReviews
     });
   }
 }

--- a/lib/proposals/submitEvaluationAppealResult.ts
+++ b/lib/proposals/submitEvaluationAppealResult.ts
@@ -78,7 +78,7 @@ export async function submitEvaluationAppealResult({
   evaluation: {
     id: string;
     appealRequiredReviews: number | null;
-    proposalEvaluationReviews: {
+    proposalEvaluationAppealReviews: {
       result: ProposalEvaluationResult;
     }[];
   };
@@ -86,24 +86,23 @@ export async function submitEvaluationAppealResult({
   const evaluationId = evaluation.id;
   const requiredAppealReviews = evaluation.appealRequiredReviews ?? 1;
 
-  await prisma.proposalEvaluationReview.create({
+  await prisma.proposalEvaluationAppealReview.create({
     data: {
       evaluationId,
       result,
       reviewerId: decidedBy,
-      declineReasons,
-      appeal: true
+      declineReasons
     }
   });
 
-  if (evaluation.proposalEvaluationReviews.length + 1 >= requiredAppealReviews) {
+  if (evaluation.proposalEvaluationAppealReviews.length + 1 >= requiredAppealReviews) {
     await updateEvaluationResult({
       decidedBy,
       proposalId,
       evaluationId,
       result,
       spaceId,
-      existingEvaluationReviews: evaluation.proposalEvaluationReviews
+      existingEvaluationReviews: evaluation.proposalEvaluationAppealReviews
     });
   }
 }

--- a/lib/proposals/submitEvaluationResult.ts
+++ b/lib/proposals/submitEvaluationResult.ts
@@ -82,7 +82,7 @@ export async function submitEvaluationResult({
     type: ProposalEvaluationType;
     title: string;
     requiredReviews: number;
-    proposalEvaluationReviews: {
+    reviews: {
       result: ProposalEvaluationResult;
     }[];
   };
@@ -101,14 +101,14 @@ export async function submitEvaluationResult({
     });
   }
 
-  if (evaluation.proposalEvaluationReviews.length + 1 >= requiredReviews) {
+  if (evaluation.reviews.length + 1 >= requiredReviews) {
     await updateEvaluationResult({
       decidedBy,
       proposalId,
       evaluationId,
       result,
       spaceId,
-      existingEvaluationReviews: evaluation.proposalEvaluationReviews
+      existingEvaluationReviews: evaluation.reviews
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
     "@ceramicnetwork/http-client": "^5.6.0",
-    "@charmverse/core": "^0.51.0",
+    "@charmverse/core": "^0.51.1-rc-feat-refactor-p.0",
     "@column-resizer/core": "^1.0.2",
     "@composedb/devtools": "^0.7.1",
     "@composedb/devtools-node": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@bangle.dev/utils": "^0.31.6",
     "@beam-australia/react-env": "^3.1.1",
     "@ceramicnetwork/http-client": "^5.6.0",
-    "@charmverse/core": "^0.51.1-rc-feat-refactor-p.0",
+    "@charmverse/core": "^0.51.1-rc-feat-refactor-p.1",
     "@column-resizer/core": "^1.0.2",
     "@composedb/devtools": "^0.7.1",
     "@composedb/devtools-node": "^0.7.1",

--- a/pages/api/proposals/[id]/reset-review.ts
+++ b/pages/api/proposals/[id]/reset-review.ts
@@ -57,8 +57,7 @@ async function resetReviewEndpoint(req: NextApiRequest, res: NextApiResponse) {
   await prisma.proposalEvaluationReview.deleteMany({
     where: {
       evaluationId,
-      reviewerId: userId,
-      appeal: null
+      reviewerId: userId
     }
   });
 

--- a/pages/api/proposals/[id]/submit-result.ts
+++ b/pages/api/proposals/[id]/submit-result.ts
@@ -30,7 +30,7 @@ async function updateEvaluationResultEndpoint(req: NextApiRequest, res: NextApiR
       id: evaluationId
     },
     include: {
-      proposalEvaluationReviews: {
+      reviews: {
         select: {
           result: true,
           reviewerId: true
@@ -63,7 +63,7 @@ async function updateEvaluationResultEndpoint(req: NextApiRequest, res: NextApiR
     return res.status(200).end();
   }
 
-  const hasCurrentReviewerReviewed = evaluation.proposalEvaluationReviews.some((r) => r.reviewerId === userId);
+  const hasCurrentReviewerReviewed = evaluation.reviews.some((r) => r.reviewerId === userId);
   if (hasCurrentReviewerReviewed) {
     throw new ActionNotPermittedError('You have already reviewed this evaluation');
   }

--- a/pages/api/proposals/evaluations/[id]/appeal/reset-review.ts
+++ b/pages/api/proposals/evaluations/[id]/appeal/reset-review.ts
@@ -52,11 +52,10 @@ async function resetEvaluationAppealReviewEndpoint(req: NextApiRequest, res: Nex
     throw new ActionNotPermittedError(`You cannot reset a review that has been completed.`);
   }
 
-  await prisma.proposalEvaluationReview.deleteMany({
+  await prisma.proposalEvaluationAppealReview.deleteMany({
     where: {
       evaluationId,
-      reviewerId: userId,
-      appeal: true
+      reviewerId: userId
     }
   });
 

--- a/pages/api/proposals/evaluations/[id]/appeal/submit-result.ts
+++ b/pages/api/proposals/evaluations/[id]/appeal/submit-result.ts
@@ -28,7 +28,7 @@ async function submitEvaluationAppealResultEndpoint(req: NextApiRequest, res: Ne
       appealable: true,
       appealedAt: true,
       appealRequiredReviews: true,
-      proposalEvaluationAppealReviews: true,
+      appealReviews: true,
       proposal: {
         select: {
           archived: true,
@@ -63,7 +63,7 @@ async function submitEvaluationAppealResultEndpoint(req: NextApiRequest, res: Ne
     throw new ActionNotPermittedError(`You cannot move an archived proposal to a different step.`);
   }
 
-  if ((proposalEvaluation.appealRequiredReviews ?? 1) === proposalEvaluation.proposalEvaluationAppealReviews.length) {
+  if ((proposalEvaluation.appealRequiredReviews ?? 1) === proposalEvaluation.appealReviews.length) {
     throw new ActionNotPermittedError('This evaluation appeal has already been reviewed.');
   }
 

--- a/pages/api/proposals/evaluations/[id]/appeal/submit-result.ts
+++ b/pages/api/proposals/evaluations/[id]/appeal/submit-result.ts
@@ -28,11 +28,7 @@ async function submitEvaluationAppealResultEndpoint(req: NextApiRequest, res: Ne
       appealable: true,
       appealedAt: true,
       appealRequiredReviews: true,
-      proposalEvaluationReviews: {
-        where: {
-          appeal: true
-        }
-      },
+      proposalEvaluationAppealReviews: true,
       proposal: {
         select: {
           archived: true,
@@ -43,11 +39,10 @@ async function submitEvaluationAppealResultEndpoint(req: NextApiRequest, res: Ne
     }
   });
 
-  const existingEvaluationAppealReview = await prisma.proposalEvaluationReview.findFirst({
+  const existingEvaluationAppealReview = await prisma.proposalEvaluationAppealReview.findFirst({
     where: {
       evaluationId,
-      reviewerId: userId,
-      appeal: true
+      reviewerId: userId
     },
     select: {
       result: true
@@ -68,7 +63,7 @@ async function submitEvaluationAppealResultEndpoint(req: NextApiRequest, res: Ne
     throw new ActionNotPermittedError(`You cannot move an archived proposal to a different step.`);
   }
 
-  if ((proposalEvaluation.appealRequiredReviews ?? 1) === proposalEvaluation.proposalEvaluationReviews.length) {
+  if ((proposalEvaluation.appealRequiredReviews ?? 1) === proposalEvaluation.proposalEvaluationAppealReviews.length) {
     throw new ActionNotPermittedError('This evaluation appeal has already been reviewed.');
   }
 

--- a/scripts/migrations/2024_05_21_createProposalEvaluationAppealReviews.ts
+++ b/scripts/migrations/2024_05_21_createProposalEvaluationAppealReviews.ts
@@ -1,0 +1,34 @@
+import { prisma } from '@charmverse/core/prisma-client';
+
+async function createProposalEvaluationAppealReviews() {
+  const proposalEvaluationReviews = await prisma.proposalEvaluationReview.findMany({
+    where: {
+      appeal: true
+    }
+  })
+
+  for (const proposalEvaluationReview of proposalEvaluationReviews) {
+    try {
+      await prisma.$transaction([
+        prisma.proposalEvaluationAppealReview.create({
+          data: {
+            evaluationId: proposalEvaluationReview.evaluationId,
+            reviewerId: proposalEvaluationReview.reviewerId,
+            result: proposalEvaluationReview.result,
+            completedAt: proposalEvaluationReview.completedAt,
+            declineReasons: proposalEvaluationReview.declineReasons,
+          }
+        }),
+        prisma.proposalEvaluationReview.delete({
+          where: {
+            id: proposalEvaluationReview.id
+          }
+        })
+      ]);
+    } catch (error) {
+      console.error(`Error creating proposal evaluation appeal review: ${error}`);
+    }
+  }
+}
+
+createProposalEvaluationAppealReviews().then(() => console.log('Done!'));


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

1. We were using the `ProposalEvaluationReview` model previously with appeal: true, this PR makes the necessary changes to support a different table just for appeal reviews
