### PR TITLE
refresh proposal rubric answers when evaluation id changes

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/RubricEvaluation.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/RubricEvaluation.tsx
@@ -27,12 +27,13 @@ export function RubricEvaluation({ proposal, isCurrent, evaluation, refreshPropo
   const rubricCriteria = evaluation?.rubricCriteria;
   const myRubricAnswers = useMemo(
     () => evaluation?.rubricAnswers.filter((answer) => answer.userId === user?.id) || [],
-    [user?.id, !!evaluation?.rubricAnswers]
+    // watch the evaluation id in case more than one evaluation has answers
+    [user?.id, evaluation.id, !!evaluation?.rubricAnswers]
   );
   const myDraftRubricAnswers = useMemo(
     () => evaluation?.draftRubricAnswers.filter((answer) => answer.userId === user?.id),
     // watch the size of draft answers so they refresh when the user deletes them
-    [user?.id, !!evaluation?.draftRubricAnswers?.length]
+    [user?.id, evaluation.id, !!evaluation?.draftRubricAnswers?.length]
   );
 
   const isAuthor = proposal.authors.some((a) => a.userId === user?.id);


### PR DESCRIPTION
I believe this is why we see the error "Could not find criteria ..." sometimes. Today a user was showing us a related error: the proposal id 1d1fd249-736c-467e-8341-2070f0bcc38c has two rubric evaluation steps, the first one has 3 questions and the second has 2 questions. The frontend was sending the evaluation id of the first step, with an array of 3 answers but the 3rd result was empty, and the rubricCriteriaIds were from the second step. My theory is that the frontend loaded questions for the second step first. When the user opened questions from the first step, the answers were memoized and didn't update.