### PR TITLE
fix duplicate token label

### DIFF
--- a/components/rewards/components/RewardAmount.tsx
+++ b/components/rewards/components/RewardAmount.tsx
@@ -93,17 +93,6 @@ export function RewardAmount({
                 {truncatedAmount} {tokenInfo.isContract && tokenInfo.tokenSymbol}
               </Typography>
             )}
-            {tokenInfo.isContract && tokenInfo.tokenSymbol && (
-              <Typography
-                component='span'
-                variant='body2'
-                data-test='reward-amount'
-                textTransform='uppercase'
-                {...typographyProps}
-              >
-                {tokenInfo.isContract && tokenInfo.tokenSymbol}
-              </Typography>
-            )}
             {!truncatedAmount && noAmountText && <EmptyPlaceholder>{noAmountText}</EmptyPlaceholder>}
           </>
         )}


### PR DESCRIPTION
I think this was a bug introduced in my cleanup PR: https://github.com/charmverse/app.charmverse.io/commit/010eb94948ead3786bbe3d38d754981ab1b8cd06

I just forgot to remove part of the old code