### PR TITLE
Fix clicking Table of Contents

### DIFF
--- a/components/common/CharmEditor/components/heading.ts
+++ b/components/common/CharmEditor/components/heading.ts
@@ -100,8 +100,12 @@ function specFactory(): RawSpecs {
           }
         };
       }),
+      // Note: toDOM is not constantly called, so this really only works when the heading is already created when we render the page
       toDOM: (node: Node) => {
-        const result: any = [`h${node.attrs.level}`, { id: node.attrs.id }, 0];
+        // @ts-ignore
+        const headingContent = node.content?.content?.[0]?.text || '';
+        const anchorName = slugify(headingContent);
+        const result: any = [`h${node.attrs.level}`, ['a', { name: anchorName }, 0]];
 
         return result;
       }

--- a/components/common/CharmEditor/components/heading.ts
+++ b/components/common/CharmEditor/components/heading.ts
@@ -69,10 +69,6 @@ function specFactory(): RawSpecs {
     name,
     schema: {
       attrs: {
-        id: {
-          // id is used for linking from table of contents
-          default: null
-        },
         level: {
           default: 1
         },

--- a/components/common/CharmEditor/components/tableOfContents/TableOfContents.tsx
+++ b/components/common/CharmEditor/components/tableOfContents/TableOfContents.tsx
@@ -13,7 +13,6 @@ import type { CharmNodeViewProps } from '../nodeView/nodeView';
 // Table Of Contents inspiration: https://tiptap.dev/guide/node-views/examples#table-of-contents
 
 type HeadingItem = {
-  id: string;
   pos: number;
   text: string;
   level: number;
@@ -79,31 +78,16 @@ export function TableOfContents({ view }: CharmNodeViewProps) {
 
   const handleUpdate = useCallback(() => {
     const headings: HeadingItem[] = [];
-    const transaction = view.state.tr;
 
     view.state.doc.descendants((node, pos) => {
       if (node.type.name === 'heading') {
-        const id = `heading-${headings.length + 1}`;
-        if (node.attrs.id !== id) {
-          transaction.setNodeMarkup(pos, undefined, {
-            ...node.attrs,
-            id
-          });
-        }
-
         headings.push({
           level: node.attrs.level,
           pos,
-          text: node.textContent,
-          id
+          text: node.textContent
         });
       }
     });
-
-    transaction.setMeta('addToHistory', false);
-    transaction.setMeta('preventUpdate', true);
-
-    view.dispatch(transaction);
 
     setItems(headings);
   }, [view.state.doc]);


### PR DESCRIPTION
Currently if you click a link in TOC, it just highlights the heading but does not scroll you down. This is becaus we had an old system of defining numbers for each heading, but now we just use a human-readable version.