### PR TITLE
require all fields to be answered when publishing a proposal

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalStickyFooter/ProposalStickyFooter.tsx
+++ b/components/proposals/ProposalPage/components/ProposalStickyFooter/ProposalStickyFooter.tsx
@@ -47,11 +47,10 @@ export function ProposalStickyFooter({
     }
   }
   const projectProfileField = proposal?.form?.formFields?.find((field) => field.type === 'project_profile');
-  const milestoneFormInput = proposal.form?.formFields?.find((field) => field.type === 'milestone');
   const formFields =
     page.type === 'proposal_template'
       ? proposal.form?.formFields
-      : proposal.form?.formFields?.filter((field) => field.type === 'project_profile');
+      : proposal.form?.formFields?.filter((field) => field.type === 'project_profile' || field.type === 'milestone');
   const projectProfileAnswer = projectProfileField ? answerFormValues[projectProfileField.id] : null;
   const errors = getProposalErrors({
     page: {
@@ -61,7 +60,6 @@ export function ProposalStickyFooter({
       type: page.type
     },
     project: projectProfileField ? projectFormValues : null,
-    requireMilestone: milestoneFormInput?.required,
     isDraft: false, // isDraft skips all errors
     contentType: isStructuredProposal ? 'structured' : 'free_form',
     proposal: {

--- a/lib/forms/upsertProposalFormAnswers.ts
+++ b/lib/forms/upsertProposalFormAnswers.ts
@@ -51,8 +51,13 @@ export async function upsertProposalFormAnswers({ answers, proposalId }: RubricA
     })
     .filter(isTruthy);
 
-  if (!isDraft && !validateAnswers(answersToSave, form.formFields)) {
-    throw new InvalidInputError(`All required fields must be answered`);
+  if (!isDraft) {
+    const answerFieldIds = answers.map((a) => a.fieldId);
+    // only pass in the form fields being answered
+    const formFields = form.formFields.filter((field) => answerFieldIds.includes(field.id));
+    if (!validateAnswers(answersToSave, formFields)) {
+      throw new InvalidInputError(`All required fields must be answered`);
+    }
   }
 
   const res = await prisma.$transaction([

--- a/lib/forms/validateAnswers.ts
+++ b/lib/forms/validateAnswers.ts
@@ -5,12 +5,8 @@ export function validateAnswers(
   answers: FieldAnswerInput[],
   formFields: { required: boolean; id: string; type: FormFieldType }[]
 ) {
-  const answerFieldIds = answers.map((a) => a.fieldId);
   return formFields
-    .filter(
-      (formField) =>
-        formField.type !== 'milestone' && formField.type !== 'label' && answerFieldIds.includes(formField.id)
-    )
+    .filter((formField) => formField.type !== 'milestone' && formField.type !== 'label')
     .every(
       (f) =>
         !f.required ||

--- a/lib/proposals/getProposalErrors.ts
+++ b/lib/proposals/getProposalErrors.ts
@@ -21,8 +21,7 @@ export function getProposalErrors({
   contentType,
   isDraft,
   project,
-  requireTemplates,
-  requireMilestone
+  requireTemplates
 }: {
   page: Pick<CreateProposalInput['pageProps'], 'title' | 'type' | 'sourceTemplateId'> & {
     hasContent?: boolean;
@@ -32,9 +31,10 @@ export function getProposalErrors({
   contentType: 'structured' | 'free_form';
   isDraft: boolean;
   requireTemplates: boolean;
-  requireMilestone?: boolean;
 }) {
   const errors: string[] = [];
+
+  const requireMilestone = !!proposal.formFields?.find((field) => field.type === 'milestone')?.required;
 
   if (isDraft) {
     return errors;

--- a/pages/api/proposals/[id]/publish.ts
+++ b/pages/api/proposals/[id]/publish.ts
@@ -107,7 +107,6 @@ async function publishProposalStatusController(req: NextApiRequest, res: NextApi
   if (isProposalArchived) {
     throw new ActionNotPermittedError(`You cannot publish an archived proposal`);
   }
-
   const errors = getProposalErrors({
     page: {
       title: proposalPage.title ?? '',


### PR DESCRIPTION
we were filtering out form fields if there was no matchign answer, subverting the 'required' property. I'm not sure how users got past this in draft state though cuz the UI form was still correctly checking for answers