### PR TITLE
Add proposal link as rewards table custom property

### DIFF
--- a/components/rewards/components/RewardProperties/CustomPropertiesAdapter.tsx
+++ b/components/rewards/components/RewardProperties/CustomPropertiesAdapter.tsx
@@ -7,6 +7,8 @@ import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useMembers } from 'hooks/useMembers';
 import { useUser } from 'hooks/useUser';
+import type { PropertyType } from 'lib/databases/board';
+import { REWARD_PROPOSAL_LINK } from 'lib/rewards/blocks/constants';
 import type { RewardPropertiesField } from 'lib/rewards/blocks/interfaces';
 
 import { mapRewardToCard } from '../../hooks/useRewardsBoardAdapter';
@@ -48,7 +50,17 @@ export function CustomPropertiesAdapter({ reward, onChange, readOnly }: Props) {
         fields: {
           ...board.fields,
           // extract non-custom properties
-          cardProperties: board.fields.cardProperties.filter((p) => !p.id.startsWith('__'))
+          cardProperties: [
+            ...board.fields.cardProperties.filter((p) => !p.id.startsWith('__')),
+            // Add proposal link as a custom property
+            {
+              readOnly: true,
+              options: [],
+              id: REWARD_PROPOSAL_LINK,
+              name: 'Proposal',
+              type: 'proposalUrl' as PropertyType
+            }
+          ]
         }
       };
     }

--- a/components/rewards/components/RewardProperties/CustomPropertiesAdapter.tsx
+++ b/components/rewards/components/RewardProperties/CustomPropertiesAdapter.tsx
@@ -6,6 +6,7 @@ import { useRewardsBoardAndBlocks } from 'components/rewards/hooks/useRewardsBoa
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useMembers } from 'hooks/useMembers';
+import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
 import { useUser } from 'hooks/useUser';
 import type { PropertyType } from 'lib/databases/board';
 import { REWARD_PROPOSAL_LINK } from 'lib/rewards/blocks/constants';
@@ -28,6 +29,7 @@ export function CustomPropertiesAdapter({ reward, onChange, readOnly }: Props) {
   const { getRewardPage } = useRewardPage();
   const { membersRecord } = useMembers();
   const { board, cards, activeView, views } = useRewardsBoardAndBlocks();
+  const { getFeatureTitle } = useSpaceFeatures();
 
   const mutator = usePropertiesMutator({ onChange });
 
@@ -57,7 +59,7 @@ export function CustomPropertiesAdapter({ reward, onChange, readOnly }: Props) {
               readOnly: true,
               options: [],
               id: REWARD_PROPOSAL_LINK,
-              name: 'Proposal',
+              name: getFeatureTitle('Proposal'),
               type: 'proposalUrl' as PropertyType
             }
           ]

--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -62,6 +62,7 @@ export function RewardPropertiesForm({
   const proposalLinkValue = sourceProposalPage
     ? [getAbsolutePath(`/${sourceProposalPage.id}`, space?.domain), sourceProposalPage.title]
     : '';
+  const rewards = values as unknown as BoardReward;
   return (
     <Box
       className='CardDetail content'
@@ -106,10 +107,19 @@ export function RewardPropertiesForm({
         <Collapse in={isExpanded} timeout='auto' unmountOnExit>
           <CustomPropertiesAdapter
             readOnly={readOnly}
-            reward={values as unknown as BoardReward}
+            reward={{
+              ...rewards,
+              fields: {
+                ...rewards.fields,
+                properties: {
+                  ...rewards.fields.properties,
+                  [REWARD_PROPOSAL_LINK]: proposalLinkValue
+                }
+              }
+            }}
             onChange={(properties: RewardPropertiesField) => {
               applyUpdates({
-                fields: { properties: { ...properties, [REWARD_PROPOSAL_LINK]: proposalLinkValue } } as Prisma.JsonValue
+                fields: { properties: { ...properties } } as Prisma.JsonValue
               });
             }}
           />

--- a/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
+++ b/components/rewards/components/RewardProperties/RewardPropertiesForm.tsx
@@ -3,9 +3,13 @@ import { KeyboardArrowDown } from '@mui/icons-material';
 import { Box, Collapse, Divider, IconButton, Stack, Typography } from '@mui/material';
 import { useState } from 'react';
 
+import { useCurrentSpace } from 'hooks/useCurrentSpace';
+import { REWARD_PROPOSAL_LINK } from 'lib/rewards/blocks/constants';
 import type { RewardPropertiesField } from 'lib/rewards/blocks/interfaces';
 import type { RewardTemplate } from 'lib/rewards/getRewardTemplate';
+import type { RewardWithUsers } from 'lib/rewards/interfaces';
 import type { UpdateableRewardFields } from 'lib/rewards/updateRewardSettings';
+import { getAbsolutePath } from 'lib/utils/browser';
 import { isTruthy } from 'lib/utils/types';
 
 import type { UpdateableRewardFieldsWithType } from '../../hooks/useNewReward';
@@ -40,6 +44,7 @@ export function RewardPropertiesForm({
   readOnlyTemplate,
   rewardStatus
 }: Props) {
+  const { space } = useCurrentSpace();
   const [isExpanded, setIsExpanded] = useState(!!expandedByDefault);
   async function applyUpdates(updates: Partial<UpdateableRewardFields>) {
     if ('customReward' in updates) {
@@ -53,7 +58,10 @@ export function RewardPropertiesForm({
 
     onChange(updates);
   }
-
+  const sourceProposalPage = (values as RewardWithUsers).sourceProposalPage;
+  const proposalLinkValue = sourceProposalPage
+    ? [getAbsolutePath(`/${sourceProposalPage.id}`, space?.domain), sourceProposalPage.title]
+    : '';
   return (
     <Box
       className='CardDetail content'
@@ -101,7 +109,7 @@ export function RewardPropertiesForm({
             reward={values as unknown as BoardReward}
             onChange={(properties: RewardPropertiesField) => {
               applyUpdates({
-                fields: { properties: properties ? { ...properties } : {} } as Prisma.JsonValue
+                fields: { properties: { ...properties, [REWARD_PROPOSAL_LINK]: proposalLinkValue } } as Prisma.JsonValue
               });
             }}
           />


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

[Card](https://app.charmverse.io/charmverse/if-a-milestone-is-created-via-proposal-put-the-proposal-title-as-a-custom-property-5483940115308825)
