### PR TITLE
disable snapshot test

### DIFF
--- a/__integration-tests__/server/pages/api/spaces/[id]/snapshot.spec.ts
+++ b/__integration-tests__/server/pages/api/spaces/[id]/snapshot.spec.ts
@@ -1,18 +1,21 @@
-import type { Space } from '@charmverse/core/prisma';
+import type { Space, User } from '@charmverse/core/prisma';
 import type { LoggedInUser } from '@root/lib/profile/getUser';
+import { getSnapshotSpace } from '@root/lib/snapshot/getSpace';
 import request from 'supertest';
 
 import { baseUrl, loginUser } from 'testing/mockApiCall';
-import { generateSpaceUser, generateUserAndSpaceWithApiToken } from 'testing/setupDatabase';
+import { generateSpaceUser, generateUserAndSpace } from 'testing/setupDatabase';
 
-let nonAdminUser: LoggedInUser;
+const mockedGetSnapshotSpace = getSnapshotSpace as jest.MockedFunction<typeof getSnapshotSpace>;
+
+let nonAdminUser: User;
 let nonAdminUserCookie: string;
 let adminUser: LoggedInUser;
 let adminUserCookie: string;
 let space: Space;
 
 beforeAll(async () => {
-  const { space: generatedSpace, user } = await generateUserAndSpaceWithApiToken(undefined, false);
+  const { space: generatedSpace, user } = await generateUserAndSpace();
 
   space = generatedSpace;
   nonAdminUser = user;
@@ -25,7 +28,12 @@ beforeAll(async () => {
   adminUserCookie = await loginUser(adminUser.id);
 });
 
-describe('PUT /api/spaces/[id]/snapshot - Update snapshot connection', () => {
+beforeEach(() => {
+  // Reset mock before each test
+  mockedGetSnapshotSpace.mockReset();
+});
+
+xdescribe('PUT /api/spaces/[id]/snapshot - Update snapshot connection', () => {
   it("should update a space's snapshot connection if the user is a space admin, responding with 200", async () => {
     const update = {
       snapshotDomain: 'aave.eth'
@@ -40,6 +48,7 @@ describe('PUT /api/spaces/[id]/snapshot - Update snapshot connection', () => {
     ).body as Space;
 
     expect(updatedSpace.snapshotDomain).toBe(update.snapshotDomain);
+    expect(mockedGetSnapshotSpace).toHaveBeenCalledWith('aave.eth');
   });
 
   it('should fail if the user is not an admin of the space, and respond 401', async () => {
@@ -52,6 +61,9 @@ describe('PUT /api/spaces/[id]/snapshot - Update snapshot connection', () => {
       .set('Cookie', nonAdminUserCookie)
       .send(update)
       .expect(401);
+
+    // Verify the mock was not called since auth should fail first
+    expect(mockedGetSnapshotSpace).not.toHaveBeenCalled();
   });
 
   it('should fail if the domain does not exist, and respond 404', async () => {
@@ -64,5 +76,7 @@ describe('PUT /api/spaces/[id]/snapshot - Update snapshot connection', () => {
       .set('Cookie', adminUserCookie)
       .send(update)
       .expect(404);
+
+    expect(mockedGetSnapshotSpace).toHaveBeenCalledWith('completely-inexistent-domain.abc');
   });
 });


### PR DESCRIPTION
This test relies on the snapshot service responding, which we should never do. I can't use jest mock to mock the snapshot lib because this is an integration test. Just disabling for now