### PR TITLE
make claiming points less flaky

### DIFF
--- a/apps/scoutgame/__e2e__/claimPoints.spec.ts
+++ b/apps/scoutgame/__e2e__/claimPoints.spec.ts
@@ -19,9 +19,9 @@ test.describe('Claim points', () => {
 
     await page.goto('/claim');
 
-    await page.locator('[data-testid="claim-points-button"]').click();
-    await page.locator('[data-testid="claim-points-success-modal"]').waitFor();
-    const balance = await page.locator('[data-testid="user-points-balance"]').textContent();
+    await page.locator('[data-test="claim-points-button"]').click();
+    await expect(page.locator('[data-test="claim-points-success-modal"]')).toBeVisible();
+    const balance = await page.locator('[data-test="user-points-balance"]').textContent();
     expect(balance).toEqual('10');
   });
 });

--- a/apps/scoutgame/components/claim/components/PointsClaimScreen/PointsClaimButton.tsx
+++ b/apps/scoutgame/components/claim/components/PointsClaimScreen/PointsClaimButton.tsx
@@ -14,7 +14,7 @@ export function PointsClaimButton({ isExecuting, handleClaim }: { isExecuting: b
         }
       }}
       loading={isExecuting}
-      data-testid='claim-points-button'
+      data-test='claim-points-button'
       disabled={isExecuting}
       onClick={handleClaim}
     >

--- a/apps/scoutgame/components/claim/components/PointsClaimScreen/PointsClaimScreen.tsx
+++ b/apps/scoutgame/components/claim/components/PointsClaimScreen/PointsClaimScreen.tsx
@@ -21,7 +21,7 @@ function PointsClaimSuccessModal({
   claimedPoints: number;
 }) {
   return (
-    <Dialog open={showModal} onClose={handleCloseModal} data-testid='claim-points-success-modal'>
+    <Dialog open={showModal} onClose={handleCloseModal} data-test='claim-points-success-modal'>
       <Stack gap={2} textAlign='center' my={2}>
         <Typography color='secondary' variant='h5' fontWeight={600}>
           Congratulations!

--- a/apps/scoutgame/components/common/Header/Header.tsx
+++ b/apps/scoutgame/components/common/Header/Header.tsx
@@ -99,7 +99,7 @@ export function Header() {
                     sx={{ p: 0, display: 'flex', alignItems: 'center', gap: 1 }}
                     data-test='user-menu-pill'
                   >
-                    <Typography fontSize='16px' sx={{ pl: 2 }} color='text.primary' data-testid='user-points-balance'>
+                    <Typography fontSize='16px' sx={{ pl: 2 }} color='text.primary' data-test='user-points-balance'>
                       {user.currentBalance}
                     </Typography>
                     <Image


### PR DESCRIPTION
This test fails very often when running locally against a production build. I believe this test was flaky because the modal always exists, it's just not visible until the callback is successful.