### PR TITLE
add select statements to places where we query the scout

### DIFF
--- a/apps/scoutgameadmin/lib/session/getAdminUser.ts
+++ b/apps/scoutgameadmin/lib/session/getAdminUser.ts
@@ -4,7 +4,7 @@ import { isProdEnv } from '@root/config/constants';
 const whitelistedIds: number[] = [472, 4339, 4356, 1212, 318061, 10921, 828888];
 
 export async function getAdminUser({ fid }: { fid: number }) {
-  const user = await prisma.scout.findFirstOrThrow({ where: { farcasterId: fid } });
+  const user = await prisma.scout.findFirstOrThrow({ where: { farcasterId: fid }, select: { id: true } });
   if (!isProdEnv) {
     return user;
   }

--- a/apps/scoutgamecron/src/scripts/issuePoints.ts
+++ b/apps/scoutgamecron/src/scripts/issuePoints.ts
@@ -16,7 +16,8 @@ async function issuePoints({ points }: { points: number }) {
       where: {
         farcasterId: fid
       },
-      include: {
+      select: {
+        id: true,
         pointsReceived: {
           where: {
             event: {

--- a/packages/scoutgame/src/builderNfts/purchaseWithPointsAction.ts
+++ b/packages/scoutgame/src/builderNfts/purchaseWithPointsAction.ts
@@ -26,6 +26,9 @@ export const purchaseWithPointsAction = authActionClient
       prisma.scout.findFirstOrThrow({
         where: {
           id: ctx.session.scoutId
+        },
+        select: {
+          currentBalance: true
         }
       })
     ]);

--- a/packages/scoutgame/src/builderNfts/syncUserNFTsFromOnchainData.ts
+++ b/packages/scoutgame/src/builderNfts/syncUserNFTsFromOnchainData.ts
@@ -27,6 +27,9 @@ export async function syncUserNFTsFromOnchainData({
     where: {
       id: scoutId,
       path
+    },
+    select: {
+      id: true
     }
   });
 


### PR DESCRIPTION
By selecting the fields we avoid breaking a feature if prisma knows about a field that has not been yet added to the DB (eg migration has not run yet)