### PR TITLE
fix flaky e2e nft tests

### DIFF
--- a/apps/scoutgame/__e2e__/buyNft.spec.ts
+++ b/apps/scoutgame/__e2e__/buyNft.spec.ts
@@ -53,10 +53,12 @@ test.describe('Buy Nft', () => {
 
     // Card CTA button
     const scoutButton = page.locator('data-test=scout-button').first();
+    await expect(scoutButton).toBeVisible();
     await scoutButton.click();
 
     // NFT buy button
     const buyButton = page.locator('data-test=purchase-button').first();
+    await expect(buyButton).toBeVisible();
     await buyButton.click();
 
     // Success view after purchase
@@ -124,6 +126,7 @@ test.describe('Buy Nft', () => {
 
     // Card CTA button
     const scoutButton = page.locator('data-test=scout-button').first();
+    await expect(scoutButton).toBeVisible();
     await scoutButton.click();
 
     // NFT buy button

--- a/packages/scoutgame-ui/src/components/common/ScoutButton/ScoutButton.tsx
+++ b/packages/scoutgame-ui/src/components/common/ScoutButton/ScoutButton.tsx
@@ -27,7 +27,7 @@ export function ScoutButton({ builder }: { builder: NFTPurchaseProps['builder'] 
   const [isPurchasing, setIsPurchasing] = useState<boolean>(false);
   const [authPopup, setAuthPopup] = useState<boolean>(false);
   const [dialogLoadingStatus, setDialogLoadingStatus] = useState<boolean>(false);
-  const { user } = useUser();
+  const { user, isLoading } = useUser();
   const isAuthenticated = Boolean(user?.id);
 
   const purchaseCostInPoints = convertCostToPoints(builder?.price || BigInt(0));
@@ -59,7 +59,7 @@ export function ScoutButton({ builder }: { builder: NFTPurchaseProps['builder'] 
           onClick={handleClick}
           // @ts-ignore
           variant='buy'
-          data-test='scout-button'
+          data-test={isLoading ? '' : 'scout-button'}
         >
           {purchaseCostInPoints}
           <Image


### PR DESCRIPTION
i can see that the scout button is being clicked before it's even visible. but we may need to wait until the user has a change to be loaded
![image](https://github.com/user-attachments/assets/b8913dcd-fac6-414c-8816-a63828a2db99)
