### PR TITLE
Fix points attribution for first pr in a repo

### DIFF
--- a/apps/scoutgamecron/src/tasks/processBuilderActivity/__tests__/recordMergedPullRequest.spec.ts
+++ b/apps/scoutgamecron/src/tasks/processBuilderActivity/__tests__/recordMergedPullRequest.spec.ts
@@ -540,10 +540,10 @@ describe('recordMergedPullRequest', () => {
 
     await recordMergedPullRequest({ pullRequest: firstPR, repo: repo1, season: currentSeason });
 
-    // Second PR in repo2
+    // Second PR in repo2 was created a week before and merged in the last 7 days
     const secondPR = mockPullRequest({
       mergedAt: startOfWeek.plus({ days: 4 }).toISO(),
-      createdAt: startOfWeek.plus({ days: 3 }).toISO(),
+      createdAt: startOfWeek.minus({ days: 3 }).toISO(),
       state: 'MERGED',
       author: builder.githubUser,
       repo: repo2

--- a/apps/scoutgamecron/src/tasks/processBuilderActivity/recordMergedPullRequest.ts
+++ b/apps/scoutgamecron/src/tasks/processBuilderActivity/recordMergedPullRequest.ts
@@ -101,7 +101,7 @@ export async function recordMergedPullRequest({
       createdBy: pullRequest.author.id,
       type: 'merged_pull_request',
       isFirstPullRequest: true,
-      createdAt: {
+      completedAt: {
         gte: startOfWeek.toJSDate()
       }
     }


### PR DESCRIPTION
[Card](https://work.charmverse.fyi/when-de-duping-first-contributions-worth-100-points-look-at-the-merged-at-date-and-not-created-at-6164434120491211)