### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/components/common/CharmEditor/components/listItem/commands.ts
+++ b/components/common/CharmEditor/components/listItem/commands.ts
@@ -176,7 +176,7 @@ export function toggleList(listType: NodeType, itemType?: NodeType, todo?: boole
       let liftFrom = selection.$to.pos;
 
       // I am not fully sure the best solution,
-      // but if we donot handle the the nodeSelection of itemType
+      // but if we donot handle the nodeSelection of itemType
       // an incorrect content error in thrown by liftFollowingList.
       if (selection instanceof NodeSelection && selection.node.type === listItem) {
         liftFrom = selection.$from.pos + selection.node.firstChild!.content.size;
@@ -492,7 +492,7 @@ export function outdentList(type: NodeType): Command {
       return false;
     }
     // if we're backspacing at the start of a list item, unindent it
-    // take the the range of nodes we might be lifting
+    // take the range of nodes we might be lifting
 
     // the predicate is for when you're backspacing a top level list item:
     // we don't want to go up past the doc node, otherwise the range
@@ -762,7 +762,7 @@ function joinToPreviousListItem(type?: NodeType): Command {
           );
           tr.replaceWith(nodeBeforePos, $from.pos + $cut.nodeAfter.nodeSize, list);
         } else {
-          // take the text content of the paragraph and insert after the paragraph up until before the the cut
+          // take the text content of the paragraph and insert after the paragraph up until before the cut
           tr = tr.step(
             new ReplaceAroundStep(
               $lastNode.pos,

--- a/lib/permissions/bounties/__tests__/computeBountyPermissions.spec.ts
+++ b/lib/permissions/bounties/__tests__/computeBountyPermissions.spec.ts
@@ -275,7 +275,7 @@ describe('computeBountyPermissions', () => {
     });
   });
 
-  it('should return false for all bounty operations if the the user is not a member of the space', async () => {
+  it('should return false for all bounty operations if the user is not a member of the space', async () => {
     const { user, space } = await generateUserAndSpace({ isAdmin: true });
 
     const { user: externalUser } = await generateUserAndSpace({ isAdmin: true });

--- a/packages/charmeditor/src/extensions/listItem/toggleList.ts
+++ b/packages/charmeditor/src/extensions/listItem/toggleList.ts
@@ -169,7 +169,7 @@ export function toggleList(listType: NodeType, itemType?: NodeType, todo?: boole
       let liftFrom = selection.$to.pos;
 
       // I am not fully sure the best solution,
-      // but if we donot handle the the nodeSelection of itemType
+      // but if we donot handle the nodeSelection of itemType
       // an incorrect content error in thrown by liftFollowingList.
       if (selection instanceof NodeSelection && selection.node.type === listItem) {
         liftFrom = selection.$from.pos + selection.node.firstChild!.content.size;
@@ -488,7 +488,7 @@ export function outdentList(type: NodeType): Command {
       return false;
     }
     // if we're backspacing at the start of a list item, unindent it
-    // take the the range of nodes we might be lifting
+    // take the range of nodes we might be lifting
 
     // the predicate is for when you're backspacing a top level list item:
     // we don't want to go up past the doc node, otherwise the range
@@ -734,7 +734,7 @@ export function joinToPreviousListItem(type?: NodeType): Command {
           );
           tr.replaceWith(nodeBeforePos, $from.pos + $cut.nodeAfter.nodeSize, list);
         } else {
-          // take the text content of the paragraph and insert after the paragraph up until before the the cut
+          // take the text content of the paragraph and insert after the paragraph up until before the cut
           tr = tr.step(
             new ReplaceAroundStep(
               $lastNode.pos,


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

remove redundant words in comment

### WHY

<!-- why was this necessary? -->
