### PR TITLE
Show builder rank in card stats

### DIFF
--- a/apps/scoutgame/components/[username]/components/PublicBuilderProfile/PublicBuilderProfileContainer.tsx
+++ b/apps/scoutgame/components/[username]/components/PublicBuilderProfile/PublicBuilderProfileContainer.tsx
@@ -73,18 +73,7 @@ export function PublicBuilderProfileContainer({
               <BackButton />
               <Stack flexDirection='row' alignItems='center' gap={2}>
                 <Box minWidth='fit-content'>
-                  <BuilderCard
-                    builder={{
-                      ...builder,
-                      price: builder.price ?? BigInt(0),
-                      nftsSold: 0,
-                      gemsCollected: 0,
-                      builderPoints: 0
-                    }}
-                    hideDetails
-                    showPurchaseButton
-                    size='small'
-                  />
+                  <BuilderCard builder={builder} hideDetails showPurchaseButton size='small' />
                 </Box>
                 <Stack gap={1} pr={1}>
                   <UserProfile
@@ -126,17 +115,7 @@ export function PublicBuilderProfileContainer({
                     justifyContent: 'center'
                   }}
                 >
-                  <BuilderCard
-                    builder={{
-                      ...builder,
-                      price: builder.price ?? BigInt(0),
-                      nftsSold: 0,
-                      gemsCollected: 0,
-                      builderPoints: 0
-                    }}
-                    hideDetails
-                    showPurchaseButton
-                  />
+                  <BuilderCard builder={builder} hideDetails showPurchaseButton />
                   <PublicBuilderStats
                     seasonPoints={seasonPoints}
                     allTimePoints={allTimePoints}

--- a/apps/scoutgame/components/common/Card/BuilderCard/BuilderCard.tsx
+++ b/apps/scoutgame/components/common/Card/BuilderCard/BuilderCard.tsx
@@ -9,6 +9,8 @@ import { ScoutButton } from '../../ScoutButton/ScoutButton';
 import { BuilderCardNftDisplay } from './BuilderCardNftDisplay';
 import { BuilderCardStats } from './BuilderCardStats';
 
+type RequiredBuilderInfoFields = 'username' | 'displayName' | 'id';
+
 export function BuilderCard({
   builder,
   showPurchaseButton = false,
@@ -17,7 +19,7 @@ export function BuilderCard({
   size = 'medium'
 }: {
   size?: 'x-small' | 'small' | 'medium' | 'large';
-  builder: BuilderInfo;
+  builder: Omit<Partial<BuilderInfo>, RequiredBuilderInfoFields> & Pick<BuilderInfo, RequiredBuilderInfoFields>;
   hideDetails?: boolean;
   showPurchaseButton?: boolean;
   showHotIcon?: boolean;

--- a/apps/scoutgame/components/common/Card/BuilderCard/BuilderCardStats.tsx
+++ b/apps/scoutgame/components/common/Card/BuilderCard/BuilderCardStats.tsx
@@ -4,13 +4,13 @@ import Image from 'next/image';
 import { GemsIcon, PointsIcon } from 'components/common/Icons';
 
 export function BuilderCardStats({
-  gemsCollected,
   builderPoints,
-  nftsSold
+  nftsSold,
+  rank
 }: {
-  gemsCollected?: number;
   builderPoints?: number;
   nftsSold?: number;
+  rank?: number;
 }) {
   return (
     <Stack flexDirection='row' alignItems='center' justifyContent='space-between' gap={1}>
@@ -22,12 +22,11 @@ export function BuilderCardStats({
           <PointsIcon size={15} color='green' />
         </Stack>
       )}
-      {typeof gemsCollected === 'number' && (
+      {typeof rank === 'number' && (
         <Stack flexDirection='row' gap={0.2} alignItems='center'>
           <Typography variant='body2' component='span' color='text.secondary'>
-            {gemsCollected}
+            #{rank}
           </Typography>
-          <GemsIcon size={15} />
         </Stack>
       )}
       {typeof nftsSold === 'number' && (

--- a/apps/scoutgame/components/common/Card/BuilderCard/BuilderCardStats.tsx
+++ b/apps/scoutgame/components/common/Card/BuilderCard/BuilderCardStats.tsx
@@ -1,7 +1,7 @@
-import { Stack, Typography } from '@mui/material';
+import { Stack, Tooltip, Typography } from '@mui/material';
 import Image from 'next/image';
 
-import { GemsIcon, PointsIcon } from 'components/common/Icons';
+import { PointsIcon } from 'components/common/Icons';
 
 export function BuilderCardStats({
   builderPoints,
@@ -15,27 +15,33 @@ export function BuilderCardStats({
   return (
     <Stack flexDirection='row' alignItems='center' justifyContent='space-between' gap={1}>
       {typeof builderPoints === 'number' && (
-        <Stack flexDirection='row' gap={0.2} alignItems='center'>
-          <Typography variant='body2' component='span' color='green.main'>
-            {builderPoints}
-          </Typography>
-          <PointsIcon size={15} color='green' />
-        </Stack>
+        <Tooltip title='Total # of Scout Points earned this season to date'>
+          <Stack flexDirection='row' gap={0.2} alignItems='center'>
+            <Typography variant='body2' component='span' color='green.main'>
+              {builderPoints}
+            </Typography>
+            <PointsIcon size={15} color='green' />
+          </Stack>
+        </Tooltip>
       )}
       {typeof rank === 'number' && (
-        <Stack flexDirection='row' gap={0.2} alignItems='center'>
-          <Typography variant='body2' component='span' color='text.secondary'>
-            #{rank}
-          </Typography>
-        </Stack>
+        <Tooltip title='Current rank'>
+          <Stack flexDirection='row' gap={0.2} alignItems='center'>
+            <Typography variant='body2' component='span' color='text.secondary'>
+              #{rank}
+            </Typography>
+          </Stack>
+        </Tooltip>
       )}
       {typeof nftsSold === 'number' && (
-        <Stack flexDirection='row' gap={0.2} alignItems='center'>
-          <Typography variant='body2' component='span' color='orange.main'>
-            {nftsSold}
-          </Typography>
-          <Image width={12} height={12} src='/images/profile/icons/nft-orange-icon.svg' alt='Nfts' />
-        </Stack>
+        <Tooltip title='Total # of Builder NFTs sold to date'>
+          <Stack flexDirection='row' gap={0.2} alignItems='center'>
+            <Typography variant='body2' component='span' color='orange.main'>
+              {nftsSold}
+            </Typography>
+            <Image width={12} height={12} src='/images/profile/icons/nft-orange-icon.svg' alt='Nfts' />
+          </Stack>
+        </Tooltip>
       )}
     </Stack>
   );

--- a/apps/scoutgame/components/common/Card/BuilderCard/BuilderCardStats.tsx
+++ b/apps/scoutgame/components/common/Card/BuilderCard/BuilderCardStats.tsx
@@ -25,7 +25,7 @@ export function BuilderCardStats({
         </Tooltip>
       )}
       {typeof rank === 'number' && (
-        <Tooltip title='Current rank'>
+        <Tooltip title='Current week’s rank'>
           <Stack flexDirection='row' gap={0.2} alignItems='center'>
             <Typography variant='body2' component='span' color='text.secondary'>
               #{rank}
@@ -34,7 +34,7 @@ export function BuilderCardStats({
         </Tooltip>
       )}
       {typeof nftsSold === 'number' && (
-        <Tooltip title='Total # of Builder NFTs sold to date'>
+        <Tooltip title='Total # of cards sold this season to date'>
           <Stack flexDirection='row' gap={0.2} alignItems='center'>
             <Typography variant='body2' component='span' color='orange.main'>
               {nftsSold}

--- a/apps/scoutgame/components/profile/components/ScoutProfile/ScoutProfile.tsx
+++ b/apps/scoutgame/components/profile/components/ScoutProfile/ScoutProfile.tsx
@@ -10,7 +10,7 @@ import { safeAwaitSSRData } from 'lib/utils/async';
 
 import { ScoutStats } from './ScoutStats';
 
-export async function ScoutProfile({ userId, isMobile }: { userId: string; isMobile?: boolean }) {
+export async function ScoutProfile({ userId }: { userId: string }) {
   const [error, data] = await safeAwaitSSRData(
     Promise.all([getUserSeasonStats(userId), getScoutedBuilders({ scoutId: userId })])
   );

--- a/apps/scoutgame/lib/builders/getSortedBuilders.ts
+++ b/apps/scoutgame/lib/builders/getSortedBuilders.ts
@@ -23,10 +23,6 @@ export async function getSortedBuilders({
   season: string;
   cursor: CompositeCursor | null;
 }): Promise<{ builders: BuilderInfo[]; nextCursor: CompositeCursor | null }> {
-  // new is based on the most recent builder
-  // top is based on the most gems earned in their user week stats
-  // hot is based on the most points earned in the previous user week stats
-
   switch (sort) {
     case 'new': {
       const builders = await prisma.scout
@@ -67,7 +63,7 @@ export async function getSortedBuilders({
                 week
               },
               select: {
-                gemsCollected: true
+                rank: true
               }
             },
             userSeasonStats: {
@@ -94,7 +90,7 @@ export async function getSortedBuilders({
             builderPoints: scout.userAllTimeStats[0]?.pointsEarnedAsBuilder ?? 0,
             price: scout.builderNfts?.[0]?.currentPrice ?? 0,
             scoutedBy: scout.builderNfts?.[0]?.nftSoldEvents?.length ?? 0,
-            gemsCollected: scout.userWeeklyStats[0]?.gemsCollected ?? 0,
+            rank: scout.userWeeklyStats[0]?.rank ?? -1,
             nftsSold: scout.userSeasonStats[0]?.nftsSold ?? 0,
             builderStatus: scout.builderStatus
           }));
@@ -164,21 +160,19 @@ export async function getSortedBuilders({
                   }
                 }
               }
-            },
-            gemsCollected: true
+            }
           }
         })
         .then((stats) =>
           stats.map((stat) => ({
             id: stat.user.id,
-            rank: stat.rank,
+            rank: stat.rank ?? -1,
             nftImageUrl: stat.user.builderNfts[0]?.imageUrl,
             username: stat.user.username,
             displayName: stat.user.username,
             builderPoints: stat.user.userAllTimeStats[0]?.pointsEarnedAsBuilder ?? 0,
             price: stat.user.builderNfts?.[0]?.currentPrice ?? 0,
             scoutedBy: stat.user.builderNfts?.[0]?.nftSoldEvents?.length ?? 0,
-            gemsCollected: stat.gemsCollected,
             nftsSold: stat.user.userSeasonStats[0]?.nftsSold ?? 0,
             builderStatus: stat.user.builderStatus
           }))
@@ -237,14 +231,6 @@ export async function getSortedBuilders({
                     nftsSold: true
                   }
                 },
-                userWeeklyStats: {
-                  where: {
-                    week
-                  },
-                  select: {
-                    gemsCollected: true
-                  }
-                },
                 builderNfts: {
                   where: {
                     season
@@ -261,13 +247,12 @@ export async function getSortedBuilders({
         .then((stats) =>
           stats.map((stat) => ({
             id: stat.user.id,
-            rank: stat.rank,
+            rank: stat.rank ?? -1,
             nftImageUrl: stat.user.builderNfts[0]?.imageUrl,
             username: stat.user.username,
             displayName: stat.user.username,
             builderPoints: stat.user.userAllTimeStats[0]?.pointsEarnedAsBuilder ?? 0,
             price: stat.user.builderNfts?.[0]?.currentPrice ?? 0,
-            gemsCollected: stat.user.userWeeklyStats[0]?.gemsCollected ?? 0,
             nftsSold: stat.user.userSeasonStats[0]?.nftsSold ?? 0,
             builderStatus: stat.user.builderStatus
           }))

--- a/apps/scoutgame/lib/builders/getTodaysHotBuilders.ts
+++ b/apps/scoutgame/lib/builders/getTodaysHotBuilders.ts
@@ -43,7 +43,7 @@ export async function getTodaysHotBuilders(): Promise<BuilderInfo[]> {
             week: getCurrentWeek()
           },
           select: {
-            gemsCollected: true
+            rank: true
           }
         },
         builderNfts: {
@@ -68,8 +68,8 @@ export async function getTodaysHotBuilders(): Promise<BuilderInfo[]> {
           price: builder.builderNfts[0]?.currentPrice ?? 0,
           nftImageUrl: builder.builderNfts[0]?.imageUrl,
           nftsSold: builder.userSeasonStats[0]?.nftsSold || 0,
-          gemsCollected: builder.userWeeklyStats[0]?.gemsCollected || 0,
-          builderStatus: builder.builderStatus
+          builderStatus: builder.builderStatus,
+          rank: builder.userWeeklyStats[0]?.rank || -1
         };
       })
       .sort((a, b) => preselectedBuilderIds.indexOf(a.id) - preselectedBuilderIds.indexOf(b.id));
@@ -103,6 +103,14 @@ export async function getTodaysHotBuilders(): Promise<BuilderInfo[]> {
             select: {
               pointsEarnedAsBuilder: true,
               nftsSold: true
+            }
+          },
+          userWeeklyStats: {
+            where: {
+              week: getCurrentWeek()
+            },
+            select: {
+              rank: true
             }
           },
           nftPurchaseEvents: {
@@ -140,7 +148,7 @@ export async function getTodaysHotBuilders(): Promise<BuilderInfo[]> {
       price: user.builderNfts[0]?.currentPrice ?? 0,
       nftImageUrl: user.builderNfts[0]?.imageUrl,
       nftsSold: user.userSeasonStats[0]?.nftsSold || 0,
-      gemsCollected: builder.gemsCollected,
+      rank: user.userWeeklyStats[0]?.rank || -1,
       scoutedBy: user.nftPurchaseEvents.length,
       builderStatus: user.builderStatus
     };

--- a/apps/scoutgame/lib/builders/interfaces.ts
+++ b/apps/scoutgame/lib/builders/interfaces.ts
@@ -12,8 +12,8 @@ export type PointMetrics = {
 export type BuilderMetrics = {
   // scoutedBy: number;
   nftsSold: number;
-  gemsCollected: number;
   price: bigint;
+  rank: number;
   builderPoints: number;
   isBanned?: boolean;
 };

--- a/apps/scoutgame/lib/scouts/getScoutedBuilders.ts
+++ b/apps/scoutgame/lib/scouts/getScoutedBuilders.ts
@@ -57,7 +57,7 @@ export async function getScoutedBuilders({ scoutId }: { scoutId: string }): Prom
           week: getCurrentWeek()
         },
         select: {
-          gemsCollected: true
+          rank: true
         }
       }
     }
@@ -74,10 +74,10 @@ export async function getScoutedBuilders({ scoutId }: { scoutId: string }): Prom
       displayName: builder.displayName,
       builderStatus: builder.builderStatus,
       builderPoints: builder.userSeasonStats[0]?.pointsEarnedAsBuilder ?? 0,
-      gemsCollected: builder.userWeeklyStats[0]?.gemsCollected ?? 0,
       nftsSold: builder.userSeasonStats[0]?.nftsSold ?? 0,
       nftsSoldToScout,
       isBanned: builder.builderStatus === 'banned',
+      rank: builder.userWeeklyStats[0]?.rank ?? -1,
       price: builder.builderNfts[0]?.currentPrice ?? 0
     };
   });


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

[Card](https://app.charmverse.io/charmverse/change-gems-to-rank-on-nft-3690089306098805)
[Card](https://app.charmverse.io/charmverse/not-a-bug-add-tool-tips-for-stats-2546042290770323)

<img width="206" alt="image" src="https://github.com/user-attachments/assets/a18f7511-ea5d-4ae7-9873-f4764b21cdc7">

### Places updated
1. Today's hot builder carousel
2. Scout page
3. Scouted builders section on public and user profile pages
