### PR TITLE
update ceramic libs

### DIFF
--- a/apps/ceramic/package.json
+++ b/apps/ceramic/package.json
@@ -7,8 +7,8 @@
     "ceramic:graphql:stg": "npx dotenv -e .env.staging --  tsx src/ceramic-client.ts"
   },
   "dependencies": {
-    "@ceramicnetwork/http-client": "5.6",
-    "@ceramicnetwork/streamid": "^3.4.1",
+    "@ceramicnetwork/http-client": "^6.4.0",
+    "@ceramicnetwork/streamid": "^5.6.0",
     "@composedb/devtools-node": "^0.7.1",
     "dids": "^4.0.4",
     "key-did-provider-ed25519": "^3.0.2",


### PR DESCRIPTION
trying to resolve a security vuln. these version bumps are just based on dependency updates and are not really api breaking