### PR TITLE
test a faster way to generate cache keys for CI

### DIFF
--- a/.github/actions/build_app/action.yml
+++ b/.github/actions/build_app/action.yml
@@ -9,7 +9,7 @@ runs:
   using: 'composite'
   steps:
 
-    - name: Get last Git commit hash modifying packages/abc
+    - name: Get last Git commit hashes for cache key
       shell: bash
       # Instead of hasing files, use the latest git commit in a directory to speed up cache key https://github.com/actions/runner/issues/1840#issuecomment-2094847172
       run: |
@@ -28,7 +28,7 @@ runs:
         # key: app-${{ inputs.app_name }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('lib/**/*.ts', 'lib/**/*.tsx', '@connect-shared/**/*.ts', '@connect-shared/**/*.tsx', format('apps/{0}/**/*.ts', inputs.app_name), format('apps/{0}/**/*.tsx', inputs.app_name), format('apps/{0}/**/*.scss', inputs.app_name)) }}
         key: app-${{ inputs.app_name }}-${{ env.NPM_PACKAGES_COMMIT }}-${{ env.SOURCE_CODE_COMMIT }}
         restore-keys: |
-          app-${{ inputs.app_name }}-${{ npm_packages_commit }}-
+          app-${{ inputs.app_name }}-${{ env.NPM_PACKAGES_COMMIT }}-
 
     - name: Build app
       shell: bash

--- a/.github/actions/build_app/action.yml
+++ b/.github/actions/build_app/action.yml
@@ -9,6 +9,13 @@ runs:
   using: 'composite'
   steps:
 
+    - name: Get last Git commit hash modifying packages/abc
+      shell: bash
+      # Instead of hasing files, use the latest git commit in a directory to speed up cache key https://github.com/actions/runner/issues/1840#issuecomment-2094847172
+      run: |
+        echo "NPM_PACKAGES_COMMIT=$(git log -1 --pretty=format:%H -- package-lock.json)" >> $GITHUB_ENV
+        echo "SOURCE_CODE_COMMIT=$(git log -1 --pretty=format:%H -- lib @connect-shared apps/${{ inputs.app_name }})" >> $GITHUB_ENV
+
     - name: Restore build
       id: restore_build
       uses: actions/cache@v4
@@ -18,9 +25,10 @@ runs:
           apps/${{ inputs.app_name }}/.next
           apps/${{ inputs.app_name }}/public
         # Generate a new cache whenever packages or source files change.
-        key: app-${{ inputs.app_name }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('lib/**/*.ts', 'lib/**/*.tsx', '@connect-shared/**/*.ts', '@connect-shared/**/*.tsx', format('apps/{0}/**/*.ts', inputs.app_name), format('apps/{0}/**/*.tsx', inputs.app_name), format('apps/{0}/**/*.scss', inputs.app_name)) }}
+        # key: app-${{ inputs.app_name }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('lib/**/*.ts', 'lib/**/*.tsx', '@connect-shared/**/*.ts', '@connect-shared/**/*.tsx', format('apps/{0}/**/*.ts', inputs.app_name), format('apps/{0}/**/*.tsx', inputs.app_name), format('apps/{0}/**/*.scss', inputs.app_name)) }}
+        key: app-${{ inputs.app_name }}-${{ env.NPM_PACKAGES_COMMIT }}-${{ env.SOURCE_CODE_COMMIT }}
         restore-keys: |
-          app-${{ inputs.app_name }}-${{ hashFiles('**/package-lock.json') }}-
+          app-${{ inputs.app_name }}-${{ npm_packages_commit }}-
 
     - name: Build app
       shell: bash

--- a/.github/workflows/deploy_farcaster.yml
+++ b/.github/workflows/deploy_farcaster.yml
@@ -99,6 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Fetch all commits in all branches and tags
           fetch-depth: 0
 
       - name: Install dependencies

--- a/.github/workflows/deploy_scoutgame.yml
+++ b/.github/workflows/deploy_scoutgame.yml
@@ -112,6 +112,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Restore dependencies from cache
         uses: ./.github/actions/install
@@ -153,6 +155,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Restore dependencies from cache
         uses: ./.github/actions/install

--- a/.github/workflows/deploy_sunnyawards.yml
+++ b/.github/workflows/deploy_sunnyawards.yml
@@ -106,6 +106,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Restore dependencies from cache
         uses: ./.github/actions/install
@@ -147,6 +149,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Restore dependencies from cache
         uses: ./.github/actions/install
@@ -283,8 +287,7 @@ jobs:
             ebextensions: sunnyawards
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4.x
         with:

--- a/apps/farcaster/lib/postCreateCastMessage.ts
+++ b/apps/farcaster/lib/postCreateCastMessage.ts
@@ -1,3 +1,4 @@
+// send a message to the parent window to create a new cast
 export function postCreateCastMessage({ embeds, text }: { text: string; embeds: string[] }) {
   window.parent.postMessage(
     {


### PR DESCRIPTION
Uses git log instead of hashed files. Idea came from https://github.com/actions/runner/issues/1840#issuecomment-2094847172