### PR TITLE
sync reviews for optimism evaluations

### DIFF
--- a/background/cron.ts
+++ b/background/cron.ts
@@ -16,6 +16,7 @@ import { task as processMailgunWebhookMessages } from './tasks/processMailgunWeb
 import { task as processSynapsWebhookMessages } from './tasks/processSynapsWebhookMessages';
 import { refreshBountyApplications } from './tasks/refreshBountyApplications/task';
 import { sendDraftProposalNotificationTask } from './tasks/sendDraftProposalNotificationTask';
+import { syncOptimismReviewsTask } from './tasks/syncOptimismReviews';
 import { syncSummonSpacesRoles } from './tasks/syncSummonSpaceRoles/task';
 import { task as proposalTask } from './tasks/updateProposalStatus';
 import { task as voteTask } from './tasks/updateVotesStatus';
@@ -70,6 +71,9 @@ cron.schedule('0 0 * * *', syncSummonSpacesRoles);
 
 // Create external eas credentials for Gitcoin and Questbook every day at midnight
 cron.schedule('0 0 * * *', createOffchainCredentialsForExternalProjects);
+
+// Sync op reviews once an hour - remove by July 2024
+cron.schedule('0 * * * *', syncOptimismReviewsTask);
 
 const port = process.env.PORT || 4000;
 

--- a/background/cron.ts
+++ b/background/cron.ts
@@ -72,8 +72,8 @@ cron.schedule('0 0 * * *', syncSummonSpacesRoles);
 // Create external eas credentials for Gitcoin and Questbook every day at midnight
 cron.schedule('0 0 * * *', createOffchainCredentialsForExternalProjects);
 
-// Sync op reviews once an hour - remove by July 2024
-cron.schedule('0 * * * *', syncOptimismReviewsTask);
+// Sync op reviews every 15 minutes - remove by July 2024
+cron.schedule('*/15 * * * *', syncOptimismReviewsTask);
 
 const port = process.env.PORT || 4000;
 

--- a/background/tasks/syncOptimismReviews.ts
+++ b/background/tasks/syncOptimismReviews.ts
@@ -1,0 +1,51 @@
+import { log } from '@charmverse/core/log';
+import { prisma } from '@charmverse/core/prisma-client';
+
+export const spaceId = 'f3ddde2e-17e9-42b1-803d-0c72880e4669';
+export const templateId = 'a8ac2799-5c79-45f7-9527-a1d52d717625';
+
+// a custom script for grants round. copy reviews from one step to the next
+export async function syncOptimismReviewsTask() {
+  const proposals = await prisma.proposal.findMany({
+    where: {
+      spaceId,
+      status: 'published',
+      page: {
+        sourceTemplateId: templateId,
+        deletedAt: null
+      }
+    },
+    include: {
+      evaluations: {
+        include: {
+          reviews: true
+        }
+      }
+    }
+  });
+
+  let added = 0;
+
+  for (const proposal of proposals) {
+    const firstEvaluation = proposal.evaluations.find((evaluation) => evaluation.title === 'Rule Violation Check');
+    const secondEvaluation = proposal.evaluations.find((evaluation) => evaluation.title === 'Full Review');
+    if (!firstEvaluation || !secondEvaluation) {
+      throw new Error(`Could not find evaluations to update: ${proposal.id}`);
+    }
+    const reviewsToAdd = firstEvaluation.reviews.filter(
+      (review) => !secondEvaluation.reviews.some((r) => r.reviewerId === review.reviewerId)
+    );
+
+    for (const { id, declineMessage, declineReasons, ...review } of reviewsToAdd) {
+      await prisma.proposalEvaluationReview.create({
+        data: {
+          ...review,
+          evaluationId: secondEvaluation.id
+        }
+      });
+      log.info('Synced review:', { proposalId: proposal.id, result: review.result, userId: review.reviewerId });
+      added += 1;
+    }
+  }
+  log.info('Synced reviews in Optimism space:', { added });
+}


### PR DESCRIPTION
This is a special request from OP, that the votes from one step should transfer to the next step. I am hoping that, by running every 15 minutes and since there r 5 reviewers in Full Review, we dont need to worry about marking the whole step completed