### PR TITLE
gracefully handle invalid user session cookie

### DIFF
--- a/apps/connect/app/page.tsx
+++ b/apps/connect/app/page.tsx
@@ -1,3 +1,5 @@
+import { log } from '@charmverse/core/log';
+import { prisma } from '@charmverse/core/prisma-client';
 import { getSession } from '@connect-shared/lib/session/getSession';
 import { redirect } from 'next/navigation';
 
@@ -10,7 +12,17 @@ export default async function Home() {
   const session = await getSession();
 
   if (session?.user?.id) {
-    redirect('/profile');
+    const user = await prisma.user.findFirst({
+      where: {
+        id: session.user.id
+      }
+    });
+
+    if (user) {
+      redirect('/profile');
+    } else {
+      log.warn('User has session that is not found in the db', { userId: session.user.id });
+    }
   }
 
   return <HomePage />;

--- a/apps/connect/middleware.ts
+++ b/apps/connect/middleware.ts
@@ -23,8 +23,6 @@ export async function middleware(request: NextRequest) {
     !path.startsWith('/feed')
   ) {
     return NextResponse.redirect(new URL('/', request.url));
-  } else if (user && path === '/') {
-    return NextResponse.redirect(new URL('/profile', request.url));
   }
 
   return NextResponse.next();

--- a/apps/sunnyawards/app/page.tsx
+++ b/apps/sunnyawards/app/page.tsx
@@ -1,3 +1,5 @@
+import { log } from '@charmverse/core/log';
+import { prisma } from '@charmverse/core/prisma-client';
 import { getSession } from '@connect-shared/lib/session/getSession';
 import { redirect } from 'next/navigation';
 
@@ -10,7 +12,17 @@ export default async function Home() {
   const session = await getSession();
 
   if (session?.user?.id) {
-    redirect('/profile');
+    const user = await prisma.user.findFirst({
+      where: {
+        id: session.user.id
+      }
+    });
+
+    if (user) {
+      redirect('/profile');
+    } else {
+      log.warn('User has session that is not found in the db', { userId: session.user.id });
+    }
   }
 
   return <HomePage />;

--- a/apps/sunnyawards/middleware.ts
+++ b/apps/sunnyawards/middleware.ts
@@ -15,8 +15,6 @@ export async function middleware(request: NextRequest) {
 
   if (!user && path !== '/' && !isProjectPath && !path.startsWith('/u/')) {
     return NextResponse.redirect(new URL('/', request.url));
-  } else if (user && path === '/') {
-    return NextResponse.redirect(new URL('/profile', request.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
Before: if you had an invalid user id in your session, it would keep trying to redirect you to /profile, which blows up cuz the user doesn't exist
After: we check that the user actually exists, and we only do redirect to /profile in one place (does'nt need to be in the middleware)