### PR TITLE
Fix token gate crash

### DIFF
--- a/components/settings/invites/components/TokenGates/components/TokenGateModal/hooks/useCollectablesForm.tsx
+++ b/components/settings/invites/components/TokenGates/components/TokenGateModal/hooks/useCollectablesForm.tsx
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { wagmiConfig } from '@root/connectors/config';
 import { readContract } from '@wagmi/core';
+import { wagmiConfig } from 'connectors/config';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
@@ -8,6 +8,7 @@ import { ercAbi } from 'lib/tokenGates/abis/abis';
 import { subscriptionTokenV1ABI } from 'lib/tokenGates/hypersub/abi';
 import { PublicLockV13 } from 'lib/tokenGates/unlock/abi';
 import { isValidChainAddress } from 'lib/tokens/validation';
+import { isBigInt } from 'lib/utils/numbers';
 
 import { nftCheck, collectableOptions, poapNameMatch, poapTypes } from '../utils/utils';
 
@@ -93,7 +94,11 @@ const schema = yup.object({
   tokenId: yup.string().when(['collectableOption', 'check'], {
     is: (collectableOption: CollectableOptionsId, check: NftCheck) =>
       (collectableOption === 'ERC721' && check === 'individual') || collectableOption === 'ERC1155',
-    then: () => yup.string().required('Token id is required'),
+    then: () =>
+      yup
+        .string()
+        .required('Token id is required')
+        .test('isTokenId', 'Invalid token Id', (value) => isBigInt(value)),
     otherwise: () => yup.string()
   }),
   quantity: yup

--- a/lib/blockchain/updateTokenGateDetails.ts
+++ b/lib/blockchain/updateTokenGateDetails.ts
@@ -6,7 +6,6 @@ import { getLockMetadata } from '@root/lib/tokenGates/unlock/getLockMetadata';
 import { getTokenMetadata } from '@root/lib/tokens/getTokenMetadata';
 
 import { handleAllSettled } from 'lib/utils/async';
-import { toBigInt } from 'lib/utils/numbers';
 
 import { getNFT } from './getNFTs';
 import { getPoapByEventId } from './poaps';
@@ -32,7 +31,7 @@ async function getAccessControlMetaData(condition: AccessControlCondition) {
     case 'Hats':
     case 'ERC721':
     case 'ERC1155': {
-      const tokenId = toBigInt(condition.tokenIds.at(0) || '1').toString();
+      const tokenId = BigInt(condition.tokenIds.at(0) || '1').toString();
       const nft = await getNFT({
         address: condition.contractAddress,
         tokenId,

--- a/lib/blockchain/updateTokenGateDetails.ts
+++ b/lib/blockchain/updateTokenGateDetails.ts
@@ -5,6 +5,8 @@ import type { AccessControlCondition, TokenGate } from '@root/lib/tokenGates/int
 import { getLockMetadata } from '@root/lib/tokenGates/unlock/getLockMetadata';
 import { getTokenMetadata } from '@root/lib/tokens/getTokenMetadata';
 
+import { toBigInt } from '../utils/numbers';
+
 import { getNFT } from './getNFTs';
 import { getPoapByEventId } from './poaps';
 
@@ -29,7 +31,7 @@ async function getAccessControlMetaData(condition: AccessControlCondition) {
     case 'Hats':
     case 'ERC721':
     case 'ERC1155': {
-      const tokenId = BigInt(condition.tokenIds.at(0) || '1').toString();
+      const tokenId = toBigInt(condition.tokenIds.at(0) || '1').toString();
       const nft = await getNFT({
         address: condition.contractAddress,
         tokenId,

--- a/lib/blockchain/updateTokenGateDetails.ts
+++ b/lib/blockchain/updateTokenGateDetails.ts
@@ -5,13 +5,14 @@ import type { AccessControlCondition, TokenGate } from '@root/lib/tokenGates/int
 import { getLockMetadata } from '@root/lib/tokenGates/unlock/getLockMetadata';
 import { getTokenMetadata } from '@root/lib/tokens/getTokenMetadata';
 
-import { toBigInt } from '../utils/numbers';
+import { handleAllSettled } from 'lib/utils/async';
+import { toBigInt } from 'lib/utils/numbers';
 
 import { getNFT } from './getNFTs';
 import { getPoapByEventId } from './poaps';
 
 export async function updateTokenGateDetails<T extends TokenGate>(tokenGates: T[] = []): Promise<T[]> {
-  const updatedTokenGates = await Promise.all(tokenGates.map(getConditionMetadata));
+  const updatedTokenGates = await Promise.allSettled(tokenGates.map(getConditionMetadata)).then(handleAllSettled);
   return updatedTokenGates;
 }
 

--- a/lib/utils/async.ts
+++ b/lib/utils/async.ts
@@ -1,3 +1,7 @@
+import { log } from '@charmverse/core/log';
+
+import { isTruthy } from './types';
+
 // A utilitiy to recursively call and endpoint with paginated results
 export async function paginatedCall<R, Q = object | null>(
   // The first method should call an API and return the result directly
@@ -19,4 +23,18 @@ export async function delay(ms: number = 1) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+export async function handleAllSettled<T>(response: PromiseSettledResult<Awaited<T>>[]) {
+  return response
+    .map((r) => {
+      if (r.status === 'fulfilled') {
+        return r.value;
+      }
+      if (r.status === 'rejected') {
+        log.error('There was an error in one of the async functions', { error: r.reason });
+      }
+      return undefined;
+    })
+    .filter(isTruthy);
 }

--- a/lib/utils/numbers.ts
+++ b/lib/utils/numbers.ts
@@ -156,3 +156,11 @@ export function getNumberFromString(strValue: string): number | null {
 export function roundNumber(num: number | undefined | null): string | undefined {
   return num?.toLocaleString(undefined, { maximumFractionDigits: 2 });
 }
+
+export function toBigInt(value: any) {
+  try {
+    return BigInt(value);
+  } catch (e) {
+    return BigInt(1);
+  }
+}

--- a/lib/utils/numbers.ts
+++ b/lib/utils/numbers.ts
@@ -157,6 +157,14 @@ export function roundNumber(num: number | undefined | null): string | undefined 
   return num?.toLocaleString(undefined, { maximumFractionDigits: 2 });
 }
 
+export function isBigInt(value: string) {
+  try {
+    return typeof BigInt(value) === 'bigint';
+  } catch (e) {
+    return false;
+  }
+}
+
 export function toBigInt(value: any) {
   try {
     return BigInt(value);

--- a/lib/utils/numbers.ts
+++ b/lib/utils/numbers.ts
@@ -164,11 +164,3 @@ export function isBigInt(value: string) {
     return false;
   }
 }
-
-export function toBigInt(value: any) {
-  try {
-    return BigInt(value);
-  } catch (e) {
-    return BigInt(1);
-  }
-}


### PR DESCRIPTION
Issue: TokenId can be any string. If it's not a number the whole function crashes.

Fix:
- validate token id to be a bigint before the user saves his token gate
- Don't crash all the token gate list and show only the ones that are valid (by using allSettled)