### PR TITLE
Remove duplicat meta description tags

### DIFF
--- a/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
+++ b/components/[pageId]/DocumentPage/components/PageTitleInput.tsx
@@ -107,7 +107,11 @@ export function PageTitleInput({
   }, [value, updatedAtExternal, updatedAt, setTitle]);
 
   if (readOnly) {
-    return <StyledReadOnlyTitle data-test='editor-page-title'>{value || 'Untitled'}</StyledReadOnlyTitle>;
+    return (
+      <StyledReadOnlyTitle variant='h1' data-test='editor-page-title'>
+        {value || 'Untitled'}
+      </StyledReadOnlyTitle>
+    );
   }
   return (
     <StyledPageTitle

--- a/components/_app/OpenGraphData.tsx
+++ b/components/_app/OpenGraphData.tsx
@@ -17,7 +17,7 @@ export function OpenGraphData({ description, title, image }: OpenGraphProps) {
     <>
       <meta name='theme-color' content={blueColor} />
       <link rel='icon' href='/favicon.png' />
-      <meta name='description' content={displayedDescription} />
+      {displayedDescription && <meta name='description' content={displayedDescription} />}
       <meta property='og:title' content={displayedTitle} />
       <meta property='og:image' content={displayedImage} />
 

--- a/components/_app/OpenGraphData.tsx
+++ b/components/_app/OpenGraphData.tsx
@@ -7,8 +7,7 @@ export type OpenGraphProps = {
 };
 
 export function OpenGraphData({ description, title, image }: OpenGraphProps) {
-  const displayedDescription =
-    description || 'web3 operations platform handling docs, tasks, rewards, proposals, and votes.';
+  const displayedDescription = description;
 
   const displayedTitle = title || 'CharmVerse';
 

--- a/components/common/PageLayout/PageLayout.tsx
+++ b/components/common/PageLayout/PageLayout.tsx
@@ -12,7 +12,7 @@ import { useUser } from 'hooks/useUser';
 import { AnnouncementBanner } from './components/AnnouncementBanner';
 import { AppBar } from './components/AppBar';
 import { BlocksExceededBanner } from './components/BlocksExceededBanner';
-import CurrentPageFavicon from './components/CurrentPageFavicon';
+import { CurrentPageFavicon } from './components/CurrentPageFavicon';
 import { Header, HeaderSpacer } from './components/Header/Header';
 import { LayoutProviders } from './components/LayoutProviders';
 import PageContainer from './components/PageContainer';

--- a/components/common/PageLayout/SharedPageLayout.tsx
+++ b/components/common/PageLayout/SharedPageLayout.tsx
@@ -16,7 +16,7 @@ import { useSharedPage } from 'hooks/useSharedPage';
 import { useUser } from 'hooks/useUser';
 
 import { AppBar } from './components/AppBar';
-import CurrentPageFavicon from './components/CurrentPageFavicon';
+import { CurrentPageFavicon } from './components/CurrentPageFavicon';
 import { PageTitleWithBreadcrumbs } from './components/Header/components/PageTitleWithBreadcrumbs';
 import { HeaderSpacer, StyledToolbar, ToggleSidebarIcon } from './components/Header/Header';
 import { LayoutProviders } from './components/LayoutProviders';

--- a/components/common/PageLayout/components/CurrentPageFavicon.tsx
+++ b/components/common/PageLayout/components/CurrentPageFavicon.tsx
@@ -1,11 +1,23 @@
-import { usePageIdFromPath } from 'hooks/usePageFromPath';
-import { usePages } from 'hooks/usePages';
+import { useEffect, useState } from 'react';
+
+import { usePageFromPath } from 'hooks/usePageFromPath';
 
 import Favicon from './Favicon';
 
-export default function CurrentPageFavicon() {
-  const currentPageId = usePageIdFromPath();
-  const { pages } = usePages();
-  const currentPage = currentPageId ? pages[currentPageId] : undefined;
+export function CurrentPageFaviconBrowserComponent() {
+  const currentPage = usePageFromPath();
   return <Favicon pageIcon={currentPage?.icon} />;
+}
+
+// wrap the component so that it is not run until it is mounted
+export function CurrentPageFavicon() {
+  const [isComponentMounted, setIsComponentMounted] = useState(false);
+
+  useEffect(() => setIsComponentMounted(true), []);
+
+  if (!isComponentMounted) {
+    return null;
+  }
+
+  return <CurrentPageFaviconBrowserComponent />;
 }

--- a/pages/[domain]/[pageId].tsx
+++ b/pages/[domain]/[pageId].tsx
@@ -1,6 +1,5 @@
 import { prisma } from '@charmverse/core/prisma-client';
 import type { GetServerSidePropsContext } from 'next';
-import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 import { EditorPage } from 'components/[pageId]/EditorPage/EditorPage';

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -11,10 +11,6 @@ class MyDocument extends Document {
         <Head>
           <meta name='theme-color' content={blueColor} />
           <link rel='icon' href='/favicon.png' />
-          <meta
-            name='description'
-            content='web3 operations platform handling docs, tasks, rewards, proposals, and votes.'
-          />
           <script src='/__ENV.js' />
         </Head>
         <body>


### PR DESCRIPTION
This removes a redundant meta description tag, and also the default description in case that may be confusign Google crawler, making it think our pages are duplicate