### PR TITLE
make sure to use page id when applying templates

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/EvaluationsReview.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/EvaluationsReview.tsx
@@ -110,7 +110,7 @@ export function EvaluationsReview({
   const templatePageOptions = useMemo(
     () =>
       (proposalTemplates || []).map((template) => ({
-        id: template.proposalId,
+        id: template.pageId,
         title: template.title
       })),
     [proposalTemplates]

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Settings/EvaluationsSettings.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Settings/EvaluationsSettings.tsx
@@ -64,7 +64,7 @@ export function EvaluationsSettings({
   const templatePageOptions = useMemo(
     () =>
       (proposalTemplates || []).map((template) => ({
-        id: template.proposalId,
+        id: template.pageId,
         title: template.title
       })),
     [proposalTemplates]

--- a/lib/proposals/applyProposalTemplate.ts
+++ b/lib/proposals/applyProposalTemplate.ts
@@ -7,7 +7,7 @@ import { upsertRubricCriteria } from './rubric/upsertRubricCriteria';
 
 export type ApplyTemplateRequest = {
   proposalId: string;
-  templateId: string | null;
+  templateId: string | null; // note that templateId belongs to the pages db and NOT proposals
 };
 
 export async function applyProposalTemplate({

--- a/lib/proposals/getProposalTemplates.ts
+++ b/lib/proposals/getProposalTemplates.ts
@@ -6,8 +6,8 @@ import { stringUtils } from '@charmverse/core/utilities';
 import { hasAccessToSpace } from '@root/lib/users/hasAccessToSpace';
 
 export type ProposalTemplateMeta = {
-  pageId: string;
-  proposalId: string;
+  pageId: string; // this is also the canonical id for the proposal template (vs: proposalId)
+  proposalId: string; // necessary for proposal-related actions: publish, archive, etc.
   contentType: 'free_form' | 'structured';
   title: string;
   archived?: boolean;


### PR DESCRIPTION
There is a proposal template where the page id and proposalId are not the same. Most of our code deals with this fine, but the template dropdown was assuming we are using proposalId, so it would not show the template as being selected. If someone 'fixed' the template and selected it by proposalId, it would break other things