### PR TITLE
better handling of waitlist error

### DIFF
--- a/apps/waitlist/app/api/frame/[fid]/actions/goto-builders/route.ts
+++ b/apps/waitlist/app/api/frame/[fid]/actions/goto-builders/route.ts
@@ -13,6 +13,10 @@ import { joinWaitlist } from 'lib/waitlistSlots/joinWaitlist';
 export async function POST(req: Request) {
   const waitlistClicked = (await req.json()) as FarcasterFrameInteractionToValidate;
 
+  if (!waitlistClicked.trustedData.messageBytes) {
+    throw new InvalidInputError('Invalid frame interaction. No message bytes');
+  }
+
   const validatedMessage = await validateFrameInteraction(waitlistClicked.trustedData.messageBytes);
 
   const referrerFid = getReferrerFidFromUrl(req);
@@ -37,5 +41,5 @@ export async function POST(req: Request) {
     hasJoinedWaitlist: true
   })}`;
 
-  return new Response(null, { status: 302, headers: { Location: targetUrl as string } });
+  return new Response(null, { status: 302, headers: { Location: targetUrl } });
 }

--- a/apps/waitlist/app/api/frame/[fid]/actions/goto-home/route.ts
+++ b/apps/waitlist/app/api/frame/[fid]/actions/goto-home/route.ts
@@ -11,6 +11,10 @@ import { trackWaitlistMixpanelEvent } from 'lib/mixpanel/trackWaitlistMixpanelEv
 export async function POST(req: Request) {
   const waitlistClicked = (await req.json()) as FarcasterFrameInteractionToValidate;
 
+  if (!waitlistClicked.trustedData.messageBytes) {
+    throw new InvalidInputError('Invalid frame interaction. No message bytes');
+  }
+
   const validatedMessage = await validateFrameInteraction(waitlistClicked.trustedData.messageBytes);
 
   const referrerFid = getReferrerFidFromUrl(req);

--- a/apps/waitlist/app/api/frame/[fid]/actions/goto-score/route.ts
+++ b/apps/waitlist/app/api/frame/[fid]/actions/goto-score/route.ts
@@ -13,6 +13,10 @@ import { joinWaitlist } from 'lib/waitlistSlots/joinWaitlist';
 export async function POST(req: Request) {
   const waitlistClicked = (await req.json()) as FarcasterFrameInteractionToValidate;
 
+  if (!waitlistClicked.trustedData.messageBytes) {
+    throw new InvalidInputError('Invalid frame interaction. No message bytes');
+  }
+
   const validatedMessage = await validateFrameInteraction(waitlistClicked.trustedData.messageBytes);
 
   const referrerFid = getReferrerFidFromUrl(req);

--- a/apps/waitlist/app/api/frame/[fid]/actions/share/route.ts
+++ b/apps/waitlist/app/api/frame/[fid]/actions/share/route.ts
@@ -12,6 +12,10 @@ import { joinWaitlist } from 'lib/waitlistSlots/joinWaitlist';
 export async function POST(req: Request) {
   const waitlistClicked = (await req.json()) as FarcasterFrameInteractionToValidate;
 
+  if (!waitlistClicked.trustedData.messageBytes) {
+    throw new InvalidInputError('Invalid frame interaction. No message bytes');
+  }
+
   const validatedMessage = await validateFrameInteraction(waitlistClicked.trustedData.messageBytes);
 
   const referrerFid = getReferrerFidFromUrl(req);

--- a/lib/farcaster/validateFrameInteraction.ts
+++ b/lib/farcaster/validateFrameInteraction.ts
@@ -16,7 +16,7 @@ export type FarcasterFrameInteractionToValidate = {
     };
   };
   trustedData: {
-    messageBytes: string;
+    messageBytes?: string;
   };
 };
 

--- a/lib/farcaster/validateFrameInteraction.ts
+++ b/lib/farcaster/validateFrameInteraction.ts
@@ -16,7 +16,7 @@ export type FarcasterFrameInteractionToValidate = {
     };
   };
   trustedData: {
-    messageBytes?: string;
+    messageBytes: string; // WARNING: this can actually be undefined
   };
 };
 


### PR DESCRIPTION
This is only slightly better than what is there now. If it's expected to get messages w/no 'messageBytes' then we should be gracefully responding with a 200 or something.

Also, it doesn't look like logging is set up properly in the app. uncaught errors need to be logged by our logger with the correct syntax and as a warning, right now they're just being out put by console log someplace:

![image](https://github.com/user-attachments/assets/8f5c49a5-18aa-4a9f-befa-1b296f5d2491)
