### PR TITLE
use select on important queries to avoid db breakages

### DIFF
--- a/apps/scoutgame/app/api/connect-github/callback/route.ts
+++ b/apps/scoutgame/app/api/connect-github/callback/route.ts
@@ -133,7 +133,7 @@ export async function GET(req: NextRequest) {
 
   await prisma.scout.update({
     where: {
-      id: scout.id
+      id: unsealedUserId
     },
     data: {
       onboardedAt: new Date(),

--- a/apps/scoutgame/app/api/connect-github/callback/route.ts
+++ b/apps/scoutgame/app/api/connect-github/callback/route.ts
@@ -52,13 +52,13 @@ export async function GET(req: NextRequest) {
     });
   }
 
-  const scout = await prisma.scout.findUnique({
+  const exists = await prisma.scout.count({
     where: {
       id: unsealedUserId
     }
   });
 
-  if (!scout) {
+  if (!exists) {
     return new Response(null, {
       status: 302,
       headers: {

--- a/apps/scoutgame/app/api/session/refresh/route.ts
+++ b/apps/scoutgame/app/api/session/refresh/route.ts
@@ -12,6 +12,12 @@ export async function GET(req: NextRequest) {
     const scout = await prisma.scout.findUnique({
       where: {
         id: userId
+      },
+      select: {
+        bio: true,
+        displayName: true,
+        username: true,
+        farcasterId: true
       }
     });
     if (!scout) {

--- a/apps/scoutgame/lib/session/authorizeUserByLaunchDate.ts
+++ b/apps/scoutgame/lib/session/authorizeUserByLaunchDate.ts
@@ -21,14 +21,14 @@ export async function authorizeUserByLaunchDate({ fid, now = DateTime.now() }: {
     return true;
   }
 
-  const scout = await prisma.scout.findMany({
+  const matches = await prisma.scout.count({
     where: {
       farcasterId: fid
     }
   });
 
   // users who have already been whitelisted
-  if (scout.length > 0) {
+  if (matches > 0) {
     return true;
   }
 

--- a/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
@@ -16,6 +16,11 @@ export async function processPullRequests({
   const repos = await prisma.githubRepo.findMany({
     where: {
       deletedAt: null
+    },
+    select: {
+      owner: true,
+      name: true,
+      defaultBranch: true
     }
   });
   log.info(`Processing PRs from ${repos.length} repos`);

--- a/packages/scoutgame/src/scripts/uploadNFTArtwork.ts
+++ b/packages/scoutgame/src/scripts/uploadNFTArtwork.ts
@@ -7,8 +7,9 @@ async function uploadNFTArtwork() {
     where: {
       builderStatus: 'approved'
     },
-    include: {
-      githubUser: true,
+    select: {
+      avatar: true,
+      username: true,
       builderNfts: true
     }
   });


### PR DESCRIPTION
I duno really how to test this, but we know that it's best to tell Prisma what fields you want or else it will complain when the DB schema is out of sync with its own.