### PR TITLE
reduce number of page ids we request at a time to make room for datad…

### DIFF
--- a/lib/permissions/api/overridenPermissionsApiClient.ts
+++ b/lib/permissions/api/overridenPermissionsApiClient.ts
@@ -32,7 +32,7 @@ export class PermissionsApiClientWithPermissionsSwitch extends PermissionsApiCli
 
     pages.bulkComputePagePermissions = async function (args: BulkPagePermissionCompute) {
       // Large list of UUIDs will error out
-      const pagination = 350;
+      const pagination = 330;
 
       const groups = [];
 


### PR DESCRIPTION
Picture of the new headers which did not exist in the previous version of dd-trace we used:

![image](https://github.com/user-attachments/assets/2d10ed8c-9dbc-43ec-a14b-9e1a9f9c9ac8)

I do want to update dd-trace as these headers are probably going to be useful for monitoring, and long-term i really want to get rid of permissions as a service