### PR TITLE
add a new token gate option for contract method

### DIFF
--- a/components/common/SpaceAccessGate/components/TokenGate/TokenGateConditions.tsx
+++ b/components/common/SpaceAccessGate/components/TokenGate/TokenGateConditions.tsx
@@ -88,7 +88,9 @@ function Condition({
           />
         </Box>
       )}
-      <Box width='100%'>{text}</Box>
+      <Box width='100%' display='flex' alignItems='center' gap={0.5}>
+        {text}
+      </Box>
       {onDelete && (
         <Box>
           <IconButton onClick={onDelete} disabled={isLoading} color='default'>

--- a/components/common/TokenGateModal/components/TokenGateTokens.tsx
+++ b/components/common/TokenGateModal/components/TokenGateTokens.tsx
@@ -12,12 +12,12 @@ import { TokenGateTokenFields } from './TokenGateTokensFields';
  */
 export function TokenGateTokens() {
   const { setDisplayedPage, handleTokenGate } = useTokenGateModal();
-  const methods = useTokensForm();
+  const form = useTokensForm();
   const {
     getValues,
     reset,
     formState: { isValid }
-  } = methods;
+  } = form;
 
   const onSubmit = async () => {
     const values = getValues();
@@ -32,7 +32,7 @@ export function TokenGateTokens() {
   };
 
   return (
-    <FormProvider {...methods}>
+    <FormProvider {...form}>
       <TokenGateTokenFields />
       <TokenGateFooter onSubmit={onSubmit} onCancel={onCancel} isValid={isValid} />
     </FormProvider>

--- a/components/common/TokenGateModal/components/TokenGateTokensFields.tsx
+++ b/components/common/TokenGateModal/components/TokenGateTokensFields.tsx
@@ -28,7 +28,7 @@ export function TokenGateTokenFields() {
           deps: ['contract']
         })}
       />
-      <FieldWrapper label='Which group should be able to access this asset'>
+      <FieldWrapper label='Type'>
         <Select<FormValues['check']>
           displayEmpty
           fullWidth
@@ -56,9 +56,9 @@ export function TokenGateTokenFields() {
       {check === 'customContractMethod' && (
         <TextInputField
           label='Contract Method'
-          error={errors.contract?.message}
-          helperText={errors.contract?.message}
-          placeholder='getBalance'
+          error={errors.method?.message}
+          helperText={errors.method?.message}
+          placeholder='balanceOf'
           {...register('method', {
             deps: ['chain']
           })}

--- a/components/common/TokenGateModal/components/TokenGateTokensFields.tsx
+++ b/components/common/TokenGateModal/components/TokenGateTokensFields.tsx
@@ -42,12 +42,24 @@ export function TokenGateTokenFields() {
           ))}
         </Select>
       </FieldWrapper>
-      {check === 'customToken' && (
+      {(check === 'customToken' || 'customContractMethod') && (
         <TextInputField
           label='Contract Address'
           error={errors.contract?.message}
           helperText={errors.contract?.message}
+          placeholder='0x0000000000000000000000000000000000000000'
           {...register('contract', {
+            deps: ['chain']
+          })}
+        />
+      )}
+      {check === 'customContractMethod' && (
+        <TextInputField
+          label='Contract Method'
+          error={errors.contract?.message}
+          helperText={errors.contract?.message}
+          placeholder='getBalance'
+          {...register('method', {
             deps: ['chain']
           })}
         />

--- a/components/common/TokenGateModal/hooks/useTokensForm.tsx
+++ b/components/common/TokenGateModal/hooks/useTokensForm.tsx
@@ -18,7 +18,7 @@ const schema = yup.object({
     .oneOf(tokenIds)
     .test('empty-check', 'Token selection is required', (option) => !!option),
   contract: yup.string().when('check', {
-    is: (val: TokenType) => val === 'customToken',
+    is: (val: TokenType) => val === 'customToken' || val === 'customContractMethod',
     then: () =>
       yup
         .string<`0x${string}`>()
@@ -42,6 +42,29 @@ const schema = yup.object({
 
           return true;
         }),
+    otherwise: () => yup.string()
+  }),
+  method: yup.string().when('check', {
+    is: (val: TokenType) => val === 'customContractMethod',
+    then: () => yup.string().required('Method is required'),
+    // .test('isContract', 'Invalid contract or chain', async (value, context) => {
+    //   const chain = context.parent.chain;
+    //   const check = context.parent.check;
+
+    //   if (chain && check === 'customToken') {
+    //     try {
+    //       await getToken(wagmiConfig, {
+    //         address: value,
+    //         chainId: Number(chain)
+    //       });
+    //       return true;
+    //     } catch (err) {
+    //       return false;
+    //     }
+    //   }
+
+    //   return true;
+    // }),
     otherwise: () => yup.string()
   }),
   quantity: yup

--- a/components/common/TokenGateModal/hooks/useTokensForm.tsx
+++ b/components/common/TokenGateModal/hooks/useTokensForm.tsx
@@ -1,7 +1,8 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { getToken } from '@wagmi/core';
+import { getBytecode, readContracts, readContract } from '@wagmi/core';
 import { wagmiConfig } from 'connectors/config';
 import { useForm } from 'react-hook-form';
+import { erc20Abi, isAddress, parseAbi } from 'viem';
 import * as yup from 'yup';
 
 import { isValidChainAddress } from 'lib/tokens/validation';
@@ -30,9 +31,72 @@ const schema = yup.object({
 
           if (chain && check === 'customToken') {
             try {
-              await getToken(wagmiConfig, {
+              const chainId = Number(chain);
+              await readContracts(wagmiConfig, {
+                allowFailure: false,
+                contracts: [
+                  {
+                    address: value,
+                    chainId,
+                    abi: erc20Abi,
+                    functionName: 'decimals'
+                  },
+                  {
+                    address: value,
+                    chainId,
+                    abi: erc20Abi,
+                    functionName: 'totalSupply'
+                  }
+                ]
+              });
+              return true;
+            } catch (err) {
+              return false;
+            }
+          }
+
+          return true;
+        })
+        .test('contractExists', 'No contract exists at this address', async (value, context) => {
+          const chain = context.parent.chain;
+          const check = context.parent.check;
+
+          if (chain && isAddress(value) && check === 'customContractMethod') {
+            const chainId = Number(chain);
+            try {
+              const result = await getBytecode(wagmiConfig, {
                 address: value,
-                chainId: Number(chain)
+                chainId
+              });
+              return !!result;
+            } catch (err) {
+              return false;
+            }
+          }
+          return true;
+        }),
+    otherwise: () => yup.string()
+  }),
+  method: yup.string().when('check', {
+    is: (val: TokenType) => val === 'customContractMethod',
+    then: () =>
+      yup
+        .string()
+        .required('Method is required')
+        .test('isMethod', 'Invalid or incorrect method', async (value, context) => {
+          const check = context.parent.check;
+          const chain = context.parent.chain;
+          const contract = context.parent.contract;
+
+          if (chain && isAddress(contract) && check === 'customContractMethod') {
+            try {
+              const chainId = Number(chain);
+              await readContract(wagmiConfig, {
+                address: contract as `0x${string}`,
+                chainId,
+                abi: parseAbi([`function ${value}(address) view returns (uint256)`]),
+                functionName: value,
+                args: [contract] // any address should do
               });
               return true;
             } catch (err) {
@@ -42,29 +106,6 @@ const schema = yup.object({
 
           return true;
         }),
-    otherwise: () => yup.string()
-  }),
-  method: yup.string().when('check', {
-    is: (val: TokenType) => val === 'customContractMethod',
-    then: () => yup.string().required('Method is required'),
-    // .test('isContract', 'Invalid contract or chain', async (value, context) => {
-    //   const chain = context.parent.chain;
-    //   const check = context.parent.check;
-
-    //   if (chain && check === 'customToken') {
-    //     try {
-    //       await getToken(wagmiConfig, {
-    //         address: value,
-    //         chainId: Number(chain)
-    //       });
-    //       return true;
-    //     } catch (err) {
-    //       return false;
-    //     }
-    //   }
-
-    //   return true;
-    // }),
     otherwise: () => yup.string()
   }),
   quantity: yup

--- a/components/common/TokenGateModal/utils/getTokensAccessControlConditions.ts
+++ b/components/common/TokenGateModal/utils/getTokensAccessControlConditions.ts
@@ -5,7 +5,7 @@ import type { AccessControlCondition } from 'lib/tokenGates/interfaces';
 import type { FormValues } from '../hooks/useTokensForm';
 
 export function getTokensAccessControlConditions(values: FormValues): AccessControlCondition[] | undefined {
-  const { chain, contract, quantity, check } = values;
+  const { chain, contract, method, quantity, check } = values;
   const chainId = Number(chain);
   const amount = parseEther(quantity).toString();
 
@@ -17,6 +17,20 @@ export function getTokensAccessControlConditions(values: FormValues): AccessCont
         contractAddress: contract,
         method: 'balanceOf',
         type: 'ERC20',
+        tokenIds: [],
+        quantity: amount
+      }
+    ];
+  }
+
+  if (check === 'customContractMethod' && contract) {
+    return [
+      {
+        chain: chainId,
+        condition: 'evm',
+        contractAddress: contract,
+        method: method!,
+        type: 'ContractMethod',
         tokenIds: [],
         quantity: amount
       }

--- a/components/common/TokenGateModal/utils/utils.ts
+++ b/components/common/TokenGateModal/utils/utils.ts
@@ -17,8 +17,9 @@ export const poapNameMatch = [
 ] as const;
 
 export const tokenCheck = [
-  { id: 'token', name: 'Check Balance' },
-  { id: 'customToken', name: 'Custom token' }
+  { id: 'token', name: 'Check balance' },
+  { id: 'customToken', name: 'Custom token' },
+  { id: 'customContractMethod', name: 'Custom contract method' }
 ] as const;
 
 export const nftCheck = [

--- a/lib/tokenGates/humanizeConditions.ts
+++ b/lib/tokenGates/humanizeConditions.ts
@@ -151,6 +151,18 @@ export function humanizeConditionsData(conditions: TokenGate['conditions']): Hum
           };
         }
       }
+      case 'ContractMethod': {
+        return {
+          image,
+          content: [
+            { ...tokenNameOrEtherscanUrl },
+            { type: 'text', content: `returns at least` },
+            { type: 'text', content: balance },
+            { type: 'text', content: `on` },
+            { type: 'text', content: chain }
+          ]
+        };
+      }
       case 'Wallet': {
         // Controls wallet with address ${shortWalletAddress}
         return {

--- a/lib/tokenGates/interfaces.ts
+++ b/lib/tokenGates/interfaces.ts
@@ -9,6 +9,7 @@ export type AccessType =
   | 'ERC20'
   | 'ERC721'
   | 'ERC1155'
+  | 'ContractMethod'
   | 'Wallet'
   | 'MolochDAOv2.1'
   | 'Builder'
@@ -39,7 +40,7 @@ export type AccessControlCondition = {
   /** Contract address of the asset. */
   contractAddress: string;
   /** Method for querying the contract. */
-  method: Method;
+  method: Method | string; // string for custom contract methods
   /** Value of any type of token gate. */
   tokenIds: string[];
   /** The quantity of an asset. e.g. 2 ETH */

--- a/lib/tokenGates/validateTokenGateCondition.ts
+++ b/lib/tokenGates/validateTokenGateCondition.ts
@@ -35,9 +35,9 @@ export async function validateTokenGateCondition(
     case condition.type === 'ERC20' && !!contractAddress && !!condition.quantity: {
       const minimumQuantity = BigInt(condition.quantity);
       const balance = await publicClient.readContract({
-        abi: parseAbi([`function getUser(address) view returns (uint256)`]),
+        abi: ercAbi,
         address: contractAddress,
-        functionName: 'getUser',
+        functionName: 'balanceOf',
         args: [userAddress]
       });
       const decimals = await publicClient.readContract({


### PR DESCRIPTION
Allow calling a custom contract method to check a wallet's balance. This enables one space to use their staking contract: https://sepolia.etherscan.io/address/0x55105f426126952ac6d9c2e7e72c7451318617d3#code

Form:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/a8211ca9-ae7f-481f-ab60-2de445aee9ad)

Preview:
![image](https://github.com/charmverse/app.charmverse.io/assets/305398/90b14f84-6b5f-458b-b39a-33725ff19a36)
