### PR TITLE
limit the number of domains sent to Mux

### DIFF
--- a/lib/mux/updateAllowedPlaybackDomains.ts
+++ b/lib/mux/updateAllowedPlaybackDomains.ts
@@ -8,10 +8,8 @@ import { mux } from './muxClient';
 
 const charmVerseDomains = ['*.charmverse.io', '*.charmverse.co'];
 
-const domainLimit = 100; // 100 is the maximum number of allowed domains from Mux
-
 // update referrers to include all custom subdomains
-export async function updateAllowedPlaybackDomains() {
+export async function updateAllowedPlaybackDomains({ limit }: { limit?: number }) {
   if (mux && playbackRestrictionId) {
     const spaces = await prisma.space.findMany({
       where: {
@@ -21,8 +19,9 @@ export async function updateAllowedPlaybackDomains() {
       }
     });
     const customDomains = spaces.map((space) => space.customDomain).filter(isTruthy);
+    const allDomains = charmVerseDomains.concat(customDomains);
     mux.video.playbackRestrictions.updateReferrer(playbackRestrictionId, {
-      allowed_domains: charmVerseDomains.concat(customDomains).slice(0, domainLimit)
+      allowed_domains: limit ? allDomains.slice(0, limit) : allDomains
     });
     log.info('Updated referrers for mux playback restriction', { customDomains });
   }

--- a/lib/mux/updateAllowedPlaybackDomains.ts
+++ b/lib/mux/updateAllowedPlaybackDomains.ts
@@ -8,6 +8,8 @@ import { mux } from './muxClient';
 
 const charmVerseDomains = ['*.charmverse.io', '*.charmverse.co'];
 
+const domainLimit = 100; // 100 is the maximum number of allowed domains from Mux
+
 // update referrers to include all custom subdomains
 export async function updateAllowedPlaybackDomains() {
   if (mux && playbackRestrictionId) {
@@ -20,7 +22,7 @@ export async function updateAllowedPlaybackDomains() {
     });
     const customDomains = spaces.map((space) => space.customDomain).filter(isTruthy);
     mux.video.playbackRestrictions.updateReferrer(playbackRestrictionId, {
-      allowed_domains: charmVerseDomains.concat(customDomains)
+      allowed_domains: charmVerseDomains.concat(customDomains).slice(0, domainLimit)
     });
     log.info('Updated referrers for mux playback restriction', { customDomains });
   }

--- a/lib/mux/updateAllowedPlaybackDomains.ts
+++ b/lib/mux/updateAllowedPlaybackDomains.ts
@@ -9,7 +9,7 @@ import { mux } from './muxClient';
 const charmVerseDomains = ['*.charmverse.io', '*.charmverse.co'];
 
 // update referrers to include all custom subdomains
-export async function updateAllowedPlaybackDomains({ limit }: { limit?: number }) {
+export async function updateAllowedPlaybackDomains({ limit }: { limit?: number } = {}) {
   if (mux && playbackRestrictionId) {
     const spaces = await prisma.space.findMany({
       where: {

--- a/lib/spaces/updateSpaceCustomDomain.ts
+++ b/lib/spaces/updateSpaceCustomDomain.ts
@@ -1,3 +1,4 @@
+import { log } from '@charmverse/core/log';
 import { prisma } from '@charmverse/core/prisma-client';
 
 import { updateAllowedPlaybackDomains } from 'lib/mux/updateAllowedPlaybackDomains';
@@ -34,11 +35,16 @@ export async function updateSpaceCustomDomain(
     });
 
     // update referrers to include all custom subdomains
-    await updateAllowedPlaybackDomains();
+    try {
+      await updateAllowedPlaybackDomains();
+    } catch (error) {
+      log.error('Failed to update video playback referrers on Mux', { spaceId, error });
+    }
   } catch (error) {
     if (isUniqueConstraintError(error)) {
       throw new InvalidInputError(`Custom domain ${data.customDomain} is already in use`);
     }
+    log.warn('Error updating custom domain for space', { spaceId, error });
   }
   return data;
 }

--- a/scripts/mux.ts
+++ b/scripts/mux.ts
@@ -2,5 +2,6 @@ import { updateAllowedPlaybackDomains } from 'lib/mux/updateAllowedPlaybackDomai
 
 // run this to manually refresh the allowed domains for video playback via mux
 (async () => {
-  await updateAllowedPlaybackDomains();
+  // Mux limits us to 100 domains
+  await updateAllowedPlaybackDomains({ limit: 100 });
 })();


### PR DESCRIPTION
i needed a way to update the list of referrers that did not throw an error. but i do want it to throw an error in Prod if we can't actually update the list for all domains

we were also not logging the error in prod