### PR TITLE
remove eth denver from Summon apis

### DIFF
--- a/lib/summon/constants.ts
+++ b/lib/summon/constants.ts
@@ -4,8 +4,6 @@ export const API_TOKEN = process.env.XPS_API_TOKEN as string | undefined;
 export const TENANT_URLS: Record<string, string> = {
   // game7
   '355730745719783510': 'https://g7p.io',
-  // ethdenver
-  '355932655192113238': 'https://ethd-api.summon.xyz',
   // zksync
   '355932655192113587': 'https://zksync-api.summon.xyz'
 };
@@ -14,8 +12,6 @@ export const TENANT_URLS: Record<string, string> = {
 const TENANT_STAGING_URLS: Record<string, string> = {
   // game7
   '355947552633258069': 'https://staging-g7-api.summon.xyz',
-  // ethdenver
-  '355932655193224698': 'https://staging-ethd-api.summon.xyz',
   // zksync
   '355932655194335702': 'https://staging-zksync-api.summon.xyz'
 };


### PR DESCRIPTION
Confirmed with Summon they are not working with ETH Denver currently, but this is causing errors in production