### PR TITLE
Simplify project form inputs - remove "defaultRequired"

### DIFF
--- a/__e2e__/proposals/structuredProposalWithProject.spec.ts
+++ b/__e2e__/proposals/structuredProposalWithProject.spec.ts
@@ -197,8 +197,7 @@ test.describe.serial('Structured proposal template with project', () => {
       'Describe your project in one sentence'
     );
     await expect(proposalFormFieldPage.getProjectFieldLabel('member-name')).toHaveText('Name*');
-    await expect(proposalFormFieldPage.getProjectFieldLabel('member-email')).toHaveText('Email');
-    // expect(await proposalPage.page.locator('data-test=project-member-walletAddress-field-container').count()).toBe(0);
+    await expect(proposalFormFieldPage.getProjectFieldLabel('member-email')).toHaveText('Email*');
 
     const proposalTemplate = await prisma.proposal.findFirstOrThrow({
       where: {

--- a/components/common/form/FormField.tsx
+++ b/components/common/form/FormField.tsx
@@ -206,10 +206,7 @@ function ExpandedFormField({
       )}
       {formField.type === 'project_profile' ? (
         <ProjectFieldEditor
-          defaultRequired
-          fieldConfig={
-            (formField.fieldConfig ?? createDefaultProjectAndMembersFieldConfig()) as ProjectAndMembersFieldConfig
-          }
+          fieldConfig={formField.fieldConfig as ProjectAndMembersFieldConfig}
           onChange={(fieldConfig) => {
             updateFormField({
               id: formField.id,
@@ -362,13 +359,7 @@ export function FormField(
           {!isOpen || readOnly ? (
             <div style={{ cursor: 'pointer' }} onClick={toggleOpen}>
               {formField.type === 'project_profile' ? (
-                <ProjectFieldEditor
-                  fieldConfig={
-                    (formField.fieldConfig as ProjectAndMembersFieldConfig) ??
-                    createDefaultProjectAndMembersFieldConfig()
-                  }
-                  defaultRequired
-                />
+                <ProjectFieldEditor fieldConfig={formField.fieldConfig as ProjectAndMembersFieldConfig} />
               ) : (
                 <FieldTypeRenderer
                   labelEndAdornment={

--- a/components/common/form/FormField.tsx
+++ b/components/common/form/FormField.tsx
@@ -24,7 +24,6 @@ import { useDrag, useDrop } from 'react-dnd';
 
 import { useIsCharmverseSpace } from 'hooks/useIsCharmverseSpace';
 import type { FormFieldInput } from 'lib/forms/interfaces';
-import { createDefaultProjectAndMembersFieldConfig } from 'lib/projects/formField';
 import type { ProjectAndMembersFieldConfig } from 'lib/projects/formField';
 import { emptyDocument } from 'lib/prosemirror/constants';
 import type { PageContent } from 'lib/prosemirror/interfaces';

--- a/components/common/form/fields/ProjectField/ProjectFieldAnswer.tsx
+++ b/components/common/form/fields/ProjectField/ProjectFieldAnswer.tsx
@@ -37,7 +37,7 @@ export function ProjectFieldAnswer({
   proposalId: string;
   inputEndAdornment?: React.ReactNode;
   disabled?: boolean;
-  fieldConfig?: ProjectAndMembersFieldConfig;
+  fieldConfig: ProjectAndMembersFieldConfig;
   projectId?: string | null;
   onChange: (updatedValue: FormFieldValue) => void;
   applyProject: (project: ProjectWithMembers, selectedMemberIds: string[]) => void;

--- a/components/common/form/fields/ProjectField/ProjectFieldEditor.tsx
+++ b/components/common/form/fields/ProjectField/ProjectFieldEditor.tsx
@@ -7,18 +7,15 @@ import type { ProjectAndMembersFieldConfig } from 'lib/projects/formField';
 
 export function ProjectFieldEditor({
   onChange,
-  fieldConfig,
-  defaultRequired
+  fieldConfig
 }: {
   onChange?: (project: ProjectAndMembersFieldConfig) => void;
   fieldConfig: ProjectAndMembersFieldConfig;
-  defaultRequired?: boolean;
 }) {
   return (
     <Stack gap={2}>
       <Typography variant='h6'>Project Info</Typography>
       <FieldsEditor
-        defaultRequired={defaultRequired}
         fieldConfig={fieldConfig}
         properties={projectFieldProperties}
         onChange={
@@ -37,7 +34,6 @@ export function ProjectFieldEditor({
       </Typography>
       <FieldLabel>Team Lead</FieldLabel>
       <FieldsEditor
-        defaultRequired={defaultRequired}
         properties={projectMemberFieldProperties}
         fieldConfig={fieldConfig?.projectMember}
         onChange={

--- a/components/common/form/fields/ProjectField/ProjectForm.tsx
+++ b/components/common/form/fields/ProjectField/ProjectForm.tsx
@@ -33,7 +33,7 @@ export function ProjectForm({
   project?: ProjectWithMembers; // only provided if you belong to the project
   refreshProjects: KeyedMutator<ProjectWithMembers[]>;
   disabled?: boolean;
-  fieldConfig?: ProjectAndMembersFieldConfig;
+  fieldConfig: ProjectAndMembersFieldConfig;
   isTeamLead: boolean;
   selectedMemberIds: string[];
   onFormFieldChange: (field: ProjectFieldValue) => void;

--- a/components/common/form/fields/ProjectField/ProjectForm.tsx
+++ b/components/common/form/fields/ProjectField/ProjectForm.tsx
@@ -139,7 +139,7 @@ export function ProjectForm({
       <ProjectMemberFieldAnswers
         projectMemberIndex={0}
         disabled={!isTeamLead || disabled}
-        fieldConfig={fieldConfig?.projectMember}
+        fieldConfig={fieldConfig.projectMember}
         onChange={(updates) => onProjectMemberUpdate(teamLeadMemberId!, updates)}
       />
       {showTeamMemberSection && (
@@ -164,7 +164,7 @@ export function ProjectForm({
                   }}
                   projectMemberIndex={index + 1}
                   disabled={!(isTeamLead || projectMember.userId === user?.id) || disabled}
-                  fieldConfig={fieldConfig?.projectMember}
+                  fieldConfig={fieldConfig.projectMember}
                 />
               </Stack>
               <Divider sx={{ my: 1 }} />

--- a/components/common/form/fields/ProjectField/ProjectForm.tsx
+++ b/components/common/form/fields/ProjectField/ProjectForm.tsx
@@ -164,7 +164,6 @@ export function ProjectForm({
                   }}
                   projectMemberIndex={index + 1}
                   disabled={!(isTeamLead || projectMember.userId === user?.id) || disabled}
-                  defaultRequired
                   fieldConfig={fieldConfig?.projectMember}
                 />
               </Stack>

--- a/components/common/form/fields/ProjectField/ProjectForm.tsx
+++ b/components/common/form/fields/ProjectField/ProjectForm.tsx
@@ -127,7 +127,6 @@ export function ProjectForm({
     <Stack gap={2} width='100%'>
       <Typography variant='h6'>Project Info</Typography>
       <FieldAnswers
-        defaultRequired
         disabled={!isTeamLead || disabled}
         fieldConfig={fieldConfig}
         onChange={onProjectUpdate}
@@ -140,7 +139,6 @@ export function ProjectForm({
       <ProjectMemberFieldAnswers
         projectMemberIndex={0}
         disabled={!isTeamLead || disabled}
-        defaultRequired
         fieldConfig={fieldConfig?.projectMember}
         onChange={(updates) => onProjectMemberUpdate(teamLeadMemberId!, updates)}
       />

--- a/components/proposals/hooks/useProjectForm.ts
+++ b/components/proposals/hooks/useProjectForm.ts
@@ -13,7 +13,7 @@ import type { ProjectWithMembers } from 'lib/projects/interfaces';
 import { isTruthy } from 'lib/utils/types';
 
 export function useProjectForm(options: {
-  fieldConfig: ProjectAndMembersFieldConfig;
+  fieldConfig?: ProjectAndMembersFieldConfig;
   projectId?: string | null;
   selectedMemberIds?: string[];
   initialProjectValues?: ProjectWithMembers | null;

--- a/components/proposals/hooks/useProjectForm.ts
+++ b/components/proposals/hooks/useProjectForm.ts
@@ -36,7 +36,6 @@ export function useProjectForm(options: {
 
   useEffect(() => {
     yupSchema.current = createProjectYupSchema({
-      defaultRequired: true,
       fieldConfig
     });
   }, [!!fieldConfig]);

--- a/components/proposals/hooks/useProposalFormAnswers.ts
+++ b/components/proposals/hooks/useProposalFormAnswers.ts
@@ -6,7 +6,6 @@ import { useFormFields } from 'components/common/form/hooks/useFormFields';
 import { useProjectForm } from 'components/proposals/hooks/useProjectForm';
 import { useDebouncedValue } from 'hooks/useDebouncedValue';
 import type { FormFieldValue } from 'lib/forms/interfaces';
-import { createDefaultProjectAndMembersFieldConfig } from 'lib/projects/formField';
 import type { ProjectAndMembersFieldConfig } from 'lib/projects/formField';
 import type { ProposalWithUsersAndRubric } from 'lib/proposals/interfaces';
 

--- a/components/proposals/hooks/useProposalFormAnswers.ts
+++ b/components/proposals/hooks/useProposalFormAnswers.ts
@@ -51,8 +51,7 @@ export function useProposalFormAnswers({ proposal }: { proposal?: ProposalWithUs
     // initialProjectValues: proposal?.project,
     // projectId: projectAnswer?.projectId,
     // selectedMemberIds: projectAnswer?.selectedMemberIds,
-    fieldConfig:
-      (projectField?.fieldConfig as ProjectAndMembersFieldConfig) ?? createDefaultProjectAndMembersFieldConfig()
+    fieldConfig: projectField?.fieldConfig as ProjectAndMembersFieldConfig
   });
 
   const onSave = useCallback(

--- a/components/settings/projects/ProjectsSettings.tsx
+++ b/components/settings/projects/ProjectsSettings.tsx
@@ -55,8 +55,7 @@ function ProjectRow({
     reValidateMode: 'onChange',
     resolver: yupResolver(
       createProjectYupSchema({
-        fieldConfig: createDefaultProjectAndMembersFieldConfig(),
-        defaultRequired: false
+        fieldConfig: createDefaultProjectAndMembersFieldConfig()
       })
     ),
     criteriaMode: 'all',
@@ -301,8 +300,7 @@ export function ProjectsSettings() {
     reValidateMode: 'onChange',
     resolver: yupResolver(
       createProjectYupSchema({
-        fieldConfig: createDefaultProjectAndMembersFieldConfig(),
-        defaultRequired: false
+        fieldConfig: createDefaultProjectAndMembersFieldConfig()
       })
     ),
     criteriaMode: 'all',

--- a/components/settings/projects/components/FieldAnswers.tsx
+++ b/components/settings/projects/components/FieldAnswers.tsx
@@ -36,8 +36,6 @@ function FieldAnswer({
     return null;
   }
 
-  console.log('property', property.label, registeredField);
-
   return (
     <TextInputField
       key={property.label}

--- a/components/settings/projects/components/FieldAnswers.tsx
+++ b/components/settings/projects/components/FieldAnswers.tsx
@@ -42,7 +42,7 @@ function FieldAnswer({
       label={property.label}
       multiline={property.multiline}
       rows={property.rows ?? 1}
-      required={false}
+      required={fieldConfig?.required}
       disabled={disabled}
       value={(field.value as string) ?? ''}
       error={fieldState.error?.message}
@@ -67,7 +67,7 @@ export function FieldAnswers({
 }: {
   disabled?: boolean;
   name?: string;
-  fieldConfig?: FieldConfig;
+  fieldConfig: FieldConfig;
   properties: ProjectFieldProperty[];
   onChange?: (onChange: Record<string, any>) => void;
 }) {
@@ -76,7 +76,7 @@ export function FieldAnswers({
       {properties.map((property) => (
         <FieldAnswer
           name={(name ? `${name}.${property.field}` : property.field) as Path<ProjectAndMembersPayload>}
-          fieldConfig={fieldConfig?.[property.field]}
+          fieldConfig={fieldConfig[property.field]}
           key={property.field as string}
           disabled={disabled}
           property={property}

--- a/components/settings/projects/components/FieldAnswers.tsx
+++ b/components/settings/projects/components/FieldAnswers.tsx
@@ -4,22 +4,20 @@ import { useController, useFormContext } from 'react-hook-form';
 
 import { TextInputField } from 'components/common/form/fields/TextInputField';
 import { getFieldConfig } from 'lib/projects/formField';
-import type { ProjectFieldProperty, FieldConfig } from 'lib/projects/formField';
+import type { ProjectFieldProperty, FieldConfig, ProjectFieldConfig } from 'lib/projects/formField';
 import type { ProjectAndMembersPayload } from 'lib/projects/interfaces';
 
 function FieldAnswer({
   property,
   fieldConfig,
-  defaultRequired,
   name,
   disabled,
   onChange
 }: {
   disabled?: boolean;
   name: Path<ProjectAndMembersPayload>;
-  defaultRequired?: boolean;
   property: ProjectFieldProperty;
-  fieldConfig?: FieldConfig;
+  fieldConfig?: ProjectFieldConfig;
   onChange?: (payload: Record<string, any>) => void;
 }) {
   const { control, register } = useFormContext<ProjectAndMembersPayload>();
@@ -33,10 +31,12 @@ function FieldAnswer({
     setValueAs: (value) => value?.trim()
   });
 
-  const isShown = getFieldConfig(fieldConfig?.[property.field]).show;
+  const isShown = getFieldConfig(fieldConfig).show;
   if (!isShown) {
     return null;
   }
+
+  console.log('property', property.label, registeredField);
 
   return (
     <TextInputField
@@ -44,7 +44,7 @@ function FieldAnswer({
       label={property.label}
       multiline={property.multiline}
       rows={property.rows ?? 1}
-      required={fieldConfig?.[property.field]?.required ?? defaultRequired}
+      required={false}
       disabled={disabled}
       value={(field.value as string) ?? ''}
       error={fieldState.error?.message}
@@ -63,14 +63,12 @@ function FieldAnswer({
 export function FieldAnswers({
   fieldConfig,
   properties,
-  defaultRequired = false,
   name,
   disabled,
   onChange
 }: {
   disabled?: boolean;
   name?: string;
-  defaultRequired?: boolean;
   fieldConfig?: FieldConfig;
   properties: ProjectFieldProperty[];
   onChange?: (onChange: Record<string, any>) => void;
@@ -80,8 +78,7 @@ export function FieldAnswers({
       {properties.map((property) => (
         <FieldAnswer
           name={(name ? `${name}.${property.field}` : property.field) as Path<ProjectAndMembersPayload>}
-          defaultRequired={defaultRequired}
-          fieldConfig={fieldConfig}
+          fieldConfig={fieldConfig?.[property.field]}
           key={property.field as string}
           disabled={disabled}
           property={property}

--- a/components/settings/projects/components/FieldsEditor.tsx
+++ b/components/settings/projects/components/FieldsEditor.tsx
@@ -7,13 +7,11 @@ export function FieldsEditor({
   onChange,
   fieldConfig,
   properties,
-  defaultRequired,
   isProjectMember
 }: {
   onChange?: (fieldConfig: FieldConfig) => void;
   fieldConfig: FieldConfig;
   properties: ProjectFieldProperty[];
-  defaultRequired?: boolean;
   isProjectMember?: boolean;
 }) {
   return (
@@ -36,7 +34,7 @@ export function FieldsEditor({
               multiline={property.multiline}
               rows={property.rows ?? 1}
               disabled
-              required={fieldConfig?.[property.field]?.required ?? defaultRequired}
+              required={fieldConfig?.[property.field]?.required}
             />
             {/** Required fields must always be required and shown */}
             {onChange && !property.alwaysRequired && (
@@ -69,7 +67,7 @@ export function FieldsEditor({
                     <Switch
                       size='small'
                       disabled={fieldConfig?.[property.field]?.show === false}
-                      checked={fieldConfig?.[property.field]?.required ?? defaultRequired}
+                      checked={fieldConfig?.[property.field]?.required}
                       onChange={(e) => {
                         onChange({
                           ...(fieldConfig ?? {}),

--- a/components/settings/projects/components/ProjectForm.tsx
+++ b/components/settings/projects/components/ProjectForm.tsx
@@ -10,8 +10,7 @@ import { createDefaultProjectAndMembersPayload } from 'lib/projects/constants';
 import {
   projectMemberFieldProperties,
   createDefaultProjectAndMembersFieldConfig,
-  projectFieldProperties,
-  getFieldConfig
+  projectFieldProperties
 } from 'lib/projects/formField';
 import type { ProjectAndMembersPayload } from 'lib/projects/interfaces';
 

--- a/components/settings/projects/components/ProjectForm.tsx
+++ b/components/settings/projects/components/ProjectForm.tsx
@@ -33,12 +33,7 @@ export function ProjectFormAnswers({ isTeamLead }: { isTeamLead: boolean }) {
   return (
     <Stack gap={2} width='100%'>
       <Typography variant='h6'>Project Info</Typography>
-      <FieldAnswers
-        properties={projectFieldProperties}
-        defaultRequired={false}
-        disabled={!isTeamLead}
-        fieldConfig={fieldConfig}
-      />
+      <FieldAnswers properties={projectFieldProperties} disabled={!isTeamLead} fieldConfig={fieldConfig} />
       <Typography variant='h6' mt={2}>
         Team Info
       </Typography>
@@ -46,7 +41,6 @@ export function ProjectFormAnswers({ isTeamLead }: { isTeamLead: boolean }) {
       <ProjectMemberFieldAnswers
         projectMemberIndex={0}
         disabled={!isTeamLead}
-        defaultRequired={false}
         fieldConfig={fieldConfig?.projectMember}
       />
       {extraProjectMembers.length ? (
@@ -72,7 +66,6 @@ export function ProjectFormAnswers({ isTeamLead }: { isTeamLead: boolean }) {
                 ) : null}
               </Stack>
               <FieldAnswers
-                defaultRequired={false}
                 disabled={!(isTeamLead || projectMember.userId === user?.id)}
                 name={`projectMembers[${index + 1}]`}
                 fieldConfig={fieldConfig?.projectMember}
@@ -81,7 +74,6 @@ export function ProjectFormAnswers({ isTeamLead }: { isTeamLead: boolean }) {
               <ProjectMemberFieldAnswers
                 projectMemberIndex={index + 1}
                 disabled={!(isTeamLead || projectMember.userId === user?.id)}
-                defaultRequired={false}
                 fieldConfig={fieldConfig?.projectMember}
               />
             </Stack>

--- a/components/settings/projects/components/ProjectMemberFields.tsx
+++ b/components/settings/projects/components/ProjectMemberFields.tsx
@@ -6,20 +6,17 @@ import { FieldsEditor } from './FieldsEditor';
 
 export function ProjectMemberFieldAnswers({
   fieldConfig,
-  defaultRequired,
   projectMemberIndex,
   disabled,
   onChange
 }: {
   projectMemberIndex: number;
   fieldConfig?: FieldConfig;
-  defaultRequired?: boolean;
   disabled?: boolean;
   onChange?: (projectMemberPayload: Record<string, any>) => any;
 }) {
   return (
     <FieldAnswers
-      defaultRequired={defaultRequired}
       disabled={disabled}
       name={`projectMembers[${projectMemberIndex}]`}
       fieldConfig={fieldConfig}

--- a/components/settings/projects/components/ProjectMemberFields.tsx
+++ b/components/settings/projects/components/ProjectMemberFields.tsx
@@ -37,7 +37,6 @@ export function ProjectMemberFieldsEditor({
 }) {
   return (
     <FieldsEditor
-      defaultRequired={defaultRequired}
       properties={projectMemberFieldProperties}
       fieldConfig={fieldConfig}
       onChange={onChange}

--- a/components/settings/projects/components/ProjectMemberFields.tsx
+++ b/components/settings/projects/components/ProjectMemberFields.tsx
@@ -11,7 +11,7 @@ export function ProjectMemberFieldAnswers({
   onChange
 }: {
   projectMemberIndex: number;
-  fieldConfig?: FieldConfig;
+  fieldConfig: FieldConfig;
   disabled?: boolean;
   onChange?: (projectMemberPayload: Record<string, any>) => any;
 }) {

--- a/lib/projects/createProjectYupSchema.ts
+++ b/lib/projects/createProjectYupSchema.ts
@@ -46,11 +46,11 @@ function addMatchersToSchema({
   }
 }
 
-export function createProjectYupSchema({ fieldConfig }: { fieldConfig: ProjectAndMembersFieldConfig }) {
+export function createProjectYupSchema({ fieldConfig }: { fieldConfig?: ProjectAndMembersFieldConfig }) {
   const yupProjectSchemaObject: Partial<Record<ProjectField, yup.StringSchema>> = {};
   const yupProjectMemberSchemaObject: Partial<Record<ProjectMemberField, yup.StringSchema>> = {};
   projectFieldProperties.forEach((projectFieldProperty) => {
-    const projectFieldConfig = fieldConfig[projectFieldProperty.field] ?? {
+    const projectFieldConfig = fieldConfig?.[projectFieldProperty.field] ?? {
       required: false,
       show: true
     };
@@ -73,7 +73,7 @@ export function createProjectYupSchema({ fieldConfig }: { fieldConfig: ProjectAn
   });
 
   projectMemberFieldProperties.forEach((projectMemberFieldProperty) => {
-    const projectMemberFieldConfig = fieldConfig.projectMember[projectMemberFieldProperty.field] ?? {
+    const projectMemberFieldConfig = fieldConfig?.projectMember[projectMemberFieldProperty.field] ?? {
       required: false,
       show: true
     };

--- a/lib/projects/createProjectYupSchema.ts
+++ b/lib/projects/createProjectYupSchema.ts
@@ -46,22 +46,16 @@ function addMatchersToSchema({
   }
 }
 
-export function createProjectYupSchema({
-  fieldConfig,
-  defaultRequired = false
-}: {
-  fieldConfig: ProjectAndMembersFieldConfig;
-  defaultRequired?: boolean;
-}) {
+export function createProjectYupSchema({ fieldConfig }: { fieldConfig: ProjectAndMembersFieldConfig }) {
   const yupProjectSchemaObject: Partial<Record<ProjectField, yup.StringSchema>> = {};
   const yupProjectMemberSchemaObject: Partial<Record<ProjectMemberField, yup.StringSchema>> = {};
   projectFieldProperties.forEach((projectFieldProperty) => {
     const projectFieldConfig = fieldConfig[projectFieldProperty.field] ?? {
-      required: defaultRequired,
+      required: false,
       show: true
     };
 
-    projectFieldConfig.required = projectFieldConfig.required ?? defaultRequired;
+    projectFieldConfig.required = projectFieldConfig.required ?? false;
 
     if (projectFieldConfig.show !== false) {
       if (projectFieldConfig.required) {
@@ -80,10 +74,10 @@ export function createProjectYupSchema({
 
   projectMemberFieldProperties.forEach((projectMemberFieldProperty) => {
     const projectMemberFieldConfig = fieldConfig.projectMember[projectMemberFieldProperty.field] ?? {
-      required: defaultRequired,
+      required: false,
       show: true
     };
-    projectMemberFieldConfig.required = projectMemberFieldConfig.required ?? defaultRequired;
+    projectMemberFieldConfig.required = projectMemberFieldConfig.required ?? false;
     if (projectMemberFieldConfig.show !== false) {
       if (projectMemberFieldConfig.required) {
         yupProjectMemberSchemaObject[projectMemberFieldProperty.field as ProjectMemberField] = yup.string().required();

--- a/lib/projects/formField.ts
+++ b/lib/projects/formField.ts
@@ -223,7 +223,7 @@ export function createDefaultProjectAndMembersFieldConfig({
       }
     }
   } as ProjectAndMembersFieldConfig;
-  // loop thro project fields
+  // loop thru project fields
   projectFieldProperties.forEach((field) => {
     config[field.field] = getFieldConfig({
       required: allFieldsRequired || field.alwaysRequired
@@ -232,7 +232,8 @@ export function createDefaultProjectAndMembersFieldConfig({
   // loop thru team member fields
   projectMemberFieldProperties.forEach((field) => {
     config.projectMember[field.field] = getFieldConfig({
-      private: field.allowPrivate
+      private: field.allowPrivate,
+      required: allFieldsRequired || field.alwaysRequired
     });
   });
 

--- a/lib/projects/formField.ts
+++ b/lib/projects/formField.ts
@@ -201,8 +201,10 @@ export const projectFieldProperties: ProjectFieldProperty[] = [
   }
 ];
 
-export function createDefaultProjectAndMembersFieldConfig(): ProjectAndMembersFieldConfig {
-  return {
+export function createDefaultProjectAndMembersFieldConfig({
+  allFieldsRequired
+}: { allFieldsRequired?: boolean } = {}): ProjectAndMembersFieldConfig {
+  const config = {
     name: {
       required: true
     },
@@ -221,6 +223,20 @@ export function createDefaultProjectAndMembersFieldConfig(): ProjectAndMembersFi
       }
     }
   } as ProjectAndMembersFieldConfig;
+  // loop thro project fields
+  projectFieldProperties.forEach((field) => {
+    config[field.field] = getFieldConfig({
+      required: allFieldsRequired || field.alwaysRequired
+    });
+  });
+  // loop thru team member fields
+  projectMemberFieldProperties.forEach((field) => {
+    config.projectMember[field.field] = getFieldConfig({
+      private: field.allowPrivate
+    });
+  });
+
+  return config;
 }
 
 export function getFieldConfig(field?: ProjectFieldConfig): ProjectFieldConfig {

--- a/lib/proposals/createDraftProposal.ts
+++ b/lib/proposals/createDraftProposal.ts
@@ -132,7 +132,7 @@ export async function createDraftProposal(input: CreateDraftProposalInput) {
               private: false,
               required: true,
               id: uuid(),
-              fieldConfig: createDefaultProjectAndMembersFieldConfig()
+              fieldConfig: createDefaultProjectAndMembersFieldConfig({ allFieldsRequired: true })
             }
           ]
         : [],

--- a/lib/proposals/form/getProposalFormFields.ts
+++ b/lib/proposals/form/getProposalFormFields.ts
@@ -1,26 +1,37 @@
 import type { FormFieldInput } from 'lib/forms/interfaces';
 import type { ProjectAndMembersFieldConfig } from 'lib/projects/formField';
+import { createDefaultProjectAndMembersFieldConfig } from 'lib/projects/formField';
 
 export function getProposalFormFields(fields: FormFieldInput[] | null | undefined, canViewPrivateFields: boolean) {
   if (!fields) {
     return null;
   }
-  if (canViewPrivateFields) {
-    return fields;
-  }
   fields.forEach((field) => {
     if (field.type === 'project_profile') {
-      const fieldConfig = field.fieldConfig as ProjectAndMembersFieldConfig;
-      for (const subField of Object.values(fieldConfig)) {
-        if (subField.private) {
-          subField.show = false;
+      // grab default properties for fields
+      const configDefaults = createDefaultProjectAndMembersFieldConfig({ allFieldsRequired: true });
+      const savedFieldConfig = field.fieldConfig as ProjectAndMembersFieldConfig;
+      const fieldConfig: ProjectAndMembersFieldConfig = {
+        ...configDefaults,
+        ...savedFieldConfig,
+        projectMember: {
+          ...configDefaults.projectMember,
+          ...savedFieldConfig.projectMember
+        }
+      };
+      if (!canViewPrivateFields) {
+        for (const subField of Object.values(fieldConfig)) {
+          if (subField.private) {
+            subField.show = false;
+          }
+        }
+        for (const subField of Object.values(fieldConfig.projectMember)) {
+          if (subField.private) {
+            subField.show = false;
+          }
         }
       }
-      for (const subField of Object.values(fieldConfig.projectMember)) {
-        if (subField.private) {
-          subField.show = false;
-        }
-      }
+      Object.assign(field, { fieldConfig });
     }
   });
 

--- a/lib/proposals/getProposal.ts
+++ b/lib/proposals/getProposal.ts
@@ -21,8 +21,6 @@ export async function getProposal({
   id: string;
   permissionsByStep: PermissionsMap;
 }): Promise<ProposalWithUsersAndRubric> {
-  console.log('GET PROPOSAL');
-  console.log('GET PROPOSAL222');
   const proposal = await prisma.proposal.findUniqueOrThrow({
     where: {
       id

--- a/lib/proposals/getProposal.ts
+++ b/lib/proposals/getProposal.ts
@@ -21,6 +21,7 @@ export async function getProposal({
   id: string;
   permissionsByStep: PermissionsMap;
 }): Promise<ProposalWithUsersAndRubric> {
+  console.log('GET PROPOSAL');
   const proposal = await prisma.proposal.findUniqueOrThrow({
     where: {
       id
@@ -72,17 +73,6 @@ export async function getProposal({
 
   const currentEvaluation = getCurrentEvaluation(proposal.evaluations);
 
-  const workflow = proposal.workflowId
-    ? await prisma.proposalWorkflow.findFirst({
-        where: {
-          id: proposal.workflowId
-        },
-        select: {
-          evaluations: true
-        }
-      })
-    : null;
-
   const currentPermissions =
     proposal.status === 'draft'
       ? permissionsByStep.draft
@@ -92,28 +82,38 @@ export async function getProposal({
     throw new Error('Could not find permissions for proposal');
   }
 
-  const credentials = await getProposalOrApplicationCredentials({ proposalId: id }).catch((error) => {
-    log.error('Error fetching proposal credentials', { error, proposalId: id });
-    return [];
-  });
-
   const evaluationIds = proposal.evaluations.map((e) => e.id);
 
-  const proposalEvaluationReviews = await prisma.proposalEvaluationReview.findMany({
-    where: {
-      evaluationId: {
-        in: evaluationIds
+  const [workflow, credentials, proposalEvaluationReviews, proposalEvaluationAppealReviews] = await Promise.all([
+    proposal.workflowId
+      ? await prisma.proposalWorkflow.findFirst({
+          where: {
+            id: proposal.workflowId
+          },
+          select: {
+            evaluations: true
+          }
+        })
+      : Promise.resolve(null),
+    getProposalOrApplicationCredentials({ proposalId: id }).catch((error) => {
+      log.error('Error fetching proposal credentials', { error, proposalId: id });
+      return [];
+    }),
+    prisma.proposalEvaluationReview.findMany({
+      where: {
+        evaluationId: {
+          in: evaluationIds
+        }
       }
-    }
-  });
-
-  const proposalEvaluationAppealReviews = await prisma.proposalEvaluationAppealReview.findMany({
-    where: {
-      evaluationId: {
-        in: evaluationIds
+    }),
+    prisma.proposalEvaluationAppealReview.findMany({
+      where: {
+        evaluationId: {
+          in: evaluationIds
+        }
       }
-    }
-  });
+    })
+  ]);
 
   const isPublicPage =
     proposal.space.publicProposals ||

--- a/lib/proposals/getProposal.ts
+++ b/lib/proposals/getProposal.ts
@@ -22,6 +22,7 @@ export async function getProposal({
   permissionsByStep: PermissionsMap;
 }): Promise<ProposalWithUsersAndRubric> {
   console.log('GET PROPOSAL');
+  console.log('GET PROPOSAL222');
   const proposal = await prisma.proposal.findUniqueOrThrow({
     where: {
       id

--- a/lib/proposals/validateProposalProject.ts
+++ b/lib/proposals/validateProposalProject.ts
@@ -30,8 +30,7 @@ export function validateProposalProject({
   }
 
   const projectSchema = createProjectYupSchema({
-    fieldConfig: projectField.fieldConfig as ProjectAndMembersFieldConfig,
-    defaultRequired: true
+    fieldConfig: projectField.fieldConfig as ProjectAndMembersFieldConfig
   });
 
   if (typeof projectFieldAnswer === 'object' && 'selectedMemberIds' in projectFieldAnswer) {


### PR DESCRIPTION
The "defaultRequired" override on form inputs was causing unexpected behavior for me. There should be no need for low-level components to be "smart" or have special overrides if the form state at the top of heierarchy is set up correctly.