### PR TITLE
fix bug when selecting a template that is required

### DIFF
--- a/components/common/PageActions/components/ForumPostActionList.tsx
+++ b/components/common/PageActions/components/ForumPostActionList.tsx
@@ -67,8 +67,8 @@ export function ForumPostActionList({
     }
   }
 
-  async function convertToProposal(pageId: string) {
-    navigateToSpacePath(`/proposals/new`, { sourcePostId: post?.id });
+  async function convertToProposal(sourcePostId: string) {
+    navigateToSpacePath(`/proposals/new`, { sourcePostId });
   }
 
   return (


### PR DESCRIPTION
### WHAT

Fixes bug: when template is required but empty by default, the "Publish" button does not know that a template is selected. One way to reproduce this is to 'convert from post' but could also just click "Create" without selecting a template.

Notes: navigating a way thereby getting SWR to update the page fixes the issue on its own

### WHY

By broadcasting a websocket event we update the page state which is used to disable the Publish button
