### PR TITLE
Session domain setting

### DIFF
--- a/apps/connect-api/src/server.ts
+++ b/apps/connect-api/src/server.ts
@@ -4,6 +4,7 @@ import cors from '@koa/cors';
 import { getIronSession } from 'iron-session';
 import Koa from 'koa';
 
+import { authSecret, baseUrl, cookieName, isProdEnv } from 'config/constants';
 import type { SessionData } from 'lib/session/config';
 import { getIronOptions } from 'lib/session/getIronOptions';
 
@@ -39,9 +40,12 @@ app.use(
   })
 );
 
+// for now, make sure we set cross-subdomain cookies
+const domain = isProdEnv ? 'charmverse.io' : undefined;
+
 // Session middleware
 app.use(async (ctx, next) => {
-  ctx.request.session = await getIronSession<SessionData>(ctx.req, ctx.res, getIronOptions());
+  ctx.request.session = await getIronSession<SessionData>(ctx.req, ctx.res, getIronOptions({ domain }));
   await next();
 });
 

--- a/apps/connect-api/src/server.ts
+++ b/apps/connect-api/src/server.ts
@@ -41,6 +41,7 @@ app.use(
 );
 
 // for now, make sure we set cross-subdomain cookies
+// be careful not to use this when the app serves multiple domains
 const domain = isProdEnv ? 'charmverse.io' : undefined;
 
 // Session middleware

--- a/lib/session/getIronOptions.ts
+++ b/lib/session/getIronOptions.ts
@@ -1,13 +1,12 @@
 import type { SessionOptions } from 'iron-session';
 
 // import the "optional" auth secret here so it doesnt throw an error at build time
-import { authSecret, baseUrl, cookieName, isProdEnv } from 'config/constants';
+import { authSecret, baseUrl, cookieName } from 'config/constants';
 
-export function getIronOptions(): SessionOptions {
+export function getIronOptions({ domain }: { domain?: string }): SessionOptions {
   if (!authSecret) {
     throw new Error('AUTH_SECRET is not defined');
   }
-  const domain = isProdEnv ? 'charmverse.io' : undefined;
   const ironOptions: SessionOptions = {
     cookieName,
     password: authSecret,

--- a/lib/session/getIronOptions.ts
+++ b/lib/session/getIronOptions.ts
@@ -3,7 +3,7 @@ import type { SessionOptions } from 'iron-session';
 // import the "optional" auth secret here so it doesnt throw an error at build time
 import { authSecret, baseUrl, cookieName } from 'config/constants';
 
-export function getIronOptions({ domain }: { domain?: string }): SessionOptions {
+export function getIronOptions({ domain }: { domain?: string } = {}): SessionOptions {
   if (!authSecret) {
     throw new Error('AUTH_SECRET is not defined');
   }


### PR DESCRIPTION
My update last night broke logging in/out with custom domains. we'll need a better fix but not sure what that is yet. It would be easier if we can get the origin header on the request