### PR TITLE
allow user to log in using any chain

### DIFF
--- a/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -73,7 +73,13 @@ export function WalletSelector() {
         <Grid item xs={12}>
           <ConnectorButton
             name='WalletConnect'
-            onClick={() => walletConnectConnector && handleConnect(walletConnectConnector)}
+            onClick={() => {
+              if (walletConnectConnector) {
+                handleConnect(walletConnectConnector);
+              } else {
+                log.warn('WalletConnect connector not found');
+              }
+            }}
             iconUrl='walletconnect.svg'
             disabled={isWalletConnected(walletConnectConnector?.id) || !!isLoadingConnectorId}
             isActive={isWalletConnected(walletConnectConnector?.id)}
@@ -83,7 +89,13 @@ export function WalletSelector() {
         <Grid item xs={12}>
           <ConnectorButton
             name='Coinbase Wallet'
-            onClick={() => coinbaseWalletConnector && handleConnect(coinbaseWalletConnector)}
+            onClick={() => {
+              if (coinbaseWalletConnector) {
+                handleConnect(coinbaseWalletConnector);
+              } else {
+                log.warn('Coinbase connector not found');
+              }
+            }}
             iconUrl='coinbasewallet.png'
             disabled={isWalletConnected(coinbaseWalletConnector?.id) || !!isLoadingConnectorId}
             isActive={isWalletConnected(coinbaseWalletConnector?.id)}

--- a/hooks/useWeb3Account.tsx
+++ b/hooks/useWeb3Account.tsx
@@ -80,7 +80,7 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
   const { signer, provider } = useWeb3Signer({ chainId });
 
   const requestSignature = useCallback(async () => {
-    if (!account || !chainId) {
+    if (!account) {
       throw new MissingWeb3AccountError();
     }
 
@@ -92,7 +92,7 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
         address: getAddress(account), // convert to EIP-55 format or else SIWE complains
         uri: globalThis.location.origin,
         version: '1',
-        chainId: 1 // this chainId is provided to prevent replay attacks, but we are just asking the user to verify their address
+        chainId: chainId || 1
       };
 
       const message = new SiweMessage(preparedMessage);

--- a/hooks/useWeb3Account.tsx
+++ b/hooks/useWeb3Account.tsx
@@ -1,8 +1,9 @@
 import { log } from '@charmverse/core/log';
 import type { UserWallet } from '@charmverse/core/prisma';
 import type { Web3Provider } from '@ethersproject/providers';
-import { watchAccount } from '@wagmi/core';
 import { getWagmiConfig } from '@root/connectors/config';
+import type { LoggedInUser } from '@root/models';
+import { watchAccount } from '@wagmi/core';
 import type { Signer } from 'ethers';
 import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
@@ -21,7 +22,6 @@ import type {
 import type { SystemError } from 'lib/utils/errors';
 import { MissingWeb3AccountError } from 'lib/utils/errors';
 import { lowerCaseEqual } from 'lib/utils/strings';
-import type { LoggedInUser } from '@root/models';
 
 import { useUser } from './useUser';
 import { useVerifyLoginOtp } from './useVerifyLoginOtp';
@@ -87,12 +87,12 @@ export function Web3AccountProvider({ children }: { children: ReactNode }) {
     setIsSigning(true);
 
     try {
-      const preparedMessage = {
+      const preparedMessage: Partial<SiweMessage> = {
         domain: window.location.host,
         address: getAddress(account), // convert to EIP-55 format or else SIWE complains
         uri: globalThis.location.origin,
         version: '1',
-        chainId
+        chainId: 1 // this chainId is provided to prevent replay attacks, but we are just asking the user to verify their address
       };
 
       const message = new SiweMessage(preparedMessage);


### PR DESCRIPTION
If you're not on a supported chain, when you try to log in it will log an error "No connected wallet detected. This is required to proceed." and not show the user anything. I did some tests and the sign-in works even if chain id is undefined. It seems to onyl be necessary for creating signatures that can be played on a specific network. For log in tho, we don't really care


I left the chainId in as input because it seems necessary for Gnosis + Wallet Connect to work, based on a comment inside the useEffect? But more info would be great