### PR TITLE
ask user to try again if warpcast log in fails

### DIFF
--- a/apps/scoutgame/components/common/WarpcastLogin/WarpcastLoginButton.tsx
+++ b/apps/scoutgame/components/common/WarpcastLogin/WarpcastLoginButton.tsx
@@ -96,7 +96,10 @@ export function WarpcastLoginButton({ children, ...props }: ButtonProps) {
   }
 
   const errorMessage =
-    (connectionError && connectionError.message) ||
+    (connectionError &&
+      (connectionError.errCode === 'unavailable'
+        ? 'Could not connect to network. Please try again'
+        : connectionError.message)) ||
     (hasErrored &&
       (result?.serverError?.message?.includes('private beta')
         ? 'Scout Game is in private beta'


### PR DESCRIPTION
Sometimes the request to alchemy times out / fails to load, can't figure out why. I tested with a fake URL and Farcaster does retries, but the user just sees an ugly message. so now ask the user to try again

Discord: https://discord.com/channels/894960387743698944/1295166542056652842