### PR TITLE
only send appeal notifications to appeal reveiwers

### DIFF
--- a/lib/notifications/proposals/createProposalNotifications.ts
+++ b/lib/notifications/proposals/createProposalNotifications.ts
@@ -283,12 +283,7 @@ export async function createProposalNotifications(webhookData: {
 
         const isAppealReviewer = proposalPermissions.evaluate_appeal;
 
-        // Only notify reviewers for hidden evaluations
-        if (
-          proposal.workflow?.privateEvaluations &&
-          !isAppealReviewer &&
-          privateEvaluationSteps.includes(currentEvaluation.type)
-        ) {
+        if (!isAppealReviewer) {
           continue;
         }
 


### PR DESCRIPTION
The condition required private evaluations to be enabled, otherwise everyone in the space will get a notification.

This seems to have been wrong since the feature was added: https://github.com/charmverse/app.charmverse.io/commit/f3862154bb6060edc1ff229278462ce57bcd7dff#diff-133705a1ff46d0b4a6a049c073023360b8c818d0232c43217f3d32cac673c51eR272