### PR TITLE
save a copy of pending rewards when we publish them

### DIFF
--- a/lib/proposals/createRewardsForProposal.ts
+++ b/lib/proposals/createRewardsForProposal.ts
@@ -145,7 +145,8 @@ export async function createRewardsForProposal({ proposalId, userId }: { userId:
 
   const createdPageIds = (await Promise.all(rewardsPromises)).filter(isTruthy);
 
-  const updatedFields = { ...fields, pendingRewards: rewardsToCreate };
+  // keep a copy of the pending rewards that were published
+  const updatedFields = { ...fields, pendingRewards: rewardsToCreate, pendingRewardsPublished: pendingRewards };
 
   const updatedProposal = await prisma.proposal.update({
     where: {


### PR DESCRIPTION
this helps debug any bugs where we may have lost data