### PR TITLE
Send notification to authors for proposal passed/failed and rewards passed events in private evaluations

### DIFF
--- a/lib/notifications/proposals/createProposalNotifications.ts
+++ b/lib/notifications/proposals/createProposalNotifications.ts
@@ -105,15 +105,6 @@ export async function createProposalNotifications(webhookData: {
         const isAuthor = proposalAuthorIds.includes(spaceRole.userId);
         const isReviewer = proposalPermissions.evaluate;
 
-        // Only notify reviewers for hidden evaluations
-        if (
-          proposal.workflow?.privateEvaluations &&
-          !isReviewer &&
-          privateEvaluationSteps.includes(currentEvaluation.type)
-        ) {
-          continue;
-        }
-
         // New proposal permissions .vote is invalid
         const isVoter = proposalPermissions.evaluate;
         const canComment = proposalPermissions.comment && proposalPermissions.view;
@@ -127,6 +118,19 @@ export async function createProposalNotifications(webhookData: {
         });
 
         if (!action) {
+          continue;
+        }
+
+        // Only notify reviewers for hidden evaluations
+        if (
+          proposal.workflow?.privateEvaluations &&
+          !isReviewer &&
+          // Allow these following notifications for proposal authors
+          action !== 'proposal_passed' &&
+          action !== 'proposal_failed' &&
+          action !== 'reward_published' &&
+          privateEvaluationSteps.includes(currentEvaluation.type)
+        ) {
           continue;
         }
 


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

[Card](https://app.charmverse.io/charmverse/verify-notifications-are-still-being-sent-when-a-proposal-has-hidden-steps-6495614505402232)
