### PR TITLE
collapse navigation bar if workflow sidebar is open

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPageProviders.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPageProviders.tsx
@@ -1,7 +1,5 @@
 import type { ReactNode } from 'react';
-import { memo } from 'react';
 
-import { PageSidebarProvider } from 'components/[pageId]/DocumentPage/hooks/usePageSidebar';
 import { ProposalsProvider } from 'components/proposals/hooks/useProposals';
 import { CharmEditorProvider } from 'hooks/useCharmEditor';
 import { CharmEditorViewProvider } from 'hooks/useCharmEditorView';
@@ -17,9 +15,7 @@ export function DocumentPageProviders({ children }: { children: React.ReactNode 
         <CharmEditorProvider>
           <ThreadsProvider>
             <VotesProvider>
-              <ProposalsProvider>
-                <PageSidebarProvider>{children}</PageSidebarProvider>
-              </ProposalsProvider>
+              <ProposalsProvider>{children}</ProposalsProvider>
             </VotesProvider>
           </ThreadsProvider>
         </CharmEditorProvider>

--- a/components/[pageId]/DocumentPage/DocumentPageWithSidebars.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPageWithSidebars.tsx
@@ -104,6 +104,10 @@ function DocumentPageWithSidebarsComponent(props: DocumentPageWithSidebarsProps)
   useEffect(() => {
     setActiveView(defaultSidebarView);
     setDefaultView(null);
+    return () => {
+      // clear sidebar so we can show left sidebar
+      setActiveView(null);
+    };
   }, []);
 
   return (

--- a/components/[pageId]/DocumentPage/hooks/usePageSidebar.tsx
+++ b/components/[pageId]/DocumentPage/hooks/usePageSidebar.tsx
@@ -1,8 +1,6 @@
 import type { ReactNode } from 'react';
 import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 
-import { useCurrentPage } from 'hooks/useCurrentPage';
-
 export type PageSidebarView = 'comments' | 'suggestions' | 'proposal_evaluation' | 'reward_evaluation';
 
 export type IPageSidebarContext = {

--- a/components/rewards/NewRewardPage.tsx
+++ b/components/rewards/NewRewardPage.tsx
@@ -195,6 +195,10 @@ export function NewRewardPage({
     setPageTitle('');
     setActiveView('reward_evaluation');
     setDefaultView(null);
+    return () => {
+      // clear sidebar so we
+      setActiveView(null);
+    };
   }, []);
 
   useEffect(() => {

--- a/components/rewards/components/RewardApplicationPage/RewardApplicationPage.tsx
+++ b/components/rewards/components/RewardApplicationPage/RewardApplicationPage.tsx
@@ -73,6 +73,10 @@ export function RewardApplicationPage({ applicationId: _applicationId, rewardId 
   useEffect(() => {
     setActiveView(defaultSidebarView);
     setDefaultView(null);
+    return () => {
+      // clear sidebar so we
+      setActiveView(null);
+    };
   }, []);
 
   async function updateReward(updateContent: UpdateableRewardFields) {


### PR DESCRIPTION
The new logic does two basic things:

1) if workflow sidebar is open, don't show navigation sidebar
2) manually toggling navigation sidebar will close the workflow sidebar so that navigation can be seen

The goal is to show the user only one sidebar a time when looking at a proposal or reward. The left nav sidebar adds a lot of noise that takes away from the main content and the workflow sidebar. We wanted to emulate UX from Notion desktop screens where opening one sidebar collapses the other side (for example when opening pages on a database).

This was tricky to implement. At first I thought I'd use a useEffect inside PageLayout and add some dependency between the two sidebar states. But we don't know if a sidebar was toggled due to user action or just some logic. 