### PR TITLE
Telegram redirects and startapp param improvement

### DIFF
--- a/apps/scoutgametelegram/app/api/session/telegram-user/route.ts
+++ b/apps/scoutgametelegram/app/api/session/telegram-user/route.ts
@@ -24,5 +24,5 @@ export async function POST(request: Request) {
   session.anonymousUserId = undefined;
   await session.save();
 
-  return Response.json(user);
+  return Response.json(validatedData);
 }

--- a/apps/scoutgametelegram/app/api/session/user/route.ts
+++ b/apps/scoutgametelegram/app/api/session/user/route.ts
@@ -3,6 +3,6 @@ import { NextResponse } from 'next/server';
 
 // This API Route is non-blocking and called on every page load. Use it to refresh things about the current user
 export async function GET() {
-  const user = await getUserFromSession();
+  const user = await getUserFromSession({ sameSite: 'none' });
   return NextResponse.json(user);
 }

--- a/apps/scoutgametelegram/components/friends/components/InviteButtons.tsx
+++ b/apps/scoutgametelegram/components/friends/components/InviteButtons.tsx
@@ -6,21 +6,24 @@ import WebApp from '@twa-dev/sdk';
 import { useState } from 'react';
 import { LuCopy } from 'react-icons/lu';
 
+import { telegramBotName } from 'lib/telegram/config';
+
 export function InviteButtons() {
   const { user } = useUser();
   const [copied, setCopied] = useState('');
   const referral = user?.referralCode;
-  const url = encodeURIComponent(`https://t.me/ScoutGameXYZBot/start?startapp=${referral}`);
+  const url = `https://t.me/${telegramBotName}/start?startapp=ref_${referral}`;
+  const encodedUrl = encodeURIComponent(url);
   const text = encodeURIComponent('Pick great builders. Earn rewards.');
 
-  const shareUrl = `https://t.me/share/url?url=${url}&text=${text}`;
+  const shareUrl = `https://t.me/share/url?url=${encodedUrl}&text=${text}`;
 
   const onCopy = async () => {
     if (typeof window !== 'undefined') {
       WebApp.requestWriteAccess(async (access) => {
         if (access) {
           try {
-            await navigator.clipboard.writeText(shareUrl);
+            await navigator.clipboard.writeText(url);
           } catch (_) {
             // permissions error
           }

--- a/apps/scoutgametelegram/hooks/api/session.ts
+++ b/apps/scoutgametelegram/hooks/api/session.ts
@@ -1,4 +1,5 @@
 import { useGETImmutable, usePOST } from '@packages/scoutgame-ui/hooks/helpers';
+import type { WebAppInitData } from '@twa-dev/types';
 
 export function useGetClaimablePoints() {
   return useGETImmutable<{ points: number }>(
@@ -11,5 +12,5 @@ export function useGetClaimablePoints() {
 }
 
 export function useInitTelegramUser() {
-  return usePOST<{ initData: string }, { id: string }>('/api/session/telegram-user');
+  return usePOST<{ initData: string }, WebAppInitData>('/api/session/telegram-user');
 }

--- a/apps/scoutgametelegram/hooks/useInitTelegramData.ts
+++ b/apps/scoutgametelegram/hooks/useInitTelegramData.ts
@@ -1,6 +1,7 @@
 import { log } from '@charmverse/core/log';
 import { useUser } from '@packages/scoutgame-ui/providers/UserProvider';
 import WebApp from '@twa-dev/sdk';
+import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
 import { useInitTelegramUser } from './api/session';
@@ -9,6 +10,7 @@ export function useInitTelegramData() {
   const initData = typeof window !== 'undefined' ? WebApp.initData : null;
   const { trigger, isMutating } = useInitTelegramUser();
   const { refreshUser, isLoading } = useUser();
+  const router = useRouter();
 
   useEffect(() => {
     // Load the Telegram Web App SDK
@@ -25,6 +27,13 @@ export function useInitTelegramData() {
           onSuccess: async (data) => {
             if (data) {
               await refreshUser();
+              const param = data.start_param;
+              if (param && param.startsWith('page_')) {
+                const redirectUrl = param.replace('page_', '/').trim();
+                router.push(redirectUrl);
+              } else {
+                router.push('/welcome');
+              }
             }
           },
           onError: (error) => {

--- a/apps/scoutgametelegram/lib/telegram/config.ts
+++ b/apps/scoutgametelegram/lib/telegram/config.ts
@@ -1,1 +1,2 @@
 export const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+export const telegramBotName = 'ScoutGameXYZBot';

--- a/apps/scoutgametelegram/middleware.ts
+++ b/apps/scoutgametelegram/middleware.ts
@@ -6,18 +6,12 @@ import { getSession } from 'lib/session/getSession';
 // Everything is private
 const privateLinks: string[] = [];
 
+// Home page handles the redirects after logging in.
 export async function middleware(request: NextRequest) {
   const session = await getSession();
   const isLoggedIn = !!session.scoutId;
   const path = request.nextUrl.pathname;
   const response = NextResponse.next(); // Create a response object to set cookies
-
-  // User flow
-  // lands on /, redirect to /welcome if logged in, otherwise stay on / (this should ideally never happen)
-  // on /welcome, redirect to /quests if onboarded, otherwise stay on /welcome
-  if (isLoggedIn && path === '/') {
-    return NextResponse.redirect(new URL('/welcome', request.url));
-  }
 
   if (!isLoggedIn && path !== '/') {
     return NextResponse.redirect(new URL('/', request.url));

--- a/packages/scoutgame/src/session/getUserFromSession.ts
+++ b/packages/scoutgame/src/session/getUserFromSession.ts
@@ -1,14 +1,18 @@
+import type { SessionOptions } from 'iron-session';
+
 import { getSession } from './getSession';
 import { cacheGetUser, getUser } from './getUser';
 import type { SessionUser } from './interfaces';
 
-export async function getUserFromSession(): Promise<SessionUser | null> {
-  const session = await getSession();
+export async function getUserFromSession(cookieOptions?: SessionOptions['cookieOptions']): Promise<SessionUser | null> {
+  const session = await getSession(cookieOptions);
   return getUser(session.scoutId);
 }
 
-export async function getCachedUserFromSession(): Promise<SessionUser | null> {
-  const session = await getSession();
+export async function getCachedUserFromSession(
+  cookieOptions?: SessionOptions['cookieOptions']
+): Promise<SessionUser | null> {
+  const session = await getSession(cookieOptions);
   const cached = cacheGetUser(session.scoutId);
 
   return cached;


### PR DESCRIPTION
## What

- `startapp` parameter from telegram can now be used for referral codes and redirects to certain pages by passing ref_1234354 or page_quests
- Handle redirects after the user was authenticated