### PR TITLE
increase root volume size for deploys

### DIFF
--- a/.cdk/ProductionStack.ts
+++ b/.cdk/ProductionStack.ts
@@ -53,7 +53,7 @@ export class ProductionStack extends Stack {
       {
         namespace: 'aws:autoscaling:launchconfiguration',
         optionName: 'RootVolumeSize',
-        value: '12' // example size in GB
+        value: '24' // example size in GB
       },
       {
         namespace: 'aws:elasticbeanstalk:environment',

--- a/.cdk/StagingStack.ts
+++ b/.cdk/StagingStack.ts
@@ -60,7 +60,7 @@ export class StagingStack extends Stack {
       {
         namespace: 'aws:autoscaling:launchconfiguration',
         optionName: 'RootVolumeSize',
-        value: '12' // example size in GB
+        value: '24' // example size in GB
       },
       {
         namespace: 'aws:elasticbeanstalk:environment',


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY
apps are running out of space when installing inside Docker.

eb-engine.log:
```
Pulling stg-sockets     ... extracting (42.7%)
Pulling stg-webapp      ... extracting (43.0%)
Pulling stg-sockets     ... extracting (43.0%)
Pulling stg-webapp      ... extracting (43.3%)
Pulling stg-sockets     ... extracting (43.3%)
Pulling stg-webapp      ... extracting (43.5%)
Pulling stg-sockets     ... extracting (43.5%)
Pulling stg-webapp      ... extracting (100.0%)
Pulling stg-sockets     ... extracting (100.0%)

ERROR: for stg-sockets  failed to register layer: Error processing tar file(exit status 1): mkdir /app/node_modules/@multiformats/multiaddr-to-uri/node_modules: no space left on device

ERROR: for stg-webapp  failed to register layer: Error processing tar file(exit status 1): mkdir /app/node_modules/@multiformats/multiaddr-to-uri/node_modules: no space left on device
failed to register layer: Error processing tar file(exit status 1): mkdir /app/node_modules/@multiformats/multiaddr-to-uri/node_modules: no space left on device
```