### PR TITLE
Show and filter custom properties in reward applicants board view

### DIFF
--- a/components/common/DatabaseEditor/components/kanban/KanbanGroupColumn.tsx
+++ b/components/common/DatabaseEditor/components/kanban/KanbanGroupColumn.tsx
@@ -25,6 +25,7 @@ type Props = {
   showCard: (cardId: string | null) => void;
   disableAddingCards?: boolean;
   hideLinkedBounty?: boolean;
+  isApplication?: boolean;
 };
 
 export function KanbanGroupColumn({
@@ -39,7 +40,8 @@ export function KanbanGroupColumn({
   onDropToCard,
   showCard,
   disableAddingCards,
-  hideLinkedBounty
+  hideLinkedBounty,
+  isApplication
 }: Props) {
   const { data: cards, pageSize, setPageSize, hasNextPage, showNextPage } = usePaginatedData(group.cards);
   return (
@@ -58,6 +60,7 @@ export function KanbanGroupColumn({
           onDrop={onDropToCard}
           showCard={showCard}
           hideLinkedBounty={hideLinkedBounty}
+          isApplication={isApplication}
         />
       ))}
       {hasNextPage && (

--- a/components/common/DatabaseEditor/components/kanban/kanban.tsx
+++ b/components/common/DatabaseEditor/components/kanban/kanban.tsx
@@ -75,6 +75,7 @@ type Props = {
   readOnlyTitle?: boolean;
   disableDnd?: boolean;
   hideLinkedBounty?: boolean;
+  isApplication?: boolean;
 };
 
 function Kanban(props: Props) {
@@ -386,6 +387,7 @@ function Kanban(props: Props) {
             <KanbanGroupColumn
               group={group}
               board={board}
+              isApplication={props.isApplication}
               visiblePropertyTemplates={visiblePropertyTemplates}
               key={group.id || 'empty'}
               readOnly={props.readOnly}

--- a/components/common/DatabaseEditor/components/kanban/kanbanCard.tsx
+++ b/components/common/DatabaseEditor/components/kanban/kanbanCard.tsx
@@ -31,6 +31,7 @@ type Props = {
   // eslint-disable-next-line
   showCard: (cardId: string | null) => void;
   hideLinkedBounty?: boolean;
+  isApplication?: boolean;
 };
 
 const BountyFooter = styled.div`
@@ -132,7 +133,9 @@ const KanbanCard = React.memo((props: Props) => {
           }}
           data-test={`kanban-card-${card.id}`}
         >
-          {!props.readOnly && <KanbanPageActionsMenuButton page={card} onClickDelete={deleteCard} />}
+          {!props.readOnly && (
+            <KanbanPageActionsMenuButton isApplication={props.isApplication} page={card} onClickDelete={deleteCard} />
+          )}
 
           <div className='octo-icontitle'>
             <div>

--- a/components/common/PageActions/KanbanPageActionButton.tsx
+++ b/components/common/PageActions/KanbanPageActionButton.tsx
@@ -11,9 +11,10 @@ type Props = {
   readOnly?: boolean;
   onClickDelete?: VoidFunction;
   onClickEdit?: VoidFunction;
+  isApplication?: boolean;
 };
 
-export function KanbanPageActionsMenuButton({ page, onClickDelete, onClickEdit, readOnly }: Props) {
+export function KanbanPageActionsMenuButton({ isApplication, page, onClickDelete, onClickEdit, readOnly }: Props) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -31,6 +32,7 @@ export function KanbanPageActionsMenuButton({ page, onClickDelete, onClickEdit, 
           anchorEl={anchorEl}
           setAnchorEl={setAnchorEl}
           page={page}
+          isApplication={isApplication}
           onClickDelete={onClickDelete}
           onClickEdit={onClickEdit}
           readOnly={readOnly}

--- a/components/common/PageActions/components/CopyPageLinkAction.tsx
+++ b/components/common/PageActions/components/CopyPageLinkAction.tsx
@@ -10,8 +10,10 @@ export function CopyPageLinkAction({
   path,
   onComplete,
   message,
-  typographyProps
+  typographyProps,
+  isApplication
 }: {
+  isApplication?: boolean;
   path: string;
   onComplete?: VoidFunction;
   message?: string;
@@ -26,7 +28,13 @@ export function CopyPageLinkAction({
   }
 
   return (
-    <CopyToClipboard text={getAbsolutePath(path, router.query.domain as string | undefined)} onCopy={onClick}>
+    <CopyToClipboard
+      text={getAbsolutePath(
+        isApplication ? `/rewards/applications${path}` : path,
+        router.query.domain as string | undefined
+      )}
+      onCopy={onClick}
+    >
       <MenuItem data-testid='copy-link-page-action' dense>
         <ListItemIcon>
           <LinkIcon fontSize='small' />

--- a/components/common/PageActions/components/DatabaseRowActionsMenu.tsx
+++ b/components/common/PageActions/components/DatabaseRowActionsMenu.tsx
@@ -36,8 +36,10 @@ export function DatabaseRowActionsMenu({
   anchorEl,
   page,
   setAnchorEl,
-  readOnly
+  readOnly,
+  isApplication
 }: {
+  isApplication?: boolean;
   onClickDelete?: VoidFunction;
   onClickEdit?: VoidFunction;
   children?: ReactNode;
@@ -61,7 +63,10 @@ export function DatabaseRowActionsMenu({
   const updatedAt = typeof page.updatedAt === 'number' ? new Date(page.updatedAt) : page.updatedAt;
 
   function getPageLink() {
-    return getAbsolutePath(pagePath, router.query.domain as string | undefined);
+    return getAbsolutePath(
+      isApplication ? `/rewards/applications/${page.id}` : pagePath,
+      router.query.domain as string | undefined
+    );
   }
 
   function onClickOpenInNewTab() {
@@ -115,7 +120,7 @@ export function DatabaseRowActionsMenu({
           pagePermissions={pagePermissions}
         />
       )}
-      <CopyPageLinkAction path={pagePath} />
+      <CopyPageLinkAction isApplication={isApplication} path={pagePath} />
       <MenuItem dense onClick={onClickOpenInNewTab}>
         <ListItemIcon>
           <LaunchIcon fontSize='small' />

--- a/components/rewards/RewardsPage.tsx
+++ b/components/rewards/RewardsPage.tsx
@@ -414,7 +414,7 @@ export function RewardsPage({ title }: { title: string }) {
                     selectedCardIds={[]}
                     readOnly={!isAdmin}
                     addCard={async () => {}}
-                    isApplication
+                    isApplication={activeView.fields.sourceType === 'reward_applications'}
                     onCardClicked={(_e, card) => showRewardOrApplication(card.id, card?.parentId)}
                     showCard={showRewardOrApplication}
                     disableAddingCards

--- a/components/rewards/RewardsPage.tsx
+++ b/components/rewards/RewardsPage.tsx
@@ -414,6 +414,7 @@ export function RewardsPage({ title }: { title: string }) {
                     selectedCardIds={[]}
                     readOnly={!isAdmin}
                     addCard={async () => {}}
+                    isApplication
                     onCardClicked={(_e, card) => showRewardOrApplication(card.id, card?.parentId)}
                     showCard={showRewardOrApplication}
                     disableAddingCards

--- a/components/rewards/hooks/useRewardsBoardAdapter.ts
+++ b/components/rewards/hooks/useRewardsBoardAdapter.ts
@@ -38,6 +38,7 @@ import { getDefaultView } from 'lib/rewards/blocks/views';
 import { countRemainingSubmissionSlots } from 'lib/rewards/countRemainingSubmissionSlots';
 import type { ApplicationMeta, RewardWithUsers } from 'lib/rewards/interfaces';
 import { getAbsolutePath } from 'lib/utils/browser';
+import { isUUID } from 'lib/utils/strings';
 import { isTruthy } from 'lib/utils/types';
 
 export type BoardReward = { id?: string; fields: RewardFields };
@@ -303,6 +304,15 @@ function mapApplicationToCard({
     ? [getAbsolutePath(`/${sourceProposalPage.id}`, spaceDomain), sourceProposalPage.title]
     : '';
 
+  const rewardCustomProperties: Record<string, any> = {};
+  const rewardProperties = (reward.fields as RewardFields)?.properties;
+
+  Object.keys(rewardProperties).forEach((rewardPropertyKey) => {
+    if (isUUID(rewardPropertyKey)) {
+      rewardCustomProperties[rewardPropertyKey] = rewardProperties[rewardPropertyKey];
+    }
+  });
+
   applicationFields.properties = {
     ...applicationFields.properties,
     // add default field values on the fly
@@ -329,7 +339,8 @@ function mapApplicationToCard({
     [REWARD_CHAIN]: (reward && 'chainId' in reward && reward.chainId?.toString()) || '',
     [REWARD_CUSTOM_VALUE]: (reward && 'customReward' in reward && reward.customReward) || '',
     [REWARD_TOKEN]: (reward && 'rewardToken' in reward && reward.rewardToken) || '',
-    [REWARD_PROPOSAL_LINK]: proposalLinkValue
+    [REWARD_PROPOSAL_LINK]: proposalLinkValue,
+    ...rewardCustomProperties
   };
 
   const isApplication =


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

[Card](https://app.charmverse.io/charmverse/reward-applicants-board-view-user-should-be-able-to-filter-by-custom-properties-9543093759683579)
