### PR TITLE
Clean up answers for rubric forms

### DIFF
--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/components/RubricAnswersForm.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/components/RubricAnswersForm.tsx
@@ -186,8 +186,10 @@ export function RubricAnswersForm({
     if (!confirmed) {
       return;
     }
+    // HACK: we are not sure why rubricCriteriaId does not exist, seems to be an issue when two sets of rubric criteria exist
+    const filteredAnswers = values.answers.filter((answer) => !!answer.rubricCriteriaId);
     await upsertRubricCriteriaAnswer({
-      answers: values.answers as unknown as RubricAnswerData[],
+      answers: filteredAnswers as unknown as RubricAnswerData[],
       evaluationId
     });
     // if draft is showing, delete it now that we updated the answers
@@ -201,8 +203,8 @@ export function RubricAnswersForm({
   }
 
   async function submitDraftAnswers(values: FormInput) {
-    // answers are optional - filter out ones with no score
-    const filteredAnswers = values.answers.filter((answer) => typeof (answer.response as any)?.score === 'number');
+    // HACK: we are not sure why rubricCriteriaId does not exist, seems to be an issue when two sets of rubric criteria exist
+    const filteredAnswers = values.answers.filter((answer) => !!answer.rubricCriteriaId);
     await upsertDraftRubricCriteriaAnswer({
       // @ts-ignore -  TODO: make answer types match
       answers: filteredAnswers,

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/components/RubricAnswersForm.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/components/RubricAnswersForm.tsx
@@ -1,3 +1,4 @@
+import { log } from '@charmverse/core/log';
 import type {
   DraftProposalRubricCriteriaAnswer,
   ProposalRubricCriteria,
@@ -188,6 +189,13 @@ export function RubricAnswersForm({
     }
     // HACK: we are not sure why rubricCriteriaId does not exist, seems to be an issue when two sets of rubric criteria exist
     const filteredAnswers = values.answers.filter((answer) => !!answer.rubricCriteriaId);
+    if (filteredAnswers.length !== values.answers.length) {
+      log.warn('Some answers did not have a rubricCriteriaId, skipping them', {
+        values,
+        filteredAnswers,
+        pageId: proposalId
+      });
+    }
     await upsertRubricCriteriaAnswer({
       answers: filteredAnswers as unknown as RubricAnswerData[],
       evaluationId
@@ -205,6 +213,11 @@ export function RubricAnswersForm({
   async function submitDraftAnswers(values: FormInput) {
     // HACK: we are not sure why rubricCriteriaId does not exist, seems to be an issue when two sets of rubric criteria exist
     const filteredAnswers = values.answers.filter((answer) => !!answer.rubricCriteriaId);
+    log.warn('Some draft answers did not have a rubricCriteriaId, skipping them', {
+      values,
+      filteredAnswers,
+      pageId: proposalId
+    });
     await upsertDraftRubricCriteriaAnswer({
       // @ts-ignore -  TODO: make answer types match
       answers: filteredAnswers,

--- a/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/components/RubricAnswersForm.tsx
+++ b/components/proposals/ProposalPage/components/ProposalEvaluations/components/Review/components/RubricEvaluation/components/RubricAnswersForm.tsx
@@ -188,7 +188,12 @@ export function RubricAnswersForm({
       return;
     }
     // HACK: we are not sure why rubricCriteriaId does not exist, seems to be an issue when two sets of rubric criteria exist
-    const filteredAnswers = values.answers.filter((answer) => !!answer.rubricCriteriaId);
+    const filteredAnswers = values.answers.filter(
+      (answer) =>
+        !!answer.rubricCriteriaId &&
+        // answers are optional - filter out ones with no score
+        typeof (answer.response as any)?.score === 'number'
+    );
     if (filteredAnswers.length !== values.answers.length) {
       log.warn('Some answers did not have a rubricCriteriaId, skipping them', {
         values,


### PR DESCRIPTION
In prod I am seeing that we are sending more answers than are necessary for the evaluation  - 8 instead of 4, but there were 8 for a previous step, so I think this workaround is safe enough for now, but i think there is some issue where we are not updating state properly that could lead to other bugs.