### PR TITLE
remove selection listener on individual rows in the table to improve …

### DIFF
--- a/components/common/DatabaseEditor/components/table/table.tsx
+++ b/components/common/DatabaseEditor/components/table/table.tsx
@@ -1,7 +1,7 @@
 import { Add } from '@mui/icons-material';
 import { Box, Typography } from '@mui/material';
-import type { Dispatch, LegacyRef, ReactNode, SetStateAction } from 'react';
-import React, { forwardRef, useCallback, useEffect, useMemo, useRef } from 'react';
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import React, { useCallback, useEffect, memo, useRef } from 'react';
 import { useDrop } from 'react-dnd';
 
 import { SelectionContext, useAreaSelection } from 'hooks/useAreaSelection';
@@ -52,10 +52,9 @@ type Props = {
   hideCalculations?: boolean;
 };
 
-const TableRowsContainer = forwardRef<HTMLDivElement, { children: ReactNode }>(({ children }, ref) => {
+const TableRowsContainer = memo(({ children }: { children: ReactNode }) => {
   return (
     <div
-      ref={ref as LegacyRef<HTMLDivElement>}
       className='table-row-container'
       style={{
         // Adding 2px margin top to show the drag and drop outline, otherwise the table header blocks it,
@@ -88,7 +87,6 @@ function Table(props: Props): JSX.Element {
     boardType
   } = props;
   const dispatch = useAppDispatch();
-  const selectContainerRef = useRef<HTMLDivElement | null>(null);
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
   const areaSelection = useAreaSelection({ readOnly, innerContainer: tableContainerRef });
   const { resetState } = areaSelection;
@@ -324,7 +322,7 @@ function Table(props: Props): JSX.Element {
 
         {/* Table rows */}
         <SelectionContext.Provider value={areaSelection}>
-          <TableRowsContainer ref={selectContainerRef}>
+          <TableRowsContainer>
             {activeView.fields.groupById && (
               <TableGroups
                 groups={visibleGroups}

--- a/components/common/DatabaseEditor/components/table/tableRow.tsx
+++ b/components/common/DatabaseEditor/components/table/tableRow.tsx
@@ -137,8 +137,8 @@ function TableRow(props: Props) {
     enabled: isDragAndDropEnabled
   });
 
-  const { selection } = useContext(SelectionContext);
-  const isSelected = useSelected(cardRef, selection);
+  // const { selection } = useContext(SelectionContext);
+  // const isSelected = useSelected(cardRef, selection);
 
   const handleDeleteCard = async () => {
     if (!card) {
@@ -169,19 +169,20 @@ function TableRow(props: Props) {
     }
   }, []);
 
-  useEffect(() => {
-    if (setCheckedIds && selection) {
-      setCheckedIds((checkedIds) => {
-        if (isSelected && !checkedIds.includes(card.id)) {
-          return Array.from(new Set([...checkedIds, card.id]));
-        } else if (!isSelected && checkedIds.includes(card.id)) {
-          return checkedIds.filter((checkedId) => checkedId !== card.id);
-        }
+  // TODO: Detect highlighted rows from the code which manages the selection, instead of each row individually
+  // useEffect(() => {
+  //   if (setCheckedIds && selection) {
+  //     setCheckedIds((checkedIds) => {
+  //       if (isSelected && !checkedIds.includes(card.id)) {
+  //         return Array.from(new Set([...checkedIds, card.id]));
+  //       } else if (!isSelected && checkedIds.includes(card.id)) {
+  //         return checkedIds.filter((checkedId) => checkedId !== card.id);
+  //       }
 
-        return checkedIds;
-      });
-    }
-  }, [isSelected, !!selection]);
+  //       return checkedIds;
+  //     });
+  //   }
+  // }, [isSelected, !!selection]);
 
   useEffect(() => {
     setTitle(pageTitle);
@@ -217,7 +218,8 @@ function TableRow(props: Props) {
       ref={mergeRefs([cardRef, preview, drop])}
       style={{
         backgroundColor:
-          isSelected || isChecked ? 'rgba(35, 131, 226, 0.14)' : isNested ? 'var(--input-bg)' : 'transparent',
+          // isSelected || isChecked ? 'rgba(35, 131, 226, 0.14)' : isNested ? 'var(--input-bg)' : 'transparent',
+          isChecked ? 'rgba(35, 131, 226, 0.14)' : isNested ? 'var(--input-bg)' : 'transparent',
         zIndex: 85,
         ...style
       }}


### PR DESCRIPTION
I want to push this to prod just to see how much of an impact it has on OP's table. We may need more optimziation but I discovered that this triggers a re-render of all rows any time you click anywhere on the table

We lose some functionality but it was not designed in an efficient way. Users will for now have to use the checkboxes directly to select rows. Video of the drag-to-select effect:

https://www.loom.com/share/137865c583a548b98949597688102e21