### PR TITLE
fix gitignore for deployment .env folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ playwright-report
 .DS_Store
 *.env*
 !.env.*.example
+# the following two lines are required to include .env files for deployment
+!.ebstalk.apps.env/
 !.ebstalk.apps.env/*.env
 *.tsbuildinfo
 


### PR DESCRIPTION
Our gitignore was not actually excluding the .ebstalks folder correctly. This should enable searching for constants inside VS Code (which ignores things ignored by .gitignore), and also make it easier to add .env files in the future.


Found a solution on this SO post: https://stackoverflow.com/questions/5533050/gitignore-exclude-folder-but-include-specific-subfolder