### PR TITLE
do not refresh rubric review any time the answers are refreshed

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/EvaluationsReview.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/EvaluationsReview.tsx
@@ -67,7 +67,7 @@ export type Props = {
   refreshPage?: VoidFunction;
 };
 
-export function FEvaluationsReview({
+export function EvaluationsReview({
   pagePath,
   pageTitle,
   pageId,

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/EvaluationsReview.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/EvaluationsReview.tsx
@@ -12,7 +12,6 @@ import { WorkflowSelect } from 'components/common/WorkflowSidebar/components/Wor
 import { CredentialSelect } from 'components/credentials/CredentialsSelect';
 import { useProposalCredentials } from 'components/proposals/hooks/useProposalCredentials';
 import { useProposalTemplates } from 'components/proposals/hooks/useProposalTemplates';
-import { useDocusign } from 'components/signing/hooks/useDocusign';
 import { useCurrentSpace } from 'hooks/useCurrentSpace';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useSnackbar } from 'hooks/useSnackbar';
@@ -68,7 +67,7 @@ export type Props = {
   refreshPage?: VoidFunction;
 };
 
-export function EvaluationsReview({
+export function FEvaluationsReview({
   pagePath,
   pageTitle,
   pageId,
@@ -87,7 +86,6 @@ export function EvaluationsReview({
   const { showMessage } = useSnackbar();
 
   const isAdmin = useIsAdmin();
-  const { envelopes } = useDocusign();
 
   const [evaluationInput, setEvaluationInput] = useState<ProposalEvaluationValues | null>(null);
   const [showEditCredentials, setShowEditCredentials] = useState(false);

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/RubricEvaluation.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/RubricEvaluation.tsx
@@ -29,11 +29,11 @@ export function RubricEvaluation({ proposal, isCurrent, evaluation, refreshPropo
   const rubricCriteria = evaluation?.rubricCriteria;
   const myRubricAnswers = useMemo(
     () => evaluation?.rubricAnswers.filter((answer) => answer.userId === user?.id) || [],
-    [user?.id, evaluation?.rubricAnswers]
+    [user?.id, !!evaluation?.rubricAnswers]
   );
   const myDraftRubricAnswers = useMemo(
     () => evaluation?.draftRubricAnswers.filter((answer) => answer.userId === user?.id),
-    [user?.id, evaluation?.draftRubricAnswers]
+    [user?.id, !!evaluation?.draftRubricAnswers]
   );
 
   const canViewRubricAnswers = isAdmin || canAnswerRubric;


### PR DESCRIPTION
Bug:
if a proposal is updated in a different view, it can reset the form of a reviewer submitting rubric evaluation

Solution:
There's really no need to refresh the answer state after being loaded, afaict, but we are getting them from the proposal which we do keep up-to-date. Also, for some reason the issue only happens if there was something changed in the proposal. It could just be changing the reviewer list on a different evaluation step

For now, i just made it so that we do not refresh the answers memo'd state. It's been a long time since this code was written, but i think that was the original intention