### PR TITLE
handle new error with TreeView

### DIFF
--- a/components/common/PageLayout/components/Sidebar/components/PageNavigation/PageNavigation.tsx
+++ b/components/common/PageLayout/components/Sidebar/components/PageNavigation/PageNavigation.tsx
@@ -72,6 +72,26 @@ function PageNavigation({ deletePage, isFavorites, rootPageIds, onClick }: PageN
 
   const mappedItems = useMemo(() => {
     const mappedPages = pageTree.mapPageTree<MenuNode>({ items: pagesArray, rootPageIds });
+    const pageIds: string[] = []; // keep track of page ids to avoid duplicates
+    mappedPages.forEach((page, index) => {
+      pageIds.push(page.id);
+    });
+    mappedPages.forEach((page, index) => {
+      page.children = page.children.filter((child) => {
+        if (pageIds.includes(child.id)) {
+          return false;
+        }
+        pageIds.push(child.id);
+        child.children = child.children.filter((_child) => {
+          if (pageIds.includes(_child.id)) {
+            return false;
+          }
+          pageIds.push(_child.id);
+          return true;
+        });
+        return true;
+      });
+    });
     if (isFavorites) {
       return rootPageIds
         ?.map((id) => mappedPages.find((page) => page.id === id))

--- a/pages/api/optimism/projects/index.ts
+++ b/pages/api/optimism/projects/index.ts
@@ -30,7 +30,7 @@ async function getProjectsController(req: NextApiRequest, res: NextApiResponse<O
   });
 
   if (!user || !user.farcasterUser) {
-    throw new InvalidInputError('User does not have a farcaster account.');
+    return res.status(200).json([]);
   }
 
   const fid = user.farcasterUser.fid;


### PR DESCRIPTION
The latest TreeView throws an error if any item id is not unique. This can happen when you have a favorate page that is also nested under another favorite page. I tried adding unique id's to all items but it doesn't seem to work right unless item.id is used... which can break a lot of assumptions so for now i am just filtering out duplicates :P