### PR TITLE
dont count banned builder gems in new scout rank

### DIFF
--- a/apps/scoutgame/lib/scouts/getNewScouts.ts
+++ b/apps/scoutgame/lib/scouts/getNewScouts.ts
@@ -40,6 +40,9 @@ export async function getNewScouts({ limit }: { limit: number }): Promise<NewSco
         nftPurchaseEvents: {
           where: {
             builderNFT: {
+              builder: {
+                builderStatus: 'approved'
+              },
               season: currentSeason
             }
           },


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

<!-- why was this necessary? -->
