### PR TITLE
Fix page crash: dont use state to capture Wagmi config

### DIFF
--- a/apps/scoutgame/components/common/WalletLogin/WagmiProvider.tsx
+++ b/apps/scoutgame/components/common/WalletLogin/WagmiProvider.tsx
@@ -8,10 +8,9 @@ import { WagmiProvider as OriginalWagmiProvider } from 'wagmi';
 
 import { getConfig } from './wagmiConfig';
 
+const config = getConfig();
+const queryClient = new QueryClient();
 export function WagmiProvider({ children, initialState }: { children: React.ReactNode; initialState?: State }) {
-  const [config] = useState(() => getConfig());
-  const [queryClient] = useState(() => new QueryClient());
-
   return (
     <OriginalWagmiProvider initialState={initialState} config={config}>
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
The examples from Rainbowkit and Wagmi create config and query client outside of React components:

https://wagmi.sh/react/getting-started
https://www.rainbowkit.com/docs/installation