### PR TITLE
Fix app crashes without a farcaster id

### DIFF
--- a/@connect-shared/lib/projects/fetchProject.ts
+++ b/@connect-shared/lib/projects/fetchProject.ts
@@ -96,7 +96,7 @@ export async function fetchProject({
           bio: farcasterUser?.bio,
           username: farcasterUser?.username,
           displayName: farcasterUser?.displayName
-        } as FarcasterProfileInfo
+        }
       };
     })
   };

--- a/apps/connect/app/page.tsx
+++ b/apps/connect/app/page.tsx
@@ -1,15 +1,15 @@
 import { redirect } from 'next/navigation';
 
 import { HomePage } from 'components/home/HomePage';
-import { getCurrentUser } from 'lib/actions/getCurrentUser';
+import { getSession } from 'lib/session/getSession';
 
 // tell Next that this route loads dynamic data
 export const dynamic = 'force-dynamic';
 
 export default async function Home() {
-  const user = await getCurrentUser();
+  const session = await getSession();
 
-  if (user?.data) {
+  if (session?.user?.id) {
     redirect('/profile');
   }
 

--- a/apps/connect/components/projects/[id]/ProjectDetailsPage.tsx
+++ b/apps/connect/components/projects/[id]/ProjectDetailsPage.tsx
@@ -4,18 +4,19 @@ import type { ConnectProjectDetails } from '@connect-shared/lib/projects/fetchPr
 import { Divider, Stack, Typography } from '@mui/material';
 
 import { FarcasterCard } from 'components/common/FarcasterCard';
-import { getCurrentUser } from 'lib/actions/getCurrentUser';
+import { getSession } from 'lib/session/getSession';
 
 import { PageWrapper } from '../../common/PageWrapper';
 import { ProjectDetails } from '../components/ProjectDetails';
 import { ProjectHeader } from '../components/ProjectHeader';
 
 export async function ProjectDetailsPage({ project }: { project: ConnectProjectDetails }) {
-  const currentUser = await getCurrentUser();
+  const session = await getSession();
 
   const isCurrentUserTeamLead = project.projectMembers.some(
-    (member) => member.teamLead && member.userId === currentUser?.data?.id
+    (member) => member.teamLead && member.userId === session.user.id
   );
+
   return (
     <PageWrapper header={<ProjectHeader name={project.name} avatar={project.avatar} coverImage={project.coverImage} />}>
       <ProjectDetails showEditButton={isCurrentUserTeamLead} project={project} />
@@ -24,7 +25,7 @@ export async function ProjectDetailsPage({ project }: { project: ConnectProjectD
       <Stack gap={1}>
         {project.projectMembers.map((member) => (
           <FarcasterCard
-            fid={parseInt(member.farcasterUser.fid.toString())}
+            fid={member.farcasterUser.fid}
             key={member.farcasterUser.fid}
             name={member.farcasterUser.displayName}
             username={member.farcasterUser.username}

--- a/apps/connect/components/projects/edit/EditProjectPage.tsx
+++ b/apps/connect/components/projects/edit/EditProjectPage.tsx
@@ -126,7 +126,7 @@ export function EditProjectPage({ user, project }: { user: LoggedInUser; project
           initialFarcasterProfiles={project.projectMembers.slice(1).map((member) => ({
             bio: member.farcasterUser.bio,
             displayName: member.farcasterUser.displayName,
-            fid: parseInt(member.farcasterUser.fid.toString()),
+            fid: member.farcasterUser.fid,
             pfpUrl: member.farcasterUser.pfpUrl,
             username: member.farcasterUser.username
           }))}

--- a/apps/sunnyawards/app/page.tsx
+++ b/apps/sunnyawards/app/page.tsx
@@ -1,15 +1,15 @@
 import { redirect } from 'next/navigation';
 
 import { HomePage } from 'components/home/HomePage';
-import { getCurrentUserAction } from 'lib/profile/getCurrentUserAction';
+import { getSession } from 'lib/session/getSession';
 
 // tell Next that this route loads dynamic data
 export const dynamic = 'force-dynamic';
 
 export default async function Home() {
-  const user = await getCurrentUserAction();
+  const session = await getSession();
 
-  if (user?.data) {
+  if (session?.user?.id) {
     redirect('/profile');
   }
 

--- a/apps/sunnyawards/components/projects/[id]/ProjectDetailsPage.tsx
+++ b/apps/sunnyawards/components/projects/[id]/ProjectDetailsPage.tsx
@@ -4,18 +4,19 @@ import type { ConnectProjectDetails } from '@connect-shared/lib/projects/fetchPr
 import { Divider, Stack, Typography } from '@mui/material';
 
 import { FarcasterCard } from 'components/common/FarcasterCard';
-import { getCurrentUserAction } from 'lib/profile/getCurrentUserAction';
+import { getSession } from 'lib/session/getSession';
 
 import { PageWrapper } from '../../common/PageWrapper';
 import { ProjectDetails } from '../components/ProjectDetails';
 import { ProjectHeader } from '../components/ProjectHeader';
 
 export async function ProjectDetailsPage({ project }: { project: ConnectProjectDetails }) {
-  const currentUser = await getCurrentUserAction();
+  const session = await getSession();
 
   const isCurrentUserTeamLead = project.projectMembers.some(
-    (member) => member.teamLead && member.userId === currentUser?.data?.id
+    (member) => member.teamLead && member.userId === session?.user?.id
   );
+
   return (
     <PageWrapper header={<ProjectHeader name={project.name} avatar={project.avatar} coverImage={project.coverImage} />}>
       <ProjectDetails project={project} showEditButton={isCurrentUserTeamLead} />
@@ -24,7 +25,7 @@ export async function ProjectDetailsPage({ project }: { project: ConnectProjectD
       <Stack gap={1}>
         {project.projectMembers.map((member) => (
           <FarcasterCard
-            fid={parseInt(member.farcasterUser.fid.toString())}
+            fid={member.farcasterUser.fid}
             key={member.farcasterUser.fid}
             name={member.farcasterUser.displayName}
             username={member.farcasterUser.username}

--- a/lib/farcaster/loginWithFarcaster.ts
+++ b/lib/farcaster/loginWithFarcaster.ts
@@ -26,15 +26,11 @@ const appClient = createAppClient({
 });
 
 export type FarcasterProfileInfo = {
-  fid: number;
+  fid: number | undefined;
   username?: string;
   displayName?: string;
   bio?: string;
   pfpUrl?: string;
-};
-
-export type FarcasterUserWithProfile = Omit<FarcasterUser, 'account'> & {
-  account: FarcasterProfileInfo;
 };
 
 export type LoginWithFarcasterParams = FarcasterBody &


### PR DESCRIPTION
### WHAT
App was crashing because of some project members not having a farcaster id in the db.
Also, it was hard to debug production because of too many error messages like "Client Error: You are not logged in. Please try to login ". I removed the getCurrentUserAction and I just get the session since it is easier and doesn't throw an error.
The error mentioned above should be a warning for users that are taking an action and they are not logged in.

### WHY
- fid can be undefined. Let's stop using assertions since they are getting in the way of finding the real issue
- when we just want to see that the user exists, let's use getSession() since it returns the user id
