### PR TITLE
allow anyone to view a project as part of a proposal

### DIFF
--- a/charmClient/hooks/projects.ts
+++ b/charmClient/hooks/projects.ts
@@ -17,10 +17,10 @@ export function useUpdateProject(projectId: string) {
   return usePUT<ProjectAndMembersPayload, ProjectWithMembers>(`/api/projects/${projectId}`);
 }
 
-export function usePatchProject(projectId: string) {
+export function usePatchProject(projectId?: string) {
   return usePUT<UpdateProjectPayload, Project>(`/api/projects/${projectId}/patch`);
 }
 
-export function useAddProjectMember(projectId: string) {
+export function useAddProjectMember(projectId?: string) {
   return usePOST<AddProjectMemberPayload, ProjectMember>(`/api/projects/${projectId}/members`);
 }

--- a/components/common/form/fields/ProjectField/ProjectFieldAnswer.tsx
+++ b/components/common/form/fields/ProjectField/ProjectFieldAnswer.tsx
@@ -108,54 +108,58 @@ export function ProjectFieldAnswer({
 
   return (
     <Stack gap={1} width='100%' mb={1}>
-      <Stack flexDirection='row' gap={1} alignItems='center'>
-        <Select
-          sx={{
-            width: '100%'
-          }}
-          key={projectId}
-          // only proposal author is able to change the project profile, not even team lead can change it
-          disabled={disabled}
-          displayEmpty
-          value={projectId ?? ''}
-          data-test='project-profile-select'
-          renderValue={() => {
-            if (!selectedProject) {
-              return <Typography color='secondary'>Select a project profile</Typography>;
-            }
-            return selectedProject.name;
-          }}
-        >
-          {projectsWithMembers?.map((_project) => {
-            return (
-              <MenuItem
-                key={_project.id}
-                data-test={`project-option-${_project.id}`}
-                value={_project.id}
-                onClick={async () => {
-                  // retrieve the latest project data
-                  const updatedList = await refreshProjects();
-                  const _selectedProject = updatedList?.find((p) => p.id === _project.id);
-                  if (_selectedProject) {
-                    onSelectProject(_selectedProject);
-                  }
-                }}
-              >
-                <Typography color={_project.name ? '' : 'secondary'}>{_project.name || 'Untitled Project'}</Typography>
-              </MenuItem>
-            );
-          })}
-          <Divider />
-          <MenuItem data-test='project-option-new' onClick={addNewProject}>
-            <Stack flexDirection='row' alignItems='center' gap={0.05}>
-              <MuiAddIcon fontSize='small' />
-              <Typography>Add a new project profile</Typography>
-            </Stack>
-          </MenuItem>
-        </Select>
-        {/** Required for support form field comments */}
-        {inputEndAdornment}
-      </Stack>
+      {!disabled && (
+        <Stack flexDirection='row' gap={1} alignItems='center'>
+          <Select
+            sx={{
+              width: '100%'
+            }}
+            key={projectId}
+            // only proposal author is able to change the project profile, not even team lead can change it
+            disabled={disabled}
+            displayEmpty
+            value={projectId ?? ''}
+            data-test='project-profile-select'
+            renderValue={() => {
+              if (!selectedProject) {
+                return <Typography color='secondary'>Select a project profile</Typography>;
+              }
+              return selectedProject.name;
+            }}
+          >
+            {projectsWithMembers?.map((_project) => {
+              return (
+                <MenuItem
+                  key={_project.id}
+                  data-test={`project-option-${_project.id}`}
+                  value={_project.id}
+                  onClick={async () => {
+                    // retrieve the latest project data
+                    const updatedList = await refreshProjects();
+                    const _selectedProject = updatedList?.find((p) => p.id === _project.id);
+                    if (_selectedProject) {
+                      onSelectProject(_selectedProject);
+                    }
+                  }}
+                >
+                  <Typography color={_project.name ? '' : 'secondary'}>
+                    {_project.name || 'Untitled Project'}
+                  </Typography>
+                </MenuItem>
+              );
+            })}
+            <Divider />
+            <MenuItem data-test='project-option-new' onClick={addNewProject}>
+              <Stack flexDirection='row' alignItems='center' gap={0.05}>
+                <MuiAddIcon fontSize='small' />
+                <Typography>Add a new project profile</Typography>
+              </Stack>
+            </MenuItem>
+          </Select>
+          {/** Required for support form field comments */}
+          {inputEndAdornment}
+        </Stack>
+      )}
       <Box p={2} mb={1} border={(theme) => `1px solid ${theme.palette.divider}`}>
         <ProjectForm
           fieldConfig={fieldConfig}

--- a/components/common/form/fields/ProjectField/ProjectFieldAnswer.tsx
+++ b/components/common/form/fields/ProjectField/ProjectFieldAnswer.tsx
@@ -156,20 +156,18 @@ export function ProjectFieldAnswer({
         {/** Required for support form field comments */}
         {inputEndAdornment}
       </Stack>
-      {selectedProject && (
-        <Box p={2} mb={1} border={(theme) => `1px solid ${theme.palette.divider}`}>
-          <ProjectForm
-            fieldConfig={fieldConfig}
-            isTeamLead={isTeamLead}
-            disabled={disabled}
-            selectedMemberIds={selectedMemberIds}
-            onFormFieldChange={onChange}
-            project={selectedProject}
-            refreshProjects={refreshProjects}
-            applyProjectMembers={applyProjectMembers}
-          />
-        </Box>
-      )}
+      <Box p={2} mb={1} border={(theme) => `1px solid ${theme.palette.divider}`}>
+        <ProjectForm
+          fieldConfig={fieldConfig}
+          isTeamLead={isTeamLead}
+          disabled={disabled}
+          selectedMemberIds={selectedMemberIds}
+          onFormFieldChange={onChange}
+          project={selectedProject}
+          refreshProjects={refreshProjects}
+          applyProjectMembers={applyProjectMembers}
+        />
+      </Box>
     </Stack>
   );
 }

--- a/components/common/form/fields/ProjectField/ProjectForm.tsx
+++ b/components/common/form/fields/ProjectField/ProjectForm.tsx
@@ -30,7 +30,7 @@ export function ProjectForm({
   onFormFieldChange,
   applyProjectMembers
 }: {
-  project: ProjectWithMembers;
+  project?: ProjectWithMembers; // only provided if you belong to the project
   refreshProjects: KeyedMutator<ProjectWithMembers[]>;
   disabled?: boolean;
   fieldConfig?: ProjectAndMembersFieldConfig;
@@ -43,7 +43,8 @@ export function ProjectForm({
 
   const { showError } = useSnackbar();
 
-  const { id: projectId, projectMembers } = project;
+  const projectId = project?.id;
+  const projectMembers = project?.projectMembers || [];
 
   // Note: selectedMemberIds never includes team lead
   const selectedProjectMembers = selectedMemberIds
@@ -53,12 +54,16 @@ export function ProjectForm({
     (projectMember) => !projectMember.teamLead && projectMember.id && !selectedMemberIds.includes(projectMember.id)
   );
   const { onProjectUpdate, onProjectMemberUpdate, onProjectMemberAdd } = useProjectUpdates({
-    projectId: project.id,
+    projectId,
     isTeamLead,
     refreshProjects
   });
 
   async function addTeamMember(selectedMemberId: string) {
+    if (!projectId) {
+      // project doesnt belong to user
+      return;
+    }
     const newMemberIds = [...selectedMemberIds];
     const newProjectMembers = selectedMemberIds
       .map((memberId) => project.projectMembers.find((member) => member.id === memberId))
@@ -94,6 +99,10 @@ export function ProjectForm({
   }
 
   function removeTeamMember(memberId: string) {
+    if (!projectId) {
+      // project doesnt belong to user
+      return;
+    }
     const newMemberIds = selectedMemberIds.filter((id) => id !== memberId);
     const newProjectMembers = projectMembers.filter(({ id }) => newMemberIds.includes(id));
     // always include team lead

--- a/components/common/form/fields/ProjectField/ProjectForm.tsx
+++ b/components/common/form/fields/ProjectField/ProjectForm.tsx
@@ -47,11 +47,15 @@ export function ProjectForm({
   const projectMembers = project?.projectMembers || [];
 
   // Note: selectedMemberIds never includes team lead
-  const selectedProjectMembers = selectedMemberIds
-    .map((memberId) => projectMembers.find((member) => member.id === memberId))
-    .filter(isTruthy);
+  const selectedProjectMembers = selectedMemberIds.map((memberId) => {
+    const member = projectMembers.find((m) => m.id === memberId);
+    return {
+      id: memberId,
+      userId: member?.userId
+    };
+  });
   const nonSelectedProjectMembers = projectMembers.filter(
-    (projectMember) => !projectMember.teamLead && projectMember.id && !selectedMemberIds.includes(projectMember.id)
+    (projectMember) => !projectMember.teamLead && !selectedMemberIds.includes(projectMember.id)
   );
   const { onProjectUpdate, onProjectMemberUpdate, onProjectMemberAdd } = useProjectUpdates({
     projectId,
@@ -116,6 +120,9 @@ export function ProjectForm({
 
   const teamLeadMemberId = projectMembers[0]?.id;
 
+  // for non-authors, hide the team members section if it is empty
+  const showTeamMemberSection = !disabled || selectedProjectMembers.length > 0;
+
   return (
     <Stack gap={2} width='100%'>
       <Typography variant='h6'>Project Info</Typography>
@@ -137,62 +144,70 @@ export function ProjectForm({
         fieldConfig={fieldConfig?.projectMember}
         onChange={(updates) => onProjectMemberUpdate(teamLeadMemberId!, updates)}
       />
-      <Divider sx={{ my: 1 }} />
-      {selectedProjectMembers.map((projectMember, index) => (
-        <Stack key={`project-member-${projectMember.id}`}>
-          <Stack direction='row' justifyContent='space-between' alignItems='center' mb={2}>
-            <Typography variant='h6'>Team member</Typography>
-            <IconButton
-              data-test='remove-project-member-button'
+      {showTeamMemberSection && (
+        <>
+          <Divider sx={{ my: 1 }} />
+          {selectedProjectMembers.map((projectMember, index) => (
+            <>
+              <Stack key={`project-member-${projectMember.id}`}>
+                <Stack direction='row' justifyContent='space-between' alignItems='center' mb={2}>
+                  <FieldLabel>Team Member</FieldLabel>
+                  <IconButton
+                    data-test='remove-project-member-button'
+                    disabled={disabled}
+                    onClick={() => removeTeamMember(projectMember.id)}
+                  >
+                    <DeleteOutlineOutlinedIcon fontSize='small' color={disabled ? 'disabled' : 'error'} />
+                  </IconButton>
+                </Stack>
+                <ProjectMemberFieldAnswers
+                  onChange={(updates) => {
+                    onProjectMemberUpdate(projectMember.id, updates);
+                  }}
+                  projectMemberIndex={index + 1}
+                  disabled={!(isTeamLead || projectMember.userId === user?.id) || disabled}
+                  defaultRequired
+                  fieldConfig={fieldConfig?.projectMember}
+                />
+              </Stack>
+              <Divider sx={{ my: 1 }} />
+            </>
+          ))}
+          {!disabled && (
+            <Select
+              displayEmpty
+              data-test='project-team-members-select'
               disabled={disabled}
-              onClick={() => removeTeamMember(projectMember.id)}
+              value=''
+              onChange={(event) => {
+                addTeamMember(event.target.value as string);
+              }}
+              renderValue={() => {
+                return 'Add a team member';
+              }}
             >
-              <DeleteOutlineOutlinedIcon fontSize='small' color={disabled ? 'disabled' : 'error'} />
-            </IconButton>
-          </Stack>
-          <ProjectMemberFieldAnswers
-            onChange={(updates) => {
-              onProjectMemberUpdate(projectMember.id, updates);
-            }}
-            projectMemberIndex={index + 1}
-            disabled={!(isTeamLead || projectMember.userId === user?.id) || disabled}
-            defaultRequired
-            fieldConfig={fieldConfig?.projectMember}
-          />
-        </Stack>
-      ))}
-      <FieldLabel>Team Members</FieldLabel>
-      <Select
-        displayEmpty
-        data-test='project-team-members-select'
-        disabled={disabled}
-        value=''
-        onChange={(event) => {
-          addTeamMember(event.target.value as string);
-        }}
-        renderValue={() => {
-          return 'Select a team member';
-        }}
-      >
-        {nonSelectedProjectMembers.map((projectMember) => (
-          <MenuItem
-            key={`project-member-${projectMember.id}`}
-            value={projectMember.id}
-            data-test='project-member-option'
-          >
-            <Typography color={projectMember.name ? '' : 'secondary'}>
-              {projectMember.name || 'Untitled Project Member'}
-            </Typography>
-          </MenuItem>
-        ))}
-        {nonSelectedProjectMembers.length && <Divider />}
-        <MenuItem data-test='project-member-option' value={newTeamMember} disabled={!isTeamLead || disabled}>
-          <Stack flexDirection='row' alignItems='center' gap={0.05}>
-            <AddIcon fontSize='small' />
-            <Typography>Add a new project member</Typography>
-          </Stack>
-        </MenuItem>
-      </Select>
+              {nonSelectedProjectMembers.map((projectMember) => (
+                <MenuItem
+                  key={`project-member-${projectMember.id}`}
+                  value={projectMember.id}
+                  data-test='project-member-option'
+                >
+                  <Typography color={projectMember.name ? '' : 'secondary'}>
+                    {projectMember.name || 'Untitled Project Member'}
+                  </Typography>
+                </MenuItem>
+              ))}
+              {nonSelectedProjectMembers.length && <Divider />}
+              <MenuItem data-test='project-member-option' value={newTeamMember} disabled={!isTeamLead || disabled}>
+                <Stack flexDirection='row' alignItems='center' gap={0.05}>
+                  <AddIcon fontSize='small' />
+                  <Typography>Add a new project member</Typography>
+                </Stack>
+              </MenuItem>
+            </Select>
+          )}
+        </>
+      )}
     </Stack>
   );
 }

--- a/components/common/form/fields/ProjectField/useProjectUpdates.ts
+++ b/components/common/form/fields/ProjectField/useProjectUpdates.ts
@@ -14,7 +14,7 @@ export function useProjectUpdates({
   refreshProjects,
   isTeamLead
 }: {
-  projectId: string;
+  projectId?: string; // projectId is only required to make changes
   refreshProjects: KeyedMutator<ProjectWithMembers[]>;
   isTeamLead: boolean;
 }) {
@@ -73,7 +73,7 @@ export function useProjectUpdates({
   const onProjectUpdateMemo = useMemo(
     () =>
       debounce(async (projectPayload: Record<string, any>) => {
-        if (!isTeamLead) {
+        if (!isTeamLead || !projectId) {
           return null;
         }
 
@@ -99,7 +99,7 @@ export function useProjectUpdates({
           memberId: string,
           projectMemberPayload: Omit<UpdateProjectMemberPayload, 'id'> & { userId?: string }
         ) => {
-          if (!isTeamLead && projectMemberPayload.userId !== user?.id) {
+          if ((!isTeamLead && projectMemberPayload.userId !== user?.id) || !projectId) {
             return null;
           }
           const updatedTeamMember = await charmClient.projects.updateProjectMember({


### PR DESCRIPTION
This works because the project is always loaded in the form state from the proposal request, so we don't actually need to wait for the user's list of projects. That is only necessary to populate the dropdowns for selecting/adding projects and team members