### PR TITLE
check the users farcaster profile before sending them a mention

### DIFF
--- a/apps/scoutgame/app/api/farcaster/user/route.ts
+++ b/apps/scoutgame/app/api/farcaster/user/route.ts
@@ -1,0 +1,29 @@
+import { log } from '@charmverse/core/log';
+import { prisma } from '@charmverse/core/prisma-client';
+import { getFarcasterUserById } from '@packages/farcaster/getFarcasterUserById';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
+  if (!userId) {
+    return new Response('userId is required', { status: 400 });
+  }
+  const user = await prisma.scout.findUniqueOrThrow({
+    where: {
+      id: userId
+    },
+    select: {
+      farcasterId: true
+    }
+  });
+  if (!user.farcasterId) {
+    log.warn('User has no Farcaster ID', { userId });
+    return Response.json(null);
+  }
+  const profile = await getFarcasterUserById(user.farcasterId).catch((error) => {
+    log.error('Error fetching Farcaster profile', { error, userId });
+    return null;
+  });
+
+  return Response.json(profile);
+}

--- a/apps/scoutgame/components/common/NFTPurchaseDialog/NFTPurchaseDialog.tsx
+++ b/apps/scoutgame/components/common/NFTPurchaseDialog/NFTPurchaseDialog.tsx
@@ -6,8 +6,8 @@ import { useAccount } from 'wagmi';
 
 import { Dialog } from 'components/common/Dialog';
 import { useSmScreen } from 'hooks/useMediaScreens';
-import type { MinimalUserInfo } from 'lib/users/interfaces';
 
+import type { NFTPurchaseProps } from './components/NFTPurchaseForm';
 import { NFTPurchaseForm } from './components/NFTPurchaseForm';
 
 import '@rainbow-me/rainbowkit/styles.css';
@@ -15,7 +15,7 @@ import '@rainbow-me/rainbowkit/styles.css';
 type NFTPurchaseDialogProps = {
   open: boolean;
   onClose: VoidFunction;
-  builder: MinimalUserInfo & { price?: bigint; nftImageUrl?: string | null };
+  builder: NFTPurchaseProps['builder'];
 };
 
 // This component opens the wallet connect modal if the user is not connected yet

--- a/apps/scoutgame/components/common/NFTPurchaseDialog/components/NFTPurchaseForm.tsx
+++ b/apps/scoutgame/components/common/NFTPurchaseDialog/components/NFTPurchaseForm.tsx
@@ -304,8 +304,8 @@ export function NFTPurchaseFormContent({ builder }: NFTPurchaseProps) {
   const displayedBalance = !balanceInfo
     ? undefined
     : selectedPaymentOption.currency === 'ETH'
-    ? (Number(balanceInfo.balance || 0) / 1e18).toFixed(4)
-    : (Number(balanceInfo.balance || 0) / 1e6).toFixed(2);
+      ? (Number(balanceInfo.balance || 0) / 1e18).toFixed(4)
+      : (Number(balanceInfo.balance || 0) / 1e6).toFixed(2);
 
   const [selectedQuantity, setSelectedQuantity] = useState<number | 'custom'>(1);
   const [customQuantity, setCustomQuantity] = useState(2);
@@ -325,7 +325,7 @@ export function NFTPurchaseFormContent({ builder }: NFTPurchaseProps) {
     typeof allowance === 'bigint' &&
     allowance < (typeof amountToPay === 'bigint' ? amountToPay : BigInt(0));
 
-  if (hasPurchasedWithPoints || (savedDecentTransaction && transactionHasSucceeded)) {
+  if (true || hasPurchasedWithPoints || (savedDecentTransaction && transactionHasSucceeded)) {
     return <SuccessView builder={builder} />;
   }
 

--- a/apps/scoutgame/components/common/NFTPurchaseDialog/components/NFTPurchaseForm.tsx
+++ b/apps/scoutgame/components/common/NFTPurchaseDialog/components/NFTPurchaseForm.tsx
@@ -325,7 +325,7 @@ export function NFTPurchaseFormContent({ builder }: NFTPurchaseProps) {
     typeof allowance === 'bigint' &&
     allowance < (typeof amountToPay === 'bigint' ? amountToPay : BigInt(0));
 
-  if (true || hasPurchasedWithPoints || (savedDecentTransaction && transactionHasSucceeded)) {
+  if (hasPurchasedWithPoints || (savedDecentTransaction && transactionHasSucceeded)) {
     return <SuccessView builder={builder} />;
   }
 

--- a/apps/scoutgame/components/common/NFTPurchaseDialog/components/SuccessView.tsx
+++ b/apps/scoutgame/components/common/NFTPurchaseDialog/components/SuccessView.tsx
@@ -2,7 +2,14 @@ import { Box, Button, Stack, Typography } from '@mui/material';
 import Image from 'next/image';
 import Link from 'next/link';
 
-export function SuccessView({ builder }: { builder: { nftImageUrl?: string | null; username: string } }) {
+import { useGetFarcasterUser } from 'hooks/api/farcaster';
+
+export function SuccessView({ builder }: { builder: { id: string; nftImageUrl?: string | null; username: string } }) {
+  // retrieve the user's latest farcaster profile
+  const { data: farcasterUser } = useGetFarcasterUser({ userId: builder.id });
+
+  const farcasterUsername = farcasterUser?.username || builder.username;
+
   return (
     <Stack gap={2} textAlign='center'>
       <Typography color='secondary' variant='h5' fontWeight={600}>
@@ -42,7 +49,7 @@ export function SuccessView({ builder }: { builder: { nftImageUrl?: string | nul
         fullWidth
         href={`https://warpcast.com/~/compose?text=${encodeURI(
           `I scouted @${builder.username} on Scout Game!`
-        )}&embeds[]=${window.location.origin}/u/${builder.username}`}
+        )}&embeds[]=${window.location.origin}/u/${farcasterUsername}`}
         target='_blank'
         rel='noopener noreferrer'
       >

--- a/apps/scoutgame/components/common/ScoutButton/ScoutButton.tsx
+++ b/apps/scoutgame/components/common/ScoutButton/ScoutButton.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { useState } from 'react';
 
+import type { NFTPurchaseProps } from 'components/common/NFTPurchaseDialog/components/NFTPurchaseForm';
 import type { MinimalUserInfo } from 'lib/users/interfaces';
 
 import { DynamicLoadingContext, LoadingComponent } from '../DynamicLoading';
@@ -24,7 +25,7 @@ export function ScoutButton({
   builder,
   isAuthenticated = true
 }: {
-  builder: MinimalUserInfo & { price?: bigint; nftImageUrl?: string | null };
+  builder: NFTPurchaseProps['builder'];
   isAuthenticated?: boolean;
 }) {
   const [isPurchasing, setIsPurchasing] = useState<boolean>(false);

--- a/apps/scoutgame/hooks/api/builders.ts
+++ b/apps/scoutgame/hooks/api/builders.ts
@@ -1,7 +1,9 @@
+import type { BuilderSearchResult } from 'lib/builders/searchBuilders';
+
 import { useGETImmutable } from './helpers';
 
 export function useSearchBuilders(username: string) {
-  return useGETImmutable<[]>(username ? '/api/builders/search' : null, {
+  return useGETImmutable<BuilderSearchResult[]>(username ? '/api/builders/search' : null, {
     username
   });
 }

--- a/apps/scoutgame/hooks/api/farcaster.ts
+++ b/apps/scoutgame/hooks/api/farcaster.ts
@@ -1,0 +1,9 @@
+import type { FarcasterUser } from '@packages/farcaster/interfaces';
+
+import { useGETImmutable } from './helpers';
+
+export function useGetFarcasterUser({ userId }: { userId: string }) {
+  return useGETImmutable<FarcasterUser | null>('/api/farcaster/user', {
+    userId
+  });
+}

--- a/apps/scoutgame/lib/builders/getLeaderboard.ts
+++ b/apps/scoutgame/lib/builders/getLeaderboard.ts
@@ -31,6 +31,7 @@ export async function getLeaderboard({ limit = 10 }: { limit: number }): Promise
       user: {
         select: {
           id: true,
+          farcasterId: true,
           avatar: true,
           username: true,
           displayName: true,

--- a/apps/scoutgame/lib/builders/getLeaderboard.ts
+++ b/apps/scoutgame/lib/builders/getLeaderboard.ts
@@ -31,7 +31,6 @@ export async function getLeaderboard({ limit = 10 }: { limit: number }): Promise
       user: {
         select: {
           id: true,
-          farcasterId: true,
           avatar: true,
           username: true,
           displayName: true,


### PR DESCRIPTION
- load the correct farcaster username when sending a cast


We could alternatively refresh the user's profile regularly, but in the future, not everyone is required to have farcaster and/or we may let u customize your username. in that case, we probably will need to retrieve your farcaster username anyway unless we start storing it someplace else