### PR TITLE
set cross-subdomain cookies in production

### DIFF
--- a/apps/connect-api/src/server.ts
+++ b/apps/connect-api/src/server.ts
@@ -4,6 +4,7 @@ import cors from '@koa/cors';
 import { getIronSession } from 'iron-session';
 import Koa from 'koa';
 
+import { isProdEnv } from 'config/constants';
 import type { SessionData } from 'lib/session/config';
 import { getIronOptions } from 'lib/session/getIronOptions';
 

--- a/apps/connect-api/src/server.ts
+++ b/apps/connect-api/src/server.ts
@@ -4,7 +4,6 @@ import cors from '@koa/cors';
 import { getIronSession } from 'iron-session';
 import Koa from 'koa';
 
-import { isProdEnv } from 'config/constants';
 import type { SessionData } from 'lib/session/config';
 import { getIronOptions } from 'lib/session/getIronOptions';
 

--- a/lib/session/getIronOptions.ts
+++ b/lib/session/getIronOptions.ts
@@ -1,17 +1,19 @@
 import type { SessionOptions } from 'iron-session';
 
 // import the "optional" auth secret here so it doesnt throw an error at build time
-import { authSecret, baseUrl, cookieName } from 'config/constants';
+import { authSecret, baseUrl, cookieName, isProdEnv } from 'config/constants';
 
 export function getIronOptions(): SessionOptions {
   if (!authSecret) {
     throw new Error('AUTH_SECRET is not defined');
   }
+  const domain = isProdEnv ? 'charmverse.io' : undefined;
   const ironOptions: SessionOptions = {
     cookieName,
     password: authSecret,
     cookieOptions: {
       sameSite: 'strict' as const,
+      domain,
       // secure: true should be used in production (HTTPS) but can't be used in development (HTTP)
       secure: typeof baseUrl === 'string' && baseUrl.includes('https')
     }


### PR DESCRIPTION
we used to do this, until Wix would clear all cookies. but now we don't use Wix and we need cross-subdomain cookies

People might get logged out of CharmVerse, i'm not really sure.. hopefully this new cookie just overrides the subdomain one. but shouldn't be a big deal TBH and now's a good time to try it instead of during the day in western hemisphere