### PR TITLE
track utm params in mixpanel

### DIFF
--- a/packages/mixpanel/src/trackUserAction.ts
+++ b/packages/mixpanel/src/trackUserAction.ts
@@ -14,7 +14,7 @@ export interface MixpanelTrackBase {
 export function trackUserAction<T extends MixpanelEventName>(
   eventName: T,
   params: MixpanelEventMap[T],
-  utmParams: UTMParams = {} // these should not be modified
+  utmParams?: UTMParams // pass these in separately as the names should not be modified
 ) {
   const { userId, ...restParams } = params;
   // map userId prop to distinct_id required by mixpanel to recognize the user
@@ -22,7 +22,7 @@ export function trackUserAction<T extends MixpanelEventName>(
     distinct_id: userId,
     ...paramsToHumanFormat(restParams),
     // when tracking utm_params in Mixpanel event, it should also update the user profile with initial_<utm_param> properties
-    // source: https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript
+    // source: https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#track-utm-tags
     ...utmParams
   };
 
@@ -30,6 +30,14 @@ export function trackUserAction<T extends MixpanelEventName>(
 
   try {
     mixpanel?.track(humanReadableEventName, mixpanelTrackParams);
+    if (utmParams) {
+      // prepend initial_ to the utm params so they are easily identifiable in Mixpanel
+      const initialUtmParams = Object.entries(utmParams).reduce((acc, [key, value]) => {
+        acc[`initial_${key}`] = value;
+        return acc;
+      }, {} as UTMParams);
+      mixpanel?.people.set_once(userId, initialUtmParams);
+    }
   } catch (error) {
     log.warn(`Failed to track mixpanel event ${eventName as string}`, {
       error,

--- a/packages/mixpanel/src/trackUserAction.ts
+++ b/packages/mixpanel/src/trackUserAction.ts
@@ -2,6 +2,7 @@ import { log } from '@charmverse/core/log';
 
 import type { MixpanelEventMap, MixpanelEventName } from './interfaces';
 import { mixpanel } from './mixpanel';
+import type { UTMParams } from './utils';
 import { eventNameToHumanFormat, paramsToHumanFormat } from './utils';
 
 export interface MixpanelTrackBase {
@@ -10,12 +11,19 @@ export interface MixpanelTrackBase {
   isAnonymous?: boolean;
 }
 
-export function trackUserAction<T extends MixpanelEventName>(eventName: T, params: MixpanelEventMap[T]) {
+export function trackUserAction<T extends MixpanelEventName>(
+  eventName: T,
+  params: MixpanelEventMap[T],
+  utmParams: UTMParams = {} // these should not be modified
+) {
   const { userId, ...restParams } = params;
   // map userId prop to distinct_id required by mixpanel to recognize the user
   const mixpanelTrackParams: MixpanelTrackBase = {
     distinct_id: userId,
-    ...paramsToHumanFormat(restParams)
+    ...paramsToHumanFormat(restParams),
+    // when tracking utm_params in Mixpanel event, it should also update the user profile with initial_<utm_param> properties
+    // source: https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript
+    ...utmParams
   };
 
   const humanReadableEventName = eventNameToHumanFormat(eventName as string);

--- a/packages/mixpanel/src/utils.ts
+++ b/packages/mixpanel/src/utils.ts
@@ -23,13 +23,20 @@ export function paramsToHumanFormat(params: Record<string, any>) {
 // searchString is the search part of the URL, starting with ?
 export type UTMParams = Record<string, string | undefined>;
 
-export function getUTMParamsFromSearch(searchString: string): UTMParams {
+export function getUTMParamsFromSearch(searchString: string): UTMParams | undefined {
   const urlParams = new URLSearchParams(searchString);
-  return {
+  const utmParams: UTMParams = {
     utm_source: urlParams.get('utm_source') || undefined,
     utm_medium: urlParams.get('utm_medium') || undefined,
     utm_campaign: urlParams.get('utm_campaign') || undefined,
     utm_term: urlParams.get('utm_term') || undefined,
     utm_content: urlParams.get('utm_content') || undefined
+  };
+  if (Object.values(utmParams).every((value) => value === undefined)) {
+    return undefined;
+  }
+  return {
+    utm_from: new Date().toLocaleDateString(), // so we know when these were created
+    ...utmParams
   };
 }

--- a/packages/mixpanel/src/utils.ts
+++ b/packages/mixpanel/src/utils.ts
@@ -19,3 +19,17 @@ export function paramsToHumanFormat(params: Record<string, any>) {
 
   return humanReadableParams;
 }
+
+// searchString is the search part of the URL, starting with ?
+export type UTMParams = Record<string, string | undefined>;
+
+export function getUTMParamsFromSearch(searchString: string): UTMParams {
+  const urlParams = new URLSearchParams(searchString);
+  return {
+    utm_source: urlParams.get('utm_source') || undefined,
+    utm_medium: urlParams.get('utm_medium') || undefined,
+    utm_campaign: urlParams.get('utm_campaign') || undefined,
+    utm_term: urlParams.get('utm_term') || undefined,
+    utm_content: urlParams.get('utm_content') || undefined
+  };
+}

--- a/packages/scoutgame/src/session/interfaces.ts
+++ b/packages/scoutgame/src/session/interfaces.ts
@@ -1,8 +1,10 @@
 import type { Scout } from '@charmverse/core/prisma-client';
+import type { UTMParams } from '@packages/mixpanel/utils';
 
 export type SessionData = {
   user?: { id: string };
   anonymousUserId?: string;
+  utmParams?: UTMParams;
   scoutId?: string; // for ScoutGame, users in the scout database
 };
 


### PR DESCRIPTION
Track utm_params on events. Mixpanel automatically attributes this to the user as initial properties: https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#track-utm-tags