### PR TITLE
fix links to headings from table of contents

### DIFF
--- a/components/common/CharmEditor/components/heading.ts
+++ b/components/common/CharmEditor/components/heading.ts
@@ -210,3 +210,10 @@ export function scrollToHeadingNode({ view, headingSlug }: { view: EditorView; h
     document.querySelector('.document-print-container')?.scrollTo({ top: domTopPosition });
   }
 }
+
+export function getHeadingLink(content: string) {
+  const url = new URL(window.location.href);
+  url.hash = '';
+  const urlWithoutHash = url.toString();
+  return `${urlWithoutHash}#${slugify(content)}`;
+}

--- a/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
+++ b/components/common/CharmEditor/components/rowActions/RowActionsMenu.tsx
@@ -26,6 +26,7 @@ import { useSnackbar } from 'hooks/useSnackbar';
 import { isMac } from 'lib/utils/browser';
 import { slugify } from 'lib/utils/strings';
 
+import { getHeadingLink } from '../heading';
 import { nestedPageNodeName } from '../nestedPage/nestedPage.constants';
 
 import { deleteRowNode, getNodeForRowPosition, type PluginState } from './rowActions';
@@ -87,12 +88,8 @@ function Component({ menuState }: { menuState: PluginState }) {
     const node = topPos.node();
 
     if (node && node.type.name === 'heading') {
-      const text = node.textContent;
-
-      const url = new URL(window.location.href);
-      url.hash = '';
-      const urlWithoutHash = url.toString();
-      copyFn(`${urlWithoutHash}#${slugify(text)}`).then(() => {
+      const link = getHeadingLink(node.textContent);
+      copyFn(link).then(() => {
         showMessage('Link copied to clipboard', 'success');
       });
     }

--- a/components/common/CharmEditor/components/tableOfContents/TableOfContents.tsx
+++ b/components/common/CharmEditor/components/tableOfContents/TableOfContents.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import Link from 'components/common/Link';
 
+import { getHeadingLink } from '../heading';
 import type { CharmNodeViewProps } from '../nodeView/nodeView';
 
 // Table Of Contents inspiration: https://tiptap.dev/guide/node-views/examples#table-of-contents
@@ -123,7 +124,7 @@ export function TableOfContents({ view }: CharmNodeViewProps) {
           color='inherit'
           draggable={false}
           key={item.id}
-          href={`#${item.id}`}
+          href={getHeadingLink(item.text)}
           onClick={() => highlightHeading(item)}
           external
           className={`toc-item--${item.level}`}


### PR DESCRIPTION
Not sure when we crossed wires, but we need to use the 'slugified' version of headers for links to work, whereas it was expecting the heading number.