### PR TITLE
Fix wagmi SSR and projectId not found

### DIFF
--- a/apps/scoutgame/components/common/WalletLogin/WagmiProvider.tsx
+++ b/apps/scoutgame/components/common/WalletLogin/WagmiProvider.tsx
@@ -1,19 +1,19 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useState } from 'react';
-import type { State } from 'wagmi';
-import { WagmiProvider as OriginalWagmiProvider } from 'wagmi';
+import { WagmiProvider as OriginalWagmiProvider, cookieToInitialState } from 'wagmi';
 
 import { getConfig } from './wagmiConfig';
 
+const queryClient = new QueryClient();
+const config = getConfig();
+
 // Use this provider for SSR https://wagmi.sh/react/guides/ssr, if we need it
-export function WagmiProvider({ children, initialState }: { children: React.ReactNode; initialState?: State }) {
-  const [config] = useState(() => getConfig());
-  const [queryClient] = useState(() => new QueryClient());
+export function WagmiProvider({ children, cookie }: { children: React.ReactNode; cookie?: string }) {
+  const initialState = cookieToInitialState(config, cookie);
 
   return (
-    <OriginalWagmiProvider initialState={initialState} config={config}>
+    <OriginalWagmiProvider config={config} initialState={initialState}>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </OriginalWagmiProvider>
   );

--- a/apps/scoutgame/components/common/WalletLogin/WagmiProvider.tsx
+++ b/apps/scoutgame/components/common/WalletLogin/WagmiProvider.tsx
@@ -1,15 +1,23 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
 import { WagmiProvider as OriginalWagmiProvider, cookieToInitialState } from 'wagmi';
 
 import { getConfig } from './wagmiConfig';
 
-const queryClient = new QueryClient();
-const config = getConfig();
-
 // Use this provider for SSR https://wagmi.sh/react/guides/ssr, if we need it
-export function WagmiProvider({ children, cookie }: { children: React.ReactNode; cookie?: string }) {
+export function WagmiProvider({
+  children,
+  cookie,
+  walletConnectProjectId
+}: {
+  children: React.ReactNode;
+  cookie?: string;
+  walletConnectProjectId?: string;
+}) {
+  const [config] = useState(() => getConfig({ projectId: walletConnectProjectId || '' }));
+  const [queryClient] = useState(() => new QueryClient());
   const initialState = cookieToInitialState(config, cookie);
 
   return (

--- a/apps/scoutgame/components/common/WalletLogin/WalletProvider.tsx
+++ b/apps/scoutgame/components/common/WalletLogin/WalletProvider.tsx
@@ -1,12 +1,7 @@
 import { headers } from 'next/headers';
-import { cookieToInitialState } from 'wagmi';
-
-import { getConfig } from 'components/common/WalletLogin/wagmiConfig';
 
 import { WagmiProvider } from './WagmiProvider';
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
-  const wagmiInitialState = cookieToInitialState(getConfig(), headers().get('cookie'));
-
-  return <WagmiProvider initialState={wagmiInitialState}>{children}</WagmiProvider>;
+  return <WagmiProvider cookie={headers().get('cookie') ?? ''}>{children}</WagmiProvider>;
 }

--- a/apps/scoutgame/components/common/WalletLogin/WalletProvider.tsx
+++ b/apps/scoutgame/components/common/WalletLogin/WalletProvider.tsx
@@ -3,5 +3,12 @@ import { headers } from 'next/headers';
 import { WagmiProvider } from './WagmiProvider';
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
-  return <WagmiProvider cookie={headers().get('cookie') ?? ''}>{children}</WagmiProvider>;
+  return (
+    <WagmiProvider
+      cookie={headers().get('cookie') ?? ''}
+      walletConnectProjectId={process.env.REACT_APP_WALLETCONNECT_PROJECTID}
+    >
+      {children}
+    </WagmiProvider>
+  );
 }

--- a/apps/scoutgame/components/common/WalletLogin/wagmiConfig.ts
+++ b/apps/scoutgame/components/common/WalletLogin/wagmiConfig.ts
@@ -18,8 +18,8 @@ import {
   baseSepolia
 } from 'wagmi/chains';
 
-export function getConfig() {
-  const walletConnectProjectId = env('WALLETCONNECT_PROJECTID') || process.env.REACT_APP_WALLETCONNECT_PROJECTID || '';
+export function getConfig(options?: Partial<Parameters<typeof getDefaultConfig>[0]>) {
+  const projectId = options?.projectId || env('WALLETCONNECT_PROJECTID') || '';
 
   const wagmiChains = [
     mainnet,
@@ -46,7 +46,7 @@ export function getConfig() {
 
   const config = getDefaultConfig({
     appName: 'Scout Game',
-    projectId: walletConnectProjectId,
+    projectId,
     chains: wagmiChains,
     ssr: true,
     storage: createStorage({ storage: cookieStorage }),

--- a/apps/scoutgame/components/common/WalletLogin/wagmiConfig.ts
+++ b/apps/scoutgame/components/common/WalletLogin/wagmiConfig.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import env from '@beam-australia/react-env';
 import { getDefaultConfig } from '@rainbow-me/rainbowkit';
 import { getAlchemyBaseUrl } from '@root/lib/blockchain/provider/alchemy/client';
 import type { Chain, Transport } from 'viem';
@@ -18,7 +19,7 @@ import {
 } from 'wagmi/chains';
 
 export function getConfig() {
-  const walletConnectProjectId = process.env.REACT_APP_WALLETCONNECT_PROJECTID || '';
+  const walletConnectProjectId = env('WALLETCONNECT_PROJECTID') || process.env.REACT_APP_WALLETCONNECT_PROJECTID || '';
 
   const wagmiChains = [
     mainnet,

--- a/apps/scoutgame/components/common/WalletLogin/wagmiConfig.ts
+++ b/apps/scoutgame/components/common/WalletLogin/wagmiConfig.ts
@@ -1,4 +1,5 @@
-import env from '@beam-australia/react-env';
+'use client';
+
 import { getDefaultConfig } from '@rainbow-me/rainbowkit';
 import { getAlchemyBaseUrl } from '@root/lib/blockchain/provider/alchemy/client';
 import type { Chain, Transport } from 'viem';
@@ -17,7 +18,7 @@ import {
 } from 'wagmi/chains';
 
 export function getConfig() {
-  const walletConnectProjectId = env('WALLETCONNECT_PROJECTID');
+  const walletConnectProjectId = process.env.REACT_APP_WALLETCONNECT_PROJECTID || '';
 
   const wagmiChains = [
     mainnet,

--- a/apps/scoutgame/components/layout/AppProviders.tsx
+++ b/apps/scoutgame/components/layout/AppProviders.tsx
@@ -3,6 +3,7 @@ import 'server-only';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { headers } from 'next/headers';
 import type { ReactNode } from 'react';
 
 import { WagmiProvider } from 'components/common/WalletLogin/WagmiProvider';
@@ -19,7 +20,7 @@ export function AppProviders({ children, user }: { children: ReactNode; user: Se
     <AppRouterCacheProvider options={{ key: 'css' }}>
       <ThemeProvider theme={theme}>
         <CssBaseline enableColorScheme />
-        <WagmiProvider>
+        <WagmiProvider cookie={headers().get('cookie') ?? ''}>
           <SWRProvider>
             <UserProvider userSession={user}>
               <SnackbarProvider>

--- a/apps/scoutgame/components/layout/AppProviders.tsx
+++ b/apps/scoutgame/components/layout/AppProviders.tsx
@@ -20,7 +20,10 @@ export function AppProviders({ children, user }: { children: ReactNode; user: Se
     <AppRouterCacheProvider options={{ key: 'css' }}>
       <ThemeProvider theme={theme}>
         <CssBaseline enableColorScheme />
-        <WagmiProvider cookie={headers().get('cookie') ?? ''}>
+        <WagmiProvider
+          cookie={headers().get('cookie') ?? ''}
+          walletConnectProjectId={process.env.REACT_APP_WALLETCONNECT_PROJECTID}
+        >
           <SWRProvider>
             <UserProvider userSession={user}>
               <SnackbarProvider>

--- a/apps/scoutgame/next.config.mjs
+++ b/apps/scoutgame/next.config.mjs
@@ -23,9 +23,6 @@ const nextConfig = {
   images: {
     unoptimized: true
   },
-  env: {
-    REACT_APP_WALLETCONNECT_PROJECTID: process.env.REACT_APP_WALLETCONNECT_PROJECTID
-  },
   productionBrowserSourceMaps: true,
   assetPrefix: useCDN ? 'https://cdn.charmverse.io' : undefined,
   webpack(_config) {

--- a/apps/scoutgame/next.config.mjs
+++ b/apps/scoutgame/next.config.mjs
@@ -23,6 +23,9 @@ const nextConfig = {
   images: {
     unoptimized: true
   },
+  env: {
+    REACT_APP_WALLETCONNECT_PROJECTID: process.env.REACT_APP_WALLETCONNECT_PROJECTID
+  },
   productionBrowserSourceMaps: true,
   assetPrefix: useCDN ? 'https://cdn.charmverse.io' : undefined,
   webpack(_config) {


### PR DESCRIPTION
### WHAT
- prepare the wagmi provider server side by passing an initial state
- sometimes env() lib doesn't load fast enough and we don't want to block the render just because of that. We can use, only for this case, the env var from the server.

### WHY

When going to a not found page, wagmi provider blows up because of an env var not found.
