### PR TITLE
Hide ts error for walletAddress migration

### DIFF
--- a/scripts/migrations/2024_10_29_moveWalletAddress.ts
+++ b/scripts/migrations/2024_10_29_moveWalletAddress.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { prisma } from '@charmverse/core/prisma-client';
 import { getAddress } from 'viem';
 


### PR DESCRIPTION
The core PR fails because the walletAddress is still called in one place.