### PR TITLE
Updates to Gem calculations

### DIFF
--- a/apps/scoutgamecron/jest.config.ts
+++ b/apps/scoutgamecron/jest.config.ts
@@ -1,5 +1,8 @@
-import { createDefaultEsmPreset } from 'ts-jest';
+import { createDefaultEsmPreset, pathsToModuleNameMapper } from 'ts-jest';
+
+import { compilerOptions } from './tsconfig.json';
 
 export default {
-  ...createDefaultEsmPreset()
+  ...createDefaultEsmPreset(),
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' })
 };

--- a/apps/scoutgamecron/package.json
+++ b/apps/scoutgamecron/package.json
@@ -8,7 +8,7 @@
     "start": "tsx watch src/main.ts",
     "start:prod": "node --import dd-trace/register.js ./dist/main.js",
     "start:prod:node18": "node --loader dd-trace/loader-hook.mjs ./dist/main.js",
-    "test": "node --experimental-vm-modules ../../node_modules/.bin/jest",
+    "test": "npm run build && node --experimental-vm-modules ../../node_modules/.bin/jest --config jest.config.compiled.ts",
     "typecheck": "../../node_modules/typescript/bin/tsc --project ./tsconfig.json  --noEmit",
     "seed": "tsx src/scripts/generateSeedData.ts"
   },

--- a/apps/scoutgamecron/src/tasks/processPullRequests/__tests__/processClosedPullRequest.spec.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/__tests__/processClosedPullRequest.spec.ts
@@ -2,7 +2,7 @@ import { prisma } from '@charmverse/core/prisma-client';
 import { jest } from '@jest/globals';
 import { v4 } from 'uuid';
 
-import { randomLargeInt } from '../../../testing/numbers';
+import { randomLargeInt } from '../../../testing/generators';
 import type { PullRequest } from '../getPullRequests';
 
 jest.unstable_mockModule('../getClosedPullRequest', () => ({

--- a/apps/scoutgamecron/src/tasks/processPullRequests/__tests__/processMergedPullRequest.spec.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/__tests__/processMergedPullRequest.spec.ts
@@ -4,8 +4,6 @@ import { timezone } from '@packages/scoutgame/utils';
 import { DateTime } from 'luxon';
 import { v4 } from 'uuid';
 
-import type { PullRequest } from '../getPullRequests';
-
 import { mockBuilder, mockRepo } from '@/testing/database';
 import { mockPullRequest, randomLargeInt } from '@/testing/generators';
 
@@ -89,64 +87,20 @@ describe('processMergedPullRequest', () => {
   });
 
   it('should create builder events, gems receipts and update weekly stats for a regular merged pull request', async () => {
-    const repoId = randomLargeInt();
-    const prNumber = randomLargeInt();
-    const githubUserId = randomLargeInt();
-    const username = v4();
+    const builder = await mockBuilder();
 
-    const builder = await prisma.scout.create({
-      data: {
-        username,
-        displayName: 'Test User',
-        builder: true
-      }
-    });
+    const repo = await mockRepo();
 
-    const githubUser = await prisma.githubUser.create({
-      data: {
-        id: githubUserId,
-        login: username,
-        builderId: builder.id
-      }
-    });
-
-    const repo = await prisma.githubRepo.create({
-      data: {
-        id: repoId,
-        owner: username,
-        name: 'Test-Repo',
-        defaultBranch: 'main'
-      }
-    });
-
-    const pullRequest: PullRequest = {
-      number: prNumber,
-      baseRefName: 'main',
+    const pullRequest = mockPullRequest({
       mergedAt: new Date().toISOString(),
       createdAt: new Date().toISOString(),
-      repository: {
-        id: repoId,
-        nameWithOwner: `${repo.owner}/${repo.name}`
-      },
-      title: 'Test PR 2',
-      url: `https://github.com/${username}/Test-Repo/pull/${prNumber}`,
+      repo,
       state: 'MERGED',
-      author: {
-        id: githubUserId,
-        login: username
-      }
-    };
+      author: builder.githubUser
+    });
+
     (getRecentPullRequestsByUser as jest.Mock<typeof getRecentPullRequestsByUser>).mockResolvedValue([
-      {
-        number: randomLargeInt(),
-        baseRefName: 'main',
-        mergedAt: new Date().toISOString(),
-        createdAt: new Date().toISOString(),
-        closedAt: new Date().toISOString(),
-        state: 'MERGED',
-        title: 'Test PR 1',
-        url: `https://github.com/${username}/Test-Repo/pull/${randomLargeInt()}`
-      }
+      mockPullRequest()
     ]);
 
     await processMergedPullRequest({ pullRequest, repo });
@@ -156,7 +110,7 @@ describe('processMergedPullRequest', () => {
         repoId: repo.id,
         pullRequestNumber: pullRequest.number,
         type: 'merged_pull_request',
-        createdBy: githubUser.id
+        createdBy: builder.githubUser.id
       }
     });
 
@@ -191,30 +145,23 @@ describe('processMergedPullRequest', () => {
     const builder = await mockBuilder();
     const repo = await mockRepo();
 
+    const latestPrDate = DateTime.fromObject({ weekday: 2 }, { zone: timezone });
+
     const pullRequest2 = mockPullRequest({
-      createdAt: DateTime.fromJSDate(new Date(), { zone: timezone }).minus({ days: 3 }).toISO(),
+      createdAt: latestPrDate.minus({ days: 4 }).toISO(),
       state: 'MERGED',
       author: builder.githubUser,
       repo
     });
 
     (getRecentPullRequestsByUser as jest.Mock<typeof getRecentPullRequestsByUser>).mockResolvedValue([
-      {
-        number: randomLargeInt(),
-        baseRefName: 'main',
-        mergedAt: new Date().toISOString(),
-        createdAt: DateTime.fromJSDate(new Date(), { zone: timezone }).minus({ days: 2 }).toISO(),
-        closedAt: new Date().toISOString(),
-        state: 'MERGED',
-        title: 'Test PR 1',
-        url: `https://github.com/${repo.owner}/${repo.name}/pull/${randomLargeInt()}`
-      }
+      mockPullRequest()
     ]);
 
     await processMergedPullRequest({ pullRequest: pullRequest2, repo });
 
     const pullRequest3 = mockPullRequest({
-      createdAt: DateTime.fromJSDate(new Date(), { zone: timezone }).minus({ days: 1 }).toISO(),
+      createdAt: latestPrDate.minus({ days: 1 }).toISO(),
       state: 'MERGED',
       repo,
       author: builder.githubUser
@@ -223,7 +170,7 @@ describe('processMergedPullRequest', () => {
     await processMergedPullRequest({ pullRequest: pullRequest3, repo });
 
     const pullRequest4 = mockPullRequest({
-      createdAt: DateTime.fromJSDate(new Date(), { zone: timezone }).toISO(),
+      createdAt: latestPrDate.toISO(),
       state: 'MERGED',
       repo,
       author: builder.githubUser
@@ -245,64 +192,28 @@ describe('processMergedPullRequest', () => {
       }
     });
 
-    expect(builderWeeklyStats.gemsCollected).toBe(5);
+    // The total is 4 because the first PR is from a previous week, but the 3rd PR counts as a streak, so 3 + 1 = 4
+    expect(builderWeeklyStats.gemsCollected).toBe(4);
   });
 
   it('should not create builder events and gems receipts for existing events', async () => {
-    const repoId = randomLargeInt();
-    const prNumber = randomLargeInt();
-    const githubUserId = randomLargeInt();
-    const username = v4();
+    const builder = await mockBuilder();
+    const repo = await mockRepo();
 
-    const builder = await prisma.scout.create({
-      data: {
-        username,
-        displayName: 'Test User',
-        builder: true
-      }
-    });
-
-    const githubUser = await prisma.githubUser.create({
-      data: {
-        id: githubUserId,
-        login: username,
-        builderId: builder.id
-      }
-    });
-
-    const githubRepo = await prisma.githubRepo.create({
-      data: {
-        id: repoId,
-        owner: username,
-        name: 'Test Repo',
-        defaultBranch: 'main'
-      }
-    });
-
-    const pullRequest: PullRequest = {
-      number: prNumber,
-      baseRefName: 'main',
+    const pullRequest = mockPullRequest({
       mergedAt: new Date().toISOString(),
       createdAt: DateTime.fromJSDate(new Date(), { zone: timezone }).minus({ days: 3 }).toISO(),
-      repository: {
-        id: repoId,
-        nameWithOwner: `${githubRepo.owner}/${githubRepo.name}`
-      },
-      title: 'Test PR 1',
-      url: `https://github.com/${username}/Test-Repo/pull/${prNumber}`,
+      repo,
       state: 'MERGED',
-      author: {
-        id: githubUserId,
-        login: username
-      }
-    };
+      author: builder.githubUser
+    });
     (getRecentPullRequestsByUser as jest.Mock<typeof getRecentPullRequestsByUser>).mockResolvedValue([]);
 
-    await processMergedPullRequest({ pullRequest, repo: githubRepo });
+    await processMergedPullRequest({ pullRequest, repo });
 
-    await processMergedPullRequest({ pullRequest, repo: githubRepo });
+    await processMergedPullRequest({ pullRequest, repo });
 
-    await processMergedPullRequest({ pullRequest, repo: githubRepo });
+    await processMergedPullRequest({ pullRequest, repo });
 
     const builderEvents = await prisma.builderEvent.count({
       where: {

--- a/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
@@ -7,8 +7,8 @@ export type PullRequest = {
   title: string;
   url: string;
   state: 'CLOSED' | 'MERGED';
-  mergedAt?: string | null;
-  closedAt?: string | null;
+  mergedAt?: string;
+  closedAt?: string;
   createdAt: string;
   author: {
     login: string;

--- a/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
@@ -7,8 +7,8 @@ export type PullRequest = {
   title: string;
   url: string;
   state: 'CLOSED' | 'MERGED';
-  mergedAt: string | null;
-  closedAt: string | null;
+  mergedAt?: string | null;
+  closedAt?: string | null;
   createdAt: string;
   author: {
     login: string;

--- a/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
@@ -8,6 +8,7 @@ export type PullRequest = {
   url: string;
   state: 'CLOSED' | 'MERGED';
   mergedAt: string | null;
+  closedAt: string | null;
   createdAt: string;
   author: {
     login: string;
@@ -58,6 +59,7 @@ const getRecentPrs = `
             state
             closedAt
             createdAt
+            mergedAt
             author {
               login
               ... on User {

--- a/apps/scoutgamecron/src/tasks/processPullRequests/getRecentPullRequestsByUser.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/getRecentPullRequestsByUser.ts
@@ -10,9 +10,9 @@ type PullRequestByUser = {
   title: string;
   number: number;
   url: string;
-  closedAt: string;
+  closedAt?: string;
   createdAt: string;
-  mergedAt: string;
+  mergedAt?: string;
   state: 'CLOSED' | 'MERGED';
 };
 

--- a/apps/scoutgamecron/src/tasks/processPullRequests/processClosedPullRequest.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/processClosedPullRequest.ts
@@ -81,7 +81,8 @@ export async function processClosedPullRequest({
                 builderId: builder.id
               }
             },
-        createdAt: pullRequest.createdAt
+        createdAt: pullRequest.createdAt,
+        completedAt: pullRequest.closedAt
       }
     });
 

--- a/apps/scoutgamecron/src/tasks/processPullRequests/processMergedPullRequest.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/processMergedPullRequest.ts
@@ -145,7 +145,8 @@ export async function processMergedPullRequest({
 
       const gemValue = gemReceiptType === 'first_pr' ? 10 : gemReceiptType === 'third_pr_in_streak' ? 3 : 1;
       const builderEventDate = pullRequestDate;
-      if (builderEventDate < start.toJSDate()) {
+
+      if (builderEventDate >= start.toJSDate()) {
         await tx.builderEvent.upsert({
           where: {
             githubEventId: event.id

--- a/apps/scoutgamecron/src/tasks/processPullRequests/processMergedPullRequest.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/processMergedPullRequest.ts
@@ -114,7 +114,8 @@ export async function processMergedPullRequest({
         isFirstPullRequest: isFirstMergedPullRequest,
         repoId: pullRequest.repository.id,
         url: pullRequest.url,
-        createdAt: pullRequest.createdAt
+        createdAt: pullRequest.createdAt,
+        completedAt: pullRequest.mergedAt
       }
     });
 
@@ -151,7 +152,6 @@ export async function processMergedPullRequest({
           week,
           type: 'merged_pull_request',
           githubEventId: event.id,
-          createdAt: pullRequest.createdAt,
           gemsReceipt: {
             create: {
               type: gemReceiptType,

--- a/apps/scoutgamecron/src/testing/database.ts
+++ b/apps/scoutgamecron/src/testing/database.ts
@@ -1,0 +1,49 @@
+import type { GithubRepo } from '@charmverse/core/prisma';
+import { prisma } from '@charmverse/core/prisma-client';
+import { v4 as uuid } from 'uuid';
+
+import { randomLargeInt } from './generators';
+
+export async function mockBuilder({
+  bannedAt,
+  githubUserId = randomLargeInt(),
+  username = uuid()
+}: {
+  bannedAt?: Date;
+  githubUserId?: number;
+  username?: string;
+} = {}) {
+  const result = await prisma.scout.create({
+    data: {
+      username,
+      displayName: 'Test User',
+      bannedAt,
+      builder: true,
+      githubUser: {
+        create: {
+          id: githubUserId,
+          login: username
+        }
+      }
+    },
+    include: {
+      githubUser: true
+    }
+  });
+  const { githubUser, ...scout } = result;
+  return { ...scout, githubUser: githubUser[0]! };
+}
+
+export type MockBuilder = Awaited<ReturnType<typeof mockBuilder>>;
+
+export function mockRepo(fields: Partial<GithubRepo> & { owner?: string } = {}) {
+  return prisma.githubRepo.create({
+    data: {
+      ...fields,
+      id: fields.id ?? randomLargeInt(),
+      name: fields.name ?? 'test_repo',
+      owner: fields.owner ?? 'test_owner',
+      defaultBranch: fields.defaultBranch ?? 'main'
+    }
+  });
+}

--- a/apps/scoutgamecron/src/testing/generators.ts
+++ b/apps/scoutgamecron/src/testing/generators.ts
@@ -1,0 +1,31 @@
+import type { PullRequest } from '../tasks/processPullRequests/getPullRequests';
+
+export const randomLargeInt = () => Math.floor(Math.random() * 1000000000) + 1000000000;
+
+export function mockPullRequest(
+  fields: Partial<PullRequest> & {
+    githubUser?: { id: number; login: string };
+    repo?: { id?: number; owner: string; name: string };
+  } = {}
+): PullRequest {
+  const owner = fields.repo?.owner ?? 'test';
+  const name = fields.repo?.name ?? 'test';
+  return {
+    title: 'Test PR',
+    url: `https://github.com/${owner}/${name}/pull/${randomLargeInt()}`,
+    state: 'MERGED',
+    author: fields.githubUser ?? {
+      id: randomLargeInt(),
+      login: 'testuser'
+    },
+    number: randomLargeInt(),
+    baseRefName: 'main',
+    mergedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    repository: {
+      id: fields.repo?.id ?? randomLargeInt(),
+      nameWithOwner: `${owner}/${name}`
+    },
+    ...fields
+  };
+}

--- a/apps/scoutgamecron/src/testing/generators.ts
+++ b/apps/scoutgamecron/src/testing/generators.ts
@@ -10,17 +10,19 @@ export function mockPullRequest(
 ): PullRequest {
   const owner = fields.repo?.owner ?? 'test';
   const name = fields.repo?.name ?? 'test';
+  const state = fields.state ?? 'MERGED';
   return {
     title: 'Test PR',
     url: `https://github.com/${owner}/${name}/pull/${randomLargeInt()}`,
-    state: 'MERGED',
+    state,
     author: fields.githubUser ?? {
       id: randomLargeInt(),
       login: 'testuser'
     },
     number: randomLargeInt(),
     baseRefName: 'main',
-    mergedAt: new Date().toISOString(),
+    closedAt: state === 'CLOSED' ? new Date().toISOString() : undefined,
+    mergedAt: state === 'MERGED' ? new Date().toISOString() : undefined,
     createdAt: new Date().toISOString(),
     repository: {
       id: fields.repo?.id ?? randomLargeInt(),

--- a/apps/scoutgamecron/src/testing/numbers.ts
+++ b/apps/scoutgamecron/src/testing/numbers.ts
@@ -1,1 +1,0 @@
-export const randomLargeInt = () => Math.floor(Math.random() * 1000000000) + 1000000000;

--- a/packages/scoutgame/src/utils.ts
+++ b/packages/scoutgame/src/utils.ts
@@ -4,6 +4,8 @@ export const timezone = 'America/New_York';
 
 export const currentSeason = 1;
 
+export const streakWindow = 7 * 24 * 60 * 60 * 1000;
+
 // Return the format of week
 export function getCurrentWeek() {
   return getFormattedWeek(new Date());

--- a/scripts/exportGithubCommits.ts
+++ b/scripts/exportGithubCommits.ts
@@ -1,0 +1,122 @@
+import { prisma } from '@charmverse/core/prisma-client';
+import { syncProposalPermissionsWithWorkflowPermissions } from '@root/lib/proposals/workflows/syncProposalPermissionsWithWorkflowPermissions';
+import { prettyPrint } from 'lib/utils/strings';
+import fs from 'fs';
+import path from 'path';
+
+async function query() {
+  // create repo
+  // const repo = await prisma.githubRepo.create({
+  //   data: {
+  //     id: 860028062,
+  //     name: 'test-repo',
+  //     owner: 'charmverse',
+  //     defaultBranch: 'main'
+  //   }
+  // });
+  // console.log(repo);
+
+  // create scout
+  // const scout = await prisma.scout.create({
+  //   data: {
+  //     username: 'mattbot',
+  //     displayName: 'Mattbot',
+  //     builder: true
+  //   }
+  // });
+  // await prisma.githubUser.update({
+  //   where: {
+  //     login: 'mattcasey'
+  //   },
+  //   data: {
+  //     builderId: scout.id
+  //   }
+  // });
+  // console.log(scout);
+
+  // update scout instead
+  // await prisma.scout.update({
+  //   where: {
+  //     username: 'mattbot'
+  //   },
+  //   data: {
+  //     builder: true
+  //   }
+  // });
+
+  // console.log(await prisma.githubRepo.findMany());
+  // console.log(await prisma.githubUser.findMany());
+  // console.log(await prisma.githubEvent.findMany());
+  const waitlists = await prisma.connectWaitlistSlot.findMany({
+    where: {
+      githubLogin: {
+        not: null
+      }
+    }
+  });
+  const githubLogins = waitlists.map((waitlist) => waitlist.githubLogin);
+  const { Octokit } = require('@octokit/rest');
+  const octokit = new Octokit({ auth: process.env.GITHUB_ACCESS_TOKEN });
+
+  const getCommitCounts = async (username: string, since: string) => {
+    const response = await octokit.search.commits({
+      q: `author:${username} author-date:>${since}`,
+      per_page: 1
+    });
+    if (response.headers['x-ratelimit-remaining'] === '2' && response.headers['x-ratelimit-reset']) {
+      const rateLimitReset = new Date(parseInt(response.headers['x-ratelimit-reset']) * 1000);
+      // wait until rate limit reset
+      const timeUntilReset = rateLimitReset.getTime() - Date.now();
+      console.log(`Waiting for rate limit reset: ${timeUntilReset}ms`);
+      await new Promise((resolve) => setTimeout(resolve, timeUntilReset + 300));
+    }
+
+    return response.data.total_count;
+  };
+
+  const getDateXMonthsAgo = (months: number) => {
+    const date = new Date();
+    date.setMonth(date.getMonth() - months);
+    return date.toISOString().split('T')[0];
+  };
+  // Append the result to a file
+  const filename = `github_commits_${new Date().toISOString().split('T')[0]}.tsv`;
+  const filePath = path.join(__dirname, filename);
+  const appendToFile = (data: string) => {
+    fs.appendFileSync(filePath, data + '\n');
+  };
+  // filter githubLogins that have already been processed
+  const processedLogins = fs.readFileSync(filePath, 'utf8').split('\n');
+  const unprocessedLogins = githubLogins.filter((login) => !processedLogins.some((row) => row.includes(login!)));
+  console.log(`Processing ${unprocessedLogins.length} logins`);
+  for (const login of unprocessedLogins) {
+    const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+    const weekCount = await getCommitCounts(login!, oneWeekAgo);
+    const monthCount = await getCommitCounts(login!, getDateXMonthsAgo(1));
+    const threeMonthCount = await getCommitCounts(login!, getDateXMonthsAgo(3));
+
+    // Get the user's GitHub join date
+    const userResponse = await octokit.users.getByUsername({
+      username: login!
+    });
+    if (userResponse.headers['x-ratelimit-remaining'] === '2' && userResponse.headers['x-ratelimit-reset']) {
+      const rateLimitReset = new Date(parseInt(userResponse.headers['x-ratelimit-reset']) * 1000);
+      const timeUntilReset = rateLimitReset.getTime() - Date.now();
+      console.log(`Waiting for profile rate limit reset: ${timeUntilReset}ms`);
+      await new Promise((resolve) => setTimeout(resolve, timeUntilReset + 300));
+    }
+    const joinDate = userResponse.data.created_at;
+
+    // Format the join date as YYYY-MM-DD
+    const formattedJoinDate = new Date(joinDate).toISOString().split('T')[0];
+
+    const logEntry = `${login}\t${weekCount}\t${monthCount}\t${threeMonthCount}\t${formattedJoinDate}`;
+    appendToFile(logEntry);
+    if (githubLogins.indexOf(login) % 10 === 0) {
+      console.log(`Processed ${githubLogins.indexOf(login)}/${githubLogins.length} logins`);
+    }
+  }
+  console.log('done!');
+}
+
+query();


### PR DESCRIPTION
- consider streaks across weeks, not just the active week
- we should show builder events based on the merge date, but calculate streaks based on the created date of the PR