### PR TITLE
Fix sunny farcaster login when user has multiple user accounts

### DIFF
--- a/lib/farcaster/loginWithFarcaster.ts
+++ b/lib/farcaster/loginWithFarcaster.ts
@@ -123,11 +123,12 @@ export async function loginWithFarcaster({
       }
     },
     include: {
-      profile: true
+      profile: true,
+      farcasterUser: true
     }
   });
 
-  if (userWithWallet) {
+  if (userWithWallet && !userWithWallet.farcasterUser?.fid) {
     const updatedUser = await prisma.user.update({
       where: {
         id: userWithWallet.id


### PR DESCRIPTION
User has a Charmverse user with a wallet and a fid. 
User tries to login with fid that is connected to the above user but it's different then the above fid.
Result: the API throws a prisma error since you can't create an farcasterUser if that user already has a farcasterUser.

Solution:
Ignore the above user and create another one with a farcasterUser.