### PR TITLE
optimize saving github events

### DIFF
--- a/apps/scoutgamecron/package.json
+++ b/apps/scoutgamecron/package.json
@@ -13,6 +13,7 @@
     "seed": "tsx src/scripts/generateSeedData.ts"
   },
   "dependencies": {
+    "@octokit/plugin-throttling": "^9.3.1",
     "@packages/farcaster": "^0.0.0",
     "@packages/github": "^0.0.0",
     "@packages/onchain": "^0.0.0",

--- a/apps/scoutgamecron/src/scripts/processPullRequests.ts
+++ b/apps/scoutgamecron/src/scripts/processPullRequests.ts
@@ -2,6 +2,7 @@ import { processPullRequests } from '../tasks/processPullRequests';
 import { DateTime } from 'luxon';
 (async () => {
   await processPullRequests({
-    createdAfter: DateTime.fromISO('2024-09-29', { zone: 'utc' }).toJSDate()
+    createdAfter: DateTime.fromISO('2024-09-29', { zone: 'utc' }).toJSDate(),
+    onlyProcessNewRepos: true
   });
 })();

--- a/apps/scoutgamecron/src/scripts/processPullRequests.ts
+++ b/apps/scoutgamecron/src/scripts/processPullRequests.ts
@@ -1,6 +1,7 @@
 import { processPullRequests } from '../tasks/processPullRequests';
 import { DateTime } from 'luxon';
-(async () => {
+import { getCurrentWeek, currentSeason } from '@packages/scoutgame/dates';
+
   await processPullRequests({
     createdAfter: DateTime.fromISO('2024-09-29', { zone: 'utc' }).toJSDate(),
     onlyProcessNewRepos: true

--- a/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
@@ -41,7 +41,6 @@ type GetRecentClosedOrMergedPRsResponse = {
       pageInfo: PageInfo;
     };
   };
-  headers: Record<string, string>;
 };
 
 const getRecentPrs = `

--- a/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
@@ -41,6 +41,7 @@ type GetRecentClosedOrMergedPRsResponse = {
       pageInfo: PageInfo;
     };
   };
+  headers: Record<string, string>;
 };
 
 const getRecentPrs = `

--- a/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/getPullRequests.ts
@@ -103,8 +103,10 @@ export async function getPullRequests({ repos, after }: { repos: RepoInput[]; af
     });
     // ignore PRs that are not on the default branch
     pullRequests.push(...repoPullRequests.filter((pr) => pr.baseRefName === repo.defaultBranch));
-    if (repos.indexOf(repo) % 100 === 0) {
-      log.debug(`Retrieved Prs from ${repos.indexOf(repo)}/${repos.length} repos`);
+    if (repos.length > 100) {
+      if (repos.indexOf(repo) % 100 === 0) {
+        log.debug(`Retrieved Prs from ${repos.indexOf(repo) + 1}/${repos.length} repos`);
+      }
     }
   }
   return pullRequests;

--- a/apps/scoutgamecron/src/tasks/processPullRequests/gqlClient.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/gqlClient.ts
@@ -1,11 +1,28 @@
-import { graphql } from '@octokit/graphql';
+import { Octokit } from '@octokit/core';
+import { throttling } from '@octokit/plugin-throttling';
 
-// Create an authenticated GraphQL client using your GitHub token
-export function getClient() {
-  return graphql.defaults({
-    headers: {
-      Authorization: `bearer ${process.env.GITHUB_ACCESS_TOKEN}`,
-      'X-Github-Next-Global-ID': 0 // force the old style ids which we can parse
+// we need to use octokit core to use the throttling plugin
+Octokit.plugin(throttling);
+
+const octokit = new Octokit({
+  auth: process.env.GITHUB_ACCESS_TOKEN,
+  throttle: {
+    onRateLimit: (retryAfter, options, _octokit, retryCount) => {
+      octokit.log.warn(`Request quota exhausted for request ${options.method} ${options.url}`);
+
+      if (retryCount < 1) {
+        // only retries once
+        octokit.log.info(`Retrying after ${retryAfter} seconds!`);
+        return true;
+      }
+    },
+    onSecondaryRateLimit: (retryAfter, options, _octokit) => {
+      // does not retry, only logs a warning
+      octokit.log.warn(`SecondaryRateLimit detected for request ${options.method} ${options.url}`);
     }
-  });
+  }
+});
+
+export function getClient() {
+  return octokit.graphql.defaults({});
 }

--- a/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
@@ -1,4 +1,5 @@
 import { log } from '@charmverse/core/log';
+import type { GithubRepo } from '@charmverse/core/prisma-client';
 import { prisma } from '@charmverse/core/prisma-client';
 import { getCurrentWeek, currentSeason } from '@packages/scoutgame/dates';
 import { DateTime } from 'luxon';
@@ -8,11 +9,19 @@ import { processClosedPullRequest } from './processClosedPullRequest';
 import { processMergedPullRequest } from './processMergedPullRequest';
 import { updateBuildersRank } from './updateBuildersRank';
 
+type Options = {
+  createdAfter?: Date;
+  skipClosedPrProcessing?: boolean;
+  season?: string;
+  onlyProcessNewRepos?: boolean;
+};
+
 export async function processPullRequests({
   createdAfter = new Date(Date.now() - 30 * 60 * 1000),
   skipClosedPrProcessing = false,
+  onlyProcessNewRepos = false,
   season = currentSeason
-}: { createdAfter?: Date; skipClosedPrProcessing?: boolean; season?: string } = {}) {
+}: Options = {}) {
   const repos = await prisma.githubRepo.findMany({
     where: {
       deletedAt: null
@@ -26,7 +35,49 @@ export async function processPullRequests({
   });
   log.info(`Found ${repos.length} repos to check for PRs`);
 
+  for (let i = 0; i < repos.length; i += 100) {
+    const reposBatch = repos.slice(i, i + 100);
+    await processPullRequestsForRepos({
+      repos: reposBatch,
+      createdAfter,
+      skipClosedPrProcessing,
+      season,
+      onlyProcessNewRepos
+    });
+    log.debug(`Processed ${i}/${repos.length} repos`);
+  }
+
+  await updateBuildersRank({ week: getCurrentWeek() });
+}
+
+async function processPullRequestsForRepos({
+  repos,
+  createdAfter,
+  skipClosedPrProcessing,
+  onlyProcessNewRepos,
+  season
+}: Options & {
+  createdAfter: Date;
+  season: string;
+  repos: Pick<GithubRepo, 'id' | 'owner' | 'name' | 'defaultBranch'>[];
+}) {
   const timer = DateTime.now();
+
+  if (onlyProcessNewRepos) {
+    const existingPullRequests = await prisma.githubEvent.findMany({
+      where: {
+        repoId: {
+          in: repos.map((r) => r.id)
+        }
+      }
+    });
+    if (existingPullRequests.length) {
+      log.info(`Skip some repos because they have been processed before`);
+      return;
+    }
+    repos = repos.filter((r) => !existingPullRequests.some((e) => e.repoId === r.id));
+  }
+
   const pullRequests = await getPullRequests({ repos, after: createdAfter });
 
   const githubEvents = await prisma.githubEvent.findMany({
@@ -79,8 +130,6 @@ export async function processPullRequests({
       log.error(`Repo not found for pull request: ${pullRequest.repository.nameWithOwner}`);
     }
   }
-
-  await updateBuildersRank({ week: getCurrentWeek() });
 
   log.info(`Processed ${pullRequests.length} pull requests in ${timer.diff(DateTime.now(), 'minutes')} minutes`);
 }

--- a/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
@@ -24,10 +24,10 @@ export async function processPullRequests({
 }: Options = {}) {
   const repos = await prisma.githubRepo.findMany({
     where: {
-      deletedAt: null,
-      id: {
-        gt: 208938406
-      }
+      deletedAt: null
+      // id: {
+      //   gt: 760314802
+      // }
     },
     // sort the repos in case it fails, so we can resume from the next one
     orderBy: {

--- a/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
@@ -24,7 +24,14 @@ export async function processPullRequests({
 }: Options = {}) {
   const repos = await prisma.githubRepo.findMany({
     where: {
-      deletedAt: null
+      deletedAt: null,
+      id: {
+        gt: 30532948
+      }
+    },
+    // sort the repos in case it fails, so we can resume from the next one
+    orderBy: {
+      id: 'asc'
     },
     select: {
       id: true,
@@ -44,7 +51,7 @@ export async function processPullRequests({
       season,
       onlyProcessNewRepos
     });
-    log.debug(`Processed ${i}/${repos.length} repos`);
+    log.debug(`Processed ${i}/${repos.length} repos, last Id: ${reposBatch[reposBatch.length - 1].id}`);
   }
 
   await updateBuildersRank({ week: getCurrentWeek() });

--- a/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
@@ -9,7 +9,7 @@ import { processClosedPullRequest } from './processClosedPullRequest';
 import { processMergedPullRequest } from './processMergedPullRequest';
 import { updateBuildersRank } from './updateBuildersRank';
 
-type Options = {
+type ProcessPullRequestsOptions = {
   createdAfter?: Date;
   skipClosedPrProcessing?: boolean;
   season?: string;
@@ -21,7 +21,7 @@ export async function processPullRequests({
   skipClosedPrProcessing = false,
   onlyProcessNewRepos = false,
   season = currentSeason
-}: Options = {}) {
+}: ProcessPullRequestsOptions = {}) {
   const repos = await prisma.githubRepo.findMany({
     where: {
       deletedAt: null
@@ -51,7 +51,7 @@ export async function processPullRequests({
       season,
       onlyProcessNewRepos
     });
-    log.debug(`Processed ${i}/${repos.length} repos, last Id: ${reposBatch[reposBatch.length - 1].id}`);
+    log.debug(`Processed ${i}/${repos.length} repos, last PR id: ${reposBatch[reposBatch.length - 1].id}`);
   }
 
   await updateBuildersRank({ week: getCurrentWeek() });
@@ -63,7 +63,7 @@ async function processPullRequestsForRepos({
   skipClosedPrProcessing,
   onlyProcessNewRepos,
   season
-}: Options & {
+}: ProcessPullRequestsOptions & {
   createdAfter: Date;
   season: string;
   repos: Pick<GithubRepo, 'id' | 'owner' | 'name' | 'defaultBranch'>[];

--- a/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
+++ b/apps/scoutgamecron/src/tasks/processPullRequests/index.ts
@@ -26,7 +26,7 @@ export async function processPullRequests({
     where: {
       deletedAt: null,
       id: {
-        gt: 30532948
+        gt: 208938406
       }
     },
     // sort the repos in case it fails, so we can resume from the next one


### PR DESCRIPTION
Basically, only process 100 repos at a time. Previously, we waited to retrieve all PRs before processing any and if we got rate limited, it would not save anything. But now we have 53k repos. The code's not beautiful, but we might be optimizing a lot in the next few days.