### PR TITLE
fix scrollable div on telegram app

### DIFF
--- a/apps/scoutgametelegram/app/(general)/layout.tsx
+++ b/apps/scoutgametelegram/app/(general)/layout.tsx
@@ -13,7 +13,6 @@ export default function Layout({
       <Box
         sx={{
           minHeight: 'calc(100vh - 117.5px)',
-          overflow: 'auto',
           px: 1
         }}
         component='main'


### PR DESCRIPTION
Tested with ngrok locally...this overflow rule doesn't seem to be necessary, and removing it fixes the issue reported here:

https://discord.com/channels/894960387743698944/1315672159494078504

I tested each of the 4 main tabs and am able to still scroll them

FWIW I still don't know why it's only in Telegram Webview. The same thing doesn't happen inside Metamask webview or the regular iOS browser. It also didn't happen if i was using my local db that had no builders/data to show. I had to use production data. And It was hard to find documentation on what might be causing the issue, so i dont know the root cause.