### PR TITLE
allow updating space for non-gold tiers

### DIFF
--- a/apps/webapp/components/rewards/components/NewRewardButton.tsx
+++ b/apps/webapp/components/rewards/components/NewRewardButton.tsx
@@ -1,5 +1,6 @@
 import { KeyboardArrowDown } from '@mui/icons-material';
 import { ButtonGroup } from '@mui/material';
+import type { RewardTemplate } from '@packages/lib/rewards/getRewardTemplate';
 import { usePopupState } from 'material-ui-popup-state/hooks';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
@@ -11,7 +12,6 @@ import { useCharmRouter } from 'hooks/useCharmRouter';
 import { useCurrentSpacePermissions } from 'hooks/useCurrentSpacePermissions';
 import { useIsAdmin } from 'hooks/useIsAdmin';
 import { useSpaceFeatures } from 'hooks/useSpaceFeatures';
-import type { RewardTemplate } from '@packages/lib/rewards/getRewardTemplate';
 
 import { useRewardTemplates } from '../hooks/useRewardTemplates';
 

--- a/apps/webapp/lib/spaces/updateSpace.ts
+++ b/apps/webapp/lib/spaces/updateSpace.ts
@@ -3,7 +3,6 @@ import { prisma } from '@charmverse/core/prisma-client';
 import { updateTrackGroupProfile } from '@packages/metrics/mixpanel/updateTrackGroupProfile';
 import { getSpaceByDomain } from '@packages/spaces/getSpaceByDomain';
 import { getSpaceDomainFromName } from '@packages/spaces/utils';
-import { hasPrimaryMemberIdentityAccess } from '@packages/subscriptions/featureRestrictions';
 import { DataNotFoundError, DuplicateDataError, InvalidInputError } from '@packages/utils/errors';
 
 import { updateSnapshotDomain } from './updateSnapshotDomain';
@@ -57,11 +56,6 @@ export async function updateSpace(spaceId: string, updates: UpdateableSpaceField
 
   if (!existingSpace) {
     throw new DataNotFoundError(`Space with id ${spaceId} not found`);
-  }
-
-  // Check if trying to set primary member identity without proper tier
-  if (updates.primaryMemberIdentity && !hasPrimaryMemberIdentityAccess(existingSpace.subscriptionTier)) {
-    throw new InvalidInputError('Primary member identity is only available for Gold tier and above');
   }
 
   const domain = updates.domain ? getSpaceDomainFromName(updates.domain) : undefined;


### PR DESCRIPTION
The space form sends all fields to the backend, whether or not they appeared in the UI. 

Also, we don't need to care much if an admin sets a feature, it's more important to just disable the feature - that way when they upgrade/downgrade, it is automatically enabled.