### PR TITLE
remove translucent effect on disabled text

### DIFF
--- a/theme/index.ts
+++ b/theme/index.ts
@@ -153,6 +153,7 @@ export const createThemeLightSensitive = (mode: PaletteMode) => {
         dark: mode === 'dark' ? backgroundDarkColorDarkMode : backgroundDarkColor
       },
       text: {
+        disabled: 'var(--primary-text)',
         primary: mode === 'dark' ? primaryTextColorDarkMode : primaryTextColor
       },
       textPrimary: {


### PR DESCRIPTION
The grey text is hard to read. This chang erequested by Chris. This little setting took me a while to find!