### PR TITLE
Ios layout

### DIFF
--- a/apps/scoutgame/app/(info)/layout.tsx
+++ b/apps/scoutgame/app/(info)/layout.tsx
@@ -9,8 +9,8 @@ export default function Layout({
   children: ReactNode;
 }>) {
   return (
-    <Box component='main' bgcolor='background.default' p={{ xs: 2, md: 3 }} minHeight='100svh'>
-      <Box maxWidth='700px' margin='auto'>
+    <Box component='main' bgcolor='background.default' p={{ md: 3 }} height='100%' minHeight='100dvh'>
+      <Box maxWidth='700px' margin='auto' height='100%'>
         {children}
       </Box>
     </Box>

--- a/apps/scoutgame/components/common/WalletLogin/WalletLogin.tsx
+++ b/apps/scoutgame/components/common/WalletLogin/WalletLogin.tsx
@@ -29,7 +29,7 @@ export function WalletLogin() {
 function WalletLoginButton() {
   const [isConnecting, setIsConnecting] = useState(false);
   const { openConnectModal } = useConnectModal();
-  const { address, chainId, isConnected, isConnecting: isConnectingAccount } = useAccount();
+  const { address, chainId, isConnected } = useAccount();
   const searchParams = useSearchParams();
   const redirectUrlEncoded = searchParams.get('redirectUrl');
   const inviteCode = searchParams.get('invite-code');
@@ -46,7 +46,11 @@ function WalletLoginButton() {
 
   const { executeAsync: revalidatePath } = useAction(revalidatePathAction);
 
-  const { executeAsync, result, isExecuting } = useAction(loginWithWalletAction, {
+  const {
+    executeAsync,
+    result,
+    isExecuting: isLoggingIn
+  } = useAction(loginWithWalletAction, {
     onSuccess: async ({ data }) => {
       const nextPage = !data?.onboarded ? '/welcome' : inviteCode ? '/welcome/builder' : redirectUrl || '/home';
 
@@ -86,7 +90,7 @@ function WalletLoginButton() {
     }
   }, [address, isConnected, isConnecting]);
 
-  const isLoading = isExecuting || isConnectingAccount || isConnecting;
+  const isLoading = isConnecting || isLoggingIn;
 
   return (
     <Box width='100%'>

--- a/apps/scoutgame/components/common/WarpcastLogin/WarpcastLogin.tsx
+++ b/apps/scoutgame/components/common/WarpcastLogin/WarpcastLogin.tsx
@@ -25,7 +25,14 @@ export function WarpcastLogin() {
           trackEvent('click_dont_have_farcaster_account');
         }}
       >
-        <Typography fontWeight={600} color='primary'>
+        <Typography
+          fontWeight={600}
+          color='primary'
+          sx={{
+            textShadow:
+              '2px 2px 8px rgba(0, 0, 0, .7),-2px -2px 8px rgba(0, 0, 0, .7),2px -2px 8px rgba(0, 0, 0, .7),-2px 2px 8px rgba(0, 0, 0, .7);'
+          }}
+        >
           Join Farcaster
         </Typography>
       </Link>

--- a/apps/scoutgame/components/common/WarpcastLogin/WarpcastLoginButton.tsx
+++ b/apps/scoutgame/components/common/WarpcastLogin/WarpcastLoginButton.tsx
@@ -121,7 +121,10 @@ export function WarpcastLoginButton() {
         data-test='sign-in-with-warpcast'
       >
         <Stack direction='row' alignItems='center' gap={1} justifyContent='flex-start' width='100%'>
-          <WarpcastIcon size='20px' />
+          {/** 24px is the size of the wallet button icon */}
+          <Box height='24px' width='24px' display='flex' alignItems='center' justifyContent='center'>
+            <WarpcastIcon size='20px' />
+          </Box>
           <Typography fontWeight={600} color='white'>
             Sign in with Warpcast
           </Typography>

--- a/apps/scoutgame/components/welcome/how-it-works/HowItWorksContent.tsx
+++ b/apps/scoutgame/components/welcome/how-it-works/HowItWorksContent.tsx
@@ -5,8 +5,11 @@ import Link from 'next/link';
 import React from 'react';
 
 import { PointsIcon } from 'components/common/Icons';
+import { useMdScreen } from 'hooks/useMediaScreens';
 
 export function HowItWorksContent({ onClickContinue }: { onClickContinue?: React.MouseEventHandler }) {
+  const isMdScreen = useMdScreen();
+  const iconSize = isMdScreen ? 24 : 18;
   return (
     <>
       <Typography color='secondary' textAlign='center' width='100%' fontWeight={700} variant='h5'>
@@ -17,7 +20,7 @@ export function HowItWorksContent({ onClickContinue }: { onClickContinue?: React
           <ListItemAvatar>
             <img src='/images/number_icon_1.png' alt='1' />
           </ListItemAvatar>
-          <Typography>
+          <Typography fontSize={{ xs: '13px', sm: '1rem' }}>
             <strong>Discover builders who are contributing to cool onchain projects.</strong> Choose from the Hot
             Builders section or explore the Scout page to find hidden gems.
           </Typography>
@@ -27,7 +30,7 @@ export function HowItWorksContent({ onClickContinue }: { onClickContinue?: React
             <img src='/images/number_icon_2.png' alt='2' />
           </ListItemAvatar>
           <Stack display='flex' gap={2}>
-            <Typography>
+            <Typography fontSize={{ xs: '13px', sm: '1rem' }}>
               <strong>
                 Scout them by buying their Builder Cards with{' '}
                 <Typography
@@ -37,7 +40,7 @@ export function HowItWorksContent({ onClickContinue }: { onClickContinue?: React
                   fontWeight='inherit'
                   style={{ display: 'inline-flex', gap: 4 }}
                 >
-                  points <PointsIcon color='blue' size={24} />
+                  points <PointsIcon color='blue' size={iconSize} />
                 </Typography>
               </strong>{' '}
               or <strong>ETH / USDC</strong> on
@@ -55,7 +58,7 @@ export function HowItWorksContent({ onClickContinue }: { onClickContinue?: React
           <ListItemAvatar>
             <img src='/images/number_icon_3.png' alt='3' />
           </ListItemAvatar>
-          <Typography>
+          <Typography fontSize={{ xs: '13px', sm: '1rem' }}>
             <strong>
               Watch your{' '}
               <Typography
@@ -65,7 +68,7 @@ export function HowItWorksContent({ onClickContinue }: { onClickContinue?: React
                 fontWeight='inherit'
                 style={{ display: 'inline-flex', gap: 4 }}
               >
-                points <PointsIcon color='blue' size={24} />
+                points <PointsIcon color='blue' size={iconSize} />
               </Typography>
               {'  '}
               increase


### PR DESCRIPTION
- adds drop shadow below 'join farcaster'
- do not show wallet button as loading on page load / when its just connecting to your wallet
- fix height/width issue on iOS - seems like a safari rendering bug but i was able to reproduce and confirm the changes are required

![image](https://github.com/user-attachments/assets/199a2357-aed8-4c7f-b509-abcf09912605)