### PR TITLE
Fix Sunny project creation failure

### DIFF
--- a/apps/sunnyawards/lib/projects/createProjectAction.ts
+++ b/apps/sunnyawards/lib/projects/createProjectAction.ts
@@ -16,7 +16,7 @@ export const createProjectAction = authActionClient
   .action(async ({ parsedInput, ctx }) => {
     const input = parsedInput;
 
-    const currentUserId = ctx.session.user!.id;
+    const currentUserId = ctx.session.user.id;
     const newProject = await createOptimismProject({
       userId: currentUserId,
       input: {
@@ -37,6 +37,8 @@ export const createProjectAction = authActionClient
       await storeProjectMetadataAndPublishGitcoinAttestation({
         projectIdOrPath: newProject.id,
         userId: currentUserId
+      }).catch((err) => {
+        log.error('Failed to store project metadata and publish gitcoin attestation', { err, userId: currentUserId });
       });
     }
 


### PR DESCRIPTION
The create project action was stopping the user flow of going to success page.

The error was inside thrown by storeProjectMetadataAndPublishGitcoinAttestation and it had the message:
 Error: insufficient funds for intrinsic transaction cost [ See: https://links.ethers.org/v5-errors-INSUFFICIENT_FUNDS ]
