### PR TITLE
fix linting for main app

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,10 +91,7 @@
     "connect-api:start:prod": "npm run start:prod --w=apps/connect-api"
   },
   "lint-staged": {
-    "apps/connect-api/**/*.{ts,tsx}": [
-      "npm run lint -w=connect-api"
-    ],
-    "(!apps)/**/*.{ts,tsx}": [
+    "*.{ts,tsx}": [
       "eslint --fix"
     ]
   },


### PR DESCRIPTION
### WHAT

fixes issue that code is not linted on commit. the connecpt api may no longer be linted but seems like a different issue is needed for monorepos: https://github.com/lint-staged/lint-staged#how-to-use-lint-staged-in-a-multi-package-monorepo


at the moment, i'd rather bring back husky for the code we work on the most