### PR TITLE
show op profile if you are not the author

### DIFF
--- a/components/[pageId]/DocumentPage/DocumentPage.tsx
+++ b/components/[pageId]/DocumentPage/DocumentPage.tsx
@@ -519,6 +519,7 @@ function DocumentPageComponent({
                         getFieldState={getFieldState}
                         onSave={onSave}
                         pageId={page.id}
+                        isAuthor={proposalAuthors.includes(user?.id || '')}
                         threads={threads}
                         // This is required to reinstate the form field state after the proposal is published, necessary to show the correct project id
                         key={proposal?.status === 'draft' ? 'draft' : 'published'}

--- a/components/common/form/FormFieldAnswers.tsx
+++ b/components/common/form/FormFieldAnswers.tsx
@@ -51,6 +51,7 @@ type FormFieldAnswersProps = {
   values?: Record<string, FormFieldValue>;
   pageId?: string;
   isDraft?: boolean;
+  isAuthor: boolean;
   threads?: Record<string, ThreadWithComments | undefined>;
   projectId?: string | null;
   proposalId: string;
@@ -71,6 +72,7 @@ export function FormFieldAnswers({
   onSave,
   formFields,
   disabled,
+  isAuthor,
   enableComments,
   getFieldState,
   control,
@@ -233,7 +235,7 @@ export function FormFieldAnswers({
                       )
                     }
                     description={formField.description as PageContent}
-                    disabled={disabled}
+                    disabled={disabled || (!isAuthor && formField.type === 'optimism_project_profile')}
                     type={formField.type === 'short_text' ? 'text_multiline' : formField.type}
                     label={formField.name}
                     options={formField.options as SelectOptionType[]}

--- a/stories/FormFields/FormFields.stories.tsx
+++ b/stories/FormFields/FormFields.stories.tsx
@@ -84,6 +84,7 @@ export function FormFieldsInputs() {
     <GlobalContext>
       <CustomFormFieldAnswers
         {...props}
+        isAuthor={true}
         enableComments={true}
         proposalId=''
         applyProject={() => {}}
@@ -172,6 +173,7 @@ export function FormFieldsInputsDisplay() {
     <GlobalContext>
       <CustomFormFieldAnswers
         {...props}
+        isAuthor={true}
         proposalId=''
         enableComments={true}
         applyProject={() => {}}


### PR DESCRIPTION
if you're an admin, the field will not be disabled and we'll show u the input, which depends on the author being connected to the farcaster account