### PR TITLE
filter hidden blocks and properties if you do not have edit access to a proposal source board

### DIFF
--- a/components/common/Icons/VisibilityIcon.tsx
+++ b/components/common/Icons/VisibilityIcon.tsx
@@ -22,9 +22,9 @@ export function VisibilityIcon({
   }
 
   const icon = visible ? (
-    <MuiVisibilityIcon color='gray' fontSize={size} onClick={handleClick} />
+    <MuiVisibilityIcon fontSize={size} onClick={handleClick} />
   ) : (
-    <VisibilityOffIcon color='gray' fontSize={size} onClick={handleClick} />
+    <VisibilityOffIcon fontSize={size} onClick={handleClick} />
   );
 
   const tooltip = visible ? visibleTooltip : hiddenTooltip;


### PR DESCRIPTION
I noticed that for public boards, we are sharing all the blocks even if you filtered them. This PR utilizes the logic for a "locked" board to reduce the data we return if you also just don't have edit permission.