### PR TITLE
Add catching for the gitcoin attestations

### DIFF
--- a/apps/sunnyawards/lib/projects/createProjectAction.ts
+++ b/apps/sunnyawards/lib/projects/createProjectAction.ts
@@ -56,6 +56,12 @@ export const createProjectAction = authActionClient
       await storeProjectMetadataAndPublishGitcoinAttestation({
         projectIdOrPath: newProject.id,
         userId: ctx.session.user.id
+      }).catch((error) => {
+        log.error('Failed to store project metadata and publish Gitcoin attestation', {
+          error,
+          projectId: newProject.id,
+          userId: currentUserId
+        });
       });
 
       await storeCharmverseProjectMetadata({

--- a/apps/sunnyawards/lib/projects/editProjectAction.ts
+++ b/apps/sunnyawards/lib/projects/editProjectAction.ts
@@ -48,6 +48,12 @@ export const editProjectAction = authActionClient
       await storeProjectMetadataAndPublishGitcoinAttestation({
         projectIdOrPath: editedProject.id,
         userId: editedProject.createdBy
+      }).catch((error) => {
+        log.error('Failed to store project metadata and publish Gitcoin attestation', {
+          error,
+          projectId: editedProject.id,
+          userId: currentUserId
+        });
       });
     }
 


### PR DESCRIPTION
### WHAT

If Gitcoin throws, it shouldn't bug application creation / editing

### WHY

<!-- why was this necessary? -->
