### PR TITLE
allow using other chains for token gating

### DIFF
--- a/components/settings/invites/components/TokenGates/components/TokenGateModal/components/TokenGateBlockchainSelect.tsx
+++ b/components/settings/invites/components/TokenGates/components/TokenGateModal/components/TokenGateBlockchainSelect.tsx
@@ -19,12 +19,7 @@ function SelectField(
   const { helperMessage, chains: chainsProp, ...restProps } = props;
 
   const { space } = useCurrentSpace();
-  const chainList =
-    chainsProp ||
-    getChainList({ enableTestnets: !!space?.enableTestnets }).filter(
-      (chain) =>
-        !!chain.alchemyUrl || isAnkrChain(chain.chainId) || isZkSyncChain(chain.chainId) || isZoraChain(chain.chainId)
-    );
+  const chainList = chainsProp || getChainList({ enableTestnets: !!space?.enableTestnets });
 
   return (
     <FieldWrapper label='Blockchain'>

--- a/components/settings/invites/components/TokenGates/components/TokenGateModal/components/TokenGateBlockchainSelect.tsx
+++ b/components/settings/invites/components/TokenGates/components/TokenGateModal/components/TokenGateBlockchainSelect.tsx
@@ -8,9 +8,6 @@ import type { Ref, ReactNode } from 'react';
 import { FieldWrapper } from 'components/common/form/fields/FieldWrapper';
 import { BlockchainLogo } from 'components/common/Icons/BlockchainLogo';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
-import { isAnkrChain } from 'lib/blockchain/provider/ankr/config';
-import { isZkSyncChain } from 'lib/blockchain/provider/zksync/config';
-import { isZoraChain } from 'lib/blockchain/provider/zora/config';
 
 function SelectField(
   props: SelectProps<string> & { helperMessage?: ReactNode; chains?: IChainDetails[] },


### PR DESCRIPTION
I checked and all the token gate options that use TokenGateBlockchainSelect specify the chains they want, except for NFT and tokens, which we can use RPC urls for.