### PR TITLE
fix generateCSV to support numeric values

### DIFF
--- a/lib/databases/generateCsv.ts
+++ b/lib/databases/generateCsv.ts
@@ -237,6 +237,7 @@ function getCSVColumns({
   visibleProperties: IPropertyTemplate<PropertyType>[];
 }) {
   const columns: string[] = [];
+
   if (!hasTitleProperty) {
     columns.push(`"${encodeText(card.title)}"`);
   }
@@ -278,7 +279,7 @@ function getCSVColumns({
       columns.push(`${baseUrl}${encodeText(Array.isArray(displayValue) ? displayValue[0] : displayValue.toString())}`);
     } else {
       // Export as string
-      columns.push(`"${encodeText(displayValue as string)}"`);
+      columns.push(`"${encodeText(displayValue.toString())}"`);
     }
   });
   return columns;


### PR DESCRIPTION
I'm not sure how this wasn't broken already but i couldn't export a rubric proposal because the score is a number and hence doesn't have a "replace" method inside encodeText


If you can suggest a good place to add a test, I'll do it! The generateCSV seemed to use lots of builder api's and it wasn't clear where to add a rubric score.. do we have tests for rubrics in proposal-source i could copy from maybe?