### PR TITLE
update the cache of projects when using project form

### DIFF
--- a/components/common/form/fields/ProjectField/ProjectFieldAnswer.tsx
+++ b/components/common/form/fields/ProjectField/ProjectFieldAnswer.tsx
@@ -165,10 +165,7 @@ export function ProjectFieldAnswer({
             selectedMemberIds={selectedMemberIds}
             onFormFieldChange={onChange}
             project={selectedProject}
-            refreshProject={async () => {
-              const updatedList = await refreshProjects();
-              return updatedList?.find((p) => p.id === selectedProject.id);
-            }}
+            refreshProjects={refreshProjects}
             applyProjectMembers={applyProjectMembers}
           />
         </Box>

--- a/components/common/form/fields/ProjectField/useProjectUpdates.ts
+++ b/components/common/form/fields/ProjectField/useProjectUpdates.ts
@@ -1,51 +1,119 @@
 import { debounce } from 'lodash';
 import { useMemo } from 'react';
+import type { KeyedMutator } from 'swr';
 
 import charmClient from 'charmClient';
 import { useAddProjectMember, usePatchProject } from 'charmClient/hooks/projects';
-import { useSnackbar } from 'hooks/useSnackbar';
 import { useUser } from 'hooks/useUser';
 import type { AddProjectMemberPayload } from 'lib/projects/addProjectMember';
 import type { ProjectWithMembers } from 'lib/projects/interfaces';
-import type { UpdateProjectPayload } from 'lib/projects/updateProject';
 import type { UpdateProjectMemberPayload } from 'lib/projects/updateProjectMember';
 
-export function useProjectUpdates({ projectId, isTeamLead }: { projectId: string; isTeamLead: boolean }) {
+export function useProjectUpdates({
+  projectId,
+  refreshProjects,
+  isTeamLead
+}: {
+  projectId: string;
+  refreshProjects: KeyedMutator<ProjectWithMembers[]>;
+  isTeamLead: boolean;
+}) {
   const { user } = useUser();
   const { trigger: updateProject } = usePatchProject(projectId);
-  // const project = projectsWithMembers?.find((_project) => _project.id === projectId);
   const { trigger: addProjectMember } = useAddProjectMember(projectId);
 
-  const { showMessage } = useSnackbar();
+  // we need to update "project cache" to update the contxt that is used when selecting project or members from the dropdown
+  function updateProjectCache(projectPayload: Partial<ProjectWithMembers>) {
+    refreshProjects(
+      (projects) =>
+        projects?.map((_project) => {
+          if (_project.id === projectId) {
+            return {
+              ..._project,
+              ...projectPayload
+            };
+          }
 
-  const onProjectUpdate = useMemo(
+          return _project;
+        }),
+      {
+        revalidate: false
+      }
+    );
+  }
+
+  // we need to update "project cache" to update the contxt that is used when selecting project or members from the dropdown
+  function updateProjectMemberCache(member: ProjectWithMembers['projectMembers'][number], isNew = false) {
+    refreshProjects(
+      (projects) =>
+        projects?.map((_project) => {
+          if (_project.id === projectId) {
+            if (isNew) {
+              return {
+                ..._project,
+                projectMembers: [..._project.projectMembers, member]
+              };
+            }
+            return {
+              ..._project,
+              projectMembers: _project.projectMembers.map((projectMember) =>
+                projectMember.id === member.id ? member : projectMember
+              )
+            };
+          }
+
+          return _project;
+        }),
+      {
+        revalidate: false
+      }
+    );
+  }
+
+  const onProjectUpdateMemo = useMemo(
     () =>
-      debounce(async (projectPayload: UpdateProjectPayload) => {
+      debounce(async (projectPayload: Record<string, any>) => {
         if (!isTeamLead) {
           return null;
         }
 
-        try {
-          const updatedProject = await updateProject(projectPayload);
-          return updatedProject;
-        } catch (_) {
-          return null;
-        }
+        const updatedProject = await updateProject({
+          ...projectPayload,
+          id: projectId
+        });
+        return updatedProject;
       }, 150),
-    [projectId, user?.id, isTeamLead]
+    [projectId, isTeamLead, updateProject]
   );
+
+  // update cache immediately, then debounce the actual update
+  function onProjectUpdate(projectPayload: Record<string, any>) {
+    updateProjectCache(projectPayload);
+    onProjectUpdateMemo(projectPayload);
+  }
 
   const onProjectMemberUpdate = useMemo(
     () =>
-      debounce(async (projectMemberPayload: UpdateProjectMemberPayload & { userId?: string }) => {
-        if (!isTeamLead && projectMemberPayload.userId !== user?.id) {
-          return null;
-        }
-        return charmClient.projects.updateProjectMember({
-          payload: projectMemberPayload,
-          projectId
-        });
-      }, 150),
+      debounce(
+        async (
+          memberId: string,
+          projectMemberPayload: Omit<UpdateProjectMemberPayload, 'id'> & { userId?: string }
+        ) => {
+          if (!isTeamLead && projectMemberPayload.userId !== user?.id) {
+            return null;
+          }
+          const updatedTeamMember = await charmClient.projects.updateProjectMember({
+            payload: {
+              ...projectMemberPayload,
+              id: memberId
+            },
+            projectId
+          });
+          updateProjectMemberCache(updatedTeamMember);
+          return updatedTeamMember;
+        },
+        150
+      ),
     [projectId, user?.id, isTeamLead]
   );
 
@@ -53,12 +121,9 @@ export function useProjectUpdates({ projectId, isTeamLead }: { projectId: string
     if (!isTeamLead || !projectId) {
       return null;
     }
-    try {
-      return addProjectMember(projectMemberPayload);
-    } catch (err) {
-      showMessage('Failed to add project member', 'error');
-      return null;
-    }
+    const newMember = await addProjectMember(projectMemberPayload);
+    updateProjectMemberCache(newMember, true);
+    return newMember;
   };
 
   return {

--- a/lib/projects/constants.ts
+++ b/lib/projects/constants.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from '@charmverse/core/prisma-client';
+import type { Prisma } from '@charmverse/core/prisma';
 
 import type { ProjectAndMembersPayload } from './interfaces';
 
@@ -20,7 +20,7 @@ export function createDefaultProjectAndMembersPayload(): ProjectAndMembersPayloa
   };
 }
 
-export function defaultProjectMember(): ProjectAndMembersPayload['projectMembers'][0] {
+export function defaultProjectMember(): ProjectAndMembersPayload['projectMembers'][number] {
   return {
     name: '',
     walletAddress: '',

--- a/lib/proposals/__tests__/validateProposalProject.spec.ts
+++ b/lib/proposals/__tests__/validateProposalProject.spec.ts
@@ -46,7 +46,7 @@ describe('validateProposalProject', () => {
           }
         ]
       })
-    ).toThrow(InvalidInputError);
+    ).toThrow();
   });
 
   it('Should not throw error if proposal project information is valid', async () => {

--- a/lib/proposals/getProposalErrors.ts
+++ b/lib/proposals/getProposalErrors.ts
@@ -1,3 +1,5 @@
+import { log } from '@charmverse/core/log';
+
 import { checkFormFieldErrors } from 'components/common/form/checkFormFieldErrors';
 import { validateAnswers } from 'lib/forms/validateAnswers';
 import type { ProjectWithMembers } from 'lib/projects/interfaces';
@@ -73,7 +75,14 @@ export function getProposalErrors({
             project
           });
         } catch (error) {
-          errors.push((error as Error).message);
+          // hack for now only log errors on the backend when form is submitted
+          if (typeof window === 'undefined') {
+            log.error(`Project profile validation failed`, {
+              error,
+              projectId: project.id
+            });
+          }
+          errors.push(`Project profile validation failed`);
         }
       }
     }

--- a/lib/proposals/validateProposalProject.ts
+++ b/lib/proposals/validateProposalProject.ts
@@ -1,5 +1,4 @@
 import { InvalidInputError } from '@charmverse/core/errors';
-import { log } from '@charmverse/core/log';
 import type { Prisma } from '@charmverse/core/prisma';
 
 import type { FormFieldInput, FormFieldValue } from 'lib/forms/interfaces';
@@ -43,13 +42,5 @@ export function validateProposalProject({
     ];
   }
 
-  try {
-    projectSchema.validateSync(convertToProjectValues(project), { abortEarly: false });
-  } catch (error) {
-    log.error(`Project profile validation failed`, {
-      error,
-      projectId: project.id
-    });
-    throw new InvalidInputError(`Project profile validation failed`);
-  }
+  projectSchema.validateSync(convertToProjectValues(project), { abortEarly: false });
 }


### PR DESCRIPTION
I figured out if i just update the SWR cache for 'useGetProjects' then i dont have to refresh so much. One thing that is kind of concerning is that this data is only relevant to the proposal owner. But I think it should be fine, even if you're editing your own team member profile on someone else's proposal since that cache is only used when adding members or changing the project.