### PR TITLE
Fix tests for scoutgame

### DIFF
--- a/apps/scoutgame/lib/builders/getSortedBuilders.ts
+++ b/apps/scoutgame/lib/builders/getSortedBuilders.ts
@@ -1,5 +1,4 @@
 import { prisma } from '@charmverse/core/prisma-client';
-import { builderContractAddress } from '@packages/scoutgame/builderNfts/constants';
 import { getPreviousWeek } from '@packages/scoutgame/dates';
 
 import type { BuilderInfo } from './interfaces';
@@ -30,8 +29,7 @@ export async function getSortedBuilders({
             builderStatus: 'approved',
             builderNfts: {
               some: {
-                season,
-                contractAddress: builderContractAddress
+                season
               }
             }
           },
@@ -46,8 +44,7 @@ export async function getSortedBuilders({
             createdAt: true,
             builderNfts: {
               where: {
-                season,
-                contractAddress: builderContractAddress
+                season
               },
               select: {
                 imageUrl: true,
@@ -104,8 +101,7 @@ export async function getSortedBuilders({
               builderStatus: 'approved',
               builderNfts: {
                 some: {
-                  season,
-                  contractAddress: builderContractAddress
+                  season
                 }
               }
             },
@@ -123,8 +119,7 @@ export async function getSortedBuilders({
                 builderStatus: true,
                 builderNfts: {
                   where: {
-                    season,
-                    contractAddress: builderContractAddress
+                    season
                   },
                   select: {
                     currentPrice: true,
@@ -179,8 +174,7 @@ export async function getSortedBuilders({
               builderStatus: 'approved',
               builderNfts: {
                 some: {
-                  season,
-                  contractAddress: builderContractAddress
+                  season
                 }
               }
             }
@@ -208,8 +202,7 @@ export async function getSortedBuilders({
                 },
                 builderNfts: {
                   where: {
-                    season,
-                    contractAddress: builderContractAddress
+                    season
                   },
                   select: {
                     currentPrice: true,

--- a/apps/scoutgame/lib/builders/getTodaysHotBuilders.ts
+++ b/apps/scoutgame/lib/builders/getTodaysHotBuilders.ts
@@ -1,5 +1,4 @@
 import { prisma } from '@charmverse/core/prisma-client';
-import { builderContractAddress } from '@packages/scoutgame/builderNfts/constants';
 import { currentSeason, getCurrentWeek } from '@packages/scoutgame/dates';
 import { isProdEnv } from '@root/config/constants';
 
@@ -59,8 +58,7 @@ export async function getTodaysHotBuilders(): Promise<BuilderInfo[]> {
         },
         builderNfts: {
           where: {
-            season: currentSeason,
-            contractAddress: builderContractAddress
+            season: currentSeason
           },
           select: {
             currentPrice: true,

--- a/apps/scoutgame/lib/builders/getTopBuilders.ts
+++ b/apps/scoutgame/lib/builders/getTopBuilders.ts
@@ -1,5 +1,4 @@
 import { prisma } from '@charmverse/core/prisma-client';
-import { builderContractAddress } from '@packages/scoutgame/builderNfts/constants';
 import { currentSeason } from '@packages/scoutgame/dates';
 import { isTruthy } from '@root/lib/utils/types';
 
@@ -47,8 +46,7 @@ export async function getTopBuilders({ limit }: { limit: number }): Promise<TopB
           },
           builderNfts: {
             where: {
-              season: currentSeason,
-              contractAddress: builderContractAddress
+              season: currentSeason
             },
             select: {
               currentPrice: true,

--- a/packages/scoutgame/src/builderNfts/__tests__/registerBuilderNFT.spec.ts
+++ b/packages/scoutgame/src/builderNfts/__tests__/registerBuilderNFT.spec.ts
@@ -7,12 +7,20 @@ import { mockBuilder, mockScout, mockBuilderNft } from '../../testing/database';
 import { randomLargeInt } from '../../testing/generators';
 import { builderContractAddress, builderNftChain } from '../constants';
 
-jest.unstable_mockModule('../clients/builderContractReadClient', () => ({
-  builderContractReadonlyApiClient: () => ({
+jest.unstable_mockModule('../clients/builderContractAdminWriteClient', () => ({
+  getBuilderContractAdminClient: () => ({
     getTokenIdForBuilder: () => Promise.resolve(randomLargeInt()),
     registerBuilderToken: jest.fn(),
     getTokenPurchasePrice: () => Promise.resolve(randomLargeInt())
   })
+}));
+
+jest.unstable_mockModule('../clients/builderContractReadClient', () => ({
+  builderContractReadonlyApiClient: {
+    getTokenIdForBuilder: () => Promise.resolve(randomLargeInt()),
+    registerBuilderToken: jest.fn(),
+    getTokenPurchasePrice: () => Promise.resolve(randomLargeInt())
+  }
 }));
 
 jest.unstable_mockModule('../createBuilderNft', () => ({


### PR DESCRIPTION
Removing a new condition about contract address for builder NFTs, which broke some tests.. but there's a lot of places we have to look for NFT by season, it's much easier to just make sure we configure the seasons correctly. So i am removing the additional condition

This also fixes tests on registerNFt that were broken because they were trying to create a wallet client