### PR TITLE
only show the application property on a reward if a link exists

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -524,7 +524,7 @@ function DocumentPageComponent({
                   <CharmEditor
                     placeholderText={
                       (page.type === 'bounty' || page.type === 'bounty_template') && !readOnly
-                        ? `Describe the reward. Type '/' to see the list of available commands`
+                        ? `Type '/' to see the list of available commands`
                         : undefined
                     }
                     key={editorKey}

--- a/components/rewards/NewRewardPage.tsx
+++ b/components/rewards/NewRewardPage.tsx
@@ -330,7 +330,7 @@ export function NewRewardPage({
                         </div>
                       </div>
                       <CharmEditor
-                        placeholderText={`Describe the reward. Type '/' to see the list of available commands`}
+                        placeholderText={`Type '/' to see the list of available commands`}
                         content={pageData.content as PageContent}
                         autoFocus={false}
                         enableVoting={false}

--- a/components/rewards/components/RewardProperties/CustomPropertiesAdapter.tsx
+++ b/components/rewards/components/RewardProperties/CustomPropertiesAdapter.tsx
@@ -47,22 +47,23 @@ export function CustomPropertiesAdapter({ reward, onChange, readOnly }: Props) {
 
   const boardCustomProperties = useMemo(() => {
     if (board) {
+      // extract non-custom properties
+      const cardProperties = board.fields.cardProperties.filter((p) => !p.id.startsWith('__'));
+      // Add proposal link as a custom property
+      if (reward.sourceProposalPage) {
+        cardProperties.push({
+          readOnly: true,
+          options: [],
+          id: REWARD_PROPOSAL_LINK,
+          name: getFeatureTitle('Proposal'),
+          type: 'proposalUrl' as PropertyType
+        });
+      }
       return {
         ...board,
         fields: {
           ...board.fields,
-          // extract non-custom properties
-          cardProperties: [
-            ...board.fields.cardProperties.filter((p) => !p.id.startsWith('__')),
-            // Add proposal link as a custom property
-            {
-              readOnly: true,
-              options: [],
-              id: REWARD_PROPOSAL_LINK,
-              name: getFeatureTitle('Proposal'),
-              type: 'proposalUrl' as PropertyType
-            }
-          ]
+          cardProperties
         }
       };
     }

--- a/components/rewards/hooks/useRewardsBoardAdapter.ts
+++ b/components/rewards/hooks/useRewardsBoardAdapter.ts
@@ -41,7 +41,7 @@ import { getAbsolutePath } from 'lib/utils/browser';
 import { isUUID } from 'lib/utils/strings';
 import { isTruthy } from 'lib/utils/types';
 
-export type BoardReward = { id?: string; fields: RewardFields };
+export type BoardReward = { id?: string; fields: RewardFields; sourceProposalPage?: string };
 
 export function useRewardsBoardAdapter() {
   const { space } = useCurrentSpace();


### PR DESCRIPTION
it was showing up on reward templates. i figure lets not even show it unless there is a proposal/ this is actually a milestone