### PR TITLE
change average calculation for rubrics

### DIFF
--- a/lib/databases/proposalsSource/__tests__/getCardProperties.spec.ts
+++ b/lib/databases/proposalsSource/__tests__/getCardProperties.spec.ts
@@ -315,7 +315,7 @@ describe('getCardPropertiesFromProposals', () => {
     ]);
     expect(cardFieldProperties[rubricEvaluation1EvaluationTotalProp.id as string]).toStrictEqual(23);
     expect(cardFieldProperties[rubricEvaluation2EvaluationTotalProp.id as string]).toStrictEqual(4);
-    expect(cardFieldProperties[rubricEvaluation1EvaluationAverageProp.id as string]).toStrictEqual(5.75);
+    expect(cardFieldProperties[rubricEvaluation1EvaluationAverageProp.id as string]).toStrictEqual(11.5);
     expect(cardFieldProperties[rubricEvaluation2EvaluationAverageProp.id as string]).toStrictEqual(4);
   });
 

--- a/lib/proposals/rubric/__tests__/aggregateResults.spec.ts
+++ b/lib/proposals/rubric/__tests__/aggregateResults.spec.ts
@@ -47,7 +47,7 @@ describe('aggregateResults', () => {
     expect(result).toMatchObject<AggregateResults>({
       allScores: {
         // Average of all individual scores (not average of averages)
-        average: 8,
+        average: 12,
         sum: 24
       },
       reviewersResults: {

--- a/lib/proposals/rubric/aggregateResults.ts
+++ b/lib/proposals/rubric/aggregateResults.ts
@@ -87,7 +87,7 @@ export function aggregateResults({
 
   const allScores = Object.values(criteriaScores).flat();
   const allScoresSum = allScores.length ? sum(allScores) : null;
-  const allScoresAverage = allScores.length ? roundNumber(mean(allScores)) : null;
+  const allScoresAverage = allScores.length ? roundNumber(sum(allScores) / reviewers.length) : null;
 
   const mappedReviewerResults = reviewersResults.reduce((acc, reviewer) => {
     acc[reviewer.id] = reviewer;


### PR DESCRIPTION
Update to the way we calculate for "proposalEvaluationAverage": https://github.com/charmverse/app.charmverse.io/blob/main/lib/databases/proposalsSource/getCardPropertiesFromRubric.ts#L105

We are supposed to sum all the scores and divide by number of users, not the number of scores.