### PR TITLE
Farcaster user from db

### DIFF
--- a/@connect-shared/lib/farcaster/fetchUserByFarcasterUsername.ts
+++ b/@connect-shared/lib/farcaster/fetchUserByFarcasterUsername.ts
@@ -1,19 +1,13 @@
 import { prisma } from '@charmverse/core/prisma-client';
-import { getFarcasterUsers } from '@root/lib/farcaster/getFarcasterUsers';
 
 export async function fetchUserByFarcasterUsername(username: string) {
-  const [farcasterUser] = await getFarcasterUsers({
-    username
-  });
-
-  if (!farcasterUser) {
-    return null;
-  }
-
   const user = await prisma.user.findFirst({
     where: {
       farcasterUser: {
-        fid: farcasterUser.fid
+        account: {
+          path: ['username'],
+          equals: username
+        }
       }
     },
     select: {

--- a/apps/connect/components/common/FarcasterCard.tsx
+++ b/apps/connect/components/common/FarcasterCard.tsx
@@ -67,7 +67,7 @@ export function FarcasterCard(props: {
   onDelete?: VoidFunction;
   enableLink?: boolean;
 }) {
-  if (!props.enableLink) {
+  if (!props.enableLink || !props.username) {
     return (
       <Card sx={{ border: 'none' }}>
         <FarcasterCardContent {...props} />

--- a/apps/sunnyawards/components/common/FarcasterCard.tsx
+++ b/apps/sunnyawards/components/common/FarcasterCard.tsx
@@ -66,7 +66,7 @@ export function FarcasterCard(props: {
   onDelete?: VoidFunction;
   enableLink?: boolean;
 }) {
-  if (!props.enableLink) {
+  if (!props.enableLink || !props.username) {
     return (
       <Card sx={{ border: 'none' }}>
         <FarcasterCardContent {...props} />


### PR DESCRIPTION
### WHAT

- Get Farcaster user from db instead of an external api 
- Don't render a link if the member does not have a farcaster username
- [Card](https://app.charmverse.io/charmverse/use-user-path-for-u-pages-on-connect-app-instead-of-looking-up-farcaster-3513535065100033)
### WHY
- The farcaster API can be down and our app could crash
- The page was crashing for non existing farcaster members
