### PR TITLE
optimize test and deploy ci

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -339,10 +339,13 @@ jobs:
       - name: Restore app from cache
         uses: ./.github/actions/build
 
-      - name: Validate code
+      - name: Validate Webapp
         run: |
           npm run lint -w apps/connect
           npm run typecheck -w apps/connect
+
+      - name: Validate API
+        run: |
           npm run lint -w apps/connect-api
 
   deploy-docker:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -608,7 +608,7 @@ jobs:
         deploy-docker,
         deploy-main,
         deploy-connect,
-        deploy-connect_api
+        deploy-connect-api
       ]
     steps:
       - name: If any of prev jobs failed notify discord

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -342,6 +342,7 @@ jobs:
       - name: Validate code
         run: |
           npm run lint -w apps/connect
+          npm run typecheck -w apps/connect
           npm run lint -w apps/connect-api
 
   deploy-docker:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -55,7 +55,7 @@ jobs:
         id: get_head_commit_message
         run: echo "commit_message=$(git show -s --format=%s)" >> "$GITHUB_OUTPUT"
 
-  test:
+  validate-code:
     name: Validate code
     runs-on: ubuntu-latest
     needs: build-app
@@ -305,12 +305,51 @@ jobs:
         # with:
         #   args: ${{matrix.test_command}}
 
-  deploy:
-    name: Deploy to production
+  test-connect:
+    name: Test Connect App
+    runs-on: ubuntu-latest
+    needs: build-app
+    if: ${{ !contains(needs.build-app.outputs.head-commit-message, 'skip-tests') }}
+    # Postgres setup copied from https://gist.github.com/2color/537f8ef13ecec80059abb007839a6878
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --hostname postgres
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore dependencies from cache
+        uses: ./.github/actions/install
+
+      - name: Setup test database
+        run: npx dotenv -e .env.test.local -- npm run prisma:reset
+
+      - name: Restore app from cache
+        uses: ./.github/actions/build
+
+      - name: Validate code
+        run: |
+          npm run lint -w apps/connect
+          npm run lint -w apps/connect-api
+
+  deploy-docker:
+    name: Deploy Docker to production
     runs-on: ubuntu-latest
     # run whether previous jobs were successful or skipped
     if: github.ref == 'refs/heads/main' && !(failure() || cancelled())
-    needs: [test, test-matrix, e2e-test-matrix]
+    needs: [build-app]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -321,12 +360,11 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install
 
-      - name: Calculate Build ID and add to env file
+      - name: Calculate Build ID
         id: get_build_id
         run: |
           build_id=${{ hashFiles('package-lock.json', 'pages/api/**/*.[jt]s', 'lib/**/*.[jt]s') }}
           echo "build_id=$build_id" >> $GITHUB_OUTPUT
-          echo "REACT_APP_BUILD_ID=$build_id" >> ./.ebstalk.apps.env/webapp.env
 
       - name: Build app
         uses: ./.github/actions/build
@@ -342,6 +380,51 @@ jobs:
           AWS_REGION: us-east-1
         with:
           ecr_registry: charmverse-web3-workspace
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload static assets to S3
+        run: |
+          aws s3 sync .next/static/ s3://charm.cdn/webapp-assets/_next/static/
+          aws s3 sync apps/connect/.next/static/ s3://charm.cdn/webapp-assets/_next/static/
+
+      - name: Upload JS source maps to Datadog
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+        run: |
+          npm install -g @datadog/datadog-ci
+          datadog-ci sourcemaps upload .next/static       \
+            --service=webapp                              \
+            --release-version=${{ steps.get_build_id.outputs.build_id }}  \
+            --minified-path-prefix=https://cdn.charmverse.io/_next/static
+
+  deploy-main:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    # run whether previous jobs were successful or skipped
+    if: github.ref == 'refs/heads/main' && !(failure() || cancelled())
+    needs: [validate-code, test-matrix, e2e-test-matrix, deploy-docker]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4.x
+
+      - name: Install dependencies
+        uses: ./.github/actions/install
+
+      - name: Calculate Build ID and add to env file
+        id: get_build_id
+        run: |
+          build_id=${{ hashFiles('package-lock.json', 'pages/api/**/*.[jt]s', 'lib/**/*.[jt]s') }}
+          echo "REACT_APP_BUILD_ID=$build_id" >> ./.ebstalk.apps.env/webapp.env
 
       - name: Set the docker compose env variables
         uses: mikefarah/yq@master
@@ -368,43 +451,21 @@ jobs:
                     .IMGTAG = "${{ github.run_id }}-${{ env.GITHUB_SHA_SHORT }}")
               ' .ebextensions_websockets/00_env_vars.config
 
-            yq -I 4 -i '
-              with(.option_settings."aws:elasticbeanstalk:application:environment";
-                    .IMGTAG = "${{ github.run_id }}-${{ env.GITHUB_SHA_SHORT }}")
-              ' .ebextensions_connect/00_env_vars.config
-
-            yq -I 4 -i '
-              with(.option_settings."aws:elasticbeanstalk:application:environment";
-                    .IMGTAG = "${{ github.run_id }}-${{ env.GITHUB_SHA_SHORT }}")
-              ' .ebextensions_connect_api/00_env_vars.config
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Upload static assets to S3
-        run: |
-          aws s3 sync .next/static/ s3://charm.cdn/webapp-assets/_next/static/
-          aws s3 sync apps/connect/.next/static/ s3://charm.cdn/webapp-assets/_next/static/
-
       - name: Package webapp
         run: |
           cat files_to_zip.txt | zip --symlinks -r@ deploy.zip
 
-      - name: Update and Package background worker
+      - name: Package cron worker
         run: |
           rm -rf .ebextensions && mv .ebextensions_cron .ebextensions
           cat files_to_zip.txt | zip --symlinks -r@ deploy_cron.zip
 
-      - name: Update and Package ceramic server
+      - name: Package ceramic server
         run: |
           rm -rf .ebextensions && mv .ebextensions_ceramic .ebextensions
           cat files_to_zip.txt | zip --symlinks -r@ deploy_ceramic.zip
 
-      - name: Update and Package websockets
+      - name: Package websockets
         id: pkg_websocket
         run: |
           rm -rf .ebextensions && mv .ebextensions_websockets .ebextensions
@@ -435,7 +496,7 @@ jobs:
           use_existing_version_if_available: true # allows triggering re-deploys with same version
           wait_for_deployment: false # set to false to save sweet Github minutes
 
-      - name: Deploy Websockets to Beanstalk
+      - name: Deploy websockets to Beanstalk
         if: steps.pkg_websocket.outputs.deploy_websocket == 'true'
         uses: einaregilsson/beanstalk-deploy@v21
         with:
@@ -449,7 +510,7 @@ jobs:
           use_existing_version_if_available: true # allows triggering re-deploys with same version
           wait_for_deployment: false # set to false to save sweet Github
 
-      - name: Deploy Background to Beanstalk
+      - name: Deploy cron worker to Beanstalk
         uses: einaregilsson/beanstalk-deploy@v21
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -462,17 +523,7 @@ jobs:
           use_existing_version_if_available: true # allows triggering re-deploys with same version
           wait_for_deployment: false # set to false to save sweet Github minutes
 
-      - name: Use datadog ci package to upload js maps
-        env:
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-        run: |
-          npm install -g @datadog/datadog-ci
-          datadog-ci sourcemaps upload .next/static       \
-            --service=webapp                              \
-            --release-version=${{ steps.get_build_id.outputs.build_id }}  \
-            --minified-path-prefix=https://cdn.charmverse.io/_next/static
-
-      - name: Deploy Ceramic to Beanstalk
+      - name: Deploy ceramic to Beanstalk
         uses: einaregilsson/beanstalk-deploy@v21
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -485,26 +536,80 @@ jobs:
           use_existing_version_if_available: true # allows triggering re-deploys with same version
           wait_for_deployment: false # set to false to save sweet Github minutes
 
-      - name: Package and deploy Connect API to production
-        run: |
-          rm -rf .ebextensions && mv .ebextensions_connect_api .ebextensions
-          cat files_to_zip.txt | zip --symlinks -r@ prd-connect-api.zip
-          npm install aws-cdk aws-cdk-lib --no-audit --no-fund --force
-          npx cdk deploy --method=direct -c name=prd-connect-api
+  deploy-connect:
+    name: Deploy Connect webapp
+    runs-on: ubuntu-latest
+    # run whether previous jobs were successful or skipped
+    if: github.ref == 'refs/heads/main' && !(failure() || cancelled())
+    needs: [test-connect, deploy-docker]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4.x
 
-      - name: Package and deploy Connect App to production
+      - name: Set the docker compose env variables
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            yq -I 4 -i '
+              with(.option_settings."aws:elasticbeanstalk:application:environment";
+                    .IMGTAG = "${{ github.run_id }}-${{ env.GITHUB_SHA_SHORT }}")
+              ' .ebextensions_connect/00_env_vars.config
+
+      - name: Package and deploy
         run: |
           rm -rf .ebextensions && mv .ebextensions_connect .ebextensions
           cat files_to_zip.txt | zip --symlinks -r@ prd-connect.zip
           npm install aws-cdk aws-cdk-lib --no-audit --no-fund --force
           npx cdk deploy --method=direct -c name=prd-connect
 
-  discord_alert:
+  deploy-connect-api:
+    name: Deploy Connect API
+    runs-on: ubuntu-latest
+    # run whether previous jobs were successful or skipped
+    if: github.ref == 'refs/heads/main' && !(failure() || cancelled())
+    needs: [test-connect, deploy-docker]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4.x
+
+      - name: Set the docker compose env variables
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            yq -I 4 -i '
+              with(.option_settings."aws:elasticbeanstalk:application:environment";
+                    .IMGTAG = "${{ github.run_id }}-${{ env.GITHUB_SHA_SHORT }}")
+              ' .ebextensions_connect_api/00_env_vars.config
+
+      - name: Package and deploy
+        run: |
+          rm -rf .ebextensions && mv .ebextensions_connect_api .ebextensions
+          cat files_to_zip.txt | zip --symlinks -r@ prd-connect-api.zip
+          npm install aws-cdk aws-cdk-lib --no-audit --no-fund --force
+          npx cdk deploy --method=direct -c name=prd-connect-api
+
+  discord-alert:
     name: Notify discord of failure
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && failure()
     # pass in all steps so we can check if any failed
-    needs: [build-app, test, test-matrix, e2e-test-matrix, deploy]
+    needs:
+      [
+        build-app,
+        validate-code,
+        test-matrix,
+        e2e-test-matrix,
+        deploy-docker,
+        deploy-main,
+        deploy-connect,
+        deploy-connect_api
+      ]
     steps:
       - name: If any of prev jobs failed notify discord
         if: contains(needs.*.result, 'failure')

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -345,11 +345,11 @@ jobs:
           npm run lint -w apps/connect-api
 
   deploy-docker:
-    name: Deploy Docker to production
+    name: Upload Docker image and assets
     runs-on: ubuntu-latest
     # run whether previous jobs were successful or skipped
     if: github.ref == 'refs/heads/main' && !(failure() || cancelled())
-    needs: [build-app]
+    needs: build-app
     steps:
       - uses: actions/checkout@v4
         with:
@@ -537,7 +537,7 @@ jobs:
           wait_for_deployment: false # set to false to save sweet Github minutes
 
   deploy-connect:
-    name: Deploy Connect webapp
+    name: Deploy Connect Webapp to production
     runs-on: ubuntu-latest
     # run whether previous jobs were successful or skipped
     if: github.ref == 'refs/heads/main' && !(failure() || cancelled())
@@ -566,7 +566,7 @@ jobs:
           npx cdk deploy --method=direct -c name=prd-connect
 
   deploy-connect-api:
-    name: Deploy Connect API
+    name: Deploy Connect API to production
     runs-on: ubuntu-latest
     # run whether previous jobs were successful or skipped
     if: github.ref == 'refs/heads/main' && !(failure() || cancelled())
@@ -595,7 +595,7 @@ jobs:
           npx cdk deploy --method=direct -c name=prd-connect-api
 
   discord-alert:
-    name: Notify discord of failure
+    name: Notify Discord of failure
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && failure()
     # pass in all steps so we can check if any failed

--- a/apps/connect-api/package.json
+++ b/apps/connect-api/package.json
@@ -6,9 +6,8 @@
     "mount-routes": "npx tsx ./src/scripts/generateRoutes.ts",
     "start": "npm run mount-routes && npx tsx --watch ./src/main.ts",
     "start:prod": "npx tsx ./dist/apps/connect-api/src/main.js",
-    "lint": "npx eslint ./src --fix -c  ./.eslintrc.json",
+    "lint": "npx eslint ./src -c  ./.eslintrc.json",
     "build": "rm -rf ./dist && ../../node_modules/typescript/bin/tsc --project ./tsconfig.json",
-    "test": "npx jest --config=./jest.config.ts",
-    "echo": "echo \"Builder api\""
+    "test": "npx jest --config=./jest.config.ts"
   }
 }

--- a/apps/connect/next.config.js
+++ b/apps/connect/next.config.js
@@ -1,6 +1,13 @@
 /** @type {import('next').NextConfig} */
 
 const nextConfig = {
+  // types are tested separately from the build
+  eslint: {
+    ignoreDuringBuilds: true
+  },
+  typescript: {
+    ignoreBuildErrors: true
+  },
   webpack(_config) {
     // Fix for: "Module not found: Can't resolve 'canvas'"
     // _config.resolve.alias.canvas = false;

--- a/apps/connect/package.json
+++ b/apps/connect/package.json
@@ -6,7 +6,8 @@
     "start": "npx next dev",
     "build": "npx next build",
     "start:prod": "npx next start",
-    "lint": "npx next lint"
+    "lint": "npx next lint",
+    "typecheck": "../../node_modules/typescript/bin/tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
     "@mui/material-nextjs": "^5.15.11",

--- a/scripts/query.ts
+++ b/scripts/query.ts
@@ -9,17 +9,13 @@ import { prisma } from '@charmverse/core/prisma-client';
 //   name: 'Greenpill Network'
 // }
 
-
 async function search() {
-  const result = await prisma.space.findFirstOrThrow({
+  const result = await prisma.project.deleteMany({
     where: {
-      
-    },
-    select: {
-      id: true,
-      paidTier: true,
+      createdBy: 'd5b4e5db-868d-47b0-bc78-ebe9b5b2c835'
     }
   });
+  console.log(result);
 }
 
 search().then(() => console.log('Done'));


### PR DESCRIPTION
This should speed up everyone since we're now building and uploading a Docker image while tests run. And further, the Connect app doesn't need to wait for other tests

I think the next big win would be to deploy smaller Docker images, or find a way to exclude source code / node modules