### PR TITLE
reset view description whenever board changes

### DIFF
--- a/components/common/DatabaseEditor/components/viewTitle.tsx
+++ b/components/common/DatabaseEditor/components/viewTitle.tsx
@@ -138,6 +138,7 @@ function ViewTitle(props: ViewTitleProps) {
       {board.fields.showDescription && (
         <div className='description'>
           <CharmEditor
+            key={board.id}
             disablePageSpecificFeatures
             isContentControlled
             disableRowHandles


### PR DESCRIPTION
### WHAT

when navigating between databases, the description does not update immediately. You will see teh description of the previous page sometimes.

### WHY

Bug on Discord: https://discord.com/channels/894960387743698944/1249742974196121610/1249742974196121610
