### PR TITLE
Fix: Database filters are not responsive on mobile

### DIFF
--- a/components/common/DatabaseEditor/components/ViewFilterControl.tsx
+++ b/components/common/DatabaseEditor/components/ViewFilterControl.tsx
@@ -39,6 +39,16 @@ export function ViewFilterControl({ activeBoard, activeView }: Props) {
         sx={{
           overflow: 'auto'
         }}
+        slotProps={{
+          paper: {
+            sx: {
+              overflowX: {
+                xs: 'auto',
+                sm: 'hidden'
+              }
+            }
+          }
+        }}
       >
         <FilterComponent properties={activeBoard?.fields.cardProperties ?? []} activeView={activeView} />
       </Popover>


### PR DESCRIPTION
Task:
https://app.charmverse.io/charmverse/database-filters-are-not-responsive-on-mobile-48855657842594336

Fix:
Let the user scroll left-right in the popover so he can access all the filters.
