### PR TITLE
Rubric score persistance

### DIFF
--- a/components/common/DateTimePicker.tsx
+++ b/components/common/DateTimePicker.tsx
@@ -4,7 +4,35 @@ import type { TextFieldProps } from '@mui/material';
 import type { DateTimePickerProps } from '@mui/x-date-pickers/DateTimePicker';
 import { DateTimePicker as MuiDateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import type { DateTime } from 'luxon';
-import { useState } from 'react';
+import { forwardRef, useState } from 'react';
+
+const StyledTextField = styled(TextField)`
+  cursor: pointer;
+  .MuiInputBase-root {
+    background: transparent;
+  }
+  .octo-propertyvalue {
+    box-sizing: border-box; // copied from focalboard
+  }
+  fieldset {
+    border: 0 none;
+  }
+`;
+
+export const FocalBoardTextFieldSlot = forwardRef<HTMLDivElement, TextFieldProps>((props, ref) => {
+  if (props.inputProps) {
+    props.inputProps.className = 'octo-propertyvalue';
+  }
+  // don't show the default placeholder from Datepicker
+  const actualValue = (props.value as string)?.startsWith('MM/DD/YYYY') ? '' : props.value;
+  return <StyledTextField {...props} ref={ref} value={actualValue} />;
+});
+
+export const TextFieldSlot = forwardRef<HTMLDivElement, TextFieldProps>((props: TextFieldProps) => {
+  // dont show the default placeholder from Datepicker
+  const actualValue = (props.value as string)?.startsWith('MM/DD/YYYY') ? '' : props.value;
+  return <TextField {...props} value={actualValue} />;
+});
 
 // customized date picker that opens when clicking the inpu
 export function DateTimePicker<T extends DateTime>({
@@ -46,32 +74,4 @@ export function DateTimePicker<T extends DateTime>({
 
 export function HiddenElement() {
   return <div />;
-}
-
-const StyledTextField = styled(TextField)`
-  cursor: pointer;
-  .MuiInputBase-root {
-    background: transparent;
-  }
-  .octo-propertyvalue {
-    box-sizing: border-box; // copied from focalboard
-  }
-  fieldset {
-    border: 0 none;
-  }
-`;
-
-export function FocalBoardTextFieldSlot(props: TextFieldProps) {
-  if (props.inputProps) {
-    props.inputProps.className = 'octo-propertyvalue';
-  }
-  // dont show the default placeholder from Datepicker
-  const actualValue = (props.value as string)?.startsWith('MM/DD/YYYY') ? '' : props.value;
-  return <StyledTextField {...props} value={actualValue} />;
-}
-
-export function TextFieldSlot(props: TextFieldProps) {
-  // dont show the default placeholder from Datepicker
-  const actualValue = (props.value as string)?.startsWith('MM/DD/YYYY') ? '' : props.value;
-  return <TextField {...props} value={actualValue} />;
 }

--- a/components/common/comments/CommentForm.tsx
+++ b/components/common/comments/CommentForm.tsx
@@ -61,7 +61,6 @@ export function CommentForm({
         minHeight: 100,
         left: 0
       },
-      key: editorKey,
       disableRowHandles: true,
       focusOnInit: false,
       placeholderText: placeholder ?? 'What are your thoughts?',
@@ -72,10 +71,10 @@ export function CommentForm({
     };
 
     if (!inlineCharmEditor) {
-      return <CharmEditor {...editorCommentProps} readOnly={disabled} />;
+      return <CharmEditor key={editorKey} {...editorCommentProps} readOnly={disabled} />;
     }
 
-    return <InlineCharmEditor {...editorCommentProps} readOnly={disabled} />;
+    return <InlineCharmEditor key={editorKey} {...editorCommentProps} readOnly={disabled} />;
   }, [inlineCharmEditor, postContent, updatePostContent]);
 
   if (!user) {

--- a/components/common/form/hooks/usePersistantFormValues.ts
+++ b/components/common/form/hooks/usePersistantFormValues.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import type { FieldValues, Path, PathValue, UseFormSetValue, UseFormWatch } from 'react-hook-form';
+
+import { getStorageValue, setStorageValue } from 'hooks/useSessionStorage';
+
+export function usePersistentFormValues<T extends FieldValues = FieldValues>(
+  name: string,
+  key: Path<T>,
+  { watch, setValue }: { watch: UseFormWatch<T>; setValue: UseFormSetValue<T> }
+) {
+  useEffect(() => {
+    const storage = getStorageValue<PathValue<T, Path<T>> | null>(name, null);
+
+    if (storage) {
+      setValue(key, storage);
+    }
+  }, [key, name]);
+
+  useEffect(() => {
+    const { unsubscribe } = watch((values) => {
+      if (values[key]) {
+        setStorageValue<T>(name, values[key]);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [key, name]);
+}

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/components/RubricAnswersForm.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/components/RubricAnswersForm.tsx
@@ -24,6 +24,7 @@ import {
 } from 'charmClient/hooks/proposals';
 import { Button } from 'components/common/Button';
 import { NumberInputField } from 'components/common/form/fields/NumberInputField';
+import { usePersistentFormValues } from 'components/common/form/hooks/usePersistantFormValues';
 import { useConfirmationModal } from 'hooks/useConfirmationModal';
 import type { RubricAnswerData } from 'lib/proposals/rubric/upsertRubricAnswers';
 import { getNumberFromString } from 'lib/utils/numbers';
@@ -151,6 +152,7 @@ export function RubricAnswersForm({
     control,
     register,
     handleSubmit,
+    setValue,
     reset,
     watch,
     formState: { isDirty }
@@ -267,6 +269,9 @@ export function RubricAnswersForm({
     // include evaluationId so that answers reset when navigating between evaluations
   }, [answers, draftAnswers]);
 
+  // persist form values to sessionStorage
+  usePersistentFormValues(`proposalId-answers-${proposalId}`, 'answers', { watch, setValue });
+
   return (
     <form>
       {showDraftBanner && (
@@ -332,7 +337,7 @@ export function RubricAnswersForm({
             <Button
               data-test='save-rubric-answers'
               sx={{ alignSelf: 'start' }}
-              disabled={answersError || disabled || (!isDirty && !showDraftAnswers)}
+              disabled={!!answersError || disabled || (!isDirty && !showDraftAnswers)}
               disabledTooltip={
                 answersError ||
                 (archived


### PR DESCRIPTION
[Card](https://app.charmverse.io/charmverse/resizing-window-when-evaluating-grants-removes-all-your-evaluation-scores-and-comments-3052262544901101)

This PR improves and adds the possibility to:
- save rubic answers in session storage

And fixes:
- a prop object containing a "key" prop is being spread into JSX
- disabled prop of a button received a string instead of a boolean
- element can't have ref. Add a forwardRef to your component

(The fixes can be seen in each commit)