### PR TITLE
Retain rubric criteria order when using proposal templates

### DIFF
--- a/lib/proposals/rubric/__tests__/upsertRubricCriteria.spec.ts
+++ b/lib/proposals/rubric/__tests__/upsertRubricCriteria.spec.ts
@@ -46,7 +46,7 @@ describe('upsertRubricCriteria', () => {
     const newRubrics = await upsertRubricCriteria({
       proposalId: proposal.id,
       evaluationId: proposal.evaluations[0].id,
-      rubricCriteria: [...rubrics, { type: 'range', title: 'Second score', parameters: { max: 7, min: 1 } }],
+      rubricCriteria: [...rubrics, { type: 'range', index: 4, title: 'Second score', parameters: { max: 7, min: 1 } }],
       actorId: user.id
     });
 
@@ -54,7 +54,7 @@ describe('upsertRubricCriteria', () => {
       rubrics[0],
       expect.objectContaining({
         id: expect.any(String),
-        index: 1,
+        index: 4,
         description: null,
         parameters: {
           max: 7,

--- a/lib/proposals/rubric/upsertRubricCriteria.ts
+++ b/lib/proposals/rubric/upsertRubricCriteria.ts
@@ -81,7 +81,7 @@ export async function upsertRubricCriteria({
           },
           create: {
             id: rubricCriteriaId,
-            index: rubric.index || index,
+            index: rubric.index ?? index,
             title: rubric.title,
             description: rubric.description,
             type: rubric.type,

--- a/lib/proposals/rubric/upsertRubricCriteria.ts
+++ b/lib/proposals/rubric/upsertRubricCriteria.ts
@@ -81,7 +81,7 @@ export async function upsertRubricCriteria({
           },
           create: {
             id: rubricCriteriaId,
-            index: rubric.index ?? index,
+            index: typeof rubric.index === 'number' && rubric.index !== -1 ? rubric.index : index,
             title: rubric.title,
             description: rubric.description,
             type: rubric.type,

--- a/lib/proposals/rubric/upsertRubricCriteria.ts
+++ b/lib/proposals/rubric/upsertRubricCriteria.ts
@@ -9,7 +9,7 @@ import { setPageUpdatedAt } from '../setPageUpdatedAt';
 import type { RubricCriteriaTypedFields, RubricCriteriaTyped } from './interfaces';
 
 export type RubricDataInput = Pick<ProposalRubricCriteria, 'title'> &
-  Partial<Pick<ProposalRubricCriteria, 'description' | 'id'>> &
+  Partial<Pick<ProposalRubricCriteria, 'description' | 'id' | 'index'>> &
   RubricCriteriaTypedFields;
 
 export type RubricCriteriaUpsert = {
@@ -81,7 +81,7 @@ export async function upsertRubricCriteria({
           },
           create: {
             id: rubricCriteriaId,
-            index,
+            index: rubric.index || index,
             title: rubric.title,
             description: rubric.description,
             type: rubric.type,

--- a/lib/proposals/rubric/upsertRubricCriteria.ts
+++ b/lib/proposals/rubric/upsertRubricCriteria.ts
@@ -92,7 +92,7 @@ export async function upsertRubricCriteria({
           update: {
             title: rubric.title,
             description: rubric.description,
-            index,
+            index: rubric.index || index,
             type: rubric.type,
             parameters: rubric.parameters
           }


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

When creating a proposal from a template, the criteria would be out of order
