### PR TITLE
speed up speed data script

### DIFF
--- a/apps/scoutgamecron/src/scripts/seeder/generateBuilderEvents.ts
+++ b/apps/scoutgamecron/src/scripts/seeder/generateBuilderEvents.ts
@@ -18,9 +18,9 @@ async function processBuilderActivity({
   pullRequests
 }: {
   builderId: string;
-  date: DateTime,
-  season: Season,
-  pullRequests: PullRequest[],
+  date: DateTime;
+  season: Season;
+  pullRequests: PullRequest[];
 }) {
   const week = getWeekFromDate(date.toJSDate());
 
@@ -84,29 +84,30 @@ async function processBuilderActivity({
       gemsCollected
     }
   });
-  log.debug(`Processed activity for builder`, {
-    userId: builderId,
-    week,
-    eventsWithWeek: thisWeekEvents.length,
-    gemsCollected
-  });
+  // log.debug(`Seeded activity for builder`, {
+  //   userId: builderId,
+  //   week,
+  //   eventsWithWeek: thisWeekEvents.length,
+  //   gemsCollected
+  // });
 }
 
-export async function generateBuilderEvents(
-  {
-    builderId,
-    date,
-    githubUser,
-    githubRepos,
-    repoPRCounters
-  }: {
-    builderId: string,
-    githubUser: Pick<GithubUser, 'id' | 'login'>,
-    githubRepos: GithubRepo[],
-    repoPRCounters: Map<number, number>,
-    date: DateTime
+export async function generateBuilderEvents({
+  builderId,
+  date,
+  githubUser,
+  githubRepos,
+  repoPRCounters
+}: {
+  builderId: string;
+  githubUser: Pick<GithubUser, 'id' | 'login'>;
+  githubRepos: GithubRepo[];
+  repoPRCounters: Map<number, number>;
+  date: DateTime;
+}) {
+  if (githubRepos.length === 0) {
+    return 0;
   }
-) {
   const builderPullRequests: PullRequest[] = [];
   const dailyGithubEvents = faker.number.int({ min: 0, max: 3 });
   for (let eventsCounter = 0; eventsCounter < dailyGithubEvents; eventsCounter++) {

--- a/apps/scoutgamecron/src/scripts/seeder/generateNftPurchaseEvents.ts
+++ b/apps/scoutgamecron/src/scripts/seeder/generateNftPurchaseEvents.ts
@@ -8,6 +8,9 @@ import { BuilderInfo } from './generateSeedData';
 import { randomTimeOfDay } from './generator';
 
 export async function generateNftPurchaseEvents(scoutId: string, assignedBuilders: BuilderInfo[], date: DateTime) {
+  if (assignedBuilders.length === 0) {
+    return 0;
+  }
   const week = getWeekFromDate(date.toJSDate());
   let totalNftsPurchasedToday = 0;
   for (let nftCount = 0; nftCount < faker.number.int({ min: 0, max: 3 }); nftCount++) {
@@ -26,9 +29,9 @@ export async function generateNftPurchaseEvents(scoutId: string, assignedBuilder
             id: builder.builderNftId
           },
           data: {
-            currentPrice: Math.ceil(nftPrice + nftPrice * 0.1),
+            currentPrice: Math.ceil(nftPrice + nftPrice * 0.1)
           }
-        })
+        });
 
         await recordNftMint({
           builderNftId,

--- a/apps/scoutgamecron/src/scripts/seeder/generateSeedData.ts
+++ b/apps/scoutgamecron/src/scripts/seeder/generateSeedData.ts
@@ -25,12 +25,12 @@ export type BuilderInfo = {
 };
 
 function assignReposToBuilder(githubRepos: GithubRepo[]): GithubRepo[] {
-  const repoCount = faker.number.int({ min: 3, max: 5 });
+  const repoCount = faker.number.int({ min: 0, max: 3 });
   return faker.helpers.arrayElements(githubRepos, repoCount);
 }
 
 function assignBuildersToScout(builders: BuilderInfo[]) {
-  const builderCount = faker.number.int({ min: 3, max: 5 });
+  const builderCount = faker.number.int({ min: 0, max: 5 });
   return faker.helpers.arrayElements(
     builders.filter((builder) => builder.builderNftId),
     builderCount
@@ -39,15 +39,13 @@ function assignBuildersToScout(builders: BuilderInfo[]) {
 
 export async function generateSeedData() {
   // Total number of users that are builders (should be less than totalUsers)
-  const totalBuilders = faker.number.int({ min: 50, max: 100 });
+  const totalBuilders = faker.number.int({ min: 10, max: 20 });
   // Total number of github repos
-  const totalGithubRepos = faker.number.int({ min: 25, max: 50 });
+  const totalGithubRepos = faker.number.int({ min: 5, max: 10 });
 
-  const totalScoutBuilders = faker.number.int({ min: 5, max: 15 });
+  const totalScouts = faker.number.int({ min: 10, max: 20 });
 
-  const totalScouts = faker.number.int({ min: 50, max: 100 });
-
-  const totalUsers = totalBuilders + totalScouts + totalScoutBuilders;
+  const totalUsers = totalBuilders + totalScouts;
 
   const [githubRepos, repoPRCounters] = await generateGithubRepos(totalGithubRepos);
 
@@ -57,7 +55,7 @@ export async function generateSeedData() {
   let totalGithubEvents = 0;
   let totalNftsPurchasedEvents = 0;
 
-  const builderPromises = Array.from({ length: totalBuilders + totalScoutBuilders }, async (_, i) => {
+  const builderPromises = Array.from({ length: totalBuilders }, async (_, i) => {
     const { githubUser, builder, builderNft } = await generateBuilder({ index: i });
     const assignedRepos = assignReposToBuilder(githubRepos);
     const isScout = i >= totalBuilders;
@@ -110,26 +108,27 @@ export async function generateSeedData() {
     const date = startDate.plus({ days: i });
     const week = getWeekFromDate(date.toJSDate());
 
-    for (const builder of builders) {
-      const dailyGithubEvents = await generateBuilderEvents({
-        builderId: builder.id,
-        githubUser: builder.githubUser,
-        githubRepos: builder.assignedRepos,
-        repoPRCounters,
-        date
-      });
-      totalGithubEvents += dailyGithubEvents;
-    }
+    await Promise.all(
+      builders.map(async (builder) => {
+        const dailyGithubEvents = await generateBuilderEvents({
+          builderId: builder.id,
+          githubUser: builder.githubUser,
+          githubRepos: builder.assignedRepos,
+          repoPRCounters,
+          date
+        });
+        totalGithubEvents += dailyGithubEvents;
+      })
+    );
 
-    for (const scout of scouts) {
-      // Do not purchase your own nft
-      const dailyNftsPurchased = await generateNftPurchaseEvents(
-        scout.id,
-        scout.assignedBuilders.filter((builder) => builder.id !== scout.id),
-        date
-      );
-      totalNftsPurchasedEvents += dailyNftsPurchased;
-    }
+    await Promise.all(
+      scouts.map(async (scout) => {
+        // Do not purchase your own nft
+        const nfts = scout.assignedBuilders.filter((builder) => builder.id !== scout.id);
+        const dailyNftsPurchased = await generateNftPurchaseEvents(scout.id, nfts, date);
+        totalNftsPurchasedEvents += dailyNftsPurchased;
+      })
+    );
 
     await updateBuilderCardActivity(date.minus({ days: 1 }));
 
@@ -175,7 +174,6 @@ export async function generateSeedData() {
   log.info('generated seed data', {
     totalUsers,
     totalBuilders,
-    totalScoutBuilders,
     totalScouts,
     totalGithubRepos: githubRepos.length,
     totalGithubEvents,


### PR DESCRIPTION
Run some queries in parallel and reduce some of the maxes. I think we just really need enough data to fill out the screen and have some extra to enable scrolling/infinite scroll.

It could still be faster by tuning what we're creating. I noticed it's having scouts buy nfts X number every day for 2 weeks which is not that realistic.