### PR TITLE
fix collabland check

### DIFF
--- a/lib/discord/collabland/verifyDiscordGateForSpace.ts
+++ b/lib/discord/collabland/verifyDiscordGateForSpace.ts
@@ -8,9 +8,9 @@ type Props = {
 
 export async function verifyDiscordGateForSpace({ discordUserId, space }: Props) {
   const discordServerId = space.discordServerId;
-
   // this is a hack for now, discordServerId is used for both collab.land and import roles from discord feature
-  if (!discordServerId || !discordUserId || !space.superApiTokenId) {
+  // xpsEngineId implies that we have a discord server id for game7
+  if (!discordUserId || !discordServerId || space.xpsEngineId) {
     return {
       isVerified: false,
       hasDiscordServer: !!(discordServerId && space.superApiTokenId),


### PR DESCRIPTION
About a year ago, i added a condition for Collabland, trying to differentiate between spaces that had Discord via Game7 vs Collabland. But it was incorrect, and basically any collabland space that did not have a super api token would fail (but super api tokens are generated for Game7, so i think the logic was inverted)

https://github.com/charmverse/app.charmverse.io/pull/1794/files