### PR TITLE
Show loading state while Rainbow kit loads

### DIFF
--- a/apps/scoutgame/components/common/DynamicLoading.tsx
+++ b/apps/scoutgame/components/common/DynamicLoading.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { createContext, useContext, useEffect } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+// Context to capture the loading state of the dialog so we can use it to show a loading state on the button
+// ref: https://github.com/vercel/next.js/discussions/10853
+export const DynamicLoadingContext = createContext<Dispatch<SetStateAction<boolean>>>(() => false);
+
+export function LoadingComponent() {
+  const setLoading = useContext(DynamicLoadingContext);
+  useEffect(() => {
+    setLoading(true);
+    return () => setLoading(false);
+  }, [setLoading]);
+
+  return null;
+}

--- a/apps/scoutgame/components/common/ScoutButton/ScoutButton.tsx
+++ b/apps/scoutgame/components/common/ScoutButton/ScoutButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@mui/material';
+import { LoadingButton } from '@mui/lab';
 import { builderTokenDecimals } from '@packages/scoutgame/builderNfts/constants';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
@@ -8,8 +8,14 @@ import { useState } from 'react';
 
 import type { MinimalUserInfo } from 'lib/users/interfaces';
 
-const NFTPurchaseDialog = dynamic(() =>
-  import('components/common/NFTPurchaseForm/NFTPurchaseDialog').then((mod) => mod.NFTPurchaseDialogWithProviders)
+import { DynamicLoadingContext, LoadingComponent } from '../DynamicLoading';
+
+const NFTPurchaseDialog = dynamic(
+  () => import('components/common/NFTPurchaseForm/NFTPurchaseDialog').then((mod) => mod.NFTPurchaseDialogWithProviders),
+  {
+    loading: LoadingComponent,
+    ssr: false
+  }
 );
 
 export function ScoutButton({
@@ -21,7 +27,7 @@ export function ScoutButton({
 }) {
   const router = useRouter();
   const [isPurchasing, setIsPurchasing] = useState<boolean>(false);
-
+  const [dialogLoadingStatus, setDialogLoadingStatus] = useState<boolean>(false);
   const handleClick = () => {
     if (isAuthenticated) {
       setIsPurchasing(true);
@@ -29,13 +35,14 @@ export function ScoutButton({
       router.push('/login');
     }
   };
-
   return (
-    <>
-      <Button fullWidth onClick={handleClick} variant='buy' data-test='scout-button'>
-        ${(Number(builder.price) / 10 ** builderTokenDecimals).toFixed(2)}
-      </Button>
-      <NFTPurchaseDialog open={isPurchasing} onClose={() => setIsPurchasing(false)} builder={builder} />
-    </>
+    <div>
+      <DynamicLoadingContext.Provider value={setDialogLoadingStatus}>
+        <LoadingButton loading={dialogLoadingStatus} fullWidth onClick={handleClick} variant='buy'>
+          ${(Number(builder.price) / 10 ** builderTokenDecimals).toFixed(2)}
+        </LoadingButton>
+        {isPurchasing && <NFTPurchaseDialog open onClose={() => setIsPurchasing(false)} builder={builder} />}
+      </DynamicLoadingContext.Provider>
+    </div>
   );
 }

--- a/apps/scoutgame/package.json
+++ b/apps/scoutgame/package.json
@@ -20,6 +20,7 @@
     "@decent.xyz/box-ui": "^3.3.5",
     "@decent.xyz/the-box": "^3.1.15",
     "@hookform/resolvers": "^3.6.0",
+    "@mui/lab": "^6.0.0-beta.10",
     "@packages/farcaster": "file:../../packages/farcaster",
     "@packages/github": "file:../../packages/github",
     "@packages/scoutgame": "^0.0.0",

--- a/apps/scoutgame/tsconfig.json
+++ b/apps/scoutgame/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "declarationMap": true,
+    "declaration": true,
     "rootDir": "../../",
     "lib": [
       "dom",


### PR DESCRIPTION
This also fixes an issue when closing RainbowKit modal, you wouldn't be able to open it again because the ScoutButton's state was not being updated. (I really wish Rainbow kit offered event callbacks instead, which is why i'm using useEffect to watch for changes).